### PR TITLE
fix: add support for minUpgradeFormatScore

### DIFF
--- a/imports/quality_profiles/radarr/1080p Balanced (radarr - master).json
+++ b/imports/quality_profiles/radarr/1080p Balanced (radarr - master).json
@@ -1,1115 +1,1116 @@
 [
-    {
-        "name": "1080p Balanced",
-        "upgradeAllowed": true,
-        "cutoff": 1004,
+  {
+    "name": "1080p Balanced",
+    "upgradeAllowed": true,
+    "cutoff": 1004,
+    "items": [
+      {
+        "quality": {
+          "id": 24,
+          "name": "WORKPRINT",
+          "source": "workprint",
+          "resolution": 0,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 29,
+          "name": "REGIONAL",
+          "source": "dvd",
+          "resolution": 480,
+          "modifier": "regional"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 28,
+          "name": "DVDSCR",
+          "source": "dvd",
+          "resolution": 480,
+          "modifier": "screener"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 1,
+          "name": "SDTV",
+          "source": "tv",
+          "resolution": 480,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 12,
+          "name": "WEBRip-480p",
+          "source": "webrip",
+          "resolution": 480,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 4,
+          "name": "HDTV-720p",
+          "source": "tv",
+          "resolution": 720,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "name": "WEB 720p",
         "items": [
-            {
-                "quality": {
-                    "id": 24,
-                    "name": "WORKPRINT",
-                    "source": "workprint",
-                    "resolution": 0,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
+          {
+            "quality": {
+              "id": 5,
+              "name": "WEBDL-720p",
+              "source": "webdl",
+              "resolution": 720,
+              "modifier": "none"
             },
-            {
-                "quality": {
-                    "id": 29,
-                    "name": "REGIONAL",
-                    "source": "dvd",
-                    "resolution": 480,
-                    "modifier": "regional"
-                },
-                "items": [],
-                "allowed": false
+            "items": [],
+            "allowed": false
+          },
+          {
+            "quality": {
+              "id": 14,
+              "name": "WEBRip-720p",
+              "source": "webrip",
+              "resolution": 720,
+              "modifier": "none"
             },
-            {
-                "quality": {
-                    "id": 28,
-                    "name": "DVDSCR",
-                    "source": "dvd",
-                    "resolution": 480,
-                    "modifier": "screener"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 1,
-                    "name": "SDTV",
-                    "source": "tv",
-                    "resolution": 480,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 12,
-                    "name": "WEBRip-480p",
-                    "source": "webrip",
-                    "resolution": 480,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 4,
-                    "name": "HDTV-720p",
-                    "source": "tv",
-                    "resolution": 720,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "name": "WEB 720p",
-                "items": [
-                    {
-                        "quality": {
-                            "id": 5,
-                            "name": "WEBDL-720p",
-                            "source": "webdl",
-                            "resolution": 720,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": false
-                    },
-                    {
-                        "quality": {
-                            "id": 14,
-                            "name": "WEBRip-720p",
-                            "source": "webrip",
-                            "resolution": 720,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": false
-                    }
-                ],
-                "allowed": false,
-                "id": 1001
-            },
-            {
-                "quality": {
-                    "id": 6,
-                    "name": "Bluray-720p",
-                    "source": "bluray",
-                    "resolution": 720,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 0,
-                    "name": "Unknown",
-                    "source": "unknown",
-                    "resolution": 0,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "name": "Else",
-                "items": [
-                    {
-                        "quality": {
-                            "id": 25,
-                            "name": "CAM",
-                            "source": "cam",
-                            "resolution": 0,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": true
-                    },
-                    {
-                        "quality": {
-                            "id": 26,
-                            "name": "TELESYNC",
-                            "source": "telesync",
-                            "resolution": 0,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": true
-                    },
-                    {
-                        "quality": {
-                            "id": 27,
-                            "name": "TELECINE",
-                            "source": "telecine",
-                            "resolution": 0,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": true
-                    },
-                    {
-                        "quality": {
-                            "id": 2,
-                            "name": "DVD",
-                            "source": "dvd",
-                            "resolution": 0,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": true
-                    },
-                    {
-                        "quality": {
-                            "id": 23,
-                            "name": "DVD-R",
-                            "source": "dvd",
-                            "resolution": 480,
-                            "modifier": "remux"
-                        },
-                        "items": [],
-                        "allowed": true
-                    },
-                    {
-                        "quality": {
-                            "id": 8,
-                            "name": "WEBDL-480p",
-                            "source": "webdl",
-                            "resolution": 480,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": true
-                    },
-                    {
-                        "quality": {
-                            "id": 20,
-                            "name": "Bluray-480p",
-                            "source": "bluray",
-                            "resolution": 480,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": true
-                    },
-                    {
-                        "quality": {
-                            "id": 21,
-                            "name": "Bluray-576p",
-                            "source": "bluray",
-                            "resolution": 576,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": true
-                    },
-                    {
-                        "quality": {
-                            "id": 9,
-                            "name": "HDTV-1080p",
-                            "source": "tv",
-                            "resolution": 1080,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": true
-                    }
-                ],
-                "allowed": true,
-                "id": 1005
-            },
-            {
-                "name": "Balanced Capable",
-                "items": [
-                    {
-                        "quality": {
-                            "id": 15,
-                            "name": "WEBRip-1080p",
-                            "source": "webrip",
-                            "resolution": 1080,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": true
-                    },
-                    {
-                        "quality": {
-                            "id": 7,
-                            "name": "Bluray-1080p",
-                            "source": "bluray",
-                            "resolution": 1080,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": true
-                    },
-                    {
-                        "quality": {
-                            "id": 3,
-                            "name": "WEBDL-1080p",
-                            "source": "webdl",
-                            "resolution": 1080,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": true
-                    }
-                ],
-                "allowed": true,
-                "id": 1004
-            },
-            {
-                "quality": {
-                    "id": 30,
-                    "name": "Remux-1080p",
-                    "source": "bluray",
-                    "resolution": 1080,
-                    "modifier": "remux"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 16,
-                    "name": "HDTV-2160p",
-                    "source": "tv",
-                    "resolution": 2160,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "name": "WEB 2160p",
-                "items": [
-                    {
-                        "quality": {
-                            "id": 18,
-                            "name": "WEBDL-2160p",
-                            "source": "webdl",
-                            "resolution": 2160,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": false
-                    },
-                    {
-                        "quality": {
-                            "id": 17,
-                            "name": "WEBRip-2160p",
-                            "source": "webrip",
-                            "resolution": 2160,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": false
-                    }
-                ],
-                "allowed": false,
-                "id": 1003
-            },
-            {
-                "quality": {
-                    "id": 19,
-                    "name": "Bluray-2160p",
-                    "source": "bluray",
-                    "resolution": 2160,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 31,
-                    "name": "Remux-2160p",
-                    "source": "bluray",
-                    "resolution": 2160,
-                    "modifier": "remux"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 22,
-                    "name": "BR-DISK",
-                    "source": "bluray",
-                    "resolution": 1080,
-                    "modifier": "brdisk"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 10,
-                    "name": "Raw-HD",
-                    "source": "tv",
-                    "resolution": 1080,
-                    "modifier": "rawhd"
-                },
-                "items": [],
-                "allowed": false
-            }
+            "items": [],
+            "allowed": false
+          }
         ],
-        "minFormatScore": 0,
-        "cutoffFormatScore": 500,
-        "formatItems": [
-            {
-                "format": 353,
-                "name": "BHDStudio (1080p x265)",
-                "score": 0
-            },
-            {
-                "format": 352,
-                "name": "E1",
-                "score": 0
-            },
-            {
-                "format": 351,
-                "name": "2160p x265",
-                "score": 0
-            },
-            {
-                "format": 349,
-                "name": "EXCiSiON",
-                "score": 0
-            },
-            {
-                "format": 348,
-                "name": "Unwanted x265 Groups",
-                "score": 0
-            },
-            {
-                "format": 347,
-                "name": "CRX",
-                "score": 0
-            },
-            {
-                "format": 346,
-                "name": "HDR10 (Missing) (x265 HDR only)",
-                "score": 0
-            },
-            {
-                "format": 345,
-                "name": "UHD Bluray",
-                "score": 0
-            },
-            {
-                "format": 344,
-                "name": "jennaortegaUHD",
-                "score": 0
-            },
-            {
-                "format": 342,
-                "name": "Freeleech25",
-                "score": 0
-            },
-            {
-                "format": 341,
-                "name": "Freeleech50",
-                "score": 0
-            },
-            {
-                "format": 340,
-                "name": "Freeleech75",
-                "score": 0
-            },
-            {
-                "format": 339,
-                "name": "Freeleech100",
-                "score": 0
-            },
-            {
-                "format": 338,
-                "name": "TEST FLAC",
-                "score": 0
-            },
-            {
-                "format": 337,
-                "name": "h265 (4k)",
-                "score": -9999
-            },
-            {
-                "format": 336,
-                "name": "MAX",
-                "score": 0
-            },
-            {
-                "format": 335,
-                "name": "Blu-Ray (Remux)",
-                "score": 0
-            },
-            {
-                "format": 334,
-                "name": "PCM",
-                "score": 0
-            },
-            {
-                "format": 333,
-                "name": "h265",
-                "score": -9999
-            },
-            {
-                "format": 331,
-                "name": "Golden Popcorn 720p",
-                "score": 0
-            },
-            {
-                "format": 330,
-                "name": "LQ",
-                "score": 0
-            },
-            {
-                "format": 329,
-                "name": "EPSiLON",
-                "score": 0
-            },
-            {
-                "format": 328,
-                "name": "playBD",
-                "score": 0
-            },
-            {
-                "format": 327,
-                "name": "BLURANiUM",
-                "score": 0
-            },
-            {
-                "format": 326,
-                "name": "PmP",
-                "score": 0
-            },
-            {
-                "format": 325,
-                "name": "WiLDCAT",
-                "score": 0
-            },
-            {
-                "format": 324,
-                "name": "TRiToN",
-                "score": 0
-            },
-            {
-                "format": 323,
-                "name": "3L",
-                "score": 0
-            },
-            {
-                "format": 322,
-                "name": "Dolby Vision w/out Fallback",
-                "score": 0
-            },
-            {
-                "format": 321,
-                "name": "UHDBits",
-                "score": 0
-            },
-            {
-                "format": 318,
-                "name": "ATMOS (Missing)",
-                "score": 0
-            },
-            {
-                "format": 317,
-                "name": "TrueHD (Missing)",
-                "score": 0
-            },
-            {
-                "format": 316,
-                "name": "HDR10 (Missing)",
-                "score": 0
-            },
-            {
-                "format": 315,
-                "name": "HDR10",
-                "score": 0
-            },
-            {
-                "format": 314,
-                "name": "Dolby Vision",
-                "score": 0
-            },
-            {
-                "format": 312,
-                "name": "HDR10+",
-                "score": 0
-            },
-            {
-                "format": 308,
-                "name": "Stream Optimised",
-                "score": 80
-            },
-            {
-                "format": 307,
-                "name": "LoRD",
-                "score": 30
-            },
-            {
-                "format": 306,
-                "name": "Scene",
-                "score": 20
-            },
-            {
-                "format": 303,
-                "name": "mHD",
-                "score": -99999
-            },
-            {
-                "format": 302,
-                "name": "AV1",
-                "score": -9999
-            },
-            {
-                "format": 301,
-                "name": "VVC",
-                "score": -9999
-            },
-            {
-                "format": 300,
-                "name": "Extras",
-                "score": -9999
-            },
-            {
-                "format": 298,
-                "name": "480p",
-                "score": 0
-            },
-            {
-                "format": 297,
-                "name": "Dariush ",
-                "score": 30
-            },
-            {
-                "format": 296,
-                "name": "TBB SD",
-                "score": 30
-            },
-            {
-                "format": 295,
-                "name": "Xvid",
-                "score": 0
-            },
-            {
-                "format": 294,
-                "name": "DVD",
-                "score": 0
-            },
-            {
-                "format": 293,
-                "name": "DVD REMUX ",
-                "score": 40
-            },
-            {
-                "format": 292,
-                "name": "HANDJOB SD",
-                "score": 20
-            },
-            {
-                "format": 291,
-                "name": "iTunes (Missing)",
-                "score": 90
-            },
-            {
-                "format": 290,
-                "name": "ROKU",
-                "score": 190
-            },
-            {
-                "format": 289,
-                "name": "BeyondHD",
-                "score": -9999
-            },
-            {
-                "format": 288,
-                "name": "Disc ",
-                "score": -9999
-            },
-            {
-                "format": 287,
-                "name": "3D",
-                "score": -9999
-            },
-            {
-                "format": 286,
-                "name": "Unwanted",
-                "score": -9999
-            },
-            {
-                "format": 285,
-                "name": "HDBits Internal",
-                "score": 30
-            },
-            {
-                "format": 284,
-                "name": "RightSIZE",
-                "score": 30
-            },
-            {
-                "format": 283,
-                "name": "Black and White",
-                "score": -9999
-            },
-            {
-                "format": 281,
-                "name": "TrueHD",
-                "score": -9999
-            },
-            {
-                "format": 280,
-                "name": "DTS-X",
-                "score": -9999
-            },
-            {
-                "format": 279,
-                "name": "FLAC",
-                "score": 0
-            },
-            {
-                "format": 278,
-                "name": "DTS-HD MA",
-                "score": -9999
-            },
-            {
-                "format": 276,
-                "name": "x265",
-                "score": -9999
-            },
-            {
-                "format": 275,
-                "name": "Golden Popcorn SD",
-                "score": 30
-            },
-            {
-                "format": 274,
-                "name": "Golden Popcorn 1080p",
-                "score": 80
-            },
-            {
-                "format": 273,
-                "name": "IMAX",
-                "score": 10
-            },
-            {
-                "format": 272,
-                "name": "ATMOS",
-                "score": 10
-            },
-            {
-                "format": 271,
-                "name": "DD",
-                "score": 0
-            },
-            {
-                "format": 270,
-                "name": "DTS",
-                "score": 0
-            },
-            {
-                "format": 269,
-                "name": "DD+",
-                "score": 0
-            },
-            {
-                "format": 268,
-                "name": "iTunes",
-                "score": 90
-            },
-            {
-                "format": 267,
-                "name": "Paramount+",
-                "score": 190
-            },
-            {
-                "format": 266,
-                "name": "Peacock TV",
-                "score": 190
-            },
-            {
-                "format": 265,
-                "name": "Hulu",
-                "score": 190
-            },
-            {
-                "format": 264,
-                "name": "Netflix",
-                "score": 200
-            },
-            {
-                "format": 263,
-                "name": "HBO Max",
-                "score": 200
-            },
-            {
-                "format": 262,
-                "name": "Disney+",
-                "score": 200
-            },
-            {
-                "format": 261,
-                "name": "Apple TV+",
-                "score": 210
-            },
-            {
-                "format": 260,
-                "name": "Movies Anywhere",
-                "score": 220
-            },
-            {
-                "format": 259,
-                "name": "Amazon Prime",
-                "score": 210
-            },
-            {
-                "format": 258,
-                "name": "REMUX",
-                "score": -9999
-            },
-            {
-                "format": 256,
-                "name": "x264",
-                "score": 10
-            },
-            {
-                "format": 255,
-                "name": "WEBRip",
-                "score": 10
-            },
-            {
-                "format": 254,
-                "name": "Blu-Ray",
-                "score": 10
-            },
-            {
-                "format": 253,
-                "name": "2160p",
-                "score": -9999
-            },
-            {
-                "format": 252,
-                "name": "720p",
-                "score": -9999
-            },
-            {
-                "format": 250,
-                "name": "1080p",
-                "score": 220
-            },
-            {
-                "format": 249,
-                "name": "BHDStudio",
-                "score": 90
-            },
-            {
-                "format": 248,
-                "name": "LEGi0N",
-                "score": 20
-            },
-            {
-                "format": 247,
-                "name": "FraMeSToR",
-                "score": 20
-            },
-            {
-                "format": 246,
-                "name": "iFT",
-                "score": 30
-            },
-            {
-                "format": 245,
-                "name": "MTeam",
-                "score": -9999
-            },
-            {
-                "format": 244,
-                "name": "EDPH",
-                "score": 20
-            },
-            {
-                "format": 243,
-                "name": "HANDJOB",
-                "score": 20
-            },
-            {
-                "format": 242,
-                "name": "c0ke",
-                "score": 70
-            },
-            {
-                "format": 241,
-                "name": "KASHMiR",
-                "score": 30
-            },
-            {
-                "format": 240,
-                "name": "WMING",
-                "score": 30
-            },
-            {
-                "format": 239,
-                "name": "playHD",
-                "score": 30
-            },
-            {
-                "format": 238,
-                "name": "E.N.D",
-                "score": 30
-            },
-            {
-                "format": 237,
-                "name": "GutS",
-                "score": 30
-            },
-            {
-                "format": 236,
-                "name": "BV",
-                "score": 30
-            },
-            {
-                "format": 235,
-                "name": "SiMPLE",
-                "score": 30
-            },
-            {
-                "format": 234,
-                "name": "W4NK3R",
-                "score": 30
-            },
-            {
-                "format": 233,
-                "name": "GS88",
-                "score": 30
-            },
-            {
-                "format": 232,
-                "name": "HiP",
-                "score": 40
-            },
-            {
-                "format": 231,
-                "name": "GALAXY",
-                "score": 30
-            },
-            {
-                "format": 230,
-                "name": "luvBB",
-                "score": 30
-            },
-            {
-                "format": 229,
-                "name": "NyHD",
-                "score": 30
-            },
-            {
-                "format": 228,
-                "name": "ZIMBO",
-                "score": 30
-            },
-            {
-                "format": 227,
-                "name": "ThD",
-                "score": 30
-            },
-            {
-                "format": 226,
-                "name": "SaNcTi",
-                "score": 30
-            },
-            {
-                "format": 225,
-                "name": "ORiGEN",
-                "score": 30
-            },
-            {
-                "format": 224,
-                "name": "Positive",
-                "score": 30
-            },
-            {
-                "format": 223,
-                "name": "ESiR",
-                "score": 30
-            },
-            {
-                "format": 222,
-                "name": "Chotab",
-                "score": 30
-            },
-            {
-                "format": 221,
-                "name": "xander",
-                "score": 30
-            },
-            {
-                "format": 220,
-                "name": "FTW-HD",
-                "score": 30
-            },
-            {
-                "format": 219,
-                "name": "Penumbra",
-                "score": 30
-            },
-            {
-                "format": 218,
-                "name": "TDD",
-                "score": 30
-            },
-            {
-                "format": 217,
-                "name": "Dariush SD",
-                "score": 30
-            },
-            {
-                "format": 216,
-                "name": "PTer",
-                "score": 30
-            },
-            {
-                "format": 215,
-                "name": "SbR",
-                "score": 30
-            },
-            {
-                "format": 214,
-                "name": "nmd",
-                "score": 30
-            },
-            {
-                "format": 213,
-                "name": "TBB",
-                "score": 30
-            },
-            {
-                "format": 212,
-                "name": "EA",
-                "score": 40
-            },
-            {
-                "format": 211,
-                "name": "BMF",
-                "score": 40
-            },
-            {
-                "format": 210,
-                "name": "LolHD",
-                "score": 40
-            },
-            {
-                "format": 209,
-                "name": "HDMaNiAcS",
-                "score": 40
-            },
-            {
-                "format": 208,
-                "name": "IDE",
-                "score": 40
-            },
-            {
-                "format": 207,
-                "name": "de[42]",
-                "score": 50
-            },
-            {
-                "format": 206,
-                "name": "NCmt",
-                "score": 60
-            },
-            {
-                "format": 205,
-                "name": "decibeL",
-                "score": 50
-            },
-            {
-                "format": 204,
-                "name": "NTb",
-                "score": 40
-            },
-            {
-                "format": 203,
-                "name": "CRiSC",
-                "score": 50
-            },
-            {
-                "format": 202,
-                "name": "SA89",
-                "score": 60
-            },
-            {
-                "format": 201,
-                "name": "HiDt",
-                "score": 60
-            },
-            {
-                "format": 200,
-                "name": "FoRM",
-                "score": 60
-            },
-            {
-                "format": 199,
-                "name": "HiFi",
-                "score": 60
-            },
-            {
-                "format": 198,
-                "name": "CtrlHD",
-                "score": 60
-            },
-            {
-                "format": 197,
-                "name": "VietHD",
-                "score": 70
-            },
-            {
-                "format": 196,
-                "name": "ZQ",
-                "score": 70
-            },
-            {
-                "format": 195,
-                "name": "TayTo",
-                "score": 70
-            },
-            {
-                "format": 194,
-                "name": "Geek",
-                "score": 70
-            },
-            {
-                "format": 193,
-                "name": "EbP",
-                "score": 80
-            },
-            {
-                "format": 192,
-                "name": "DON",
-                "score": 80
-            },
-            {
-                "format": 191,
-                "name": "D-Z0N3",
-                "score": 80
-            },
-            {
-                "format": 340,
-                "name": "Upscaled",
-                "score": -9999
-            }
+        "allowed": false,
+        "id": 1001
+      },
+      {
+        "quality": {
+          "id": 6,
+          "name": "Bluray-720p",
+          "source": "bluray",
+          "resolution": 720,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 0,
+          "name": "Unknown",
+          "source": "unknown",
+          "resolution": 0,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "name": "Else",
+        "items": [
+          {
+            "quality": {
+              "id": 25,
+              "name": "CAM",
+              "source": "cam",
+              "resolution": 0,
+              "modifier": "none"
+            },
+            "items": [],
+            "allowed": true
+          },
+          {
+            "quality": {
+              "id": 26,
+              "name": "TELESYNC",
+              "source": "telesync",
+              "resolution": 0,
+              "modifier": "none"
+            },
+            "items": [],
+            "allowed": true
+          },
+          {
+            "quality": {
+              "id": 27,
+              "name": "TELECINE",
+              "source": "telecine",
+              "resolution": 0,
+              "modifier": "none"
+            },
+            "items": [],
+            "allowed": true
+          },
+          {
+            "quality": {
+              "id": 2,
+              "name": "DVD",
+              "source": "dvd",
+              "resolution": 0,
+              "modifier": "none"
+            },
+            "items": [],
+            "allowed": true
+          },
+          {
+            "quality": {
+              "id": 23,
+              "name": "DVD-R",
+              "source": "dvd",
+              "resolution": 480,
+              "modifier": "remux"
+            },
+            "items": [],
+            "allowed": true
+          },
+          {
+            "quality": {
+              "id": 8,
+              "name": "WEBDL-480p",
+              "source": "webdl",
+              "resolution": 480,
+              "modifier": "none"
+            },
+            "items": [],
+            "allowed": true
+          },
+          {
+            "quality": {
+              "id": 20,
+              "name": "Bluray-480p",
+              "source": "bluray",
+              "resolution": 480,
+              "modifier": "none"
+            },
+            "items": [],
+            "allowed": true
+          },
+          {
+            "quality": {
+              "id": 21,
+              "name": "Bluray-576p",
+              "source": "bluray",
+              "resolution": 576,
+              "modifier": "none"
+            },
+            "items": [],
+            "allowed": true
+          },
+          {
+            "quality": {
+              "id": 9,
+              "name": "HDTV-1080p",
+              "source": "tv",
+              "resolution": 1080,
+              "modifier": "none"
+            },
+            "items": [],
+            "allowed": true
+          }
         ],
-        "language": {
-            "id": 1,
-            "name": "English"
-        }
+        "allowed": true,
+        "id": 1005
+      },
+      {
+        "name": "Balanced Capable",
+        "items": [
+          {
+            "quality": {
+              "id": 15,
+              "name": "WEBRip-1080p",
+              "source": "webrip",
+              "resolution": 1080,
+              "modifier": "none"
+            },
+            "items": [],
+            "allowed": true
+          },
+          {
+            "quality": {
+              "id": 7,
+              "name": "Bluray-1080p",
+              "source": "bluray",
+              "resolution": 1080,
+              "modifier": "none"
+            },
+            "items": [],
+            "allowed": true
+          },
+          {
+            "quality": {
+              "id": 3,
+              "name": "WEBDL-1080p",
+              "source": "webdl",
+              "resolution": 1080,
+              "modifier": "none"
+            },
+            "items": [],
+            "allowed": true
+          }
+        ],
+        "allowed": true,
+        "id": 1004
+      },
+      {
+        "quality": {
+          "id": 30,
+          "name": "Remux-1080p",
+          "source": "bluray",
+          "resolution": 1080,
+          "modifier": "remux"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 16,
+          "name": "HDTV-2160p",
+          "source": "tv",
+          "resolution": 2160,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "name": "WEB 2160p",
+        "items": [
+          {
+            "quality": {
+              "id": 18,
+              "name": "WEBDL-2160p",
+              "source": "webdl",
+              "resolution": 2160,
+              "modifier": "none"
+            },
+            "items": [],
+            "allowed": false
+          },
+          {
+            "quality": {
+              "id": 17,
+              "name": "WEBRip-2160p",
+              "source": "webrip",
+              "resolution": 2160,
+              "modifier": "none"
+            },
+            "items": [],
+            "allowed": false
+          }
+        ],
+        "allowed": false,
+        "id": 1003
+      },
+      {
+        "quality": {
+          "id": 19,
+          "name": "Bluray-2160p",
+          "source": "bluray",
+          "resolution": 2160,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 31,
+          "name": "Remux-2160p",
+          "source": "bluray",
+          "resolution": 2160,
+          "modifier": "remux"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 22,
+          "name": "BR-DISK",
+          "source": "bluray",
+          "resolution": 1080,
+          "modifier": "brdisk"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 10,
+          "name": "Raw-HD",
+          "source": "tv",
+          "resolution": 1080,
+          "modifier": "rawhd"
+        },
+        "items": [],
+        "allowed": false
+      }
+    ],
+    "minFormatScore": 0,
+    "cutoffFormatScore": 500,
+    "minUpgradeFormatScore": 1,
+    "formatItems": [
+      {
+        "format": 353,
+        "name": "BHDStudio (1080p x265)",
+        "score": 0
+      },
+      {
+        "format": 352,
+        "name": "E1",
+        "score": 0
+      },
+      {
+        "format": 351,
+        "name": "2160p x265",
+        "score": 0
+      },
+      {
+        "format": 349,
+        "name": "EXCiSiON",
+        "score": 0
+      },
+      {
+        "format": 348,
+        "name": "Unwanted x265 Groups",
+        "score": 0
+      },
+      {
+        "format": 347,
+        "name": "CRX",
+        "score": 0
+      },
+      {
+        "format": 346,
+        "name": "HDR10 (Missing) (x265 HDR only)",
+        "score": 0
+      },
+      {
+        "format": 345,
+        "name": "UHD Bluray",
+        "score": 0
+      },
+      {
+        "format": 344,
+        "name": "jennaortegaUHD",
+        "score": 0
+      },
+      {
+        "format": 342,
+        "name": "Freeleech25",
+        "score": 0
+      },
+      {
+        "format": 341,
+        "name": "Freeleech50",
+        "score": 0
+      },
+      {
+        "format": 340,
+        "name": "Freeleech75",
+        "score": 0
+      },
+      {
+        "format": 339,
+        "name": "Freeleech100",
+        "score": 0
+      },
+      {
+        "format": 338,
+        "name": "TEST FLAC",
+        "score": 0
+      },
+      {
+        "format": 337,
+        "name": "h265 (4k)",
+        "score": -9999
+      },
+      {
+        "format": 336,
+        "name": "MAX",
+        "score": 0
+      },
+      {
+        "format": 335,
+        "name": "Blu-Ray (Remux)",
+        "score": 0
+      },
+      {
+        "format": 334,
+        "name": "PCM",
+        "score": 0
+      },
+      {
+        "format": 333,
+        "name": "h265",
+        "score": -9999
+      },
+      {
+        "format": 331,
+        "name": "Golden Popcorn 720p",
+        "score": 0
+      },
+      {
+        "format": 330,
+        "name": "LQ",
+        "score": 0
+      },
+      {
+        "format": 329,
+        "name": "EPSiLON",
+        "score": 0
+      },
+      {
+        "format": 328,
+        "name": "playBD",
+        "score": 0
+      },
+      {
+        "format": 327,
+        "name": "BLURANiUM",
+        "score": 0
+      },
+      {
+        "format": 326,
+        "name": "PmP",
+        "score": 0
+      },
+      {
+        "format": 325,
+        "name": "WiLDCAT",
+        "score": 0
+      },
+      {
+        "format": 324,
+        "name": "TRiToN",
+        "score": 0
+      },
+      {
+        "format": 323,
+        "name": "3L",
+        "score": 0
+      },
+      {
+        "format": 322,
+        "name": "Dolby Vision w/out Fallback",
+        "score": 0
+      },
+      {
+        "format": 321,
+        "name": "UHDBits",
+        "score": 0
+      },
+      {
+        "format": 318,
+        "name": "ATMOS (Missing)",
+        "score": 0
+      },
+      {
+        "format": 317,
+        "name": "TrueHD (Missing)",
+        "score": 0
+      },
+      {
+        "format": 316,
+        "name": "HDR10 (Missing)",
+        "score": 0
+      },
+      {
+        "format": 315,
+        "name": "HDR10",
+        "score": 0
+      },
+      {
+        "format": 314,
+        "name": "Dolby Vision",
+        "score": 0
+      },
+      {
+        "format": 312,
+        "name": "HDR10+",
+        "score": 0
+      },
+      {
+        "format": 308,
+        "name": "Stream Optimised",
+        "score": 80
+      },
+      {
+        "format": 307,
+        "name": "LoRD",
+        "score": 30
+      },
+      {
+        "format": 306,
+        "name": "Scene",
+        "score": 20
+      },
+      {
+        "format": 303,
+        "name": "mHD",
+        "score": -99999
+      },
+      {
+        "format": 302,
+        "name": "AV1",
+        "score": -9999
+      },
+      {
+        "format": 301,
+        "name": "VVC",
+        "score": -9999
+      },
+      {
+        "format": 300,
+        "name": "Extras",
+        "score": -9999
+      },
+      {
+        "format": 298,
+        "name": "480p",
+        "score": 0
+      },
+      {
+        "format": 297,
+        "name": "Dariush ",
+        "score": 30
+      },
+      {
+        "format": 296,
+        "name": "TBB SD",
+        "score": 30
+      },
+      {
+        "format": 295,
+        "name": "Xvid",
+        "score": 0
+      },
+      {
+        "format": 294,
+        "name": "DVD",
+        "score": 0
+      },
+      {
+        "format": 293,
+        "name": "DVD REMUX ",
+        "score": 40
+      },
+      {
+        "format": 292,
+        "name": "HANDJOB SD",
+        "score": 20
+      },
+      {
+        "format": 291,
+        "name": "iTunes (Missing)",
+        "score": 90
+      },
+      {
+        "format": 290,
+        "name": "ROKU",
+        "score": 190
+      },
+      {
+        "format": 289,
+        "name": "BeyondHD",
+        "score": -9999
+      },
+      {
+        "format": 288,
+        "name": "Disc ",
+        "score": -9999
+      },
+      {
+        "format": 287,
+        "name": "3D",
+        "score": -9999
+      },
+      {
+        "format": 286,
+        "name": "Unwanted",
+        "score": -9999
+      },
+      {
+        "format": 285,
+        "name": "HDBits Internal",
+        "score": 30
+      },
+      {
+        "format": 284,
+        "name": "RightSIZE",
+        "score": 30
+      },
+      {
+        "format": 283,
+        "name": "Black and White",
+        "score": -9999
+      },
+      {
+        "format": 281,
+        "name": "TrueHD",
+        "score": -9999
+      },
+      {
+        "format": 280,
+        "name": "DTS-X",
+        "score": -9999
+      },
+      {
+        "format": 279,
+        "name": "FLAC",
+        "score": 0
+      },
+      {
+        "format": 278,
+        "name": "DTS-HD MA",
+        "score": -9999
+      },
+      {
+        "format": 276,
+        "name": "x265",
+        "score": -9999
+      },
+      {
+        "format": 275,
+        "name": "Golden Popcorn SD",
+        "score": 30
+      },
+      {
+        "format": 274,
+        "name": "Golden Popcorn 1080p",
+        "score": 80
+      },
+      {
+        "format": 273,
+        "name": "IMAX",
+        "score": 10
+      },
+      {
+        "format": 272,
+        "name": "ATMOS",
+        "score": 10
+      },
+      {
+        "format": 271,
+        "name": "DD",
+        "score": 0
+      },
+      {
+        "format": 270,
+        "name": "DTS",
+        "score": 0
+      },
+      {
+        "format": 269,
+        "name": "DD+",
+        "score": 0
+      },
+      {
+        "format": 268,
+        "name": "iTunes",
+        "score": 90
+      },
+      {
+        "format": 267,
+        "name": "Paramount+",
+        "score": 190
+      },
+      {
+        "format": 266,
+        "name": "Peacock TV",
+        "score": 190
+      },
+      {
+        "format": 265,
+        "name": "Hulu",
+        "score": 190
+      },
+      {
+        "format": 264,
+        "name": "Netflix",
+        "score": 200
+      },
+      {
+        "format": 263,
+        "name": "HBO Max",
+        "score": 200
+      },
+      {
+        "format": 262,
+        "name": "Disney+",
+        "score": 200
+      },
+      {
+        "format": 261,
+        "name": "Apple TV+",
+        "score": 210
+      },
+      {
+        "format": 260,
+        "name": "Movies Anywhere",
+        "score": 220
+      },
+      {
+        "format": 259,
+        "name": "Amazon Prime",
+        "score": 210
+      },
+      {
+        "format": 258,
+        "name": "REMUX",
+        "score": -9999
+      },
+      {
+        "format": 256,
+        "name": "x264",
+        "score": 10
+      },
+      {
+        "format": 255,
+        "name": "WEBRip",
+        "score": 10
+      },
+      {
+        "format": 254,
+        "name": "Blu-Ray",
+        "score": 10
+      },
+      {
+        "format": 253,
+        "name": "2160p",
+        "score": -9999
+      },
+      {
+        "format": 252,
+        "name": "720p",
+        "score": -9999
+      },
+      {
+        "format": 250,
+        "name": "1080p",
+        "score": 220
+      },
+      {
+        "format": 249,
+        "name": "BHDStudio",
+        "score": 90
+      },
+      {
+        "format": 248,
+        "name": "LEGi0N",
+        "score": 20
+      },
+      {
+        "format": 247,
+        "name": "FraMeSToR",
+        "score": 20
+      },
+      {
+        "format": 246,
+        "name": "iFT",
+        "score": 30
+      },
+      {
+        "format": 245,
+        "name": "MTeam",
+        "score": -9999
+      },
+      {
+        "format": 244,
+        "name": "EDPH",
+        "score": 20
+      },
+      {
+        "format": 243,
+        "name": "HANDJOB",
+        "score": 20
+      },
+      {
+        "format": 242,
+        "name": "c0ke",
+        "score": 70
+      },
+      {
+        "format": 241,
+        "name": "KASHMiR",
+        "score": 30
+      },
+      {
+        "format": 240,
+        "name": "WMING",
+        "score": 30
+      },
+      {
+        "format": 239,
+        "name": "playHD",
+        "score": 30
+      },
+      {
+        "format": 238,
+        "name": "E.N.D",
+        "score": 30
+      },
+      {
+        "format": 237,
+        "name": "GutS",
+        "score": 30
+      },
+      {
+        "format": 236,
+        "name": "BV",
+        "score": 30
+      },
+      {
+        "format": 235,
+        "name": "SiMPLE",
+        "score": 30
+      },
+      {
+        "format": 234,
+        "name": "W4NK3R",
+        "score": 30
+      },
+      {
+        "format": 233,
+        "name": "GS88",
+        "score": 30
+      },
+      {
+        "format": 232,
+        "name": "HiP",
+        "score": 40
+      },
+      {
+        "format": 231,
+        "name": "GALAXY",
+        "score": 30
+      },
+      {
+        "format": 230,
+        "name": "luvBB",
+        "score": 30
+      },
+      {
+        "format": 229,
+        "name": "NyHD",
+        "score": 30
+      },
+      {
+        "format": 228,
+        "name": "ZIMBO",
+        "score": 30
+      },
+      {
+        "format": 227,
+        "name": "ThD",
+        "score": 30
+      },
+      {
+        "format": 226,
+        "name": "SaNcTi",
+        "score": 30
+      },
+      {
+        "format": 225,
+        "name": "ORiGEN",
+        "score": 30
+      },
+      {
+        "format": 224,
+        "name": "Positive",
+        "score": 30
+      },
+      {
+        "format": 223,
+        "name": "ESiR",
+        "score": 30
+      },
+      {
+        "format": 222,
+        "name": "Chotab",
+        "score": 30
+      },
+      {
+        "format": 221,
+        "name": "xander",
+        "score": 30
+      },
+      {
+        "format": 220,
+        "name": "FTW-HD",
+        "score": 30
+      },
+      {
+        "format": 219,
+        "name": "Penumbra",
+        "score": 30
+      },
+      {
+        "format": 218,
+        "name": "TDD",
+        "score": 30
+      },
+      {
+        "format": 217,
+        "name": "Dariush SD",
+        "score": 30
+      },
+      {
+        "format": 216,
+        "name": "PTer",
+        "score": 30
+      },
+      {
+        "format": 215,
+        "name": "SbR",
+        "score": 30
+      },
+      {
+        "format": 214,
+        "name": "nmd",
+        "score": 30
+      },
+      {
+        "format": 213,
+        "name": "TBB",
+        "score": 30
+      },
+      {
+        "format": 212,
+        "name": "EA",
+        "score": 40
+      },
+      {
+        "format": 211,
+        "name": "BMF",
+        "score": 40
+      },
+      {
+        "format": 210,
+        "name": "LolHD",
+        "score": 40
+      },
+      {
+        "format": 209,
+        "name": "HDMaNiAcS",
+        "score": 40
+      },
+      {
+        "format": 208,
+        "name": "IDE",
+        "score": 40
+      },
+      {
+        "format": 207,
+        "name": "de[42]",
+        "score": 50
+      },
+      {
+        "format": 206,
+        "name": "NCmt",
+        "score": 60
+      },
+      {
+        "format": 205,
+        "name": "decibeL",
+        "score": 50
+      },
+      {
+        "format": 204,
+        "name": "NTb",
+        "score": 40
+      },
+      {
+        "format": 203,
+        "name": "CRiSC",
+        "score": 50
+      },
+      {
+        "format": 202,
+        "name": "SA89",
+        "score": 60
+      },
+      {
+        "format": 201,
+        "name": "HiDt",
+        "score": 60
+      },
+      {
+        "format": 200,
+        "name": "FoRM",
+        "score": 60
+      },
+      {
+        "format": 199,
+        "name": "HiFi",
+        "score": 60
+      },
+      {
+        "format": 198,
+        "name": "CtrlHD",
+        "score": 60
+      },
+      {
+        "format": 197,
+        "name": "VietHD",
+        "score": 70
+      },
+      {
+        "format": 196,
+        "name": "ZQ",
+        "score": 70
+      },
+      {
+        "format": 195,
+        "name": "TayTo",
+        "score": 70
+      },
+      {
+        "format": 194,
+        "name": "Geek",
+        "score": 70
+      },
+      {
+        "format": 193,
+        "name": "EbP",
+        "score": 80
+      },
+      {
+        "format": 192,
+        "name": "DON",
+        "score": 80
+      },
+      {
+        "format": 191,
+        "name": "D-Z0N3",
+        "score": 80
+      },
+      {
+        "format": 340,
+        "name": "Upscaled",
+        "score": -9999
+      }
+    ],
+    "language": {
+      "id": 1,
+      "name": "English"
     }
+  }
 ]

--- a/imports/quality_profiles/radarr/1080p Optimal (radarr - master).json
+++ b/imports/quality_profiles/radarr/1080p Optimal (radarr - master).json
@@ -1,1108 +1,1109 @@
 [
-    {
-        "name": "1080p Optimal",
-        "upgradeAllowed": true,
-        "cutoff": 30,
+  {
+    "name": "1080p Optimal",
+    "upgradeAllowed": true,
+    "cutoff": 30,
+    "items": [
+      {
+        "quality": {
+          "id": 0,
+          "name": "Unknown",
+          "source": "unknown",
+          "resolution": 0,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 24,
+          "name": "WORKPRINT",
+          "source": "workprint",
+          "resolution": 0,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 25,
+          "name": "CAM",
+          "source": "cam",
+          "resolution": 0,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 26,
+          "name": "TELESYNC",
+          "source": "telesync",
+          "resolution": 0,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 27,
+          "name": "TELECINE",
+          "source": "telecine",
+          "resolution": 0,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 29,
+          "name": "REGIONAL",
+          "source": "dvd",
+          "resolution": 480,
+          "modifier": "regional"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 28,
+          "name": "DVDSCR",
+          "source": "dvd",
+          "resolution": 480,
+          "modifier": "screener"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 1,
+          "name": "SDTV",
+          "source": "tv",
+          "resolution": 480,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": true
+      },
+      {
+        "name": "WEB 480p",
         "items": [
-            {
-                "quality": {
-                    "id": 0,
-                    "name": "Unknown",
-                    "source": "unknown",
-                    "resolution": 0,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
+          {
+            "quality": {
+              "id": 12,
+              "name": "WEBRip-480p",
+              "source": "webrip",
+              "resolution": 480,
+              "modifier": "none"
             },
-            {
-                "quality": {
-                    "id": 24,
-                    "name": "WORKPRINT",
-                    "source": "workprint",
-                    "resolution": 0,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
+            "items": [],
+            "allowed": true
+          },
+          {
+            "quality": {
+              "id": 8,
+              "name": "WEBDL-480p",
+              "source": "webdl",
+              "resolution": 480,
+              "modifier": "none"
             },
-            {
-                "quality": {
-                    "id": 25,
-                    "name": "CAM",
-                    "source": "cam",
-                    "resolution": 0,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 26,
-                    "name": "TELESYNC",
-                    "source": "telesync",
-                    "resolution": 0,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 27,
-                    "name": "TELECINE",
-                    "source": "telecine",
-                    "resolution": 0,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 29,
-                    "name": "REGIONAL",
-                    "source": "dvd",
-                    "resolution": 480,
-                    "modifier": "regional"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 28,
-                    "name": "DVDSCR",
-                    "source": "dvd",
-                    "resolution": 480,
-                    "modifier": "screener"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 1,
-                    "name": "SDTV",
-                    "source": "tv",
-                    "resolution": 480,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": true
-            },
-            {
-                "name": "WEB 480p",
-                "items": [
-                    {
-                        "quality": {
-                            "id": 12,
-                            "name": "WEBRip-480p",
-                            "source": "webrip",
-                            "resolution": 480,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": true
-                    },
-                    {
-                        "quality": {
-                            "id": 8,
-                            "name": "WEBDL-480p",
-                            "source": "webdl",
-                            "resolution": 480,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": true
-                    }
-                ],
-                "allowed": true,
-                "id": 1000
-            },
-            {
-                "quality": {
-                    "id": 2,
-                    "name": "DVD",
-                    "source": "dvd",
-                    "resolution": 0,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": true
-            },
-            {
-                "quality": {
-                    "id": 23,
-                    "name": "DVD-R",
-                    "source": "dvd",
-                    "resolution": 480,
-                    "modifier": "remux"
-                },
-                "items": [],
-                "allowed": true
-            },
-            {
-                "quality": {
-                    "id": 20,
-                    "name": "Bluray-480p",
-                    "source": "bluray",
-                    "resolution": 480,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 21,
-                    "name": "Bluray-576p",
-                    "source": "bluray",
-                    "resolution": 576,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 4,
-                    "name": "HDTV-720p",
-                    "source": "tv",
-                    "resolution": 720,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "name": "WEB 720p",
-                "items": [
-                    {
-                        "quality": {
-                            "id": 14,
-                            "name": "WEBRip-720p",
-                            "source": "webrip",
-                            "resolution": 720,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": false
-                    },
-                    {
-                        "quality": {
-                            "id": 5,
-                            "name": "WEBDL-720p",
-                            "source": "webdl",
-                            "resolution": 720,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": false
-                    }
-                ],
-                "allowed": false,
-                "id": 1001
-            },
-            {
-                "quality": {
-                    "id": 6,
-                    "name": "Bluray-720p",
-                    "source": "bluray",
-                    "resolution": 720,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 9,
-                    "name": "HDTV-1080p",
-                    "source": "tv",
-                    "resolution": 1080,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 15,
-                    "name": "WEBRip-1080p",
-                    "source": "webrip",
-                    "resolution": 1080,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 3,
-                    "name": "WEBDL-1080p",
-                    "source": "webdl",
-                    "resolution": 1080,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": true
-            },
-            {
-                "quality": {
-                    "id": 7,
-                    "name": "Bluray-1080p",
-                    "source": "bluray",
-                    "resolution": 1080,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 30,
-                    "name": "Remux-1080p",
-                    "source": "bluray",
-                    "resolution": 1080,
-                    "modifier": "remux"
-                },
-                "items": [],
-                "allowed": true
-            },
-            {
-                "quality": {
-                    "id": 16,
-                    "name": "HDTV-2160p",
-                    "source": "tv",
-                    "resolution": 2160,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "name": "WEB 2160p",
-                "items": [
-                    {
-                        "quality": {
-                            "id": 17,
-                            "name": "WEBRip-2160p",
-                            "source": "webrip",
-                            "resolution": 2160,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": false
-                    },
-                    {
-                        "quality": {
-                            "id": 18,
-                            "name": "WEBDL-2160p",
-                            "source": "webdl",
-                            "resolution": 2160,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": false
-                    }
-                ],
-                "allowed": false,
-                "id": 1003
-            },
-            {
-                "quality": {
-                    "id": 19,
-                    "name": "Bluray-2160p",
-                    "source": "bluray",
-                    "resolution": 2160,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 31,
-                    "name": "Remux-2160p",
-                    "source": "bluray",
-                    "resolution": 2160,
-                    "modifier": "remux"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 22,
-                    "name": "BR-DISK",
-                    "source": "bluray",
-                    "resolution": 1080,
-                    "modifier": "brdisk"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 10,
-                    "name": "Raw-HD",
-                    "source": "tv",
-                    "resolution": 1080,
-                    "modifier": "rawhd"
-                },
-                "items": [],
-                "allowed": false
-            }
+            "items": [],
+            "allowed": true
+          }
         ],
-        "minFormatScore": 0,
-        "cutoffFormatScore": 1000,
-        "formatItems": [
-            {
-                "format": 353,
-                "name": "BHDStudio (1080p x265)",
-                "score": 0
-            },
-            {
-                "format": 352,
-                "name": "E1",
-                "score": 0
-            },
-            {
-                "format": 351,
-                "name": "2160p x265",
-                "score": 0
-            },
-            {
-                "format": 349,
-                "name": "EXCiSiON",
-                "score": 0
-            },
-            {
-                "format": 348,
-                "name": "Unwanted x265 Groups",
-                "score": 0
-            },
-            {
-                "format": 347,
-                "name": "CRX",
-                "score": 0
-            },
-            {
-                "format": 346,
-                "name": "HDR10 (Missing) (x265 HDR only)",
-                "score": 0
-            },
-            {
-                "format": 345,
-                "name": "UHD Bluray",
-                "score": 0
-            },
-            {
-                "format": 344,
-                "name": "jennaortegaUHD",
-                "score": 0
-            },
-            {
-                "format": 342,
-                "name": "Freeleech25",
-                "score": 0
-            },
-            {
-                "format": 341,
-                "name": "Freeleech50",
-                "score": 0
-            },
-            {
-                "format": 340,
-                "name": "Freeleech75",
-                "score": 0
-            },
-            {
-                "format": 339,
-                "name": "Freeleech100",
-                "score": 0
-            },
-            {
-                "format": 338,
-                "name": "TEST FLAC",
-                "score": 0
-            },
-            {
-                "format": 337,
-                "name": "h265 (4k)",
-                "score": 0
-            },
-            {
-                "format": 336,
-                "name": "MAX",
-                "score": 0
-            },
-            {
-                "format": 335,
-                "name": "Blu-Ray (Remux)",
-                "score": 60
-            },
-            {
-                "format": 334,
-                "name": "PCM",
-                "score": 30
-            },
-            {
-                "format": 333,
-                "name": "h265",
-                "score": -9999
-            },
-            {
-                "format": 331,
-                "name": "Golden Popcorn 720p",
-                "score": 0
-            },
-            {
-                "format": 330,
-                "name": "LQ",
-                "score": -9999
-            },
-            {
-                "format": 329,
-                "name": "EPSiLON",
-                "score": 0
-            },
-            {
-                "format": 328,
-                "name": "playBD",
-                "score": 0
-            },
-            {
-                "format": 327,
-                "name": "BLURANiUM",
-                "score": 0
-            },
-            {
-                "format": 326,
-                "name": "PmP",
-                "score": 0
-            },
-            {
-                "format": 325,
-                "name": "WiLDCAT",
-                "score": 0
-            },
-            {
-                "format": 324,
-                "name": "TRiToN",
-                "score": 0
-            },
-            {
-                "format": 323,
-                "name": "3L",
-                "score": 0
-            },
-            {
-                "format": 322,
-                "name": "Dolby Vision w/out Fallback",
-                "score": -9999
-            },
-            {
-                "format": 321,
-                "name": "UHDBits",
-                "score": -9999
-            },
-            {
-                "format": 318,
-                "name": "ATMOS (Missing)",
-                "score": 10
-            },
-            {
-                "format": 317,
-                "name": "TrueHD (Missing)",
-                "score": 50
-            },
-            {
-                "format": 316,
-                "name": "HDR10 (Missing)",
-                "score": -9999
-            },
-            {
-                "format": 315,
-                "name": "HDR10",
-                "score": -9999
-            },
-            {
-                "format": 314,
-                "name": "Dolby Vision",
-                "score": -9999
-            },
-            {
-                "format": 312,
-                "name": "HDR10+",
-                "score": -9999
-            },
-            {
-                "format": 308,
-                "name": "Stream Optimised",
-                "score": 0
-            },
-            {
-                "format": 307,
-                "name": "LoRD",
-                "score": 0
-            },
-            {
-                "format": 306,
-                "name": "Scene",
-                "score": 0
-            },
-            {
-                "format": 303,
-                "name": "mHD",
-                "score": 0
-            },
-            {
-                "format": 302,
-                "name": "AV1",
-                "score": -9999
-            },
-            {
-                "format": 301,
-                "name": "VVC",
-                "score": -9999
-            },
-            {
-                "format": 300,
-                "name": "Extras",
-                "score": -9999
-            },
-            {
-                "format": 298,
-                "name": "480p",
-                "score": 0
-            },
-            {
-                "format": 297,
-                "name": "Dariush ",
-                "score": 0
-            },
-            {
-                "format": 296,
-                "name": "TBB SD",
-                "score": 30
-            },
-            {
-                "format": 295,
-                "name": "Xvid",
-                "score": 0
-            },
-            {
-                "format": 294,
-                "name": "DVD",
-                "score": 0
-            },
-            {
-                "format": 293,
-                "name": "DVD REMUX ",
-                "score": 40
-            },
-            {
-                "format": 292,
-                "name": "HANDJOB SD",
-                "score": 20
-            },
-            {
-                "format": 291,
-                "name": "iTunes (Missing)",
-                "score": 10
-            },
-            {
-                "format": 290,
-                "name": "ROKU",
-                "score": 20
-            },
-            {
-                "format": 289,
-                "name": "BeyondHD",
-                "score": 0
-            },
-            {
-                "format": 288,
-                "name": "Disc ",
-                "score": -9999
-            },
-            {
-                "format": 287,
-                "name": "3D",
-                "score": -9999
-            },
-            {
-                "format": 286,
-                "name": "Unwanted",
-                "score": -9999
-            },
-            {
-                "format": 285,
-                "name": "HDBits Internal",
-                "score": 0
-            },
-            {
-                "format": 284,
-                "name": "RightSIZE",
-                "score": 0
-            },
-            {
-                "format": 283,
-                "name": "Black and White",
-                "score": -9999
-            },
-            {
-                "format": 281,
-                "name": "TrueHD",
-                "score": 50
-            },
-            {
-                "format": 280,
-                "name": "DTS-X",
-                "score": 60
-            },
-            {
-                "format": 279,
-                "name": "FLAC",
-                "score": 30
-            },
-            {
-                "format": 278,
-                "name": "DTS-HD MA",
-                "score": 50
-            },
-            {
-                "format": 276,
-                "name": "x265",
-                "score": -9999
-            },
-            {
-                "format": 275,
-                "name": "Golden Popcorn SD",
-                "score": 30
-            },
-            {
-                "format": 274,
-                "name": "Golden Popcorn 1080p",
-                "score": 0
-            },
-            {
-                "format": 273,
-                "name": "IMAX",
-                "score": 10
-            },
-            {
-                "format": 272,
-                "name": "ATMOS",
-                "score": 10
-            },
-            {
-                "format": 271,
-                "name": "DD",
-                "score": 0
-            },
-            {
-                "format": 270,
-                "name": "DTS",
-                "score": 0
-            },
-            {
-                "format": 269,
-                "name": "DD+",
-                "score": 0
-            },
-            {
-                "format": 268,
-                "name": "iTunes",
-                "score": 10
-            },
-            {
-                "format": 267,
-                "name": "Paramount+",
-                "score": 20
-            },
-            {
-                "format": 266,
-                "name": "Peacock TV",
-                "score": 20
-            },
-            {
-                "format": 265,
-                "name": "Hulu",
-                "score": 20
-            },
-            {
-                "format": 264,
-                "name": "Netflix",
-                "score": 30
-            },
-            {
-                "format": 263,
-                "name": "HBO Max",
-                "score": 30
-            },
-            {
-                "format": 262,
-                "name": "Disney+",
-                "score": 30
-            },
-            {
-                "format": 261,
-                "name": "Apple TV+",
-                "score": 40
-            },
-            {
-                "format": 260,
-                "name": "Movies Anywhere",
-                "score": 50
-            },
-            {
-                "format": 259,
-                "name": "Amazon Prime",
-                "score": 40
-            },
-            {
-                "format": 258,
-                "name": "REMUX",
-                "score": 60
-            },
-            {
-                "format": 256,
-                "name": "x264",
-                "score": 10
-            },
-            {
-                "format": 255,
-                "name": "WEBRip",
-                "score": -9999
-            },
-            {
-                "format": 254,
-                "name": "Blu-Ray",
-                "score": -9999
-            },
-            {
-                "format": 253,
-                "name": "2160p",
-                "score": -9999
-            },
-            {
-                "format": 252,
-                "name": "720p",
-                "score": -9999
-            },
-            {
-                "format": 250,
-                "name": "1080p",
-                "score": 60
-            },
-            {
-                "format": 249,
-                "name": "BHDStudio",
-                "score": 0
-            },
-            {
-                "format": 248,
-                "name": "LEGi0N",
-                "score": 0
-            },
-            {
-                "format": 247,
-                "name": "FraMeSToR",
-                "score": 0
-            },
-            {
-                "format": 246,
-                "name": "iFT",
-                "score": 0
-            },
-            {
-                "format": 245,
-                "name": "MTeam",
-                "score": 0
-            },
-            {
-                "format": 244,
-                "name": "EDPH",
-                "score": 0
-            },
-            {
-                "format": 243,
-                "name": "HANDJOB",
-                "score": 0
-            },
-            {
-                "format": 242,
-                "name": "c0ke",
-                "score": 0
-            },
-            {
-                "format": 241,
-                "name": "KASHMiR",
-                "score": 0
-            },
-            {
-                "format": 240,
-                "name": "WMING",
-                "score": 0
-            },
-            {
-                "format": 239,
-                "name": "playHD",
-                "score": 0
-            },
-            {
-                "format": 238,
-                "name": "E.N.D",
-                "score": 0
-            },
-            {
-                "format": 237,
-                "name": "GutS",
-                "score": 0
-            },
-            {
-                "format": 236,
-                "name": "BV",
-                "score": 0
-            },
-            {
-                "format": 235,
-                "name": "SiMPLE",
-                "score": 0
-            },
-            {
-                "format": 234,
-                "name": "W4NK3R",
-                "score": 0
-            },
-            {
-                "format": 233,
-                "name": "GS88",
-                "score": 0
-            },
-            {
-                "format": 232,
-                "name": "HiP",
-                "score": 0
-            },
-            {
-                "format": 231,
-                "name": "GALAXY",
-                "score": 0
-            },
-            {
-                "format": 230,
-                "name": "luvBB",
-                "score": 0
-            },
-            {
-                "format": 229,
-                "name": "NyHD",
-                "score": 0
-            },
-            {
-                "format": 228,
-                "name": "ZIMBO",
-                "score": 0
-            },
-            {
-                "format": 227,
-                "name": "ThD",
-                "score": 0
-            },
-            {
-                "format": 226,
-                "name": "SaNcTi",
-                "score": 0
-            },
-            {
-                "format": 225,
-                "name": "ORiGEN",
-                "score": 0
-            },
-            {
-                "format": 224,
-                "name": "Positive",
-                "score": 0
-            },
-            {
-                "format": 223,
-                "name": "ESiR",
-                "score": 0
-            },
-            {
-                "format": 222,
-                "name": "Chotab",
-                "score": 0
-            },
-            {
-                "format": 221,
-                "name": "xander",
-                "score": 0
-            },
-            {
-                "format": 220,
-                "name": "FTW-HD",
-                "score": 0
-            },
-            {
-                "format": 219,
-                "name": "Penumbra",
-                "score": 0
-            },
-            {
-                "format": 218,
-                "name": "TDD",
-                "score": 0
-            },
-            {
-                "format": 217,
-                "name": "Dariush SD",
-                "score": 30
-            },
-            {
-                "format": 216,
-                "name": "PTer",
-                "score": 0
-            },
-            {
-                "format": 215,
-                "name": "SbR",
-                "score": 0
-            },
-            {
-                "format": 214,
-                "name": "nmd",
-                "score": 0
-            },
-            {
-                "format": 213,
-                "name": "TBB",
-                "score": 0
-            },
-            {
-                "format": 212,
-                "name": "EA",
-                "score": 0
-            },
-            {
-                "format": 211,
-                "name": "BMF",
-                "score": 0
-            },
-            {
-                "format": 210,
-                "name": "LolHD",
-                "score": 0
-            },
-            {
-                "format": 209,
-                "name": "HDMaNiAcS",
-                "score": 0
-            },
-            {
-                "format": 208,
-                "name": "IDE",
-                "score": 0
-            },
-            {
-                "format": 207,
-                "name": "de[42]",
-                "score": 0
-            },
-            {
-                "format": 206,
-                "name": "NCmt",
-                "score": 0
-            },
-            {
-                "format": 205,
-                "name": "decibeL",
-                "score": 0
-            },
-            {
-                "format": 204,
-                "name": "NTb",
-                "score": 0
-            },
-            {
-                "format": 203,
-                "name": "CRiSC",
-                "score": 0
-            },
-            {
-                "format": 202,
-                "name": "SA89",
-                "score": 0
-            },
-            {
-                "format": 201,
-                "name": "HiDt",
-                "score": 0
-            },
-            {
-                "format": 200,
-                "name": "FoRM",
-                "score": 0
-            },
-            {
-                "format": 199,
-                "name": "HiFi",
-                "score": 0
-            },
-            {
-                "format": 198,
-                "name": "CtrlHD",
-                "score": 0
-            },
-            {
-                "format": 197,
-                "name": "VietHD",
-                "score": 0
-            },
-            {
-                "format": 196,
-                "name": "ZQ",
-                "score": 0
-            },
-            {
-                "format": 195,
-                "name": "TayTo",
-                "score": 0
-            },
-            {
-                "format": 194,
-                "name": "Geek",
-                "score": 0
-            },
-            {
-                "format": 193,
-                "name": "EbP",
-                "score": 0
-            },
-            {
-                "format": 192,
-                "name": "DON",
-                "score": 0
-            },
-            {
-                "format": 191,
-                "name": "D-Z0N3",
-                "score": 0
-            },
-            {
-                "format": 340,
-                "name": "Upscaled",
-                "score": -9999
-            }
+        "allowed": true,
+        "id": 1000
+      },
+      {
+        "quality": {
+          "id": 2,
+          "name": "DVD",
+          "source": "dvd",
+          "resolution": 0,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": true
+      },
+      {
+        "quality": {
+          "id": 23,
+          "name": "DVD-R",
+          "source": "dvd",
+          "resolution": 480,
+          "modifier": "remux"
+        },
+        "items": [],
+        "allowed": true
+      },
+      {
+        "quality": {
+          "id": 20,
+          "name": "Bluray-480p",
+          "source": "bluray",
+          "resolution": 480,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 21,
+          "name": "Bluray-576p",
+          "source": "bluray",
+          "resolution": 576,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 4,
+          "name": "HDTV-720p",
+          "source": "tv",
+          "resolution": 720,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "name": "WEB 720p",
+        "items": [
+          {
+            "quality": {
+              "id": 14,
+              "name": "WEBRip-720p",
+              "source": "webrip",
+              "resolution": 720,
+              "modifier": "none"
+            },
+            "items": [],
+            "allowed": false
+          },
+          {
+            "quality": {
+              "id": 5,
+              "name": "WEBDL-720p",
+              "source": "webdl",
+              "resolution": 720,
+              "modifier": "none"
+            },
+            "items": [],
+            "allowed": false
+          }
         ],
-        "language": {
-            "id": -2,
-            "name": "Original"
-        }
+        "allowed": false,
+        "id": 1001
+      },
+      {
+        "quality": {
+          "id": 6,
+          "name": "Bluray-720p",
+          "source": "bluray",
+          "resolution": 720,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 9,
+          "name": "HDTV-1080p",
+          "source": "tv",
+          "resolution": 1080,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 15,
+          "name": "WEBRip-1080p",
+          "source": "webrip",
+          "resolution": 1080,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 3,
+          "name": "WEBDL-1080p",
+          "source": "webdl",
+          "resolution": 1080,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": true
+      },
+      {
+        "quality": {
+          "id": 7,
+          "name": "Bluray-1080p",
+          "source": "bluray",
+          "resolution": 1080,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 30,
+          "name": "Remux-1080p",
+          "source": "bluray",
+          "resolution": 1080,
+          "modifier": "remux"
+        },
+        "items": [],
+        "allowed": true
+      },
+      {
+        "quality": {
+          "id": 16,
+          "name": "HDTV-2160p",
+          "source": "tv",
+          "resolution": 2160,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "name": "WEB 2160p",
+        "items": [
+          {
+            "quality": {
+              "id": 17,
+              "name": "WEBRip-2160p",
+              "source": "webrip",
+              "resolution": 2160,
+              "modifier": "none"
+            },
+            "items": [],
+            "allowed": false
+          },
+          {
+            "quality": {
+              "id": 18,
+              "name": "WEBDL-2160p",
+              "source": "webdl",
+              "resolution": 2160,
+              "modifier": "none"
+            },
+            "items": [],
+            "allowed": false
+          }
+        ],
+        "allowed": false,
+        "id": 1003
+      },
+      {
+        "quality": {
+          "id": 19,
+          "name": "Bluray-2160p",
+          "source": "bluray",
+          "resolution": 2160,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 31,
+          "name": "Remux-2160p",
+          "source": "bluray",
+          "resolution": 2160,
+          "modifier": "remux"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 22,
+          "name": "BR-DISK",
+          "source": "bluray",
+          "resolution": 1080,
+          "modifier": "brdisk"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 10,
+          "name": "Raw-HD",
+          "source": "tv",
+          "resolution": 1080,
+          "modifier": "rawhd"
+        },
+        "items": [],
+        "allowed": false
+      }
+    ],
+    "minFormatScore": 0,
+    "cutoffFormatScore": 1000,
+    "minUpgradeFormatScore": 1,
+    "formatItems": [
+      {
+        "format": 353,
+        "name": "BHDStudio (1080p x265)",
+        "score": 0
+      },
+      {
+        "format": 352,
+        "name": "E1",
+        "score": 0
+      },
+      {
+        "format": 351,
+        "name": "2160p x265",
+        "score": 0
+      },
+      {
+        "format": 349,
+        "name": "EXCiSiON",
+        "score": 0
+      },
+      {
+        "format": 348,
+        "name": "Unwanted x265 Groups",
+        "score": 0
+      },
+      {
+        "format": 347,
+        "name": "CRX",
+        "score": 0
+      },
+      {
+        "format": 346,
+        "name": "HDR10 (Missing) (x265 HDR only)",
+        "score": 0
+      },
+      {
+        "format": 345,
+        "name": "UHD Bluray",
+        "score": 0
+      },
+      {
+        "format": 344,
+        "name": "jennaortegaUHD",
+        "score": 0
+      },
+      {
+        "format": 342,
+        "name": "Freeleech25",
+        "score": 0
+      },
+      {
+        "format": 341,
+        "name": "Freeleech50",
+        "score": 0
+      },
+      {
+        "format": 340,
+        "name": "Freeleech75",
+        "score": 0
+      },
+      {
+        "format": 339,
+        "name": "Freeleech100",
+        "score": 0
+      },
+      {
+        "format": 338,
+        "name": "TEST FLAC",
+        "score": 0
+      },
+      {
+        "format": 337,
+        "name": "h265 (4k)",
+        "score": 0
+      },
+      {
+        "format": 336,
+        "name": "MAX",
+        "score": 0
+      },
+      {
+        "format": 335,
+        "name": "Blu-Ray (Remux)",
+        "score": 60
+      },
+      {
+        "format": 334,
+        "name": "PCM",
+        "score": 30
+      },
+      {
+        "format": 333,
+        "name": "h265",
+        "score": -9999
+      },
+      {
+        "format": 331,
+        "name": "Golden Popcorn 720p",
+        "score": 0
+      },
+      {
+        "format": 330,
+        "name": "LQ",
+        "score": -9999
+      },
+      {
+        "format": 329,
+        "name": "EPSiLON",
+        "score": 0
+      },
+      {
+        "format": 328,
+        "name": "playBD",
+        "score": 0
+      },
+      {
+        "format": 327,
+        "name": "BLURANiUM",
+        "score": 0
+      },
+      {
+        "format": 326,
+        "name": "PmP",
+        "score": 0
+      },
+      {
+        "format": 325,
+        "name": "WiLDCAT",
+        "score": 0
+      },
+      {
+        "format": 324,
+        "name": "TRiToN",
+        "score": 0
+      },
+      {
+        "format": 323,
+        "name": "3L",
+        "score": 0
+      },
+      {
+        "format": 322,
+        "name": "Dolby Vision w/out Fallback",
+        "score": -9999
+      },
+      {
+        "format": 321,
+        "name": "UHDBits",
+        "score": -9999
+      },
+      {
+        "format": 318,
+        "name": "ATMOS (Missing)",
+        "score": 10
+      },
+      {
+        "format": 317,
+        "name": "TrueHD (Missing)",
+        "score": 50
+      },
+      {
+        "format": 316,
+        "name": "HDR10 (Missing)",
+        "score": -9999
+      },
+      {
+        "format": 315,
+        "name": "HDR10",
+        "score": -9999
+      },
+      {
+        "format": 314,
+        "name": "Dolby Vision",
+        "score": -9999
+      },
+      {
+        "format": 312,
+        "name": "HDR10+",
+        "score": -9999
+      },
+      {
+        "format": 308,
+        "name": "Stream Optimised",
+        "score": 0
+      },
+      {
+        "format": 307,
+        "name": "LoRD",
+        "score": 0
+      },
+      {
+        "format": 306,
+        "name": "Scene",
+        "score": 0
+      },
+      {
+        "format": 303,
+        "name": "mHD",
+        "score": 0
+      },
+      {
+        "format": 302,
+        "name": "AV1",
+        "score": -9999
+      },
+      {
+        "format": 301,
+        "name": "VVC",
+        "score": -9999
+      },
+      {
+        "format": 300,
+        "name": "Extras",
+        "score": -9999
+      },
+      {
+        "format": 298,
+        "name": "480p",
+        "score": 0
+      },
+      {
+        "format": 297,
+        "name": "Dariush ",
+        "score": 0
+      },
+      {
+        "format": 296,
+        "name": "TBB SD",
+        "score": 30
+      },
+      {
+        "format": 295,
+        "name": "Xvid",
+        "score": 0
+      },
+      {
+        "format": 294,
+        "name": "DVD",
+        "score": 0
+      },
+      {
+        "format": 293,
+        "name": "DVD REMUX ",
+        "score": 40
+      },
+      {
+        "format": 292,
+        "name": "HANDJOB SD",
+        "score": 20
+      },
+      {
+        "format": 291,
+        "name": "iTunes (Missing)",
+        "score": 10
+      },
+      {
+        "format": 290,
+        "name": "ROKU",
+        "score": 20
+      },
+      {
+        "format": 289,
+        "name": "BeyondHD",
+        "score": 0
+      },
+      {
+        "format": 288,
+        "name": "Disc ",
+        "score": -9999
+      },
+      {
+        "format": 287,
+        "name": "3D",
+        "score": -9999
+      },
+      {
+        "format": 286,
+        "name": "Unwanted",
+        "score": -9999
+      },
+      {
+        "format": 285,
+        "name": "HDBits Internal",
+        "score": 0
+      },
+      {
+        "format": 284,
+        "name": "RightSIZE",
+        "score": 0
+      },
+      {
+        "format": 283,
+        "name": "Black and White",
+        "score": -9999
+      },
+      {
+        "format": 281,
+        "name": "TrueHD",
+        "score": 50
+      },
+      {
+        "format": 280,
+        "name": "DTS-X",
+        "score": 60
+      },
+      {
+        "format": 279,
+        "name": "FLAC",
+        "score": 30
+      },
+      {
+        "format": 278,
+        "name": "DTS-HD MA",
+        "score": 50
+      },
+      {
+        "format": 276,
+        "name": "x265",
+        "score": -9999
+      },
+      {
+        "format": 275,
+        "name": "Golden Popcorn SD",
+        "score": 30
+      },
+      {
+        "format": 274,
+        "name": "Golden Popcorn 1080p",
+        "score": 0
+      },
+      {
+        "format": 273,
+        "name": "IMAX",
+        "score": 10
+      },
+      {
+        "format": 272,
+        "name": "ATMOS",
+        "score": 10
+      },
+      {
+        "format": 271,
+        "name": "DD",
+        "score": 0
+      },
+      {
+        "format": 270,
+        "name": "DTS",
+        "score": 0
+      },
+      {
+        "format": 269,
+        "name": "DD+",
+        "score": 0
+      },
+      {
+        "format": 268,
+        "name": "iTunes",
+        "score": 10
+      },
+      {
+        "format": 267,
+        "name": "Paramount+",
+        "score": 20
+      },
+      {
+        "format": 266,
+        "name": "Peacock TV",
+        "score": 20
+      },
+      {
+        "format": 265,
+        "name": "Hulu",
+        "score": 20
+      },
+      {
+        "format": 264,
+        "name": "Netflix",
+        "score": 30
+      },
+      {
+        "format": 263,
+        "name": "HBO Max",
+        "score": 30
+      },
+      {
+        "format": 262,
+        "name": "Disney+",
+        "score": 30
+      },
+      {
+        "format": 261,
+        "name": "Apple TV+",
+        "score": 40
+      },
+      {
+        "format": 260,
+        "name": "Movies Anywhere",
+        "score": 50
+      },
+      {
+        "format": 259,
+        "name": "Amazon Prime",
+        "score": 40
+      },
+      {
+        "format": 258,
+        "name": "REMUX",
+        "score": 60
+      },
+      {
+        "format": 256,
+        "name": "x264",
+        "score": 10
+      },
+      {
+        "format": 255,
+        "name": "WEBRip",
+        "score": -9999
+      },
+      {
+        "format": 254,
+        "name": "Blu-Ray",
+        "score": -9999
+      },
+      {
+        "format": 253,
+        "name": "2160p",
+        "score": -9999
+      },
+      {
+        "format": 252,
+        "name": "720p",
+        "score": -9999
+      },
+      {
+        "format": 250,
+        "name": "1080p",
+        "score": 60
+      },
+      {
+        "format": 249,
+        "name": "BHDStudio",
+        "score": 0
+      },
+      {
+        "format": 248,
+        "name": "LEGi0N",
+        "score": 0
+      },
+      {
+        "format": 247,
+        "name": "FraMeSToR",
+        "score": 0
+      },
+      {
+        "format": 246,
+        "name": "iFT",
+        "score": 0
+      },
+      {
+        "format": 245,
+        "name": "MTeam",
+        "score": 0
+      },
+      {
+        "format": 244,
+        "name": "EDPH",
+        "score": 0
+      },
+      {
+        "format": 243,
+        "name": "HANDJOB",
+        "score": 0
+      },
+      {
+        "format": 242,
+        "name": "c0ke",
+        "score": 0
+      },
+      {
+        "format": 241,
+        "name": "KASHMiR",
+        "score": 0
+      },
+      {
+        "format": 240,
+        "name": "WMING",
+        "score": 0
+      },
+      {
+        "format": 239,
+        "name": "playHD",
+        "score": 0
+      },
+      {
+        "format": 238,
+        "name": "E.N.D",
+        "score": 0
+      },
+      {
+        "format": 237,
+        "name": "GutS",
+        "score": 0
+      },
+      {
+        "format": 236,
+        "name": "BV",
+        "score": 0
+      },
+      {
+        "format": 235,
+        "name": "SiMPLE",
+        "score": 0
+      },
+      {
+        "format": 234,
+        "name": "W4NK3R",
+        "score": 0
+      },
+      {
+        "format": 233,
+        "name": "GS88",
+        "score": 0
+      },
+      {
+        "format": 232,
+        "name": "HiP",
+        "score": 0
+      },
+      {
+        "format": 231,
+        "name": "GALAXY",
+        "score": 0
+      },
+      {
+        "format": 230,
+        "name": "luvBB",
+        "score": 0
+      },
+      {
+        "format": 229,
+        "name": "NyHD",
+        "score": 0
+      },
+      {
+        "format": 228,
+        "name": "ZIMBO",
+        "score": 0
+      },
+      {
+        "format": 227,
+        "name": "ThD",
+        "score": 0
+      },
+      {
+        "format": 226,
+        "name": "SaNcTi",
+        "score": 0
+      },
+      {
+        "format": 225,
+        "name": "ORiGEN",
+        "score": 0
+      },
+      {
+        "format": 224,
+        "name": "Positive",
+        "score": 0
+      },
+      {
+        "format": 223,
+        "name": "ESiR",
+        "score": 0
+      },
+      {
+        "format": 222,
+        "name": "Chotab",
+        "score": 0
+      },
+      {
+        "format": 221,
+        "name": "xander",
+        "score": 0
+      },
+      {
+        "format": 220,
+        "name": "FTW-HD",
+        "score": 0
+      },
+      {
+        "format": 219,
+        "name": "Penumbra",
+        "score": 0
+      },
+      {
+        "format": 218,
+        "name": "TDD",
+        "score": 0
+      },
+      {
+        "format": 217,
+        "name": "Dariush SD",
+        "score": 30
+      },
+      {
+        "format": 216,
+        "name": "PTer",
+        "score": 0
+      },
+      {
+        "format": 215,
+        "name": "SbR",
+        "score": 0
+      },
+      {
+        "format": 214,
+        "name": "nmd",
+        "score": 0
+      },
+      {
+        "format": 213,
+        "name": "TBB",
+        "score": 0
+      },
+      {
+        "format": 212,
+        "name": "EA",
+        "score": 0
+      },
+      {
+        "format": 211,
+        "name": "BMF",
+        "score": 0
+      },
+      {
+        "format": 210,
+        "name": "LolHD",
+        "score": 0
+      },
+      {
+        "format": 209,
+        "name": "HDMaNiAcS",
+        "score": 0
+      },
+      {
+        "format": 208,
+        "name": "IDE",
+        "score": 0
+      },
+      {
+        "format": 207,
+        "name": "de[42]",
+        "score": 0
+      },
+      {
+        "format": 206,
+        "name": "NCmt",
+        "score": 0
+      },
+      {
+        "format": 205,
+        "name": "decibeL",
+        "score": 0
+      },
+      {
+        "format": 204,
+        "name": "NTb",
+        "score": 0
+      },
+      {
+        "format": 203,
+        "name": "CRiSC",
+        "score": 0
+      },
+      {
+        "format": 202,
+        "name": "SA89",
+        "score": 0
+      },
+      {
+        "format": 201,
+        "name": "HiDt",
+        "score": 0
+      },
+      {
+        "format": 200,
+        "name": "FoRM",
+        "score": 0
+      },
+      {
+        "format": 199,
+        "name": "HiFi",
+        "score": 0
+      },
+      {
+        "format": 198,
+        "name": "CtrlHD",
+        "score": 0
+      },
+      {
+        "format": 197,
+        "name": "VietHD",
+        "score": 0
+      },
+      {
+        "format": 196,
+        "name": "ZQ",
+        "score": 0
+      },
+      {
+        "format": 195,
+        "name": "TayTo",
+        "score": 0
+      },
+      {
+        "format": 194,
+        "name": "Geek",
+        "score": 0
+      },
+      {
+        "format": 193,
+        "name": "EbP",
+        "score": 0
+      },
+      {
+        "format": 192,
+        "name": "DON",
+        "score": 0
+      },
+      {
+        "format": 191,
+        "name": "D-Z0N3",
+        "score": 0
+      },
+      {
+        "format": 340,
+        "name": "Upscaled",
+        "score": -9999
+      }
+    ],
+    "language": {
+      "id": -2,
+      "name": "Original"
     }
+  }
 ]

--- a/imports/quality_profiles/radarr/1080p Transparent (Double Grab) (radarr - master).json
+++ b/imports/quality_profiles/radarr/1080p Transparent (Double Grab) (radarr - master).json
@@ -1,1115 +1,1116 @@
 [
-    {
-        "name": "1080p Transparent (Double Grab)",
-        "upgradeAllowed": true,
-        "cutoff": 1002,
+  {
+    "name": "1080p Transparent (Double Grab)",
+    "upgradeAllowed": true,
+    "cutoff": 1002,
+    "items": [
+      {
+        "quality": {
+          "id": 24,
+          "name": "WORKPRINT",
+          "source": "workprint",
+          "resolution": 0,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 29,
+          "name": "REGIONAL",
+          "source": "dvd",
+          "resolution": 480,
+          "modifier": "regional"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 4,
+          "name": "HDTV-720p",
+          "source": "tv",
+          "resolution": 720,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "name": "WEB 720p",
         "items": [
-            {
-                "quality": {
-                    "id": 24,
-                    "name": "WORKPRINT",
-                    "source": "workprint",
-                    "resolution": 0,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
+          {
+            "quality": {
+              "id": 5,
+              "name": "WEBDL-720p",
+              "source": "webdl",
+              "resolution": 720,
+              "modifier": "none"
             },
-            {
-                "quality": {
-                    "id": 29,
-                    "name": "REGIONAL",
-                    "source": "dvd",
-                    "resolution": 480,
-                    "modifier": "regional"
-                },
-                "items": [],
-                "allowed": false
+            "items": [],
+            "allowed": false
+          },
+          {
+            "quality": {
+              "id": 14,
+              "name": "WEBRip-720p",
+              "source": "webrip",
+              "resolution": 720,
+              "modifier": "none"
             },
-            {
-                "quality": {
-                    "id": 4,
-                    "name": "HDTV-720p",
-                    "source": "tv",
-                    "resolution": 720,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "name": "WEB 720p",
-                "items": [
-                    {
-                        "quality": {
-                            "id": 5,
-                            "name": "WEBDL-720p",
-                            "source": "webdl",
-                            "resolution": 720,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": false
-                    },
-                    {
-                        "quality": {
-                            "id": 14,
-                            "name": "WEBRip-720p",
-                            "source": "webrip",
-                            "resolution": 720,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": false
-                    }
-                ],
-                "allowed": false,
-                "id": 1001
-            },
-            {
-                "quality": {
-                    "id": 6,
-                    "name": "Bluray-720p",
-                    "source": "bluray",
-                    "resolution": 720,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 1,
-                    "name": "SDTV",
-                    "source": "tv",
-                    "resolution": 480,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 20,
-                    "name": "Bluray-480p",
-                    "source": "bluray",
-                    "resolution": 480,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 21,
-                    "name": "Bluray-576p",
-                    "source": "bluray",
-                    "resolution": 576,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 23,
-                    "name": "DVD-R",
-                    "source": "dvd",
-                    "resolution": 480,
-                    "modifier": "remux"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "name": "CAM",
-                "items": [
-                    {
-                        "quality": {
-                            "id": 25,
-                            "name": "CAM",
-                            "source": "cam",
-                            "resolution": 0,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": true
-                    },
-                    {
-                        "quality": {
-                            "id": 26,
-                            "name": "TELESYNC",
-                            "source": "telesync",
-                            "resolution": 0,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": true
-                    },
-                    {
-                        "quality": {
-                            "id": 27,
-                            "name": "TELECINE",
-                            "source": "telecine",
-                            "resolution": 0,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": true
-                    }
-                ],
-                "allowed": true,
-                "id": 1004
-            },
-            {
-                "quality": {
-                    "id": 0,
-                    "name": "Unknown",
-                    "source": "unknown",
-                    "resolution": 0,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": true
-            },
-            {
-                "name": "DVD",
-                "items": [
-                    {
-                        "quality": {
-                            "id": 28,
-                            "name": "DVDSCR",
-                            "source": "dvd",
-                            "resolution": 480,
-                            "modifier": "screener"
-                        },
-                        "items": [],
-                        "allowed": false
-                    },
-                    {
-                        "quality": {
-                            "id": 12,
-                            "name": "WEBRip-480p",
-                            "source": "webrip",
-                            "resolution": 480,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": false
-                    },
-                    {
-                        "quality": {
-                            "id": 2,
-                            "name": "DVD",
-                            "source": "dvd",
-                            "resolution": 0,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": true
-                    },
-                    {
-                        "quality": {
-                            "id": 8,
-                            "name": "WEBDL-480p",
-                            "source": "webdl",
-                            "resolution": 480,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": true
-                    }
-                ],
-                "allowed": true,
-                "id": 1003
-            },
-            {
-                "quality": {
-                    "id": 9,
-                    "name": "HDTV-1080p",
-                    "source": "tv",
-                    "resolution": 1080,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": true
-            },
-            {
-                "name": "Transparent Capable",
-                "items": [
-                    {
-                        "quality": {
-                            "id": 3,
-                            "name": "WEBDL-1080p",
-                            "source": "webdl",
-                            "resolution": 1080,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": true
-                    },
-                    {
-                        "quality": {
-                            "id": 15,
-                            "name": "WEBRip-1080p",
-                            "source": "webrip",
-                            "resolution": 1080,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": true
-                    },
-                    {
-                        "quality": {
-                            "id": 7,
-                            "name": "Bluray-1080p",
-                            "source": "bluray",
-                            "resolution": 1080,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": true
-                    }
-                ],
-                "allowed": true,
-                "id": 1002
-            },
-            {
-                "quality": {
-                    "id": 30,
-                    "name": "Remux-1080p",
-                    "source": "bluray",
-                    "resolution": 1080,
-                    "modifier": "remux"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 16,
-                    "name": "HDTV-2160p",
-                    "source": "tv",
-                    "resolution": 2160,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 18,
-                    "name": "WEBDL-2160p",
-                    "source": "webdl",
-                    "resolution": 2160,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 17,
-                    "name": "WEBRip-2160p",
-                    "source": "webrip",
-                    "resolution": 2160,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 19,
-                    "name": "Bluray-2160p",
-                    "source": "bluray",
-                    "resolution": 2160,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 31,
-                    "name": "Remux-2160p",
-                    "source": "bluray",
-                    "resolution": 2160,
-                    "modifier": "remux"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 22,
-                    "name": "BR-DISK",
-                    "source": "bluray",
-                    "resolution": 1080,
-                    "modifier": "brdisk"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 10,
-                    "name": "Raw-HD",
-                    "source": "tv",
-                    "resolution": 1080,
-                    "modifier": "rawhd"
-                },
-                "items": [],
-                "allowed": false
-            }
+            "items": [],
+            "allowed": false
+          }
         ],
-        "minFormatScore": 0,
-        "cutoffFormatScore": 140,
-        "formatItems": [
-            {
-                "format": 353,
-                "name": "BHDStudio (1080p x265)",
-                "score": 0
-            },
-            {
-                "format": 352,
-                "name": "E1",
-                "score": 0
-            },
-            {
-                "format": 351,
-                "name": "2160p x265",
-                "score": 0
-            },
-            {
-                "format": 349,
-                "name": "EXCiSiON",
-                "score": 0
-            },
-            {
-                "format": 348,
-                "name": "Unwanted x265 Groups",
-                "score": 0
-            },
-            {
-                "format": 347,
-                "name": "CRX",
-                "score": 0
-            },
-            {
-                "format": 346,
-                "name": "HDR10 (Missing) (x265 HDR only)",
-                "score": 0
-            },
-            {
-                "format": 345,
-                "name": "UHD Bluray",
-                "score": 0
-            },
-            {
-                "format": 344,
-                "name": "jennaortegaUHD",
-                "score": 0
-            },
-            {
-                "format": 342,
-                "name": "Freeleech25",
-                "score": 0
-            },
-            {
-                "format": 341,
-                "name": "Freeleech50",
-                "score": 0
-            },
-            {
-                "format": 340,
-                "name": "Freeleech75",
-                "score": 0
-            },
-            {
-                "format": 339,
-                "name": "Freeleech100",
-                "score": 0
-            },
-            {
-                "format": 338,
-                "name": "TEST FLAC",
-                "score": 0
-            },
-            {
-                "format": 337,
-                "name": "h265 (4k)",
-                "score": 0
-            },
-            {
-                "format": 336,
-                "name": "MAX",
-                "score": 0
-            },
-            {
-                "format": 335,
-                "name": "Blu-Ray (Remux)",
-                "score": 0
-            },
-            {
-                "format": 334,
-                "name": "PCM",
-                "score": 0
-            },
-            {
-                "format": 333,
-                "name": "h265",
-                "score": -9999
-            },
-            {
-                "format": 331,
-                "name": "Golden Popcorn 720p",
-                "score": 0
-            },
-            {
-                "format": 330,
-                "name": "LQ",
-                "score": -9999
-            },
-            {
-                "format": 329,
-                "name": "EPSiLON",
-                "score": 0
-            },
-            {
-                "format": 328,
-                "name": "playBD",
-                "score": 0
-            },
-            {
-                "format": 327,
-                "name": "BLURANiUM",
-                "score": 0
-            },
-            {
-                "format": 326,
-                "name": "PmP",
-                "score": 0
-            },
-            {
-                "format": 325,
-                "name": "WiLDCAT",
-                "score": 0
-            },
-            {
-                "format": 324,
-                "name": "TRiToN",
-                "score": 0
-            },
-            {
-                "format": 323,
-                "name": "3L",
-                "score": 0
-            },
-            {
-                "format": 322,
-                "name": "Dolby Vision w/out Fallback",
-                "score": -9999
-            },
-            {
-                "format": 321,
-                "name": "UHDBits",
-                "score": 0
-            },
-            {
-                "format": 318,
-                "name": "ATMOS (Missing)",
-                "score": 0
-            },
-            {
-                "format": 317,
-                "name": "TrueHD (Missing)",
-                "score": -9999
-            },
-            {
-                "format": 316,
-                "name": "HDR10 (Missing)",
-                "score": -9999
-            },
-            {
-                "format": 315,
-                "name": "HDR10",
-                "score": -9999
-            },
-            {
-                "format": 314,
-                "name": "Dolby Vision",
-                "score": -9999
-            },
-            {
-                "format": 312,
-                "name": "HDR10+",
-                "score": -9999
-            },
-            {
-                "format": 308,
-                "name": "Stream Optimised",
-                "score": 0
-            },
-            {
-                "format": 307,
-                "name": "LoRD",
-                "score": 70
-            },
-            {
-                "format": 306,
-                "name": "Scene",
-                "score": 30
-            },
-            {
-                "format": 303,
-                "name": "mHD",
-                "score": -999999
-            },
-            {
-                "format": 302,
-                "name": "AV1",
-                "score": -9999
-            },
-            {
-                "format": 301,
-                "name": "VVC",
-                "score": -9999
-            },
-            {
-                "format": 300,
-                "name": "Extras",
-                "score": -9999
-            },
-            {
-                "format": 298,
-                "name": "480p",
-                "score": 0
-            },
-            {
-                "format": 297,
-                "name": "Dariush ",
-                "score": 20
-            },
-            {
-                "format": 296,
-                "name": "TBB SD",
-                "score": 30
-            },
-            {
-                "format": 295,
-                "name": "Xvid",
-                "score": 0
-            },
-            {
-                "format": 294,
-                "name": "DVD",
-                "score": 0
-            },
-            {
-                "format": 293,
-                "name": "DVD REMUX ",
-                "score": 40
-            },
-            {
-                "format": 292,
-                "name": "HANDJOB SD",
-                "score": 20
-            },
-            {
-                "format": 291,
-                "name": "iTunes (Missing)",
-                "score": 20
-            },
-            {
-                "format": 290,
-                "name": "ROKU",
-                "score": 60
-            },
-            {
-                "format": 289,
-                "name": "BeyondHD",
-                "score": -10000
-            },
-            {
-                "format": 288,
-                "name": "Disc ",
-                "score": -9999
-            },
-            {
-                "format": 287,
-                "name": "3D",
-                "score": -9999
-            },
-            {
-                "format": 286,
-                "name": "Unwanted",
-                "score": -9999
-            },
-            {
-                "format": 285,
-                "name": "HDBits Internal",
-                "score": 70
-            },
-            {
-                "format": 284,
-                "name": "RightSIZE",
-                "score": 70
-            },
-            {
-                "format": 283,
-                "name": "Black and White",
-                "score": -9999
-            },
-            {
-                "format": 281,
-                "name": "TrueHD",
-                "score": -9999
-            },
-            {
-                "format": 280,
-                "name": "DTS-X",
-                "score": -9999
-            },
-            {
-                "format": 279,
-                "name": "FLAC",
-                "score": 0
-            },
-            {
-                "format": 278,
-                "name": "DTS-HD MA",
-                "score": -9999
-            },
-            {
-                "format": 276,
-                "name": "x265",
-                "score": -9999
-            },
-            {
-                "format": 275,
-                "name": "Golden Popcorn SD",
-                "score": 30
-            },
-            {
-                "format": 274,
-                "name": "Golden Popcorn 1080p",
-                "score": 120
-            },
-            {
-                "format": 273,
-                "name": "IMAX",
-                "score": 0
-            },
-            {
-                "format": 272,
-                "name": "ATMOS",
-                "score": 0
-            },
-            {
-                "format": 271,
-                "name": "DD",
-                "score": 0
-            },
-            {
-                "format": 270,
-                "name": "DTS",
-                "score": 0
-            },
-            {
-                "format": 269,
-                "name": "DD+",
-                "score": 0
-            },
-            {
-                "format": 268,
-                "name": "iTunes",
-                "score": 20
-            },
-            {
-                "format": 267,
-                "name": "Paramount+",
-                "score": 60
-            },
-            {
-                "format": 266,
-                "name": "Peacock TV",
-                "score": 60
-            },
-            {
-                "format": 265,
-                "name": "Hulu",
-                "score": 60
-            },
-            {
-                "format": 264,
-                "name": "Netflix",
-                "score": 60
-            },
-            {
-                "format": 263,
-                "name": "HBO Max",
-                "score": 60
-            },
-            {
-                "format": 262,
-                "name": "Disney+",
-                "score": 60
-            },
-            {
-                "format": 261,
-                "name": "Apple TV+",
-                "score": 60
-            },
-            {
-                "format": 260,
-                "name": "Movies Anywhere",
-                "score": 60
-            },
-            {
-                "format": 259,
-                "name": "Amazon Prime",
-                "score": 60
-            },
-            {
-                "format": 258,
-                "name": "REMUX",
-                "score": -9999
-            },
-            {
-                "format": 256,
-                "name": "x264",
-                "score": 10
-            },
-            {
-                "format": 255,
-                "name": "WEBRip",
-                "score": 0
-            },
-            {
-                "format": 254,
-                "name": "Blu-Ray",
-                "score": 0
-            },
-            {
-                "format": 253,
-                "name": "2160p",
-                "score": -9999
-            },
-            {
-                "format": 252,
-                "name": "720p",
-                "score": -10000
-            },
-            {
-                "format": 250,
-                "name": "1080p",
-                "score": 60
-            },
-            {
-                "format": 249,
-                "name": "BHDStudio",
-                "score": 50
-            },
-            {
-                "format": 248,
-                "name": "LEGi0N",
-                "score": 30
-            },
-            {
-                "format": 247,
-                "name": "FraMeSToR",
-                "score": 30
-            },
-            {
-                "format": 246,
-                "name": "iFT",
-                "score": 70
-            },
-            {
-                "format": 245,
-                "name": "MTeam",
-                "score": -9999
-            },
-            {
-                "format": 244,
-                "name": "EDPH",
-                "score": 30
-            },
-            {
-                "format": 243,
-                "name": "HANDJOB",
-                "score": 30
-            },
-            {
-                "format": 242,
-                "name": "c0ke",
-                "score": 110
-            },
-            {
-                "format": 241,
-                "name": "KASHMiR",
-                "score": 70
-            },
-            {
-                "format": 240,
-                "name": "WMING",
-                "score": 70
-            },
-            {
-                "format": 239,
-                "name": "playHD",
-                "score": 70
-            },
-            {
-                "format": 238,
-                "name": "E.N.D",
-                "score": 70
-            },
-            {
-                "format": 237,
-                "name": "GutS",
-                "score": 70
-            },
-            {
-                "format": 236,
-                "name": "BV",
-                "score": 70
-            },
-            {
-                "format": 235,
-                "name": "SiMPLE",
-                "score": 70
-            },
-            {
-                "format": 234,
-                "name": "W4NK3R",
-                "score": 70
-            },
-            {
-                "format": 233,
-                "name": "GS88",
-                "score": 70
-            },
-            {
-                "format": 232,
-                "name": "HiP",
-                "score": 80
-            },
-            {
-                "format": 231,
-                "name": "GALAXY",
-                "score": 70
-            },
-            {
-                "format": 230,
-                "name": "luvBB",
-                "score": 70
-            },
-            {
-                "format": 229,
-                "name": "NyHD",
-                "score": 70
-            },
-            {
-                "format": 228,
-                "name": "ZIMBO",
-                "score": 70
-            },
-            {
-                "format": 227,
-                "name": "ThD",
-                "score": 70
-            },
-            {
-                "format": 226,
-                "name": "SaNcTi",
-                "score": 70
-            },
-            {
-                "format": 225,
-                "name": "ORiGEN",
-                "score": 70
-            },
-            {
-                "format": 224,
-                "name": "Positive",
-                "score": 70
-            },
-            {
-                "format": 223,
-                "name": "ESiR",
-                "score": 70
-            },
-            {
-                "format": 222,
-                "name": "Chotab",
-                "score": 70
-            },
-            {
-                "format": 221,
-                "name": "xander",
-                "score": 70
-            },
-            {
-                "format": 220,
-                "name": "FTW-HD",
-                "score": 70
-            },
-            {
-                "format": 219,
-                "name": "Penumbra",
-                "score": 70
-            },
-            {
-                "format": 218,
-                "name": "TDD",
-                "score": 70
-            },
-            {
-                "format": 217,
-                "name": "Dariush SD",
-                "score": 70
-            },
-            {
-                "format": 216,
-                "name": "PTer",
-                "score": 70
-            },
-            {
-                "format": 215,
-                "name": "SbR",
-                "score": 70
-            },
-            {
-                "format": 214,
-                "name": "nmd",
-                "score": 70
-            },
-            {
-                "format": 213,
-                "name": "TBB",
-                "score": 70
-            },
-            {
-                "format": 212,
-                "name": "EA",
-                "score": 80
-            },
-            {
-                "format": 211,
-                "name": "BMF",
-                "score": 80
-            },
-            {
-                "format": 210,
-                "name": "LolHD",
-                "score": 80
-            },
-            {
-                "format": 209,
-                "name": "HDMaNiAcS",
-                "score": 80
-            },
-            {
-                "format": 208,
-                "name": "IDE",
-                "score": 80
-            },
-            {
-                "format": 207,
-                "name": "de[42]",
-                "score": 90
-            },
-            {
-                "format": 206,
-                "name": "NCmt",
-                "score": 100
-            },
-            {
-                "format": 205,
-                "name": "decibeL",
-                "score": 90
-            },
-            {
-                "format": 204,
-                "name": "NTb",
-                "score": 80
-            },
-            {
-                "format": 203,
-                "name": "CRiSC",
-                "score": 90
-            },
-            {
-                "format": 202,
-                "name": "SA89",
-                "score": 100
-            },
-            {
-                "format": 201,
-                "name": "HiDt",
-                "score": 100
-            },
-            {
-                "format": 200,
-                "name": "FoRM",
-                "score": 100
-            },
-            {
-                "format": 199,
-                "name": "HiFi",
-                "score": 100
-            },
-            {
-                "format": 198,
-                "name": "CtrlHD",
-                "score": 100
-            },
-            {
-                "format": 197,
-                "name": "VietHD",
-                "score": 110
-            },
-            {
-                "format": 196,
-                "name": "ZQ",
-                "score": 110
-            },
-            {
-                "format": 195,
-                "name": "TayTo",
-                "score": 110
-            },
-            {
-                "format": 194,
-                "name": "Geek",
-                "score": 110
-            },
-            {
-                "format": 193,
-                "name": "EbP",
-                "score": 120
-            },
-            {
-                "format": 192,
-                "name": "DON",
-                "score": 120
-            },
-            {
-                "format": 191,
-                "name": "D-Z0N3",
-                "score": 120
-            },
-            {
-                "format": 340,
-                "name": "Upscaled",
-                "score": -9999
-            }
+        "allowed": false,
+        "id": 1001
+      },
+      {
+        "quality": {
+          "id": 6,
+          "name": "Bluray-720p",
+          "source": "bluray",
+          "resolution": 720,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 1,
+          "name": "SDTV",
+          "source": "tv",
+          "resolution": 480,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 20,
+          "name": "Bluray-480p",
+          "source": "bluray",
+          "resolution": 480,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 21,
+          "name": "Bluray-576p",
+          "source": "bluray",
+          "resolution": 576,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 23,
+          "name": "DVD-R",
+          "source": "dvd",
+          "resolution": 480,
+          "modifier": "remux"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "name": "CAM",
+        "items": [
+          {
+            "quality": {
+              "id": 25,
+              "name": "CAM",
+              "source": "cam",
+              "resolution": 0,
+              "modifier": "none"
+            },
+            "items": [],
+            "allowed": true
+          },
+          {
+            "quality": {
+              "id": 26,
+              "name": "TELESYNC",
+              "source": "telesync",
+              "resolution": 0,
+              "modifier": "none"
+            },
+            "items": [],
+            "allowed": true
+          },
+          {
+            "quality": {
+              "id": 27,
+              "name": "TELECINE",
+              "source": "telecine",
+              "resolution": 0,
+              "modifier": "none"
+            },
+            "items": [],
+            "allowed": true
+          }
         ],
-        "language": {
-            "id": -1,
-            "name": "Any"
-        }
+        "allowed": true,
+        "id": 1004
+      },
+      {
+        "quality": {
+          "id": 0,
+          "name": "Unknown",
+          "source": "unknown",
+          "resolution": 0,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": true
+      },
+      {
+        "name": "DVD",
+        "items": [
+          {
+            "quality": {
+              "id": 28,
+              "name": "DVDSCR",
+              "source": "dvd",
+              "resolution": 480,
+              "modifier": "screener"
+            },
+            "items": [],
+            "allowed": false
+          },
+          {
+            "quality": {
+              "id": 12,
+              "name": "WEBRip-480p",
+              "source": "webrip",
+              "resolution": 480,
+              "modifier": "none"
+            },
+            "items": [],
+            "allowed": false
+          },
+          {
+            "quality": {
+              "id": 2,
+              "name": "DVD",
+              "source": "dvd",
+              "resolution": 0,
+              "modifier": "none"
+            },
+            "items": [],
+            "allowed": true
+          },
+          {
+            "quality": {
+              "id": 8,
+              "name": "WEBDL-480p",
+              "source": "webdl",
+              "resolution": 480,
+              "modifier": "none"
+            },
+            "items": [],
+            "allowed": true
+          }
+        ],
+        "allowed": true,
+        "id": 1003
+      },
+      {
+        "quality": {
+          "id": 9,
+          "name": "HDTV-1080p",
+          "source": "tv",
+          "resolution": 1080,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": true
+      },
+      {
+        "name": "Transparent Capable",
+        "items": [
+          {
+            "quality": {
+              "id": 3,
+              "name": "WEBDL-1080p",
+              "source": "webdl",
+              "resolution": 1080,
+              "modifier": "none"
+            },
+            "items": [],
+            "allowed": true
+          },
+          {
+            "quality": {
+              "id": 15,
+              "name": "WEBRip-1080p",
+              "source": "webrip",
+              "resolution": 1080,
+              "modifier": "none"
+            },
+            "items": [],
+            "allowed": true
+          },
+          {
+            "quality": {
+              "id": 7,
+              "name": "Bluray-1080p",
+              "source": "bluray",
+              "resolution": 1080,
+              "modifier": "none"
+            },
+            "items": [],
+            "allowed": true
+          }
+        ],
+        "allowed": true,
+        "id": 1002
+      },
+      {
+        "quality": {
+          "id": 30,
+          "name": "Remux-1080p",
+          "source": "bluray",
+          "resolution": 1080,
+          "modifier": "remux"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 16,
+          "name": "HDTV-2160p",
+          "source": "tv",
+          "resolution": 2160,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 18,
+          "name": "WEBDL-2160p",
+          "source": "webdl",
+          "resolution": 2160,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 17,
+          "name": "WEBRip-2160p",
+          "source": "webrip",
+          "resolution": 2160,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 19,
+          "name": "Bluray-2160p",
+          "source": "bluray",
+          "resolution": 2160,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 31,
+          "name": "Remux-2160p",
+          "source": "bluray",
+          "resolution": 2160,
+          "modifier": "remux"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 22,
+          "name": "BR-DISK",
+          "source": "bluray",
+          "resolution": 1080,
+          "modifier": "brdisk"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 10,
+          "name": "Raw-HD",
+          "source": "tv",
+          "resolution": 1080,
+          "modifier": "rawhd"
+        },
+        "items": [],
+        "allowed": false
+      }
+    ],
+    "minFormatScore": 0,
+    "cutoffFormatScore": 140,
+    "minUpgradeFormatScore": 1,
+    "formatItems": [
+      {
+        "format": 353,
+        "name": "BHDStudio (1080p x265)",
+        "score": 0
+      },
+      {
+        "format": 352,
+        "name": "E1",
+        "score": 0
+      },
+      {
+        "format": 351,
+        "name": "2160p x265",
+        "score": 0
+      },
+      {
+        "format": 349,
+        "name": "EXCiSiON",
+        "score": 0
+      },
+      {
+        "format": 348,
+        "name": "Unwanted x265 Groups",
+        "score": 0
+      },
+      {
+        "format": 347,
+        "name": "CRX",
+        "score": 0
+      },
+      {
+        "format": 346,
+        "name": "HDR10 (Missing) (x265 HDR only)",
+        "score": 0
+      },
+      {
+        "format": 345,
+        "name": "UHD Bluray",
+        "score": 0
+      },
+      {
+        "format": 344,
+        "name": "jennaortegaUHD",
+        "score": 0
+      },
+      {
+        "format": 342,
+        "name": "Freeleech25",
+        "score": 0
+      },
+      {
+        "format": 341,
+        "name": "Freeleech50",
+        "score": 0
+      },
+      {
+        "format": 340,
+        "name": "Freeleech75",
+        "score": 0
+      },
+      {
+        "format": 339,
+        "name": "Freeleech100",
+        "score": 0
+      },
+      {
+        "format": 338,
+        "name": "TEST FLAC",
+        "score": 0
+      },
+      {
+        "format": 337,
+        "name": "h265 (4k)",
+        "score": 0
+      },
+      {
+        "format": 336,
+        "name": "MAX",
+        "score": 0
+      },
+      {
+        "format": 335,
+        "name": "Blu-Ray (Remux)",
+        "score": 0
+      },
+      {
+        "format": 334,
+        "name": "PCM",
+        "score": 0
+      },
+      {
+        "format": 333,
+        "name": "h265",
+        "score": -9999
+      },
+      {
+        "format": 331,
+        "name": "Golden Popcorn 720p",
+        "score": 0
+      },
+      {
+        "format": 330,
+        "name": "LQ",
+        "score": -9999
+      },
+      {
+        "format": 329,
+        "name": "EPSiLON",
+        "score": 0
+      },
+      {
+        "format": 328,
+        "name": "playBD",
+        "score": 0
+      },
+      {
+        "format": 327,
+        "name": "BLURANiUM",
+        "score": 0
+      },
+      {
+        "format": 326,
+        "name": "PmP",
+        "score": 0
+      },
+      {
+        "format": 325,
+        "name": "WiLDCAT",
+        "score": 0
+      },
+      {
+        "format": 324,
+        "name": "TRiToN",
+        "score": 0
+      },
+      {
+        "format": 323,
+        "name": "3L",
+        "score": 0
+      },
+      {
+        "format": 322,
+        "name": "Dolby Vision w/out Fallback",
+        "score": -9999
+      },
+      {
+        "format": 321,
+        "name": "UHDBits",
+        "score": 0
+      },
+      {
+        "format": 318,
+        "name": "ATMOS (Missing)",
+        "score": 0
+      },
+      {
+        "format": 317,
+        "name": "TrueHD (Missing)",
+        "score": -9999
+      },
+      {
+        "format": 316,
+        "name": "HDR10 (Missing)",
+        "score": -9999
+      },
+      {
+        "format": 315,
+        "name": "HDR10",
+        "score": -9999
+      },
+      {
+        "format": 314,
+        "name": "Dolby Vision",
+        "score": -9999
+      },
+      {
+        "format": 312,
+        "name": "HDR10+",
+        "score": -9999
+      },
+      {
+        "format": 308,
+        "name": "Stream Optimised",
+        "score": 0
+      },
+      {
+        "format": 307,
+        "name": "LoRD",
+        "score": 70
+      },
+      {
+        "format": 306,
+        "name": "Scene",
+        "score": 30
+      },
+      {
+        "format": 303,
+        "name": "mHD",
+        "score": -999999
+      },
+      {
+        "format": 302,
+        "name": "AV1",
+        "score": -9999
+      },
+      {
+        "format": 301,
+        "name": "VVC",
+        "score": -9999
+      },
+      {
+        "format": 300,
+        "name": "Extras",
+        "score": -9999
+      },
+      {
+        "format": 298,
+        "name": "480p",
+        "score": 0
+      },
+      {
+        "format": 297,
+        "name": "Dariush ",
+        "score": 20
+      },
+      {
+        "format": 296,
+        "name": "TBB SD",
+        "score": 30
+      },
+      {
+        "format": 295,
+        "name": "Xvid",
+        "score": 0
+      },
+      {
+        "format": 294,
+        "name": "DVD",
+        "score": 0
+      },
+      {
+        "format": 293,
+        "name": "DVD REMUX ",
+        "score": 40
+      },
+      {
+        "format": 292,
+        "name": "HANDJOB SD",
+        "score": 20
+      },
+      {
+        "format": 291,
+        "name": "iTunes (Missing)",
+        "score": 20
+      },
+      {
+        "format": 290,
+        "name": "ROKU",
+        "score": 60
+      },
+      {
+        "format": 289,
+        "name": "BeyondHD",
+        "score": -10000
+      },
+      {
+        "format": 288,
+        "name": "Disc ",
+        "score": -9999
+      },
+      {
+        "format": 287,
+        "name": "3D",
+        "score": -9999
+      },
+      {
+        "format": 286,
+        "name": "Unwanted",
+        "score": -9999
+      },
+      {
+        "format": 285,
+        "name": "HDBits Internal",
+        "score": 70
+      },
+      {
+        "format": 284,
+        "name": "RightSIZE",
+        "score": 70
+      },
+      {
+        "format": 283,
+        "name": "Black and White",
+        "score": -9999
+      },
+      {
+        "format": 281,
+        "name": "TrueHD",
+        "score": -9999
+      },
+      {
+        "format": 280,
+        "name": "DTS-X",
+        "score": -9999
+      },
+      {
+        "format": 279,
+        "name": "FLAC",
+        "score": 0
+      },
+      {
+        "format": 278,
+        "name": "DTS-HD MA",
+        "score": -9999
+      },
+      {
+        "format": 276,
+        "name": "x265",
+        "score": -9999
+      },
+      {
+        "format": 275,
+        "name": "Golden Popcorn SD",
+        "score": 30
+      },
+      {
+        "format": 274,
+        "name": "Golden Popcorn 1080p",
+        "score": 120
+      },
+      {
+        "format": 273,
+        "name": "IMAX",
+        "score": 0
+      },
+      {
+        "format": 272,
+        "name": "ATMOS",
+        "score": 0
+      },
+      {
+        "format": 271,
+        "name": "DD",
+        "score": 0
+      },
+      {
+        "format": 270,
+        "name": "DTS",
+        "score": 0
+      },
+      {
+        "format": 269,
+        "name": "DD+",
+        "score": 0
+      },
+      {
+        "format": 268,
+        "name": "iTunes",
+        "score": 20
+      },
+      {
+        "format": 267,
+        "name": "Paramount+",
+        "score": 60
+      },
+      {
+        "format": 266,
+        "name": "Peacock TV",
+        "score": 60
+      },
+      {
+        "format": 265,
+        "name": "Hulu",
+        "score": 60
+      },
+      {
+        "format": 264,
+        "name": "Netflix",
+        "score": 60
+      },
+      {
+        "format": 263,
+        "name": "HBO Max",
+        "score": 60
+      },
+      {
+        "format": 262,
+        "name": "Disney+",
+        "score": 60
+      },
+      {
+        "format": 261,
+        "name": "Apple TV+",
+        "score": 60
+      },
+      {
+        "format": 260,
+        "name": "Movies Anywhere",
+        "score": 60
+      },
+      {
+        "format": 259,
+        "name": "Amazon Prime",
+        "score": 60
+      },
+      {
+        "format": 258,
+        "name": "REMUX",
+        "score": -9999
+      },
+      {
+        "format": 256,
+        "name": "x264",
+        "score": 10
+      },
+      {
+        "format": 255,
+        "name": "WEBRip",
+        "score": 0
+      },
+      {
+        "format": 254,
+        "name": "Blu-Ray",
+        "score": 0
+      },
+      {
+        "format": 253,
+        "name": "2160p",
+        "score": -9999
+      },
+      {
+        "format": 252,
+        "name": "720p",
+        "score": -10000
+      },
+      {
+        "format": 250,
+        "name": "1080p",
+        "score": 60
+      },
+      {
+        "format": 249,
+        "name": "BHDStudio",
+        "score": 50
+      },
+      {
+        "format": 248,
+        "name": "LEGi0N",
+        "score": 30
+      },
+      {
+        "format": 247,
+        "name": "FraMeSToR",
+        "score": 30
+      },
+      {
+        "format": 246,
+        "name": "iFT",
+        "score": 70
+      },
+      {
+        "format": 245,
+        "name": "MTeam",
+        "score": -9999
+      },
+      {
+        "format": 244,
+        "name": "EDPH",
+        "score": 30
+      },
+      {
+        "format": 243,
+        "name": "HANDJOB",
+        "score": 30
+      },
+      {
+        "format": 242,
+        "name": "c0ke",
+        "score": 110
+      },
+      {
+        "format": 241,
+        "name": "KASHMiR",
+        "score": 70
+      },
+      {
+        "format": 240,
+        "name": "WMING",
+        "score": 70
+      },
+      {
+        "format": 239,
+        "name": "playHD",
+        "score": 70
+      },
+      {
+        "format": 238,
+        "name": "E.N.D",
+        "score": 70
+      },
+      {
+        "format": 237,
+        "name": "GutS",
+        "score": 70
+      },
+      {
+        "format": 236,
+        "name": "BV",
+        "score": 70
+      },
+      {
+        "format": 235,
+        "name": "SiMPLE",
+        "score": 70
+      },
+      {
+        "format": 234,
+        "name": "W4NK3R",
+        "score": 70
+      },
+      {
+        "format": 233,
+        "name": "GS88",
+        "score": 70
+      },
+      {
+        "format": 232,
+        "name": "HiP",
+        "score": 80
+      },
+      {
+        "format": 231,
+        "name": "GALAXY",
+        "score": 70
+      },
+      {
+        "format": 230,
+        "name": "luvBB",
+        "score": 70
+      },
+      {
+        "format": 229,
+        "name": "NyHD",
+        "score": 70
+      },
+      {
+        "format": 228,
+        "name": "ZIMBO",
+        "score": 70
+      },
+      {
+        "format": 227,
+        "name": "ThD",
+        "score": 70
+      },
+      {
+        "format": 226,
+        "name": "SaNcTi",
+        "score": 70
+      },
+      {
+        "format": 225,
+        "name": "ORiGEN",
+        "score": 70
+      },
+      {
+        "format": 224,
+        "name": "Positive",
+        "score": 70
+      },
+      {
+        "format": 223,
+        "name": "ESiR",
+        "score": 70
+      },
+      {
+        "format": 222,
+        "name": "Chotab",
+        "score": 70
+      },
+      {
+        "format": 221,
+        "name": "xander",
+        "score": 70
+      },
+      {
+        "format": 220,
+        "name": "FTW-HD",
+        "score": 70
+      },
+      {
+        "format": 219,
+        "name": "Penumbra",
+        "score": 70
+      },
+      {
+        "format": 218,
+        "name": "TDD",
+        "score": 70
+      },
+      {
+        "format": 217,
+        "name": "Dariush SD",
+        "score": 70
+      },
+      {
+        "format": 216,
+        "name": "PTer",
+        "score": 70
+      },
+      {
+        "format": 215,
+        "name": "SbR",
+        "score": 70
+      },
+      {
+        "format": 214,
+        "name": "nmd",
+        "score": 70
+      },
+      {
+        "format": 213,
+        "name": "TBB",
+        "score": 70
+      },
+      {
+        "format": 212,
+        "name": "EA",
+        "score": 80
+      },
+      {
+        "format": 211,
+        "name": "BMF",
+        "score": 80
+      },
+      {
+        "format": 210,
+        "name": "LolHD",
+        "score": 80
+      },
+      {
+        "format": 209,
+        "name": "HDMaNiAcS",
+        "score": 80
+      },
+      {
+        "format": 208,
+        "name": "IDE",
+        "score": 80
+      },
+      {
+        "format": 207,
+        "name": "de[42]",
+        "score": 90
+      },
+      {
+        "format": 206,
+        "name": "NCmt",
+        "score": 100
+      },
+      {
+        "format": 205,
+        "name": "decibeL",
+        "score": 90
+      },
+      {
+        "format": 204,
+        "name": "NTb",
+        "score": 80
+      },
+      {
+        "format": 203,
+        "name": "CRiSC",
+        "score": 90
+      },
+      {
+        "format": 202,
+        "name": "SA89",
+        "score": 100
+      },
+      {
+        "format": 201,
+        "name": "HiDt",
+        "score": 100
+      },
+      {
+        "format": 200,
+        "name": "FoRM",
+        "score": 100
+      },
+      {
+        "format": 199,
+        "name": "HiFi",
+        "score": 100
+      },
+      {
+        "format": 198,
+        "name": "CtrlHD",
+        "score": 100
+      },
+      {
+        "format": 197,
+        "name": "VietHD",
+        "score": 110
+      },
+      {
+        "format": 196,
+        "name": "ZQ",
+        "score": 110
+      },
+      {
+        "format": 195,
+        "name": "TayTo",
+        "score": 110
+      },
+      {
+        "format": 194,
+        "name": "Geek",
+        "score": 110
+      },
+      {
+        "format": 193,
+        "name": "EbP",
+        "score": 120
+      },
+      {
+        "format": 192,
+        "name": "DON",
+        "score": 120
+      },
+      {
+        "format": 191,
+        "name": "D-Z0N3",
+        "score": 120
+      },
+      {
+        "format": 340,
+        "name": "Upscaled",
+        "score": -9999
+      }
+    ],
+    "language": {
+      "id": -1,
+      "name": "Any"
     }
+  }
 ]

--- a/imports/quality_profiles/radarr/1080p Transparent (radarr - master).json
+++ b/imports/quality_profiles/radarr/1080p Transparent (radarr - master).json
@@ -1,1115 +1,1116 @@
 [
-    {
-        "name": "1080p Transparent",
-        "upgradeAllowed": true,
-        "cutoff": 1002,
+  {
+    "name": "1080p Transparent",
+    "upgradeAllowed": true,
+    "cutoff": 1002,
+    "items": [
+      {
+        "quality": {
+          "id": 24,
+          "name": "WORKPRINT",
+          "source": "workprint",
+          "resolution": 0,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 29,
+          "name": "REGIONAL",
+          "source": "dvd",
+          "resolution": 480,
+          "modifier": "regional"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 4,
+          "name": "HDTV-720p",
+          "source": "tv",
+          "resolution": 720,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "name": "WEB 720p",
         "items": [
-            {
-                "quality": {
-                    "id": 24,
-                    "name": "WORKPRINT",
-                    "source": "workprint",
-                    "resolution": 0,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
+          {
+            "quality": {
+              "id": 5,
+              "name": "WEBDL-720p",
+              "source": "webdl",
+              "resolution": 720,
+              "modifier": "none"
             },
-            {
-                "quality": {
-                    "id": 29,
-                    "name": "REGIONAL",
-                    "source": "dvd",
-                    "resolution": 480,
-                    "modifier": "regional"
-                },
-                "items": [],
-                "allowed": false
+            "items": [],
+            "allowed": false
+          },
+          {
+            "quality": {
+              "id": 14,
+              "name": "WEBRip-720p",
+              "source": "webrip",
+              "resolution": 720,
+              "modifier": "none"
             },
-            {
-                "quality": {
-                    "id": 4,
-                    "name": "HDTV-720p",
-                    "source": "tv",
-                    "resolution": 720,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "name": "WEB 720p",
-                "items": [
-                    {
-                        "quality": {
-                            "id": 5,
-                            "name": "WEBDL-720p",
-                            "source": "webdl",
-                            "resolution": 720,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": false
-                    },
-                    {
-                        "quality": {
-                            "id": 14,
-                            "name": "WEBRip-720p",
-                            "source": "webrip",
-                            "resolution": 720,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": false
-                    }
-                ],
-                "allowed": false,
-                "id": 1001
-            },
-            {
-                "quality": {
-                    "id": 6,
-                    "name": "Bluray-720p",
-                    "source": "bluray",
-                    "resolution": 720,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 1,
-                    "name": "SDTV",
-                    "source": "tv",
-                    "resolution": 480,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 20,
-                    "name": "Bluray-480p",
-                    "source": "bluray",
-                    "resolution": 480,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 21,
-                    "name": "Bluray-576p",
-                    "source": "bluray",
-                    "resolution": 576,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 23,
-                    "name": "DVD-R",
-                    "source": "dvd",
-                    "resolution": 480,
-                    "modifier": "remux"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "name": "CAM",
-                "items": [
-                    {
-                        "quality": {
-                            "id": 25,
-                            "name": "CAM",
-                            "source": "cam",
-                            "resolution": 0,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": true
-                    },
-                    {
-                        "quality": {
-                            "id": 26,
-                            "name": "TELESYNC",
-                            "source": "telesync",
-                            "resolution": 0,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": true
-                    },
-                    {
-                        "quality": {
-                            "id": 27,
-                            "name": "TELECINE",
-                            "source": "telecine",
-                            "resolution": 0,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": true
-                    }
-                ],
-                "allowed": true,
-                "id": 1004
-            },
-            {
-                "quality": {
-                    "id": 0,
-                    "name": "Unknown",
-                    "source": "unknown",
-                    "resolution": 0,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": true
-            },
-            {
-                "name": "DVD",
-                "items": [
-                    {
-                        "quality": {
-                            "id": 28,
-                            "name": "DVDSCR",
-                            "source": "dvd",
-                            "resolution": 480,
-                            "modifier": "screener"
-                        },
-                        "items": [],
-                        "allowed": false
-                    },
-                    {
-                        "quality": {
-                            "id": 12,
-                            "name": "WEBRip-480p",
-                            "source": "webrip",
-                            "resolution": 480,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": false
-                    },
-                    {
-                        "quality": {
-                            "id": 2,
-                            "name": "DVD",
-                            "source": "dvd",
-                            "resolution": 0,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": true
-                    },
-                    {
-                        "quality": {
-                            "id": 8,
-                            "name": "WEBDL-480p",
-                            "source": "webdl",
-                            "resolution": 480,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": true
-                    }
-                ],
-                "allowed": true,
-                "id": 1003
-            },
-            {
-                "quality": {
-                    "id": 9,
-                    "name": "HDTV-1080p",
-                    "source": "tv",
-                    "resolution": 1080,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": true
-            },
-            {
-                "name": "Transparent Capable",
-                "items": [
-                    {
-                        "quality": {
-                            "id": 3,
-                            "name": "WEBDL-1080p",
-                            "source": "webdl",
-                            "resolution": 1080,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": true
-                    },
-                    {
-                        "quality": {
-                            "id": 15,
-                            "name": "WEBRip-1080p",
-                            "source": "webrip",
-                            "resolution": 1080,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": true
-                    },
-                    {
-                        "quality": {
-                            "id": 7,
-                            "name": "Bluray-1080p",
-                            "source": "bluray",
-                            "resolution": 1080,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": true
-                    }
-                ],
-                "allowed": true,
-                "id": 1002
-            },
-            {
-                "quality": {
-                    "id": 30,
-                    "name": "Remux-1080p",
-                    "source": "bluray",
-                    "resolution": 1080,
-                    "modifier": "remux"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 16,
-                    "name": "HDTV-2160p",
-                    "source": "tv",
-                    "resolution": 2160,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 18,
-                    "name": "WEBDL-2160p",
-                    "source": "webdl",
-                    "resolution": 2160,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 17,
-                    "name": "WEBRip-2160p",
-                    "source": "webrip",
-                    "resolution": 2160,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 19,
-                    "name": "Bluray-2160p",
-                    "source": "bluray",
-                    "resolution": 2160,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 31,
-                    "name": "Remux-2160p",
-                    "source": "bluray",
-                    "resolution": 2160,
-                    "modifier": "remux"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 22,
-                    "name": "BR-DISK",
-                    "source": "bluray",
-                    "resolution": 1080,
-                    "modifier": "brdisk"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 10,
-                    "name": "Raw-HD",
-                    "source": "tv",
-                    "resolution": 1080,
-                    "modifier": "rawhd"
-                },
-                "items": [],
-                "allowed": false
-            }
+            "items": [],
+            "allowed": false
+          }
         ],
-        "minFormatScore": 0,
-        "cutoffFormatScore": 500,
-        "formatItems": [
-            {
-                "format": 353,
-                "name": "BHDStudio (1080p x265)",
-                "score": 0
-            },
-            {
-                "format": 352,
-                "name": "E1",
-                "score": 0
-            },
-            {
-                "format": 351,
-                "name": "2160p x265",
-                "score": 0
-            },
-            {
-                "format": 349,
-                "name": "EXCiSiON",
-                "score": 0
-            },
-            {
-                "format": 348,
-                "name": "Unwanted x265 Groups",
-                "score": 0
-            },
-            {
-                "format": 347,
-                "name": "CRX",
-                "score": 0
-            },
-            {
-                "format": 346,
-                "name": "HDR10 (Missing) (x265 HDR only)",
-                "score": 0
-            },
-            {
-                "format": 345,
-                "name": "UHD Bluray",
-                "score": 0
-            },
-            {
-                "format": 344,
-                "name": "jennaortegaUHD",
-                "score": 0
-            },
-            {
-                "format": 342,
-                "name": "Freeleech25",
-                "score": 0
-            },
-            {
-                "format": 341,
-                "name": "Freeleech50",
-                "score": 0
-            },
-            {
-                "format": 340,
-                "name": "Freeleech75",
-                "score": 0
-            },
-            {
-                "format": 339,
-                "name": "Freeleech100",
-                "score": 0
-            },
-            {
-                "format": 338,
-                "name": "TEST FLAC",
-                "score": 0
-            },
-            {
-                "format": 337,
-                "name": "h265 (4k)",
-                "score": 0
-            },
-            {
-                "format": 336,
-                "name": "MAX",
-                "score": 0
-            },
-            {
-                "format": 335,
-                "name": "Blu-Ray (Remux)",
-                "score": 0
-            },
-            {
-                "format": 334,
-                "name": "PCM",
-                "score": 0
-            },
-            {
-                "format": 333,
-                "name": "h265",
-                "score": -9999
-            },
-            {
-                "format": 331,
-                "name": "Golden Popcorn 720p",
-                "score": 0
-            },
-            {
-                "format": 330,
-                "name": "LQ",
-                "score": -9999
-            },
-            {
-                "format": 329,
-                "name": "EPSiLON",
-                "score": 0
-            },
-            {
-                "format": 328,
-                "name": "playBD",
-                "score": 0
-            },
-            {
-                "format": 327,
-                "name": "BLURANiUM",
-                "score": 0
-            },
-            {
-                "format": 326,
-                "name": "PmP",
-                "score": 0
-            },
-            {
-                "format": 325,
-                "name": "WiLDCAT",
-                "score": 0
-            },
-            {
-                "format": 324,
-                "name": "TRiToN",
-                "score": 0
-            },
-            {
-                "format": 323,
-                "name": "3L",
-                "score": 0
-            },
-            {
-                "format": 322,
-                "name": "Dolby Vision w/out Fallback",
-                "score": -9999
-            },
-            {
-                "format": 321,
-                "name": "UHDBits",
-                "score": 0
-            },
-            {
-                "format": 318,
-                "name": "ATMOS (Missing)",
-                "score": 0
-            },
-            {
-                "format": 317,
-                "name": "TrueHD (Missing)",
-                "score": 0
-            },
-            {
-                "format": 316,
-                "name": "HDR10 (Missing)",
-                "score": -9999
-            },
-            {
-                "format": 315,
-                "name": "HDR10",
-                "score": -9999
-            },
-            {
-                "format": 314,
-                "name": "Dolby Vision",
-                "score": -9999
-            },
-            {
-                "format": 312,
-                "name": "HDR10+",
-                "score": -9999
-            },
-            {
-                "format": 308,
-                "name": "Stream Optimised",
-                "score": 0
-            },
-            {
-                "format": 307,
-                "name": "LoRD",
-                "score": 70
-            },
-            {
-                "format": 306,
-                "name": "Scene",
-                "score": 30
-            },
-            {
-                "format": 303,
-                "name": "mHD",
-                "score": -99999
-            },
-            {
-                "format": 302,
-                "name": "AV1",
-                "score": -9999
-            },
-            {
-                "format": 301,
-                "name": "VVC",
-                "score": -9999
-            },
-            {
-                "format": 300,
-                "name": "Extras",
-                "score": -9999
-            },
-            {
-                "format": 298,
-                "name": "480p",
-                "score": 0
-            },
-            {
-                "format": 297,
-                "name": "Dariush ",
-                "score": 20
-            },
-            {
-                "format": 296,
-                "name": "TBB SD",
-                "score": 30
-            },
-            {
-                "format": 295,
-                "name": "Xvid",
-                "score": 0
-            },
-            {
-                "format": 294,
-                "name": "DVD",
-                "score": 0
-            },
-            {
-                "format": 293,
-                "name": "DVD REMUX ",
-                "score": 40
-            },
-            {
-                "format": 292,
-                "name": "HANDJOB SD",
-                "score": 20
-            },
-            {
-                "format": 291,
-                "name": "iTunes (Missing)",
-                "score": 20
-            },
-            {
-                "format": 290,
-                "name": "ROKU",
-                "score": 30
-            },
-            {
-                "format": 289,
-                "name": "BeyondHD",
-                "score": -10000
-            },
-            {
-                "format": 288,
-                "name": "Disc ",
-                "score": -9999
-            },
-            {
-                "format": 287,
-                "name": "3D",
-                "score": -9999
-            },
-            {
-                "format": 286,
-                "name": "Unwanted",
-                "score": -9999
-            },
-            {
-                "format": 285,
-                "name": "HDBits Internal",
-                "score": 70
-            },
-            {
-                "format": 284,
-                "name": "RightSIZE",
-                "score": 70
-            },
-            {
-                "format": 283,
-                "name": "Black and White",
-                "score": -9999
-            },
-            {
-                "format": 281,
-                "name": "TrueHD",
-                "score": 0
-            },
-            {
-                "format": 280,
-                "name": "DTS-X",
-                "score": 0
-            },
-            {
-                "format": 279,
-                "name": "FLAC",
-                "score": 0
-            },
-            {
-                "format": 278,
-                "name": "DTS-HD MA",
-                "score": 0
-            },
-            {
-                "format": 276,
-                "name": "x265",
-                "score": -9999
-            },
-            {
-                "format": 275,
-                "name": "Golden Popcorn SD",
-                "score": 30
-            },
-            {
-                "format": 274,
-                "name": "Golden Popcorn 1080p",
-                "score": 120
-            },
-            {
-                "format": 273,
-                "name": "IMAX",
-                "score": 10
-            },
-            {
-                "format": 272,
-                "name": "ATMOS",
-                "score": 5
-            },
-            {
-                "format": 271,
-                "name": "DD",
-                "score": 0
-            },
-            {
-                "format": 270,
-                "name": "DTS",
-                "score": 0
-            },
-            {
-                "format": 269,
-                "name": "DD+",
-                "score": 0
-            },
-            {
-                "format": 268,
-                "name": "iTunes",
-                "score": 20
-            },
-            {
-                "format": 267,
-                "name": "Paramount+",
-                "score": 30
-            },
-            {
-                "format": 266,
-                "name": "Peacock TV",
-                "score": 30
-            },
-            {
-                "format": 265,
-                "name": "Hulu",
-                "score": 30
-            },
-            {
-                "format": 264,
-                "name": "Netflix",
-                "score": 40
-            },
-            {
-                "format": 263,
-                "name": "HBO Max",
-                "score": 40
-            },
-            {
-                "format": 262,
-                "name": "Disney+",
-                "score": 40
-            },
-            {
-                "format": 261,
-                "name": "Apple TV+",
-                "score": 50
-            },
-            {
-                "format": 260,
-                "name": "Movies Anywhere",
-                "score": 60
-            },
-            {
-                "format": 259,
-                "name": "Amazon Prime",
-                "score": 50
-            },
-            {
-                "format": 258,
-                "name": "REMUX",
-                "score": -9999
-            },
-            {
-                "format": 256,
-                "name": "x264",
-                "score": 10
-            },
-            {
-                "format": 255,
-                "name": "WEBRip",
-                "score": 0
-            },
-            {
-                "format": 254,
-                "name": "Blu-Ray",
-                "score": 0
-            },
-            {
-                "format": 253,
-                "name": "2160p",
-                "score": -9999
-            },
-            {
-                "format": 252,
-                "name": "720p",
-                "score": -10000
-            },
-            {
-                "format": 250,
-                "name": "1080p",
-                "score": 60
-            },
-            {
-                "format": 249,
-                "name": "BHDStudio",
-                "score": 30
-            },
-            {
-                "format": 248,
-                "name": "LEGi0N",
-                "score": 30
-            },
-            {
-                "format": 247,
-                "name": "FraMeSToR",
-                "score": 30
-            },
-            {
-                "format": 246,
-                "name": "iFT",
-                "score": 70
-            },
-            {
-                "format": 245,
-                "name": "MTeam",
-                "score": -9999
-            },
-            {
-                "format": 244,
-                "name": "EDPH",
-                "score": 30
-            },
-            {
-                "format": 243,
-                "name": "HANDJOB",
-                "score": 30
-            },
-            {
-                "format": 242,
-                "name": "c0ke",
-                "score": 110
-            },
-            {
-                "format": 241,
-                "name": "KASHMiR",
-                "score": 70
-            },
-            {
-                "format": 240,
-                "name": "WMING",
-                "score": 70
-            },
-            {
-                "format": 239,
-                "name": "playHD",
-                "score": 70
-            },
-            {
-                "format": 238,
-                "name": "E.N.D",
-                "score": 70
-            },
-            {
-                "format": 237,
-                "name": "GutS",
-                "score": 70
-            },
-            {
-                "format": 236,
-                "name": "BV",
-                "score": 70
-            },
-            {
-                "format": 235,
-                "name": "SiMPLE",
-                "score": 70
-            },
-            {
-                "format": 234,
-                "name": "W4NK3R",
-                "score": 70
-            },
-            {
-                "format": 233,
-                "name": "GS88",
-                "score": 70
-            },
-            {
-                "format": 232,
-                "name": "HiP",
-                "score": 80
-            },
-            {
-                "format": 231,
-                "name": "GALAXY",
-                "score": 70
-            },
-            {
-                "format": 230,
-                "name": "luvBB",
-                "score": 70
-            },
-            {
-                "format": 229,
-                "name": "NyHD",
-                "score": 70
-            },
-            {
-                "format": 228,
-                "name": "ZIMBO",
-                "score": 70
-            },
-            {
-                "format": 227,
-                "name": "ThD",
-                "score": 70
-            },
-            {
-                "format": 226,
-                "name": "SaNcTi",
-                "score": 70
-            },
-            {
-                "format": 225,
-                "name": "ORiGEN",
-                "score": 70
-            },
-            {
-                "format": 224,
-                "name": "Positive",
-                "score": 70
-            },
-            {
-                "format": 223,
-                "name": "ESiR",
-                "score": 70
-            },
-            {
-                "format": 222,
-                "name": "Chotab",
-                "score": 70
-            },
-            {
-                "format": 221,
-                "name": "xander",
-                "score": 70
-            },
-            {
-                "format": 220,
-                "name": "FTW-HD",
-                "score": 70
-            },
-            {
-                "format": 219,
-                "name": "Penumbra",
-                "score": 70
-            },
-            {
-                "format": 218,
-                "name": "TDD",
-                "score": 70
-            },
-            {
-                "format": 217,
-                "name": "Dariush SD",
-                "score": 70
-            },
-            {
-                "format": 216,
-                "name": "PTer",
-                "score": 70
-            },
-            {
-                "format": 215,
-                "name": "SbR",
-                "score": 70
-            },
-            {
-                "format": 214,
-                "name": "nmd",
-                "score": 70
-            },
-            {
-                "format": 213,
-                "name": "TBB",
-                "score": 70
-            },
-            {
-                "format": 212,
-                "name": "EA",
-                "score": 80
-            },
-            {
-                "format": 211,
-                "name": "BMF",
-                "score": 80
-            },
-            {
-                "format": 210,
-                "name": "LolHD",
-                "score": 80
-            },
-            {
-                "format": 209,
-                "name": "HDMaNiAcS",
-                "score": 80
-            },
-            {
-                "format": 208,
-                "name": "IDE",
-                "score": 80
-            },
-            {
-                "format": 207,
-                "name": "de[42]",
-                "score": 90
-            },
-            {
-                "format": 206,
-                "name": "NCmt",
-                "score": 100
-            },
-            {
-                "format": 205,
-                "name": "decibeL",
-                "score": 90
-            },
-            {
-                "format": 204,
-                "name": "NTb",
-                "score": 80
-            },
-            {
-                "format": 203,
-                "name": "CRiSC",
-                "score": 90
-            },
-            {
-                "format": 202,
-                "name": "SA89",
-                "score": 100
-            },
-            {
-                "format": 201,
-                "name": "HiDt",
-                "score": 100
-            },
-            {
-                "format": 200,
-                "name": "FoRM",
-                "score": 100
-            },
-            {
-                "format": 199,
-                "name": "HiFi",
-                "score": 100
-            },
-            {
-                "format": 198,
-                "name": "CtrlHD",
-                "score": 100
-            },
-            {
-                "format": 197,
-                "name": "VietHD",
-                "score": 110
-            },
-            {
-                "format": 196,
-                "name": "ZQ",
-                "score": 110
-            },
-            {
-                "format": 195,
-                "name": "TayTo",
-                "score": 110
-            },
-            {
-                "format": 194,
-                "name": "Geek",
-                "score": 110
-            },
-            {
-                "format": 193,
-                "name": "EbP",
-                "score": 120
-            },
-            {
-                "format": 192,
-                "name": "DON",
-                "score": 120
-            },
-            {
-                "format": 191,
-                "name": "D-Z0N3",
-                "score": 120
-            },
-            {
-                "format": 340,
-                "name": "Upscaled",
-                "score": -9999
-            }
+        "allowed": false,
+        "id": 1001
+      },
+      {
+        "quality": {
+          "id": 6,
+          "name": "Bluray-720p",
+          "source": "bluray",
+          "resolution": 720,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 1,
+          "name": "SDTV",
+          "source": "tv",
+          "resolution": 480,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 20,
+          "name": "Bluray-480p",
+          "source": "bluray",
+          "resolution": 480,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 21,
+          "name": "Bluray-576p",
+          "source": "bluray",
+          "resolution": 576,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 23,
+          "name": "DVD-R",
+          "source": "dvd",
+          "resolution": 480,
+          "modifier": "remux"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "name": "CAM",
+        "items": [
+          {
+            "quality": {
+              "id": 25,
+              "name": "CAM",
+              "source": "cam",
+              "resolution": 0,
+              "modifier": "none"
+            },
+            "items": [],
+            "allowed": true
+          },
+          {
+            "quality": {
+              "id": 26,
+              "name": "TELESYNC",
+              "source": "telesync",
+              "resolution": 0,
+              "modifier": "none"
+            },
+            "items": [],
+            "allowed": true
+          },
+          {
+            "quality": {
+              "id": 27,
+              "name": "TELECINE",
+              "source": "telecine",
+              "resolution": 0,
+              "modifier": "none"
+            },
+            "items": [],
+            "allowed": true
+          }
         ],
-        "language": {
-            "id": -1,
-            "name": "Any"
-        }
+        "allowed": true,
+        "id": 1004
+      },
+      {
+        "quality": {
+          "id": 0,
+          "name": "Unknown",
+          "source": "unknown",
+          "resolution": 0,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": true
+      },
+      {
+        "name": "DVD",
+        "items": [
+          {
+            "quality": {
+              "id": 28,
+              "name": "DVDSCR",
+              "source": "dvd",
+              "resolution": 480,
+              "modifier": "screener"
+            },
+            "items": [],
+            "allowed": false
+          },
+          {
+            "quality": {
+              "id": 12,
+              "name": "WEBRip-480p",
+              "source": "webrip",
+              "resolution": 480,
+              "modifier": "none"
+            },
+            "items": [],
+            "allowed": false
+          },
+          {
+            "quality": {
+              "id": 2,
+              "name": "DVD",
+              "source": "dvd",
+              "resolution": 0,
+              "modifier": "none"
+            },
+            "items": [],
+            "allowed": true
+          },
+          {
+            "quality": {
+              "id": 8,
+              "name": "WEBDL-480p",
+              "source": "webdl",
+              "resolution": 480,
+              "modifier": "none"
+            },
+            "items": [],
+            "allowed": true
+          }
+        ],
+        "allowed": true,
+        "id": 1003
+      },
+      {
+        "quality": {
+          "id": 9,
+          "name": "HDTV-1080p",
+          "source": "tv",
+          "resolution": 1080,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": true
+      },
+      {
+        "name": "Transparent Capable",
+        "items": [
+          {
+            "quality": {
+              "id": 3,
+              "name": "WEBDL-1080p",
+              "source": "webdl",
+              "resolution": 1080,
+              "modifier": "none"
+            },
+            "items": [],
+            "allowed": true
+          },
+          {
+            "quality": {
+              "id": 15,
+              "name": "WEBRip-1080p",
+              "source": "webrip",
+              "resolution": 1080,
+              "modifier": "none"
+            },
+            "items": [],
+            "allowed": true
+          },
+          {
+            "quality": {
+              "id": 7,
+              "name": "Bluray-1080p",
+              "source": "bluray",
+              "resolution": 1080,
+              "modifier": "none"
+            },
+            "items": [],
+            "allowed": true
+          }
+        ],
+        "allowed": true,
+        "id": 1002
+      },
+      {
+        "quality": {
+          "id": 30,
+          "name": "Remux-1080p",
+          "source": "bluray",
+          "resolution": 1080,
+          "modifier": "remux"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 16,
+          "name": "HDTV-2160p",
+          "source": "tv",
+          "resolution": 2160,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 18,
+          "name": "WEBDL-2160p",
+          "source": "webdl",
+          "resolution": 2160,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 17,
+          "name": "WEBRip-2160p",
+          "source": "webrip",
+          "resolution": 2160,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 19,
+          "name": "Bluray-2160p",
+          "source": "bluray",
+          "resolution": 2160,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 31,
+          "name": "Remux-2160p",
+          "source": "bluray",
+          "resolution": 2160,
+          "modifier": "remux"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 22,
+          "name": "BR-DISK",
+          "source": "bluray",
+          "resolution": 1080,
+          "modifier": "brdisk"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 10,
+          "name": "Raw-HD",
+          "source": "tv",
+          "resolution": 1080,
+          "modifier": "rawhd"
+        },
+        "items": [],
+        "allowed": false
+      }
+    ],
+    "minFormatScore": 0,
+    "cutoffFormatScore": 500,
+    "minUpgradeFormatScore": 1,
+    "formatItems": [
+      {
+        "format": 353,
+        "name": "BHDStudio (1080p x265)",
+        "score": 0
+      },
+      {
+        "format": 352,
+        "name": "E1",
+        "score": 0
+      },
+      {
+        "format": 351,
+        "name": "2160p x265",
+        "score": 0
+      },
+      {
+        "format": 349,
+        "name": "EXCiSiON",
+        "score": 0
+      },
+      {
+        "format": 348,
+        "name": "Unwanted x265 Groups",
+        "score": 0
+      },
+      {
+        "format": 347,
+        "name": "CRX",
+        "score": 0
+      },
+      {
+        "format": 346,
+        "name": "HDR10 (Missing) (x265 HDR only)",
+        "score": 0
+      },
+      {
+        "format": 345,
+        "name": "UHD Bluray",
+        "score": 0
+      },
+      {
+        "format": 344,
+        "name": "jennaortegaUHD",
+        "score": 0
+      },
+      {
+        "format": 342,
+        "name": "Freeleech25",
+        "score": 0
+      },
+      {
+        "format": 341,
+        "name": "Freeleech50",
+        "score": 0
+      },
+      {
+        "format": 340,
+        "name": "Freeleech75",
+        "score": 0
+      },
+      {
+        "format": 339,
+        "name": "Freeleech100",
+        "score": 0
+      },
+      {
+        "format": 338,
+        "name": "TEST FLAC",
+        "score": 0
+      },
+      {
+        "format": 337,
+        "name": "h265 (4k)",
+        "score": 0
+      },
+      {
+        "format": 336,
+        "name": "MAX",
+        "score": 0
+      },
+      {
+        "format": 335,
+        "name": "Blu-Ray (Remux)",
+        "score": 0
+      },
+      {
+        "format": 334,
+        "name": "PCM",
+        "score": 0
+      },
+      {
+        "format": 333,
+        "name": "h265",
+        "score": -9999
+      },
+      {
+        "format": 331,
+        "name": "Golden Popcorn 720p",
+        "score": 0
+      },
+      {
+        "format": 330,
+        "name": "LQ",
+        "score": -9999
+      },
+      {
+        "format": 329,
+        "name": "EPSiLON",
+        "score": 0
+      },
+      {
+        "format": 328,
+        "name": "playBD",
+        "score": 0
+      },
+      {
+        "format": 327,
+        "name": "BLURANiUM",
+        "score": 0
+      },
+      {
+        "format": 326,
+        "name": "PmP",
+        "score": 0
+      },
+      {
+        "format": 325,
+        "name": "WiLDCAT",
+        "score": 0
+      },
+      {
+        "format": 324,
+        "name": "TRiToN",
+        "score": 0
+      },
+      {
+        "format": 323,
+        "name": "3L",
+        "score": 0
+      },
+      {
+        "format": 322,
+        "name": "Dolby Vision w/out Fallback",
+        "score": -9999
+      },
+      {
+        "format": 321,
+        "name": "UHDBits",
+        "score": 0
+      },
+      {
+        "format": 318,
+        "name": "ATMOS (Missing)",
+        "score": 0
+      },
+      {
+        "format": 317,
+        "name": "TrueHD (Missing)",
+        "score": 0
+      },
+      {
+        "format": 316,
+        "name": "HDR10 (Missing)",
+        "score": -9999
+      },
+      {
+        "format": 315,
+        "name": "HDR10",
+        "score": -9999
+      },
+      {
+        "format": 314,
+        "name": "Dolby Vision",
+        "score": -9999
+      },
+      {
+        "format": 312,
+        "name": "HDR10+",
+        "score": -9999
+      },
+      {
+        "format": 308,
+        "name": "Stream Optimised",
+        "score": 0
+      },
+      {
+        "format": 307,
+        "name": "LoRD",
+        "score": 70
+      },
+      {
+        "format": 306,
+        "name": "Scene",
+        "score": 30
+      },
+      {
+        "format": 303,
+        "name": "mHD",
+        "score": -99999
+      },
+      {
+        "format": 302,
+        "name": "AV1",
+        "score": -9999
+      },
+      {
+        "format": 301,
+        "name": "VVC",
+        "score": -9999
+      },
+      {
+        "format": 300,
+        "name": "Extras",
+        "score": -9999
+      },
+      {
+        "format": 298,
+        "name": "480p",
+        "score": 0
+      },
+      {
+        "format": 297,
+        "name": "Dariush ",
+        "score": 20
+      },
+      {
+        "format": 296,
+        "name": "TBB SD",
+        "score": 30
+      },
+      {
+        "format": 295,
+        "name": "Xvid",
+        "score": 0
+      },
+      {
+        "format": 294,
+        "name": "DVD",
+        "score": 0
+      },
+      {
+        "format": 293,
+        "name": "DVD REMUX ",
+        "score": 40
+      },
+      {
+        "format": 292,
+        "name": "HANDJOB SD",
+        "score": 20
+      },
+      {
+        "format": 291,
+        "name": "iTunes (Missing)",
+        "score": 20
+      },
+      {
+        "format": 290,
+        "name": "ROKU",
+        "score": 30
+      },
+      {
+        "format": 289,
+        "name": "BeyondHD",
+        "score": -10000
+      },
+      {
+        "format": 288,
+        "name": "Disc ",
+        "score": -9999
+      },
+      {
+        "format": 287,
+        "name": "3D",
+        "score": -9999
+      },
+      {
+        "format": 286,
+        "name": "Unwanted",
+        "score": -9999
+      },
+      {
+        "format": 285,
+        "name": "HDBits Internal",
+        "score": 70
+      },
+      {
+        "format": 284,
+        "name": "RightSIZE",
+        "score": 70
+      },
+      {
+        "format": 283,
+        "name": "Black and White",
+        "score": -9999
+      },
+      {
+        "format": 281,
+        "name": "TrueHD",
+        "score": 0
+      },
+      {
+        "format": 280,
+        "name": "DTS-X",
+        "score": 0
+      },
+      {
+        "format": 279,
+        "name": "FLAC",
+        "score": 0
+      },
+      {
+        "format": 278,
+        "name": "DTS-HD MA",
+        "score": 0
+      },
+      {
+        "format": 276,
+        "name": "x265",
+        "score": -9999
+      },
+      {
+        "format": 275,
+        "name": "Golden Popcorn SD",
+        "score": 30
+      },
+      {
+        "format": 274,
+        "name": "Golden Popcorn 1080p",
+        "score": 120
+      },
+      {
+        "format": 273,
+        "name": "IMAX",
+        "score": 10
+      },
+      {
+        "format": 272,
+        "name": "ATMOS",
+        "score": 5
+      },
+      {
+        "format": 271,
+        "name": "DD",
+        "score": 0
+      },
+      {
+        "format": 270,
+        "name": "DTS",
+        "score": 0
+      },
+      {
+        "format": 269,
+        "name": "DD+",
+        "score": 0
+      },
+      {
+        "format": 268,
+        "name": "iTunes",
+        "score": 20
+      },
+      {
+        "format": 267,
+        "name": "Paramount+",
+        "score": 30
+      },
+      {
+        "format": 266,
+        "name": "Peacock TV",
+        "score": 30
+      },
+      {
+        "format": 265,
+        "name": "Hulu",
+        "score": 30
+      },
+      {
+        "format": 264,
+        "name": "Netflix",
+        "score": 40
+      },
+      {
+        "format": 263,
+        "name": "HBO Max",
+        "score": 40
+      },
+      {
+        "format": 262,
+        "name": "Disney+",
+        "score": 40
+      },
+      {
+        "format": 261,
+        "name": "Apple TV+",
+        "score": 50
+      },
+      {
+        "format": 260,
+        "name": "Movies Anywhere",
+        "score": 60
+      },
+      {
+        "format": 259,
+        "name": "Amazon Prime",
+        "score": 50
+      },
+      {
+        "format": 258,
+        "name": "REMUX",
+        "score": -9999
+      },
+      {
+        "format": 256,
+        "name": "x264",
+        "score": 10
+      },
+      {
+        "format": 255,
+        "name": "WEBRip",
+        "score": 0
+      },
+      {
+        "format": 254,
+        "name": "Blu-Ray",
+        "score": 0
+      },
+      {
+        "format": 253,
+        "name": "2160p",
+        "score": -9999
+      },
+      {
+        "format": 252,
+        "name": "720p",
+        "score": -10000
+      },
+      {
+        "format": 250,
+        "name": "1080p",
+        "score": 60
+      },
+      {
+        "format": 249,
+        "name": "BHDStudio",
+        "score": 30
+      },
+      {
+        "format": 248,
+        "name": "LEGi0N",
+        "score": 30
+      },
+      {
+        "format": 247,
+        "name": "FraMeSToR",
+        "score": 30
+      },
+      {
+        "format": 246,
+        "name": "iFT",
+        "score": 70
+      },
+      {
+        "format": 245,
+        "name": "MTeam",
+        "score": -9999
+      },
+      {
+        "format": 244,
+        "name": "EDPH",
+        "score": 30
+      },
+      {
+        "format": 243,
+        "name": "HANDJOB",
+        "score": 30
+      },
+      {
+        "format": 242,
+        "name": "c0ke",
+        "score": 110
+      },
+      {
+        "format": 241,
+        "name": "KASHMiR",
+        "score": 70
+      },
+      {
+        "format": 240,
+        "name": "WMING",
+        "score": 70
+      },
+      {
+        "format": 239,
+        "name": "playHD",
+        "score": 70
+      },
+      {
+        "format": 238,
+        "name": "E.N.D",
+        "score": 70
+      },
+      {
+        "format": 237,
+        "name": "GutS",
+        "score": 70
+      },
+      {
+        "format": 236,
+        "name": "BV",
+        "score": 70
+      },
+      {
+        "format": 235,
+        "name": "SiMPLE",
+        "score": 70
+      },
+      {
+        "format": 234,
+        "name": "W4NK3R",
+        "score": 70
+      },
+      {
+        "format": 233,
+        "name": "GS88",
+        "score": 70
+      },
+      {
+        "format": 232,
+        "name": "HiP",
+        "score": 80
+      },
+      {
+        "format": 231,
+        "name": "GALAXY",
+        "score": 70
+      },
+      {
+        "format": 230,
+        "name": "luvBB",
+        "score": 70
+      },
+      {
+        "format": 229,
+        "name": "NyHD",
+        "score": 70
+      },
+      {
+        "format": 228,
+        "name": "ZIMBO",
+        "score": 70
+      },
+      {
+        "format": 227,
+        "name": "ThD",
+        "score": 70
+      },
+      {
+        "format": 226,
+        "name": "SaNcTi",
+        "score": 70
+      },
+      {
+        "format": 225,
+        "name": "ORiGEN",
+        "score": 70
+      },
+      {
+        "format": 224,
+        "name": "Positive",
+        "score": 70
+      },
+      {
+        "format": 223,
+        "name": "ESiR",
+        "score": 70
+      },
+      {
+        "format": 222,
+        "name": "Chotab",
+        "score": 70
+      },
+      {
+        "format": 221,
+        "name": "xander",
+        "score": 70
+      },
+      {
+        "format": 220,
+        "name": "FTW-HD",
+        "score": 70
+      },
+      {
+        "format": 219,
+        "name": "Penumbra",
+        "score": 70
+      },
+      {
+        "format": 218,
+        "name": "TDD",
+        "score": 70
+      },
+      {
+        "format": 217,
+        "name": "Dariush SD",
+        "score": 70
+      },
+      {
+        "format": 216,
+        "name": "PTer",
+        "score": 70
+      },
+      {
+        "format": 215,
+        "name": "SbR",
+        "score": 70
+      },
+      {
+        "format": 214,
+        "name": "nmd",
+        "score": 70
+      },
+      {
+        "format": 213,
+        "name": "TBB",
+        "score": 70
+      },
+      {
+        "format": 212,
+        "name": "EA",
+        "score": 80
+      },
+      {
+        "format": 211,
+        "name": "BMF",
+        "score": 80
+      },
+      {
+        "format": 210,
+        "name": "LolHD",
+        "score": 80
+      },
+      {
+        "format": 209,
+        "name": "HDMaNiAcS",
+        "score": 80
+      },
+      {
+        "format": 208,
+        "name": "IDE",
+        "score": 80
+      },
+      {
+        "format": 207,
+        "name": "de[42]",
+        "score": 90
+      },
+      {
+        "format": 206,
+        "name": "NCmt",
+        "score": 100
+      },
+      {
+        "format": 205,
+        "name": "decibeL",
+        "score": 90
+      },
+      {
+        "format": 204,
+        "name": "NTb",
+        "score": 80
+      },
+      {
+        "format": 203,
+        "name": "CRiSC",
+        "score": 90
+      },
+      {
+        "format": 202,
+        "name": "SA89",
+        "score": 100
+      },
+      {
+        "format": 201,
+        "name": "HiDt",
+        "score": 100
+      },
+      {
+        "format": 200,
+        "name": "FoRM",
+        "score": 100
+      },
+      {
+        "format": 199,
+        "name": "HiFi",
+        "score": 100
+      },
+      {
+        "format": 198,
+        "name": "CtrlHD",
+        "score": 100
+      },
+      {
+        "format": 197,
+        "name": "VietHD",
+        "score": 110
+      },
+      {
+        "format": 196,
+        "name": "ZQ",
+        "score": 110
+      },
+      {
+        "format": 195,
+        "name": "TayTo",
+        "score": 110
+      },
+      {
+        "format": 194,
+        "name": "Geek",
+        "score": 110
+      },
+      {
+        "format": 193,
+        "name": "EbP",
+        "score": 120
+      },
+      {
+        "format": 192,
+        "name": "DON",
+        "score": 120
+      },
+      {
+        "format": 191,
+        "name": "D-Z0N3",
+        "score": 120
+      },
+      {
+        "format": 340,
+        "name": "Upscaled",
+        "score": -9999
+      }
+    ],
+    "language": {
+      "id": -1,
+      "name": "Any"
     }
+  }
 ]

--- a/imports/quality_profiles/radarr/1080p x265 HDR Transparent (radarr - master).json
+++ b/imports/quality_profiles/radarr/1080p x265 HDR Transparent (radarr - master).json
@@ -1,1115 +1,1116 @@
 [
-    {
-        "name": "1080p x265 HDR Transparent",
-        "upgradeAllowed": true,
-        "cutoff": 1002,
+  {
+    "name": "1080p x265 HDR Transparent",
+    "upgradeAllowed": true,
+    "cutoff": 1002,
+    "items": [
+      {
+        "quality": {
+          "id": 24,
+          "name": "WORKPRINT",
+          "source": "workprint",
+          "resolution": 0,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 29,
+          "name": "REGIONAL",
+          "source": "dvd",
+          "resolution": 480,
+          "modifier": "regional"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 4,
+          "name": "HDTV-720p",
+          "source": "tv",
+          "resolution": 720,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "name": "WEB 720p",
         "items": [
-            {
-                "quality": {
-                    "id": 24,
-                    "name": "WORKPRINT",
-                    "source": "workprint",
-                    "resolution": 0,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
+          {
+            "quality": {
+              "id": 5,
+              "name": "WEBDL-720p",
+              "source": "webdl",
+              "resolution": 720,
+              "modifier": "none"
             },
-            {
-                "quality": {
-                    "id": 29,
-                    "name": "REGIONAL",
-                    "source": "dvd",
-                    "resolution": 480,
-                    "modifier": "regional"
-                },
-                "items": [],
-                "allowed": false
+            "items": [],
+            "allowed": false
+          },
+          {
+            "quality": {
+              "id": 14,
+              "name": "WEBRip-720p",
+              "source": "webrip",
+              "resolution": 720,
+              "modifier": "none"
             },
-            {
-                "quality": {
-                    "id": 4,
-                    "name": "HDTV-720p",
-                    "source": "tv",
-                    "resolution": 720,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "name": "WEB 720p",
-                "items": [
-                    {
-                        "quality": {
-                            "id": 5,
-                            "name": "WEBDL-720p",
-                            "source": "webdl",
-                            "resolution": 720,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": false
-                    },
-                    {
-                        "quality": {
-                            "id": 14,
-                            "name": "WEBRip-720p",
-                            "source": "webrip",
-                            "resolution": 720,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": false
-                    }
-                ],
-                "allowed": false,
-                "id": 1001
-            },
-            {
-                "quality": {
-                    "id": 6,
-                    "name": "Bluray-720p",
-                    "source": "bluray",
-                    "resolution": 720,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 1,
-                    "name": "SDTV",
-                    "source": "tv",
-                    "resolution": 480,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 20,
-                    "name": "Bluray-480p",
-                    "source": "bluray",
-                    "resolution": 480,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 21,
-                    "name": "Bluray-576p",
-                    "source": "bluray",
-                    "resolution": 576,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 23,
-                    "name": "DVD-R",
-                    "source": "dvd",
-                    "resolution": 480,
-                    "modifier": "remux"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "name": "CAM",
-                "items": [
-                    {
-                        "quality": {
-                            "id": 25,
-                            "name": "CAM",
-                            "source": "cam",
-                            "resolution": 0,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": true
-                    },
-                    {
-                        "quality": {
-                            "id": 26,
-                            "name": "TELESYNC",
-                            "source": "telesync",
-                            "resolution": 0,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": true
-                    },
-                    {
-                        "quality": {
-                            "id": 27,
-                            "name": "TELECINE",
-                            "source": "telecine",
-                            "resolution": 0,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": true
-                    }
-                ],
-                "allowed": true,
-                "id": 1004
-            },
-            {
-                "quality": {
-                    "id": 0,
-                    "name": "Unknown",
-                    "source": "unknown",
-                    "resolution": 0,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": true
-            },
-            {
-                "name": "DVD",
-                "items": [
-                    {
-                        "quality": {
-                            "id": 28,
-                            "name": "DVDSCR",
-                            "source": "dvd",
-                            "resolution": 480,
-                            "modifier": "screener"
-                        },
-                        "items": [],
-                        "allowed": false
-                    },
-                    {
-                        "quality": {
-                            "id": 12,
-                            "name": "WEBRip-480p",
-                            "source": "webrip",
-                            "resolution": 480,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": false
-                    },
-                    {
-                        "quality": {
-                            "id": 2,
-                            "name": "DVD",
-                            "source": "dvd",
-                            "resolution": 0,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": true
-                    },
-                    {
-                        "quality": {
-                            "id": 8,
-                            "name": "WEBDL-480p",
-                            "source": "webdl",
-                            "resolution": 480,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": true
-                    }
-                ],
-                "allowed": true,
-                "id": 1003
-            },
-            {
-                "quality": {
-                    "id": 9,
-                    "name": "HDTV-1080p",
-                    "source": "tv",
-                    "resolution": 1080,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": true
-            },
-            {
-                "name": "Transparent Capable",
-                "items": [
-                    {
-                        "quality": {
-                            "id": 3,
-                            "name": "WEBDL-1080p",
-                            "source": "webdl",
-                            "resolution": 1080,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": true
-                    },
-                    {
-                        "quality": {
-                            "id": 15,
-                            "name": "WEBRip-1080p",
-                            "source": "webrip",
-                            "resolution": 1080,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": true
-                    },
-                    {
-                        "quality": {
-                            "id": 7,
-                            "name": "Bluray-1080p",
-                            "source": "bluray",
-                            "resolution": 1080,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": true
-                    }
-                ],
-                "allowed": true,
-                "id": 1002
-            },
-            {
-                "quality": {
-                    "id": 30,
-                    "name": "Remux-1080p",
-                    "source": "bluray",
-                    "resolution": 1080,
-                    "modifier": "remux"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 16,
-                    "name": "HDTV-2160p",
-                    "source": "tv",
-                    "resolution": 2160,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 18,
-                    "name": "WEBDL-2160p",
-                    "source": "webdl",
-                    "resolution": 2160,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 17,
-                    "name": "WEBRip-2160p",
-                    "source": "webrip",
-                    "resolution": 2160,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 19,
-                    "name": "Bluray-2160p",
-                    "source": "bluray",
-                    "resolution": 2160,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 31,
-                    "name": "Remux-2160p",
-                    "source": "bluray",
-                    "resolution": 2160,
-                    "modifier": "remux"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 22,
-                    "name": "BR-DISK",
-                    "source": "bluray",
-                    "resolution": 1080,
-                    "modifier": "brdisk"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 10,
-                    "name": "Raw-HD",
-                    "source": "tv",
-                    "resolution": 1080,
-                    "modifier": "rawhd"
-                },
-                "items": [],
-                "allowed": false
-            }
+            "items": [],
+            "allowed": false
+          }
         ],
-        "minFormatScore": 0,
-        "cutoffFormatScore": 500,
-        "formatItems": [
-            {
-                "format": 353,
-                "name": "BHDStudio (1080p x265)",
-                "score": -9999
-            },
-            {
-                "format": 352,
-                "name": "E1",
-                "score": 70
-            },
-            {
-                "format": 351,
-                "name": "2160p x265",
-                "score": -9999
-            },
-            {
-                "format": 349,
-                "name": "EXCiSiON",
-                "score": 70
-            },
-            {
-                "format": 348,
-                "name": "Unwanted x265 Groups",
-                "score": -9999
-            },
-            {
-                "format": 347,
-                "name": "CRX",
-                "score": 70
-            },
-            {
-                "format": 346,
-                "name": "HDR10 (Missing) (x265 HDR only)",
-                "score": 10
-            },
-            {
-                "format": 345,
-                "name": "UHD Bluray",
-                "score": 350
-            },
-            {
-                "format": 344,
-                "name": "jennaortegaUHD",
-                "score": 0
-            },
-            {
-                "format": 342,
-                "name": "Freeleech25",
-                "score": 0
-            },
-            {
-                "format": 341,
-                "name": "Freeleech50",
-                "score": 0
-            },
-            {
-                "format": 340,
-                "name": "Freeleech75",
-                "score": 0
-            },
-            {
-                "format": 339,
-                "name": "Freeleech100",
-                "score": 0
-            },
-            {
-                "format": 338,
-                "name": "TEST FLAC",
-                "score": 0
-            },
-            {
-                "format": 337,
-                "name": "h265 (4k)",
-                "score": 0
-            },
-            {
-                "format": 336,
-                "name": "MAX",
-                "score": 0
-            },
-            {
-                "format": 335,
-                "name": "Blu-Ray (Remux)",
-                "score": -9999
-            },
-            {
-                "format": 334,
-                "name": "PCM",
-                "score": 0
-            },
-            {
-                "format": 333,
-                "name": "h265",
-                "score": -9999
-            },
-            {
-                "format": 331,
-                "name": "Golden Popcorn 720p",
-                "score": 0
-            },
-            {
-                "format": 330,
-                "name": "LQ",
-                "score": -9999
-            },
-            {
-                "format": 329,
-                "name": "EPSiLON",
-                "score": 0
-            },
-            {
-                "format": 328,
-                "name": "playBD",
-                "score": 0
-            },
-            {
-                "format": 327,
-                "name": "BLURANiUM",
-                "score": 0
-            },
-            {
-                "format": 326,
-                "name": "PmP",
-                "score": 0
-            },
-            {
-                "format": 325,
-                "name": "WiLDCAT",
-                "score": 0
-            },
-            {
-                "format": 324,
-                "name": "TRiToN",
-                "score": 0
-            },
-            {
-                "format": 323,
-                "name": "3L",
-                "score": 0
-            },
-            {
-                "format": 322,
-                "name": "Dolby Vision w/out Fallback",
-                "score": -9999
-            },
-            {
-                "format": 321,
-                "name": "UHDBits",
-                "score": -9999
-            },
-            {
-                "format": 318,
-                "name": "ATMOS (Missing)",
-                "score": 0
-            },
-            {
-                "format": 317,
-                "name": "TrueHD (Missing)",
-                "score": 0
-            },
-            {
-                "format": 316,
-                "name": "HDR10 (Missing)",
-                "score": 10
-            },
-            {
-                "format": 315,
-                "name": "HDR10",
-                "score": 10
-            },
-            {
-                "format": 314,
-                "name": "Dolby Vision",
-                "score": 30
-            },
-            {
-                "format": 312,
-                "name": "HDR10+",
-                "score": 20
-            },
-            {
-                "format": 308,
-                "name": "Stream Optimised",
-                "score": 0
-            },
-            {
-                "format": 307,
-                "name": "LoRD",
-                "score": 70
-            },
-            {
-                "format": 306,
-                "name": "Scene",
-                "score": 30
-            },
-            {
-                "format": 303,
-                "name": "mHD",
-                "score": -99999
-            },
-            {
-                "format": 302,
-                "name": "AV1",
-                "score": -9999
-            },
-            {
-                "format": 301,
-                "name": "VVC",
-                "score": -9999
-            },
-            {
-                "format": 300,
-                "name": "Extras",
-                "score": -9999
-            },
-            {
-                "format": 298,
-                "name": "480p",
-                "score": 0
-            },
-            {
-                "format": 297,
-                "name": "Dariush ",
-                "score": 20
-            },
-            {
-                "format": 296,
-                "name": "TBB SD",
-                "score": 30
-            },
-            {
-                "format": 295,
-                "name": "Xvid",
-                "score": 0
-            },
-            {
-                "format": 294,
-                "name": "DVD",
-                "score": 0
-            },
-            {
-                "format": 293,
-                "name": "DVD REMUX ",
-                "score": 40
-            },
-            {
-                "format": 292,
-                "name": "HANDJOB SD",
-                "score": 20
-            },
-            {
-                "format": 291,
-                "name": "iTunes (Missing)",
-                "score": 20
-            },
-            {
-                "format": 290,
-                "name": "ROKU",
-                "score": 30
-            },
-            {
-                "format": 289,
-                "name": "BeyondHD",
-                "score": -10000
-            },
-            {
-                "format": 288,
-                "name": "Disc ",
-                "score": -9999
-            },
-            {
-                "format": 287,
-                "name": "3D",
-                "score": -9999
-            },
-            {
-                "format": 286,
-                "name": "Unwanted",
-                "score": -9999
-            },
-            {
-                "format": 285,
-                "name": "HDBits Internal",
-                "score": 70
-            },
-            {
-                "format": 284,
-                "name": "RightSIZE",
-                "score": 70
-            },
-            {
-                "format": 283,
-                "name": "Black and White",
-                "score": -9999
-            },
-            {
-                "format": 281,
-                "name": "TrueHD",
-                "score": 0
-            },
-            {
-                "format": 280,
-                "name": "DTS-X",
-                "score": 0
-            },
-            {
-                "format": 279,
-                "name": "FLAC",
-                "score": 0
-            },
-            {
-                "format": 278,
-                "name": "DTS-HD MA",
-                "score": 0
-            },
-            {
-                "format": 276,
-                "name": "x265",
-                "score": -90
-            },
-            {
-                "format": 275,
-                "name": "Golden Popcorn SD",
-                "score": 30
-            },
-            {
-                "format": 274,
-                "name": "Golden Popcorn 1080p",
-                "score": 120
-            },
-            {
-                "format": 273,
-                "name": "IMAX",
-                "score": 10
-            },
-            {
-                "format": 272,
-                "name": "ATMOS",
-                "score": 5
-            },
-            {
-                "format": 271,
-                "name": "DD",
-                "score": 0
-            },
-            {
-                "format": 270,
-                "name": "DTS",
-                "score": 0
-            },
-            {
-                "format": 269,
-                "name": "DD+",
-                "score": 0
-            },
-            {
-                "format": 268,
-                "name": "iTunes",
-                "score": 20
-            },
-            {
-                "format": 267,
-                "name": "Paramount+",
-                "score": 30
-            },
-            {
-                "format": 266,
-                "name": "Peacock TV",
-                "score": 30
-            },
-            {
-                "format": 265,
-                "name": "Hulu",
-                "score": 30
-            },
-            {
-                "format": 264,
-                "name": "Netflix",
-                "score": 40
-            },
-            {
-                "format": 263,
-                "name": "HBO Max",
-                "score": 40
-            },
-            {
-                "format": 262,
-                "name": "Disney+",
-                "score": 40
-            },
-            {
-                "format": 261,
-                "name": "Apple TV+",
-                "score": 50
-            },
-            {
-                "format": 260,
-                "name": "Movies Anywhere",
-                "score": 60
-            },
-            {
-                "format": 259,
-                "name": "Amazon Prime",
-                "score": 50
-            },
-            {
-                "format": 258,
-                "name": "REMUX",
-                "score": -9999
-            },
-            {
-                "format": 256,
-                "name": "x264",
-                "score": 10
-            },
-            {
-                "format": 255,
-                "name": "WEBRip",
-                "score": 0
-            },
-            {
-                "format": 254,
-                "name": "Blu-Ray",
-                "score": 0
-            },
-            {
-                "format": 253,
-                "name": "2160p",
-                "score": -9999
-            },
-            {
-                "format": 252,
-                "name": "720p",
-                "score": -10000
-            },
-            {
-                "format": 250,
-                "name": "1080p",
-                "score": 60
-            },
-            {
-                "format": 249,
-                "name": "BHDStudio",
-                "score": 30
-            },
-            {
-                "format": 248,
-                "name": "LEGi0N",
-                "score": 30
-            },
-            {
-                "format": 247,
-                "name": "FraMeSToR",
-                "score": 30
-            },
-            {
-                "format": 246,
-                "name": "iFT",
-                "score": 70
-            },
-            {
-                "format": 245,
-                "name": "MTeam",
-                "score": -9999
-            },
-            {
-                "format": 244,
-                "name": "EDPH",
-                "score": 30
-            },
-            {
-                "format": 243,
-                "name": "HANDJOB",
-                "score": 30
-            },
-            {
-                "format": 242,
-                "name": "c0ke",
-                "score": 110
-            },
-            {
-                "format": 241,
-                "name": "KASHMiR",
-                "score": 70
-            },
-            {
-                "format": 240,
-                "name": "WMING",
-                "score": 70
-            },
-            {
-                "format": 239,
-                "name": "playHD",
-                "score": 70
-            },
-            {
-                "format": 238,
-                "name": "E.N.D",
-                "score": 70
-            },
-            {
-                "format": 237,
-                "name": "GutS",
-                "score": 70
-            },
-            {
-                "format": 236,
-                "name": "BV",
-                "score": 70
-            },
-            {
-                "format": 235,
-                "name": "SiMPLE",
-                "score": 70
-            },
-            {
-                "format": 234,
-                "name": "W4NK3R",
-                "score": 70
-            },
-            {
-                "format": 233,
-                "name": "GS88",
-                "score": 70
-            },
-            {
-                "format": 232,
-                "name": "HiP",
-                "score": 80
-            },
-            {
-                "format": 231,
-                "name": "GALAXY",
-                "score": 70
-            },
-            {
-                "format": 230,
-                "name": "luvBB",
-                "score": 70
-            },
-            {
-                "format": 229,
-                "name": "NyHD",
-                "score": 70
-            },
-            {
-                "format": 228,
-                "name": "ZIMBO",
-                "score": 70
-            },
-            {
-                "format": 227,
-                "name": "ThD",
-                "score": 70
-            },
-            {
-                "format": 226,
-                "name": "SaNcTi",
-                "score": 70
-            },
-            {
-                "format": 225,
-                "name": "ORiGEN",
-                "score": 70
-            },
-            {
-                "format": 224,
-                "name": "Positive",
-                "score": 70
-            },
-            {
-                "format": 223,
-                "name": "ESiR",
-                "score": 70
-            },
-            {
-                "format": 222,
-                "name": "Chotab",
-                "score": 70
-            },
-            {
-                "format": 221,
-                "name": "xander",
-                "score": 70
-            },
-            {
-                "format": 220,
-                "name": "FTW-HD",
-                "score": 70
-            },
-            {
-                "format": 219,
-                "name": "Penumbra",
-                "score": 70
-            },
-            {
-                "format": 218,
-                "name": "TDD",
-                "score": 70
-            },
-            {
-                "format": 217,
-                "name": "Dariush SD",
-                "score": 70
-            },
-            {
-                "format": 216,
-                "name": "PTer",
-                "score": 70
-            },
-            {
-                "format": 215,
-                "name": "SbR",
-                "score": 70
-            },
-            {
-                "format": 214,
-                "name": "nmd",
-                "score": 70
-            },
-            {
-                "format": 213,
-                "name": "TBB",
-                "score": 70
-            },
-            {
-                "format": 212,
-                "name": "EA",
-                "score": 80
-            },
-            {
-                "format": 211,
-                "name": "BMF",
-                "score": 80
-            },
-            {
-                "format": 210,
-                "name": "LolHD",
-                "score": 80
-            },
-            {
-                "format": 209,
-                "name": "HDMaNiAcS",
-                "score": 80
-            },
-            {
-                "format": 208,
-                "name": "IDE",
-                "score": 80
-            },
-            {
-                "format": 207,
-                "name": "de[42]",
-                "score": 90
-            },
-            {
-                "format": 206,
-                "name": "NCmt",
-                "score": 100
-            },
-            {
-                "format": 205,
-                "name": "decibeL",
-                "score": 90
-            },
-            {
-                "format": 204,
-                "name": "NTb",
-                "score": 80
-            },
-            {
-                "format": 203,
-                "name": "CRiSC",
-                "score": 90
-            },
-            {
-                "format": 202,
-                "name": "SA89",
-                "score": 100
-            },
-            {
-                "format": 201,
-                "name": "HiDt",
-                "score": 100
-            },
-            {
-                "format": 200,
-                "name": "FoRM",
-                "score": 100
-            },
-            {
-                "format": 199,
-                "name": "HiFi",
-                "score": 100
-            },
-            {
-                "format": 198,
-                "name": "CtrlHD",
-                "score": 100
-            },
-            {
-                "format": 197,
-                "name": "VietHD",
-                "score": 110
-            },
-            {
-                "format": 196,
-                "name": "ZQ",
-                "score": 110
-            },
-            {
-                "format": 195,
-                "name": "TayTo",
-                "score": 110
-            },
-            {
-                "format": 194,
-                "name": "Geek",
-                "score": 110
-            },
-            {
-                "format": 193,
-                "name": "EbP",
-                "score": 120
-            },
-            {
-                "format": 192,
-                "name": "DON",
-                "score": 120
-            },
-            {
-                "format": 191,
-                "name": "D-Z0N3",
-                "score": 120
-            },
-            {
-                "format": 340,
-                "name": "Upscaled",
-                "score": -9999
-            }
+        "allowed": false,
+        "id": 1001
+      },
+      {
+        "quality": {
+          "id": 6,
+          "name": "Bluray-720p",
+          "source": "bluray",
+          "resolution": 720,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 1,
+          "name": "SDTV",
+          "source": "tv",
+          "resolution": 480,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 20,
+          "name": "Bluray-480p",
+          "source": "bluray",
+          "resolution": 480,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 21,
+          "name": "Bluray-576p",
+          "source": "bluray",
+          "resolution": 576,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 23,
+          "name": "DVD-R",
+          "source": "dvd",
+          "resolution": 480,
+          "modifier": "remux"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "name": "CAM",
+        "items": [
+          {
+            "quality": {
+              "id": 25,
+              "name": "CAM",
+              "source": "cam",
+              "resolution": 0,
+              "modifier": "none"
+            },
+            "items": [],
+            "allowed": true
+          },
+          {
+            "quality": {
+              "id": 26,
+              "name": "TELESYNC",
+              "source": "telesync",
+              "resolution": 0,
+              "modifier": "none"
+            },
+            "items": [],
+            "allowed": true
+          },
+          {
+            "quality": {
+              "id": 27,
+              "name": "TELECINE",
+              "source": "telecine",
+              "resolution": 0,
+              "modifier": "none"
+            },
+            "items": [],
+            "allowed": true
+          }
         ],
-        "language": {
-            "id": -1,
-            "name": "Any"
-        }
+        "allowed": true,
+        "id": 1004
+      },
+      {
+        "quality": {
+          "id": 0,
+          "name": "Unknown",
+          "source": "unknown",
+          "resolution": 0,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": true
+      },
+      {
+        "name": "DVD",
+        "items": [
+          {
+            "quality": {
+              "id": 28,
+              "name": "DVDSCR",
+              "source": "dvd",
+              "resolution": 480,
+              "modifier": "screener"
+            },
+            "items": [],
+            "allowed": false
+          },
+          {
+            "quality": {
+              "id": 12,
+              "name": "WEBRip-480p",
+              "source": "webrip",
+              "resolution": 480,
+              "modifier": "none"
+            },
+            "items": [],
+            "allowed": false
+          },
+          {
+            "quality": {
+              "id": 2,
+              "name": "DVD",
+              "source": "dvd",
+              "resolution": 0,
+              "modifier": "none"
+            },
+            "items": [],
+            "allowed": true
+          },
+          {
+            "quality": {
+              "id": 8,
+              "name": "WEBDL-480p",
+              "source": "webdl",
+              "resolution": 480,
+              "modifier": "none"
+            },
+            "items": [],
+            "allowed": true
+          }
+        ],
+        "allowed": true,
+        "id": 1003
+      },
+      {
+        "quality": {
+          "id": 9,
+          "name": "HDTV-1080p",
+          "source": "tv",
+          "resolution": 1080,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": true
+      },
+      {
+        "name": "Transparent Capable",
+        "items": [
+          {
+            "quality": {
+              "id": 3,
+              "name": "WEBDL-1080p",
+              "source": "webdl",
+              "resolution": 1080,
+              "modifier": "none"
+            },
+            "items": [],
+            "allowed": true
+          },
+          {
+            "quality": {
+              "id": 15,
+              "name": "WEBRip-1080p",
+              "source": "webrip",
+              "resolution": 1080,
+              "modifier": "none"
+            },
+            "items": [],
+            "allowed": true
+          },
+          {
+            "quality": {
+              "id": 7,
+              "name": "Bluray-1080p",
+              "source": "bluray",
+              "resolution": 1080,
+              "modifier": "none"
+            },
+            "items": [],
+            "allowed": true
+          }
+        ],
+        "allowed": true,
+        "id": 1002
+      },
+      {
+        "quality": {
+          "id": 30,
+          "name": "Remux-1080p",
+          "source": "bluray",
+          "resolution": 1080,
+          "modifier": "remux"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 16,
+          "name": "HDTV-2160p",
+          "source": "tv",
+          "resolution": 2160,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 18,
+          "name": "WEBDL-2160p",
+          "source": "webdl",
+          "resolution": 2160,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 17,
+          "name": "WEBRip-2160p",
+          "source": "webrip",
+          "resolution": 2160,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 19,
+          "name": "Bluray-2160p",
+          "source": "bluray",
+          "resolution": 2160,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 31,
+          "name": "Remux-2160p",
+          "source": "bluray",
+          "resolution": 2160,
+          "modifier": "remux"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 22,
+          "name": "BR-DISK",
+          "source": "bluray",
+          "resolution": 1080,
+          "modifier": "brdisk"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 10,
+          "name": "Raw-HD",
+          "source": "tv",
+          "resolution": 1080,
+          "modifier": "rawhd"
+        },
+        "items": [],
+        "allowed": false
+      }
+    ],
+    "minFormatScore": 0,
+    "cutoffFormatScore": 500,
+    "minUpgradeFormatScore": 1,
+    "formatItems": [
+      {
+        "format": 353,
+        "name": "BHDStudio (1080p x265)",
+        "score": -9999
+      },
+      {
+        "format": 352,
+        "name": "E1",
+        "score": 70
+      },
+      {
+        "format": 351,
+        "name": "2160p x265",
+        "score": -9999
+      },
+      {
+        "format": 349,
+        "name": "EXCiSiON",
+        "score": 70
+      },
+      {
+        "format": 348,
+        "name": "Unwanted x265 Groups",
+        "score": -9999
+      },
+      {
+        "format": 347,
+        "name": "CRX",
+        "score": 70
+      },
+      {
+        "format": 346,
+        "name": "HDR10 (Missing) (x265 HDR only)",
+        "score": 10
+      },
+      {
+        "format": 345,
+        "name": "UHD Bluray",
+        "score": 350
+      },
+      {
+        "format": 344,
+        "name": "jennaortegaUHD",
+        "score": 0
+      },
+      {
+        "format": 342,
+        "name": "Freeleech25",
+        "score": 0
+      },
+      {
+        "format": 341,
+        "name": "Freeleech50",
+        "score": 0
+      },
+      {
+        "format": 340,
+        "name": "Freeleech75",
+        "score": 0
+      },
+      {
+        "format": 339,
+        "name": "Freeleech100",
+        "score": 0
+      },
+      {
+        "format": 338,
+        "name": "TEST FLAC",
+        "score": 0
+      },
+      {
+        "format": 337,
+        "name": "h265 (4k)",
+        "score": 0
+      },
+      {
+        "format": 336,
+        "name": "MAX",
+        "score": 0
+      },
+      {
+        "format": 335,
+        "name": "Blu-Ray (Remux)",
+        "score": -9999
+      },
+      {
+        "format": 334,
+        "name": "PCM",
+        "score": 0
+      },
+      {
+        "format": 333,
+        "name": "h265",
+        "score": -9999
+      },
+      {
+        "format": 331,
+        "name": "Golden Popcorn 720p",
+        "score": 0
+      },
+      {
+        "format": 330,
+        "name": "LQ",
+        "score": -9999
+      },
+      {
+        "format": 329,
+        "name": "EPSiLON",
+        "score": 0
+      },
+      {
+        "format": 328,
+        "name": "playBD",
+        "score": 0
+      },
+      {
+        "format": 327,
+        "name": "BLURANiUM",
+        "score": 0
+      },
+      {
+        "format": 326,
+        "name": "PmP",
+        "score": 0
+      },
+      {
+        "format": 325,
+        "name": "WiLDCAT",
+        "score": 0
+      },
+      {
+        "format": 324,
+        "name": "TRiToN",
+        "score": 0
+      },
+      {
+        "format": 323,
+        "name": "3L",
+        "score": 0
+      },
+      {
+        "format": 322,
+        "name": "Dolby Vision w/out Fallback",
+        "score": -9999
+      },
+      {
+        "format": 321,
+        "name": "UHDBits",
+        "score": -9999
+      },
+      {
+        "format": 318,
+        "name": "ATMOS (Missing)",
+        "score": 0
+      },
+      {
+        "format": 317,
+        "name": "TrueHD (Missing)",
+        "score": 0
+      },
+      {
+        "format": 316,
+        "name": "HDR10 (Missing)",
+        "score": 10
+      },
+      {
+        "format": 315,
+        "name": "HDR10",
+        "score": 10
+      },
+      {
+        "format": 314,
+        "name": "Dolby Vision",
+        "score": 30
+      },
+      {
+        "format": 312,
+        "name": "HDR10+",
+        "score": 20
+      },
+      {
+        "format": 308,
+        "name": "Stream Optimised",
+        "score": 0
+      },
+      {
+        "format": 307,
+        "name": "LoRD",
+        "score": 70
+      },
+      {
+        "format": 306,
+        "name": "Scene",
+        "score": 30
+      },
+      {
+        "format": 303,
+        "name": "mHD",
+        "score": -99999
+      },
+      {
+        "format": 302,
+        "name": "AV1",
+        "score": -9999
+      },
+      {
+        "format": 301,
+        "name": "VVC",
+        "score": -9999
+      },
+      {
+        "format": 300,
+        "name": "Extras",
+        "score": -9999
+      },
+      {
+        "format": 298,
+        "name": "480p",
+        "score": 0
+      },
+      {
+        "format": 297,
+        "name": "Dariush ",
+        "score": 20
+      },
+      {
+        "format": 296,
+        "name": "TBB SD",
+        "score": 30
+      },
+      {
+        "format": 295,
+        "name": "Xvid",
+        "score": 0
+      },
+      {
+        "format": 294,
+        "name": "DVD",
+        "score": 0
+      },
+      {
+        "format": 293,
+        "name": "DVD REMUX ",
+        "score": 40
+      },
+      {
+        "format": 292,
+        "name": "HANDJOB SD",
+        "score": 20
+      },
+      {
+        "format": 291,
+        "name": "iTunes (Missing)",
+        "score": 20
+      },
+      {
+        "format": 290,
+        "name": "ROKU",
+        "score": 30
+      },
+      {
+        "format": 289,
+        "name": "BeyondHD",
+        "score": -10000
+      },
+      {
+        "format": 288,
+        "name": "Disc ",
+        "score": -9999
+      },
+      {
+        "format": 287,
+        "name": "3D",
+        "score": -9999
+      },
+      {
+        "format": 286,
+        "name": "Unwanted",
+        "score": -9999
+      },
+      {
+        "format": 285,
+        "name": "HDBits Internal",
+        "score": 70
+      },
+      {
+        "format": 284,
+        "name": "RightSIZE",
+        "score": 70
+      },
+      {
+        "format": 283,
+        "name": "Black and White",
+        "score": -9999
+      },
+      {
+        "format": 281,
+        "name": "TrueHD",
+        "score": 0
+      },
+      {
+        "format": 280,
+        "name": "DTS-X",
+        "score": 0
+      },
+      {
+        "format": 279,
+        "name": "FLAC",
+        "score": 0
+      },
+      {
+        "format": 278,
+        "name": "DTS-HD MA",
+        "score": 0
+      },
+      {
+        "format": 276,
+        "name": "x265",
+        "score": -90
+      },
+      {
+        "format": 275,
+        "name": "Golden Popcorn SD",
+        "score": 30
+      },
+      {
+        "format": 274,
+        "name": "Golden Popcorn 1080p",
+        "score": 120
+      },
+      {
+        "format": 273,
+        "name": "IMAX",
+        "score": 10
+      },
+      {
+        "format": 272,
+        "name": "ATMOS",
+        "score": 5
+      },
+      {
+        "format": 271,
+        "name": "DD",
+        "score": 0
+      },
+      {
+        "format": 270,
+        "name": "DTS",
+        "score": 0
+      },
+      {
+        "format": 269,
+        "name": "DD+",
+        "score": 0
+      },
+      {
+        "format": 268,
+        "name": "iTunes",
+        "score": 20
+      },
+      {
+        "format": 267,
+        "name": "Paramount+",
+        "score": 30
+      },
+      {
+        "format": 266,
+        "name": "Peacock TV",
+        "score": 30
+      },
+      {
+        "format": 265,
+        "name": "Hulu",
+        "score": 30
+      },
+      {
+        "format": 264,
+        "name": "Netflix",
+        "score": 40
+      },
+      {
+        "format": 263,
+        "name": "HBO Max",
+        "score": 40
+      },
+      {
+        "format": 262,
+        "name": "Disney+",
+        "score": 40
+      },
+      {
+        "format": 261,
+        "name": "Apple TV+",
+        "score": 50
+      },
+      {
+        "format": 260,
+        "name": "Movies Anywhere",
+        "score": 60
+      },
+      {
+        "format": 259,
+        "name": "Amazon Prime",
+        "score": 50
+      },
+      {
+        "format": 258,
+        "name": "REMUX",
+        "score": -9999
+      },
+      {
+        "format": 256,
+        "name": "x264",
+        "score": 10
+      },
+      {
+        "format": 255,
+        "name": "WEBRip",
+        "score": 0
+      },
+      {
+        "format": 254,
+        "name": "Blu-Ray",
+        "score": 0
+      },
+      {
+        "format": 253,
+        "name": "2160p",
+        "score": -9999
+      },
+      {
+        "format": 252,
+        "name": "720p",
+        "score": -10000
+      },
+      {
+        "format": 250,
+        "name": "1080p",
+        "score": 60
+      },
+      {
+        "format": 249,
+        "name": "BHDStudio",
+        "score": 30
+      },
+      {
+        "format": 248,
+        "name": "LEGi0N",
+        "score": 30
+      },
+      {
+        "format": 247,
+        "name": "FraMeSToR",
+        "score": 30
+      },
+      {
+        "format": 246,
+        "name": "iFT",
+        "score": 70
+      },
+      {
+        "format": 245,
+        "name": "MTeam",
+        "score": -9999
+      },
+      {
+        "format": 244,
+        "name": "EDPH",
+        "score": 30
+      },
+      {
+        "format": 243,
+        "name": "HANDJOB",
+        "score": 30
+      },
+      {
+        "format": 242,
+        "name": "c0ke",
+        "score": 110
+      },
+      {
+        "format": 241,
+        "name": "KASHMiR",
+        "score": 70
+      },
+      {
+        "format": 240,
+        "name": "WMING",
+        "score": 70
+      },
+      {
+        "format": 239,
+        "name": "playHD",
+        "score": 70
+      },
+      {
+        "format": 238,
+        "name": "E.N.D",
+        "score": 70
+      },
+      {
+        "format": 237,
+        "name": "GutS",
+        "score": 70
+      },
+      {
+        "format": 236,
+        "name": "BV",
+        "score": 70
+      },
+      {
+        "format": 235,
+        "name": "SiMPLE",
+        "score": 70
+      },
+      {
+        "format": 234,
+        "name": "W4NK3R",
+        "score": 70
+      },
+      {
+        "format": 233,
+        "name": "GS88",
+        "score": 70
+      },
+      {
+        "format": 232,
+        "name": "HiP",
+        "score": 80
+      },
+      {
+        "format": 231,
+        "name": "GALAXY",
+        "score": 70
+      },
+      {
+        "format": 230,
+        "name": "luvBB",
+        "score": 70
+      },
+      {
+        "format": 229,
+        "name": "NyHD",
+        "score": 70
+      },
+      {
+        "format": 228,
+        "name": "ZIMBO",
+        "score": 70
+      },
+      {
+        "format": 227,
+        "name": "ThD",
+        "score": 70
+      },
+      {
+        "format": 226,
+        "name": "SaNcTi",
+        "score": 70
+      },
+      {
+        "format": 225,
+        "name": "ORiGEN",
+        "score": 70
+      },
+      {
+        "format": 224,
+        "name": "Positive",
+        "score": 70
+      },
+      {
+        "format": 223,
+        "name": "ESiR",
+        "score": 70
+      },
+      {
+        "format": 222,
+        "name": "Chotab",
+        "score": 70
+      },
+      {
+        "format": 221,
+        "name": "xander",
+        "score": 70
+      },
+      {
+        "format": 220,
+        "name": "FTW-HD",
+        "score": 70
+      },
+      {
+        "format": 219,
+        "name": "Penumbra",
+        "score": 70
+      },
+      {
+        "format": 218,
+        "name": "TDD",
+        "score": 70
+      },
+      {
+        "format": 217,
+        "name": "Dariush SD",
+        "score": 70
+      },
+      {
+        "format": 216,
+        "name": "PTer",
+        "score": 70
+      },
+      {
+        "format": 215,
+        "name": "SbR",
+        "score": 70
+      },
+      {
+        "format": 214,
+        "name": "nmd",
+        "score": 70
+      },
+      {
+        "format": 213,
+        "name": "TBB",
+        "score": 70
+      },
+      {
+        "format": 212,
+        "name": "EA",
+        "score": 80
+      },
+      {
+        "format": 211,
+        "name": "BMF",
+        "score": 80
+      },
+      {
+        "format": 210,
+        "name": "LolHD",
+        "score": 80
+      },
+      {
+        "format": 209,
+        "name": "HDMaNiAcS",
+        "score": 80
+      },
+      {
+        "format": 208,
+        "name": "IDE",
+        "score": 80
+      },
+      {
+        "format": 207,
+        "name": "de[42]",
+        "score": 90
+      },
+      {
+        "format": 206,
+        "name": "NCmt",
+        "score": 100
+      },
+      {
+        "format": 205,
+        "name": "decibeL",
+        "score": 90
+      },
+      {
+        "format": 204,
+        "name": "NTb",
+        "score": 80
+      },
+      {
+        "format": 203,
+        "name": "CRiSC",
+        "score": 90
+      },
+      {
+        "format": 202,
+        "name": "SA89",
+        "score": 100
+      },
+      {
+        "format": 201,
+        "name": "HiDt",
+        "score": 100
+      },
+      {
+        "format": 200,
+        "name": "FoRM",
+        "score": 100
+      },
+      {
+        "format": 199,
+        "name": "HiFi",
+        "score": 100
+      },
+      {
+        "format": 198,
+        "name": "CtrlHD",
+        "score": 100
+      },
+      {
+        "format": 197,
+        "name": "VietHD",
+        "score": 110
+      },
+      {
+        "format": 196,
+        "name": "ZQ",
+        "score": 110
+      },
+      {
+        "format": 195,
+        "name": "TayTo",
+        "score": 110
+      },
+      {
+        "format": 194,
+        "name": "Geek",
+        "score": 110
+      },
+      {
+        "format": 193,
+        "name": "EbP",
+        "score": 120
+      },
+      {
+        "format": 192,
+        "name": "DON",
+        "score": 120
+      },
+      {
+        "format": 191,
+        "name": "D-Z0N3",
+        "score": 120
+      },
+      {
+        "format": 340,
+        "name": "Upscaled",
+        "score": -9999
+      }
+    ],
+    "language": {
+      "id": -1,
+      "name": "Any"
     }
+  }
 ]

--- a/imports/quality_profiles/radarr/2160p Optimal (radarr - master).json
+++ b/imports/quality_profiles/radarr/2160p Optimal (radarr - master).json
@@ -1,1101 +1,1102 @@
 [
-    {
-        "name": "2160p Optimal",
-        "upgradeAllowed": true,
-        "cutoff": 31,
+  {
+    "name": "2160p Optimal",
+    "upgradeAllowed": true,
+    "cutoff": 31,
+    "items": [
+      {
+        "quality": {
+          "id": 0,
+          "name": "Unknown",
+          "source": "unknown",
+          "resolution": 0,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 24,
+          "name": "WORKPRINT",
+          "source": "workprint",
+          "resolution": 0,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 25,
+          "name": "CAM",
+          "source": "cam",
+          "resolution": 0,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 26,
+          "name": "TELESYNC",
+          "source": "telesync",
+          "resolution": 0,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 27,
+          "name": "TELECINE",
+          "source": "telecine",
+          "resolution": 0,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 29,
+          "name": "REGIONAL",
+          "source": "dvd",
+          "resolution": 480,
+          "modifier": "regional"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 28,
+          "name": "DVDSCR",
+          "source": "dvd",
+          "resolution": 480,
+          "modifier": "screener"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 1,
+          "name": "SDTV",
+          "source": "tv",
+          "resolution": 480,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": true
+      },
+      {
+        "name": "WEB 480p",
         "items": [
-            {
-                "quality": {
-                    "id": 0,
-                    "name": "Unknown",
-                    "source": "unknown",
-                    "resolution": 0,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
+          {
+            "quality": {
+              "id": 12,
+              "name": "WEBRip-480p",
+              "source": "webrip",
+              "resolution": 480,
+              "modifier": "none"
             },
-            {
-                "quality": {
-                    "id": 24,
-                    "name": "WORKPRINT",
-                    "source": "workprint",
-                    "resolution": 0,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
+            "items": [],
+            "allowed": true
+          },
+          {
+            "quality": {
+              "id": 8,
+              "name": "WEBDL-480p",
+              "source": "webdl",
+              "resolution": 480,
+              "modifier": "none"
             },
-            {
-                "quality": {
-                    "id": 25,
-                    "name": "CAM",
-                    "source": "cam",
-                    "resolution": 0,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 26,
-                    "name": "TELESYNC",
-                    "source": "telesync",
-                    "resolution": 0,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 27,
-                    "name": "TELECINE",
-                    "source": "telecine",
-                    "resolution": 0,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 29,
-                    "name": "REGIONAL",
-                    "source": "dvd",
-                    "resolution": 480,
-                    "modifier": "regional"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 28,
-                    "name": "DVDSCR",
-                    "source": "dvd",
-                    "resolution": 480,
-                    "modifier": "screener"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 1,
-                    "name": "SDTV",
-                    "source": "tv",
-                    "resolution": 480,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": true
-            },
-            {
-                "name": "WEB 480p",
-                "items": [
-                    {
-                        "quality": {
-                            "id": 12,
-                            "name": "WEBRip-480p",
-                            "source": "webrip",
-                            "resolution": 480,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": true
-                    },
-                    {
-                        "quality": {
-                            "id": 8,
-                            "name": "WEBDL-480p",
-                            "source": "webdl",
-                            "resolution": 480,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": true
-                    }
-                ],
-                "allowed": true,
-                "id": 1000
-            },
-            {
-                "quality": {
-                    "id": 2,
-                    "name": "DVD",
-                    "source": "dvd",
-                    "resolution": 0,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": true
-            },
-            {
-                "quality": {
-                    "id": 23,
-                    "name": "DVD-R",
-                    "source": "dvd",
-                    "resolution": 480,
-                    "modifier": "remux"
-                },
-                "items": [],
-                "allowed": true
-            },
-            {
-                "quality": {
-                    "id": 20,
-                    "name": "Bluray-480p",
-                    "source": "bluray",
-                    "resolution": 480,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 21,
-                    "name": "Bluray-576p",
-                    "source": "bluray",
-                    "resolution": 576,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 4,
-                    "name": "HDTV-720p",
-                    "source": "tv",
-                    "resolution": 720,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "name": "WEB 720p",
-                "items": [
-                    {
-                        "quality": {
-                            "id": 14,
-                            "name": "WEBRip-720p",
-                            "source": "webrip",
-                            "resolution": 720,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": false
-                    },
-                    {
-                        "quality": {
-                            "id": 5,
-                            "name": "WEBDL-720p",
-                            "source": "webdl",
-                            "resolution": 720,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": false
-                    }
-                ],
-                "allowed": false,
-                "id": 1001
-            },
-            {
-                "quality": {
-                    "id": 6,
-                    "name": "Bluray-720p",
-                    "source": "bluray",
-                    "resolution": 720,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 9,
-                    "name": "HDTV-1080p",
-                    "source": "tv",
-                    "resolution": 1080,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 15,
-                    "name": "WEBRip-1080p",
-                    "source": "webrip",
-                    "resolution": 1080,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 7,
-                    "name": "Bluray-1080p",
-                    "source": "bluray",
-                    "resolution": 1080,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 16,
-                    "name": "HDTV-2160p",
-                    "source": "tv",
-                    "resolution": 2160,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 17,
-                    "name": "WEBRip-2160p",
-                    "source": "webrip",
-                    "resolution": 2160,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 19,
-                    "name": "Bluray-2160p",
-                    "source": "bluray",
-                    "resolution": 2160,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 3,
-                    "name": "WEBDL-1080p",
-                    "source": "webdl",
-                    "resolution": 1080,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": true
-            },
-            {
-                "quality": {
-                    "id": 18,
-                    "name": "WEBDL-2160p",
-                    "source": "webdl",
-                    "resolution": 2160,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": true
-            },
-            {
-                "quality": {
-                    "id": 30,
-                    "name": "Remux-1080p",
-                    "source": "bluray",
-                    "resolution": 1080,
-                    "modifier": "remux"
-                },
-                "items": [],
-                "allowed": true
-            },
-            {
-                "quality": {
-                    "id": 31,
-                    "name": "Remux-2160p",
-                    "source": "bluray",
-                    "resolution": 2160,
-                    "modifier": "remux"
-                },
-                "items": [],
-                "allowed": true
-            },
-            {
-                "quality": {
-                    "id": 22,
-                    "name": "BR-DISK",
-                    "source": "bluray",
-                    "resolution": 1080,
-                    "modifier": "brdisk"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 10,
-                    "name": "Raw-HD",
-                    "source": "tv",
-                    "resolution": 1080,
-                    "modifier": "rawhd"
-                },
-                "items": [],
-                "allowed": false
-            }
+            "items": [],
+            "allowed": true
+          }
         ],
-        "minFormatScore": 0,
-        "cutoffFormatScore": 350,
-        "formatItems": [
-            {
-                "format": 353,
-                "name": "BHDStudio (1080p x265)",
-                "score": 0
-            },
-            {
-                "format": 352,
-                "name": "E1",
-                "score": 0
-            },
-            {
-                "format": 351,
-                "name": "2160p x265",
-                "score": 0
-            },
-            {
-                "format": 349,
-                "name": "EXCiSiON",
-                "score": 0
-            },
-            {
-                "format": 348,
-                "name": "Unwanted x265 Groups",
-                "score": 0
-            },
-            {
-                "format": 347,
-                "name": "CRX",
-                "score": 0
-            },
-            {
-                "format": 346,
-                "name": "HDR10 (Missing) (x265 HDR only)",
-                "score": 0
-            },
-            {
-                "format": 345,
-                "name": "UHD Bluray",
-                "score": 0
-            },
-            {
-                "format": 344,
-                "name": "jennaortegaUHD",
-                "score": -9999
-            },
-            {
-                "format": 342,
-                "name": "Freeleech25",
-                "score": 0
-            },
-            {
-                "format": 341,
-                "name": "Freeleech50",
-                "score": 0
-            },
-            {
-                "format": 340,
-                "name": "Freeleech75",
-                "score": 0
-            },
-            {
-                "format": 339,
-                "name": "Freeleech100",
-                "score": 0
-            },
-            {
-                "format": 338,
-                "name": "TEST FLAC",
-                "score": 0
-            },
-            {
-                "format": 337,
-                "name": "h265 (4k)",
-                "score": 0
-            },
-            {
-                "format": 336,
-                "name": "MAX",
-                "score": 0
-            },
-            {
-                "format": 335,
-                "name": "Blu-Ray (Remux)",
-                "score": 60
-            },
-            {
-                "format": 334,
-                "name": "PCM",
-                "score": 30
-            },
-            {
-                "format": 333,
-                "name": "h265",
-                "score": 0
-            },
-            {
-                "format": 331,
-                "name": "Golden Popcorn 720p",
-                "score": 0
-            },
-            {
-                "format": 330,
-                "name": "LQ",
-                "score": -9999
-            },
-            {
-                "format": 329,
-                "name": "EPSiLON",
-                "score": 0
-            },
-            {
-                "format": 328,
-                "name": "playBD",
-                "score": 0
-            },
-            {
-                "format": 327,
-                "name": "BLURANiUM",
-                "score": 0
-            },
-            {
-                "format": 326,
-                "name": "PmP",
-                "score": 0
-            },
-            {
-                "format": 325,
-                "name": "WiLDCAT",
-                "score": 0
-            },
-            {
-                "format": 324,
-                "name": "TRiToN",
-                "score": 0
-            },
-            {
-                "format": 323,
-                "name": "3L",
-                "score": 0
-            },
-            {
-                "format": 322,
-                "name": "Dolby Vision w/out Fallback",
-                "score": -9999
-            },
-            {
-                "format": 321,
-                "name": "UHDBits",
-                "score": -9999
-            },
-            {
-                "format": 318,
-                "name": "ATMOS (Missing)",
-                "score": 10
-            },
-            {
-                "format": 317,
-                "name": "TrueHD (Missing)",
-                "score": 50
-            },
-            {
-                "format": 316,
-                "name": "HDR10 (Missing)",
-                "score": 10
-            },
-            {
-                "format": 315,
-                "name": "HDR10",
-                "score": 10
-            },
-            {
-                "format": 314,
-                "name": "Dolby Vision",
-                "score": 30
-            },
-            {
-                "format": 312,
-                "name": "HDR10+",
-                "score": 20
-            },
-            {
-                "format": 308,
-                "name": "Stream Optimised",
-                "score": 0
-            },
-            {
-                "format": 307,
-                "name": "LoRD",
-                "score": 0
-            },
-            {
-                "format": 306,
-                "name": "Scene",
-                "score": 0
-            },
-            {
-                "format": 303,
-                "name": "mHD",
-                "score": 0
-            },
-            {
-                "format": 302,
-                "name": "AV1",
-                "score": -9999
-            },
-            {
-                "format": 301,
-                "name": "VVC",
-                "score": -9999
-            },
-            {
-                "format": 300,
-                "name": "Extras",
-                "score": -9999
-            },
-            {
-                "format": 298,
-                "name": "480p",
-                "score": 0
-            },
-            {
-                "format": 297,
-                "name": "Dariush ",
-                "score": 0
-            },
-            {
-                "format": 296,
-                "name": "TBB SD",
-                "score": 30
-            },
-            {
-                "format": 295,
-                "name": "Xvid",
-                "score": 0
-            },
-            {
-                "format": 294,
-                "name": "DVD",
-                "score": 0
-            },
-            {
-                "format": 293,
-                "name": "DVD REMUX ",
-                "score": 40
-            },
-            {
-                "format": 292,
-                "name": "HANDJOB SD",
-                "score": 20
-            },
-            {
-                "format": 291,
-                "name": "iTunes (Missing)",
-                "score": 10
-            },
-            {
-                "format": 290,
-                "name": "ROKU",
-                "score": 20
-            },
-            {
-                "format": 289,
-                "name": "BeyondHD",
-                "score": 0
-            },
-            {
-                "format": 288,
-                "name": "Disc ",
-                "score": -9999
-            },
-            {
-                "format": 287,
-                "name": "3D",
-                "score": -9999
-            },
-            {
-                "format": 286,
-                "name": "Unwanted",
-                "score": -9999
-            },
-            {
-                "format": 285,
-                "name": "HDBits Internal",
-                "score": 0
-            },
-            {
-                "format": 284,
-                "name": "RightSIZE",
-                "score": 0
-            },
-            {
-                "format": 283,
-                "name": "Black and White",
-                "score": -9999
-            },
-            {
-                "format": 281,
-                "name": "TrueHD",
-                "score": 50
-            },
-            {
-                "format": 280,
-                "name": "DTS-X",
-                "score": 60
-            },
-            {
-                "format": 279,
-                "name": "FLAC",
-                "score": 30
-            },
-            {
-                "format": 278,
-                "name": "DTS-HD MA",
-                "score": 50
-            },
-            {
-                "format": 276,
-                "name": "x265",
-                "score": -9999
-            },
-            {
-                "format": 275,
-                "name": "Golden Popcorn SD",
-                "score": 30
-            },
-            {
-                "format": 274,
-                "name": "Golden Popcorn 1080p",
-                "score": 0
-            },
-            {
-                "format": 273,
-                "name": "IMAX",
-                "score": 10
-            },
-            {
-                "format": 272,
-                "name": "ATMOS",
-                "score": 10
-            },
-            {
-                "format": 271,
-                "name": "DD",
-                "score": 0
-            },
-            {
-                "format": 270,
-                "name": "DTS",
-                "score": 0
-            },
-            {
-                "format": 269,
-                "name": "DD+",
-                "score": 0
-            },
-            {
-                "format": 268,
-                "name": "iTunes",
-                "score": 10
-            },
-            {
-                "format": 267,
-                "name": "Paramount+",
-                "score": 20
-            },
-            {
-                "format": 266,
-                "name": "Peacock TV",
-                "score": 20
-            },
-            {
-                "format": 265,
-                "name": "Hulu",
-                "score": 20
-            },
-            {
-                "format": 264,
-                "name": "Netflix",
-                "score": 30
-            },
-            {
-                "format": 263,
-                "name": "HBO Max",
-                "score": 30
-            },
-            {
-                "format": 262,
-                "name": "Disney+",
-                "score": 30
-            },
-            {
-                "format": 261,
-                "name": "Apple TV+",
-                "score": 40
-            },
-            {
-                "format": 260,
-                "name": "Movies Anywhere",
-                "score": 50
-            },
-            {
-                "format": 259,
-                "name": "Amazon Prime",
-                "score": 40
-            },
-            {
-                "format": 258,
-                "name": "REMUX",
-                "score": 60
-            },
-            {
-                "format": 256,
-                "name": "x264",
-                "score": 10
-            },
-            {
-                "format": 255,
-                "name": "WEBRip",
-                "score": -9999
-            },
-            {
-                "format": 254,
-                "name": "Blu-Ray",
-                "score": 60
-            },
-            {
-                "format": 253,
-                "name": "2160p",
-                "score": 120
-            },
-            {
-                "format": 252,
-                "name": "720p",
-                "score": -9999
-            },
-            {
-                "format": 250,
-                "name": "1080p",
-                "score": 60
-            },
-            {
-                "format": 249,
-                "name": "BHDStudio",
-                "score": 0
-            },
-            {
-                "format": 248,
-                "name": "LEGi0N",
-                "score": 0
-            },
-            {
-                "format": 247,
-                "name": "FraMeSToR",
-                "score": 0
-            },
-            {
-                "format": 246,
-                "name": "iFT",
-                "score": 0
-            },
-            {
-                "format": 245,
-                "name": "MTeam",
-                "score": 0
-            },
-            {
-                "format": 244,
-                "name": "EDPH",
-                "score": 0
-            },
-            {
-                "format": 243,
-                "name": "HANDJOB",
-                "score": 0
-            },
-            {
-                "format": 242,
-                "name": "c0ke",
-                "score": 0
-            },
-            {
-                "format": 241,
-                "name": "KASHMiR",
-                "score": 0
-            },
-            {
-                "format": 240,
-                "name": "WMING",
-                "score": 0
-            },
-            {
-                "format": 239,
-                "name": "playHD",
-                "score": 0
-            },
-            {
-                "format": 238,
-                "name": "E.N.D",
-                "score": 0
-            },
-            {
-                "format": 237,
-                "name": "GutS",
-                "score": 0
-            },
-            {
-                "format": 236,
-                "name": "BV",
-                "score": 0
-            },
-            {
-                "format": 235,
-                "name": "SiMPLE",
-                "score": 0
-            },
-            {
-                "format": 234,
-                "name": "W4NK3R",
-                "score": 0
-            },
-            {
-                "format": 233,
-                "name": "GS88",
-                "score": 0
-            },
-            {
-                "format": 232,
-                "name": "HiP",
-                "score": 0
-            },
-            {
-                "format": 231,
-                "name": "GALAXY",
-                "score": 0
-            },
-            {
-                "format": 230,
-                "name": "luvBB",
-                "score": 0
-            },
-            {
-                "format": 229,
-                "name": "NyHD",
-                "score": 0
-            },
-            {
-                "format": 228,
-                "name": "ZIMBO",
-                "score": 0
-            },
-            {
-                "format": 227,
-                "name": "ThD",
-                "score": 0
-            },
-            {
-                "format": 226,
-                "name": "SaNcTi",
-                "score": 0
-            },
-            {
-                "format": 225,
-                "name": "ORiGEN",
-                "score": 0
-            },
-            {
-                "format": 224,
-                "name": "Positive",
-                "score": 0
-            },
-            {
-                "format": 223,
-                "name": "ESiR",
-                "score": 0
-            },
-            {
-                "format": 222,
-                "name": "Chotab",
-                "score": 0
-            },
-            {
-                "format": 221,
-                "name": "xander",
-                "score": 0
-            },
-            {
-                "format": 220,
-                "name": "FTW-HD",
-                "score": 0
-            },
-            {
-                "format": 219,
-                "name": "Penumbra",
-                "score": 0
-            },
-            {
-                "format": 218,
-                "name": "TDD",
-                "score": 0
-            },
-            {
-                "format": 217,
-                "name": "Dariush SD",
-                "score": 30
-            },
-            {
-                "format": 216,
-                "name": "PTer",
-                "score": 0
-            },
-            {
-                "format": 215,
-                "name": "SbR",
-                "score": 0
-            },
-            {
-                "format": 214,
-                "name": "nmd",
-                "score": 0
-            },
-            {
-                "format": 213,
-                "name": "TBB",
-                "score": 0
-            },
-            {
-                "format": 212,
-                "name": "EA",
-                "score": 0
-            },
-            {
-                "format": 211,
-                "name": "BMF",
-                "score": 0
-            },
-            {
-                "format": 210,
-                "name": "LolHD",
-                "score": 0
-            },
-            {
-                "format": 209,
-                "name": "HDMaNiAcS",
-                "score": 0
-            },
-            {
-                "format": 208,
-                "name": "IDE",
-                "score": 0
-            },
-            {
-                "format": 207,
-                "name": "de[42]",
-                "score": 0
-            },
-            {
-                "format": 206,
-                "name": "NCmt",
-                "score": 0
-            },
-            {
-                "format": 205,
-                "name": "decibeL",
-                "score": 0
-            },
-            {
-                "format": 204,
-                "name": "NTb",
-                "score": 0
-            },
-            {
-                "format": 203,
-                "name": "CRiSC",
-                "score": 0
-            },
-            {
-                "format": 202,
-                "name": "SA89",
-                "score": 0
-            },
-            {
-                "format": 201,
-                "name": "HiDt",
-                "score": 0
-            },
-            {
-                "format": 200,
-                "name": "FoRM",
-                "score": 0
-            },
-            {
-                "format": 199,
-                "name": "HiFi",
-                "score": 0
-            },
-            {
-                "format": 198,
-                "name": "CtrlHD",
-                "score": 0
-            },
-            {
-                "format": 197,
-                "name": "VietHD",
-                "score": 0
-            },
-            {
-                "format": 196,
-                "name": "ZQ",
-                "score": 0
-            },
-            {
-                "format": 195,
-                "name": "TayTo",
-                "score": 0
-            },
-            {
-                "format": 194,
-                "name": "Geek",
-                "score": 0
-            },
-            {
-                "format": 193,
-                "name": "EbP",
-                "score": 0
-            },
-            {
-                "format": 192,
-                "name": "DON",
-                "score": 0
-            },
-            {
-                "format": 191,
-                "name": "D-Z0N3",
-                "score": 0
-            },
-            {
-                "format": 340,
-                "name": "Upscaled",
-                "score": -9999
-            }
+        "allowed": true,
+        "id": 1000
+      },
+      {
+        "quality": {
+          "id": 2,
+          "name": "DVD",
+          "source": "dvd",
+          "resolution": 0,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": true
+      },
+      {
+        "quality": {
+          "id": 23,
+          "name": "DVD-R",
+          "source": "dvd",
+          "resolution": 480,
+          "modifier": "remux"
+        },
+        "items": [],
+        "allowed": true
+      },
+      {
+        "quality": {
+          "id": 20,
+          "name": "Bluray-480p",
+          "source": "bluray",
+          "resolution": 480,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 21,
+          "name": "Bluray-576p",
+          "source": "bluray",
+          "resolution": 576,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 4,
+          "name": "HDTV-720p",
+          "source": "tv",
+          "resolution": 720,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "name": "WEB 720p",
+        "items": [
+          {
+            "quality": {
+              "id": 14,
+              "name": "WEBRip-720p",
+              "source": "webrip",
+              "resolution": 720,
+              "modifier": "none"
+            },
+            "items": [],
+            "allowed": false
+          },
+          {
+            "quality": {
+              "id": 5,
+              "name": "WEBDL-720p",
+              "source": "webdl",
+              "resolution": 720,
+              "modifier": "none"
+            },
+            "items": [],
+            "allowed": false
+          }
         ],
-        "language": {
-            "id": -2,
-            "name": "Original"
-        }
+        "allowed": false,
+        "id": 1001
+      },
+      {
+        "quality": {
+          "id": 6,
+          "name": "Bluray-720p",
+          "source": "bluray",
+          "resolution": 720,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 9,
+          "name": "HDTV-1080p",
+          "source": "tv",
+          "resolution": 1080,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 15,
+          "name": "WEBRip-1080p",
+          "source": "webrip",
+          "resolution": 1080,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 7,
+          "name": "Bluray-1080p",
+          "source": "bluray",
+          "resolution": 1080,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 16,
+          "name": "HDTV-2160p",
+          "source": "tv",
+          "resolution": 2160,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 17,
+          "name": "WEBRip-2160p",
+          "source": "webrip",
+          "resolution": 2160,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 19,
+          "name": "Bluray-2160p",
+          "source": "bluray",
+          "resolution": 2160,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 3,
+          "name": "WEBDL-1080p",
+          "source": "webdl",
+          "resolution": 1080,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": true
+      },
+      {
+        "quality": {
+          "id": 18,
+          "name": "WEBDL-2160p",
+          "source": "webdl",
+          "resolution": 2160,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": true
+      },
+      {
+        "quality": {
+          "id": 30,
+          "name": "Remux-1080p",
+          "source": "bluray",
+          "resolution": 1080,
+          "modifier": "remux"
+        },
+        "items": [],
+        "allowed": true
+      },
+      {
+        "quality": {
+          "id": 31,
+          "name": "Remux-2160p",
+          "source": "bluray",
+          "resolution": 2160,
+          "modifier": "remux"
+        },
+        "items": [],
+        "allowed": true
+      },
+      {
+        "quality": {
+          "id": 22,
+          "name": "BR-DISK",
+          "source": "bluray",
+          "resolution": 1080,
+          "modifier": "brdisk"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 10,
+          "name": "Raw-HD",
+          "source": "tv",
+          "resolution": 1080,
+          "modifier": "rawhd"
+        },
+        "items": [],
+        "allowed": false
+      }
+    ],
+    "minFormatScore": 0,
+    "cutoffFormatScore": 350,
+    "minUpgradeFormatScore": 1,
+    "formatItems": [
+      {
+        "format": 353,
+        "name": "BHDStudio (1080p x265)",
+        "score": 0
+      },
+      {
+        "format": 352,
+        "name": "E1",
+        "score": 0
+      },
+      {
+        "format": 351,
+        "name": "2160p x265",
+        "score": 0
+      },
+      {
+        "format": 349,
+        "name": "EXCiSiON",
+        "score": 0
+      },
+      {
+        "format": 348,
+        "name": "Unwanted x265 Groups",
+        "score": 0
+      },
+      {
+        "format": 347,
+        "name": "CRX",
+        "score": 0
+      },
+      {
+        "format": 346,
+        "name": "HDR10 (Missing) (x265 HDR only)",
+        "score": 0
+      },
+      {
+        "format": 345,
+        "name": "UHD Bluray",
+        "score": 0
+      },
+      {
+        "format": 344,
+        "name": "jennaortegaUHD",
+        "score": -9999
+      },
+      {
+        "format": 342,
+        "name": "Freeleech25",
+        "score": 0
+      },
+      {
+        "format": 341,
+        "name": "Freeleech50",
+        "score": 0
+      },
+      {
+        "format": 340,
+        "name": "Freeleech75",
+        "score": 0
+      },
+      {
+        "format": 339,
+        "name": "Freeleech100",
+        "score": 0
+      },
+      {
+        "format": 338,
+        "name": "TEST FLAC",
+        "score": 0
+      },
+      {
+        "format": 337,
+        "name": "h265 (4k)",
+        "score": 0
+      },
+      {
+        "format": 336,
+        "name": "MAX",
+        "score": 0
+      },
+      {
+        "format": 335,
+        "name": "Blu-Ray (Remux)",
+        "score": 60
+      },
+      {
+        "format": 334,
+        "name": "PCM",
+        "score": 30
+      },
+      {
+        "format": 333,
+        "name": "h265",
+        "score": 0
+      },
+      {
+        "format": 331,
+        "name": "Golden Popcorn 720p",
+        "score": 0
+      },
+      {
+        "format": 330,
+        "name": "LQ",
+        "score": -9999
+      },
+      {
+        "format": 329,
+        "name": "EPSiLON",
+        "score": 0
+      },
+      {
+        "format": 328,
+        "name": "playBD",
+        "score": 0
+      },
+      {
+        "format": 327,
+        "name": "BLURANiUM",
+        "score": 0
+      },
+      {
+        "format": 326,
+        "name": "PmP",
+        "score": 0
+      },
+      {
+        "format": 325,
+        "name": "WiLDCAT",
+        "score": 0
+      },
+      {
+        "format": 324,
+        "name": "TRiToN",
+        "score": 0
+      },
+      {
+        "format": 323,
+        "name": "3L",
+        "score": 0
+      },
+      {
+        "format": 322,
+        "name": "Dolby Vision w/out Fallback",
+        "score": -9999
+      },
+      {
+        "format": 321,
+        "name": "UHDBits",
+        "score": -9999
+      },
+      {
+        "format": 318,
+        "name": "ATMOS (Missing)",
+        "score": 10
+      },
+      {
+        "format": 317,
+        "name": "TrueHD (Missing)",
+        "score": 50
+      },
+      {
+        "format": 316,
+        "name": "HDR10 (Missing)",
+        "score": 10
+      },
+      {
+        "format": 315,
+        "name": "HDR10",
+        "score": 10
+      },
+      {
+        "format": 314,
+        "name": "Dolby Vision",
+        "score": 30
+      },
+      {
+        "format": 312,
+        "name": "HDR10+",
+        "score": 20
+      },
+      {
+        "format": 308,
+        "name": "Stream Optimised",
+        "score": 0
+      },
+      {
+        "format": 307,
+        "name": "LoRD",
+        "score": 0
+      },
+      {
+        "format": 306,
+        "name": "Scene",
+        "score": 0
+      },
+      {
+        "format": 303,
+        "name": "mHD",
+        "score": 0
+      },
+      {
+        "format": 302,
+        "name": "AV1",
+        "score": -9999
+      },
+      {
+        "format": 301,
+        "name": "VVC",
+        "score": -9999
+      },
+      {
+        "format": 300,
+        "name": "Extras",
+        "score": -9999
+      },
+      {
+        "format": 298,
+        "name": "480p",
+        "score": 0
+      },
+      {
+        "format": 297,
+        "name": "Dariush ",
+        "score": 0
+      },
+      {
+        "format": 296,
+        "name": "TBB SD",
+        "score": 30
+      },
+      {
+        "format": 295,
+        "name": "Xvid",
+        "score": 0
+      },
+      {
+        "format": 294,
+        "name": "DVD",
+        "score": 0
+      },
+      {
+        "format": 293,
+        "name": "DVD REMUX ",
+        "score": 40
+      },
+      {
+        "format": 292,
+        "name": "HANDJOB SD",
+        "score": 20
+      },
+      {
+        "format": 291,
+        "name": "iTunes (Missing)",
+        "score": 10
+      },
+      {
+        "format": 290,
+        "name": "ROKU",
+        "score": 20
+      },
+      {
+        "format": 289,
+        "name": "BeyondHD",
+        "score": 0
+      },
+      {
+        "format": 288,
+        "name": "Disc ",
+        "score": -9999
+      },
+      {
+        "format": 287,
+        "name": "3D",
+        "score": -9999
+      },
+      {
+        "format": 286,
+        "name": "Unwanted",
+        "score": -9999
+      },
+      {
+        "format": 285,
+        "name": "HDBits Internal",
+        "score": 0
+      },
+      {
+        "format": 284,
+        "name": "RightSIZE",
+        "score": 0
+      },
+      {
+        "format": 283,
+        "name": "Black and White",
+        "score": -9999
+      },
+      {
+        "format": 281,
+        "name": "TrueHD",
+        "score": 50
+      },
+      {
+        "format": 280,
+        "name": "DTS-X",
+        "score": 60
+      },
+      {
+        "format": 279,
+        "name": "FLAC",
+        "score": 30
+      },
+      {
+        "format": 278,
+        "name": "DTS-HD MA",
+        "score": 50
+      },
+      {
+        "format": 276,
+        "name": "x265",
+        "score": -9999
+      },
+      {
+        "format": 275,
+        "name": "Golden Popcorn SD",
+        "score": 30
+      },
+      {
+        "format": 274,
+        "name": "Golden Popcorn 1080p",
+        "score": 0
+      },
+      {
+        "format": 273,
+        "name": "IMAX",
+        "score": 10
+      },
+      {
+        "format": 272,
+        "name": "ATMOS",
+        "score": 10
+      },
+      {
+        "format": 271,
+        "name": "DD",
+        "score": 0
+      },
+      {
+        "format": 270,
+        "name": "DTS",
+        "score": 0
+      },
+      {
+        "format": 269,
+        "name": "DD+",
+        "score": 0
+      },
+      {
+        "format": 268,
+        "name": "iTunes",
+        "score": 10
+      },
+      {
+        "format": 267,
+        "name": "Paramount+",
+        "score": 20
+      },
+      {
+        "format": 266,
+        "name": "Peacock TV",
+        "score": 20
+      },
+      {
+        "format": 265,
+        "name": "Hulu",
+        "score": 20
+      },
+      {
+        "format": 264,
+        "name": "Netflix",
+        "score": 30
+      },
+      {
+        "format": 263,
+        "name": "HBO Max",
+        "score": 30
+      },
+      {
+        "format": 262,
+        "name": "Disney+",
+        "score": 30
+      },
+      {
+        "format": 261,
+        "name": "Apple TV+",
+        "score": 40
+      },
+      {
+        "format": 260,
+        "name": "Movies Anywhere",
+        "score": 50
+      },
+      {
+        "format": 259,
+        "name": "Amazon Prime",
+        "score": 40
+      },
+      {
+        "format": 258,
+        "name": "REMUX",
+        "score": 60
+      },
+      {
+        "format": 256,
+        "name": "x264",
+        "score": 10
+      },
+      {
+        "format": 255,
+        "name": "WEBRip",
+        "score": -9999
+      },
+      {
+        "format": 254,
+        "name": "Blu-Ray",
+        "score": 60
+      },
+      {
+        "format": 253,
+        "name": "2160p",
+        "score": 120
+      },
+      {
+        "format": 252,
+        "name": "720p",
+        "score": -9999
+      },
+      {
+        "format": 250,
+        "name": "1080p",
+        "score": 60
+      },
+      {
+        "format": 249,
+        "name": "BHDStudio",
+        "score": 0
+      },
+      {
+        "format": 248,
+        "name": "LEGi0N",
+        "score": 0
+      },
+      {
+        "format": 247,
+        "name": "FraMeSToR",
+        "score": 0
+      },
+      {
+        "format": 246,
+        "name": "iFT",
+        "score": 0
+      },
+      {
+        "format": 245,
+        "name": "MTeam",
+        "score": 0
+      },
+      {
+        "format": 244,
+        "name": "EDPH",
+        "score": 0
+      },
+      {
+        "format": 243,
+        "name": "HANDJOB",
+        "score": 0
+      },
+      {
+        "format": 242,
+        "name": "c0ke",
+        "score": 0
+      },
+      {
+        "format": 241,
+        "name": "KASHMiR",
+        "score": 0
+      },
+      {
+        "format": 240,
+        "name": "WMING",
+        "score": 0
+      },
+      {
+        "format": 239,
+        "name": "playHD",
+        "score": 0
+      },
+      {
+        "format": 238,
+        "name": "E.N.D",
+        "score": 0
+      },
+      {
+        "format": 237,
+        "name": "GutS",
+        "score": 0
+      },
+      {
+        "format": 236,
+        "name": "BV",
+        "score": 0
+      },
+      {
+        "format": 235,
+        "name": "SiMPLE",
+        "score": 0
+      },
+      {
+        "format": 234,
+        "name": "W4NK3R",
+        "score": 0
+      },
+      {
+        "format": 233,
+        "name": "GS88",
+        "score": 0
+      },
+      {
+        "format": 232,
+        "name": "HiP",
+        "score": 0
+      },
+      {
+        "format": 231,
+        "name": "GALAXY",
+        "score": 0
+      },
+      {
+        "format": 230,
+        "name": "luvBB",
+        "score": 0
+      },
+      {
+        "format": 229,
+        "name": "NyHD",
+        "score": 0
+      },
+      {
+        "format": 228,
+        "name": "ZIMBO",
+        "score": 0
+      },
+      {
+        "format": 227,
+        "name": "ThD",
+        "score": 0
+      },
+      {
+        "format": 226,
+        "name": "SaNcTi",
+        "score": 0
+      },
+      {
+        "format": 225,
+        "name": "ORiGEN",
+        "score": 0
+      },
+      {
+        "format": 224,
+        "name": "Positive",
+        "score": 0
+      },
+      {
+        "format": 223,
+        "name": "ESiR",
+        "score": 0
+      },
+      {
+        "format": 222,
+        "name": "Chotab",
+        "score": 0
+      },
+      {
+        "format": 221,
+        "name": "xander",
+        "score": 0
+      },
+      {
+        "format": 220,
+        "name": "FTW-HD",
+        "score": 0
+      },
+      {
+        "format": 219,
+        "name": "Penumbra",
+        "score": 0
+      },
+      {
+        "format": 218,
+        "name": "TDD",
+        "score": 0
+      },
+      {
+        "format": 217,
+        "name": "Dariush SD",
+        "score": 30
+      },
+      {
+        "format": 216,
+        "name": "PTer",
+        "score": 0
+      },
+      {
+        "format": 215,
+        "name": "SbR",
+        "score": 0
+      },
+      {
+        "format": 214,
+        "name": "nmd",
+        "score": 0
+      },
+      {
+        "format": 213,
+        "name": "TBB",
+        "score": 0
+      },
+      {
+        "format": 212,
+        "name": "EA",
+        "score": 0
+      },
+      {
+        "format": 211,
+        "name": "BMF",
+        "score": 0
+      },
+      {
+        "format": 210,
+        "name": "LolHD",
+        "score": 0
+      },
+      {
+        "format": 209,
+        "name": "HDMaNiAcS",
+        "score": 0
+      },
+      {
+        "format": 208,
+        "name": "IDE",
+        "score": 0
+      },
+      {
+        "format": 207,
+        "name": "de[42]",
+        "score": 0
+      },
+      {
+        "format": 206,
+        "name": "NCmt",
+        "score": 0
+      },
+      {
+        "format": 205,
+        "name": "decibeL",
+        "score": 0
+      },
+      {
+        "format": 204,
+        "name": "NTb",
+        "score": 0
+      },
+      {
+        "format": 203,
+        "name": "CRiSC",
+        "score": 0
+      },
+      {
+        "format": 202,
+        "name": "SA89",
+        "score": 0
+      },
+      {
+        "format": 201,
+        "name": "HiDt",
+        "score": 0
+      },
+      {
+        "format": 200,
+        "name": "FoRM",
+        "score": 0
+      },
+      {
+        "format": 199,
+        "name": "HiFi",
+        "score": 0
+      },
+      {
+        "format": 198,
+        "name": "CtrlHD",
+        "score": 0
+      },
+      {
+        "format": 197,
+        "name": "VietHD",
+        "score": 0
+      },
+      {
+        "format": 196,
+        "name": "ZQ",
+        "score": 0
+      },
+      {
+        "format": 195,
+        "name": "TayTo",
+        "score": 0
+      },
+      {
+        "format": 194,
+        "name": "Geek",
+        "score": 0
+      },
+      {
+        "format": 193,
+        "name": "EbP",
+        "score": 0
+      },
+      {
+        "format": 192,
+        "name": "DON",
+        "score": 0
+      },
+      {
+        "format": 191,
+        "name": "D-Z0N3",
+        "score": 0
+      },
+      {
+        "format": 340,
+        "name": "Upscaled",
+        "score": -9999
+      }
+    ],
+    "language": {
+      "id": -2,
+      "name": "Original"
     }
+  }
 ]

--- a/imports/quality_profiles/radarr/Balanced (HEVC) [Beta] (radarr - master).json
+++ b/imports/quality_profiles/radarr/Balanced (HEVC) [Beta] (radarr - master).json
@@ -1,1215 +1,1216 @@
 [
-    {
-        "name": "Balanced (HEVC) [Beta]",
-        "upgradeAllowed": true,
-        "cutoff": 1004,
+  {
+    "name": "Balanced (HEVC) [Beta]",
+    "upgradeAllowed": true,
+    "cutoff": 1004,
+    "items": [
+      {
+        "quality": {
+          "id": 24,
+          "name": "WORKPRINT",
+          "source": "workprint",
+          "resolution": 0,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 29,
+          "name": "REGIONAL",
+          "source": "dvd",
+          "resolution": 480,
+          "modifier": "regional"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 28,
+          "name": "DVDSCR",
+          "source": "dvd",
+          "resolution": 480,
+          "modifier": "screener"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 1,
+          "name": "SDTV",
+          "source": "tv",
+          "resolution": 480,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 12,
+          "name": "WEBRip-480p",
+          "source": "webrip",
+          "resolution": 480,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 4,
+          "name": "HDTV-720p",
+          "source": "tv",
+          "resolution": 720,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "name": "WEB 720p",
         "items": [
-            {
-                "quality": {
-                    "id": 24,
-                    "name": "WORKPRINT",
-                    "source": "workprint",
-                    "resolution": 0,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
+          {
+            "quality": {
+              "id": 5,
+              "name": "WEBDL-720p",
+              "source": "webdl",
+              "resolution": 720,
+              "modifier": "none"
             },
-            {
-                "quality": {
-                    "id": 29,
-                    "name": "REGIONAL",
-                    "source": "dvd",
-                    "resolution": 480,
-                    "modifier": "regional"
-                },
-                "items": [],
-                "allowed": false
+            "items": [],
+            "allowed": false
+          },
+          {
+            "quality": {
+              "id": 14,
+              "name": "WEBRip-720p",
+              "source": "webrip",
+              "resolution": 720,
+              "modifier": "none"
             },
-            {
-                "quality": {
-                    "id": 28,
-                    "name": "DVDSCR",
-                    "source": "dvd",
-                    "resolution": 480,
-                    "modifier": "screener"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 1,
-                    "name": "SDTV",
-                    "source": "tv",
-                    "resolution": 480,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 12,
-                    "name": "WEBRip-480p",
-                    "source": "webrip",
-                    "resolution": 480,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 4,
-                    "name": "HDTV-720p",
-                    "source": "tv",
-                    "resolution": 720,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "name": "WEB 720p",
-                "items": [
-                    {
-                        "quality": {
-                            "id": 5,
-                            "name": "WEBDL-720p",
-                            "source": "webdl",
-                            "resolution": 720,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": false
-                    },
-                    {
-                        "quality": {
-                            "id": 14,
-                            "name": "WEBRip-720p",
-                            "source": "webrip",
-                            "resolution": 720,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": false
-                    }
-                ],
-                "allowed": false,
-                "id": 1001
-            },
-            {
-                "quality": {
-                    "id": 6,
-                    "name": "Bluray-720p",
-                    "source": "bluray",
-                    "resolution": 720,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 0,
-                    "name": "Unknown",
-                    "source": "unknown",
-                    "resolution": 0,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "name": "Else",
-                "items": [
-                    {
-                        "quality": {
-                            "id": 25,
-                            "name": "CAM",
-                            "source": "cam",
-                            "resolution": 0,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": true
-                    },
-                    {
-                        "quality": {
-                            "id": 26,
-                            "name": "TELESYNC",
-                            "source": "telesync",
-                            "resolution": 0,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": true
-                    },
-                    {
-                        "quality": {
-                            "id": 27,
-                            "name": "TELECINE",
-                            "source": "telecine",
-                            "resolution": 0,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": true
-                    },
-                    {
-                        "quality": {
-                            "id": 2,
-                            "name": "DVD",
-                            "source": "dvd",
-                            "resolution": 0,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": true
-                    },
-                    {
-                        "quality": {
-                            "id": 23,
-                            "name": "DVD-R",
-                            "source": "dvd",
-                            "resolution": 480,
-                            "modifier": "remux"
-                        },
-                        "items": [],
-                        "allowed": true
-                    },
-                    {
-                        "quality": {
-                            "id": 8,
-                            "name": "WEBDL-480p",
-                            "source": "webdl",
-                            "resolution": 480,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": true
-                    },
-                    {
-                        "quality": {
-                            "id": 20,
-                            "name": "Bluray-480p",
-                            "source": "bluray",
-                            "resolution": 480,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": true
-                    },
-                    {
-                        "quality": {
-                            "id": 21,
-                            "name": "Bluray-576p",
-                            "source": "bluray",
-                            "resolution": 576,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": true
-                    },
-                    {
-                        "quality": {
-                            "id": 9,
-                            "name": "HDTV-1080p",
-                            "source": "tv",
-                            "resolution": 1080,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": true
-                    }
-                ],
-                "allowed": true,
-                "id": 1005
-            },
-            {
-                "quality": {
-                    "id": 30,
-                    "name": "Remux-1080p",
-                    "source": "bluray",
-                    "resolution": 1080,
-                    "modifier": "remux"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "name": "Balanced Capable",
-                "items": [
-                    {
-                        "quality": {
-                            "id": 15,
-                            "name": "WEBRip-1080p",
-                            "source": "webrip",
-                            "resolution": 1080,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": true
-                    },
-                    {
-                        "quality": {
-                            "id": 7,
-                            "name": "Bluray-1080p",
-                            "source": "bluray",
-                            "resolution": 1080,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": true
-                    },
-                    {
-                        "quality": {
-                            "id": 3,
-                            "name": "WEBDL-1080p",
-                            "source": "webdl",
-                            "resolution": 1080,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": true
-                    }
-                ],
-                "allowed": true,
-                "id": 1004
-            },
-            {
-                "quality": {
-                    "id": 16,
-                    "name": "HDTV-2160p",
-                    "source": "tv",
-                    "resolution": 2160,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "name": "WEB 2160p",
-                "items": [
-                    {
-                        "quality": {
-                            "id": 18,
-                            "name": "WEBDL-2160p",
-                            "source": "webdl",
-                            "resolution": 2160,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": false
-                    },
-                    {
-                        "quality": {
-                            "id": 17,
-                            "name": "WEBRip-2160p",
-                            "source": "webrip",
-                            "resolution": 2160,
-                            "modifier": "none"
-                        },
-                        "items": [],
-                        "allowed": false
-                    }
-                ],
-                "allowed": false,
-                "id": 1003
-            },
-            {
-                "quality": {
-                    "id": 19,
-                    "name": "Bluray-2160p",
-                    "source": "bluray",
-                    "resolution": 2160,
-                    "modifier": "none"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 31,
-                    "name": "Remux-2160p",
-                    "source": "bluray",
-                    "resolution": 2160,
-                    "modifier": "remux"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 22,
-                    "name": "BR-DISK",
-                    "source": "bluray",
-                    "resolution": 1080,
-                    "modifier": "brdisk"
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 10,
-                    "name": "Raw-HD",
-                    "source": "tv",
-                    "resolution": 1080,
-                    "modifier": "rawhd"
-                },
-                "items": [],
-                "allowed": false
-            }
+            "items": [],
+            "allowed": false
+          }
         ],
-        "minFormatScore": 0,
-        "cutoffFormatScore": 520,
-        "formatItems": [
-            {
-                "format": 373,
-                "name": "Tigole",
-                "score": 500
-            },
-            {
-                "format": 372,
-                "name": "x265 (Missing)",
-                "score": -500
-            },
-            {
-                "format": 371,
-                "name": "edge2020",
-                "score": 500
-            },
-            {
-                "format": 370,
-                "name": "x265 (Web)",
-                "score": -9999
-            },
-            {
-                "format": 369,
-                "name": "MainFrame",
-                "score": 700
-            },
-            {
-                "format": 368,
-                "name": "LEGi0N (x265)",
-                "score": 500
-            },
-            {
-                "format": 367,
-                "name": "SEV",
-                "score": 500
-            },
-            {
-                "format": 366,
-                "name": "LSt",
-                "score": 700
-            },
-            {
-                "format": 365,
-                "name": "AnoZu",
-                "score": 500
-            },
-            {
-                "format": 364,
-                "name": "dkore",
-                "score": 680
-            },
-            {
-                "format": 363,
-                "name": "R1GY3B / B3YG1R",
-                "score": -9999
-            },
-            {
-                "format": 362,
-                "name": "QxR",
-                "score": 680
-            },
-            {
-                "format": 361,
-                "name": "Ralphy",
-                "score": 680
-            },
-            {
-                "format": 360,
-                "name": "Vyndros",
-                "score": 680
-            },
-            {
-                "format": 359,
-                "name": "TAoE",
-                "score": 680
-            },
-            {
-                "format": 358,
-                "name": "GRiMM",
-                "score": 680
-            },
-            {
-                "format": 357,
-                "name": "Chivaman",
-                "score": 700
-            },
-            {
-                "format": 356,
-                "name": "TimeDistortion",
-                "score": 680
-            },
-            {
-                "format": 355,
-                "name": "NAN0",
-                "score": 780
-            },
-            {
-                "format": 354,
-                "name": "HONE",
-                "score": 780
-            },
-            {
-                "format": 353,
-                "name": "BHDStudio (1080p x265)",
-                "score": 0
-            },
-            {
-                "format": 352,
-                "name": "E1",
-                "score": 0
-            },
-            {
-                "format": 351,
-                "name": "2160p x265",
-                "score": 0
-            },
-            {
-                "format": 349,
-                "name": "EXCiSiON",
-                "score": 0
-            },
-            {
-                "format": 348,
-                "name": "Unwanted x265 Groups",
-                "score": 0
-            },
-            {
-                "format": 347,
-                "name": "CRX",
-                "score": 0
-            },
-            {
-                "format": 346,
-                "name": "HDR10 (Missing) (x265 HDR only)",
-                "score": 0
-            },
-            {
-                "format": 345,
-                "name": "UHD Bluray",
-                "score": 0
-            },
-            {
-                "format": 344,
-                "name": "jennaortegaUHD",
-                "score": 0
-            },
-            {
-                "format": 342,
-                "name": "Freeleech25",
-                "score": 0
-            },
-            {
-                "format": 341,
-                "name": "Freeleech50",
-                "score": 0
-            },
-            {
-                "format": 340,
-                "name": "Freeleech75",
-                "score": 0
-            },
-            {
-                "format": 339,
-                "name": "Freeleech100",
-                "score": 0
-            },
-            {
-                "format": 338,
-                "name": "TEST FLAC",
-                "score": 0
-            },
-            {
-                "format": 337,
-                "name": "h265 (4k)",
-                "score": 0
-            },
-            {
-                "format": 336,
-                "name": "MAX",
-                "score": 0
-            },
-            {
-                "format": 335,
-                "name": "Blu-Ray (Remux)",
-                "score": 0
-            },
-            {
-                "format": 334,
-                "name": "PCM",
-                "score": 0
-            },
-            {
-                "format": 333,
-                "name": "h265",
-                "score": 60
-            },
-            {
-                "format": 331,
-                "name": "Golden Popcorn 720p",
-                "score": 0
-            },
-            {
-                "format": 330,
-                "name": "LQ",
-                "score": 0
-            },
-            {
-                "format": 329,
-                "name": "EPSiLON",
-                "score": 0
-            },
-            {
-                "format": 328,
-                "name": "playBD",
-                "score": 0
-            },
-            {
-                "format": 327,
-                "name": "BLURANiUM",
-                "score": 0
-            },
-            {
-                "format": 326,
-                "name": "PmP",
-                "score": 0
-            },
-            {
-                "format": 325,
-                "name": "WiLDCAT",
-                "score": 0
-            },
-            {
-                "format": 324,
-                "name": "TRiToN",
-                "score": 0
-            },
-            {
-                "format": 323,
-                "name": "3L",
-                "score": 0
-            },
-            {
-                "format": 322,
-                "name": "Dolby Vision w/out Fallback",
-                "score": -9999
-            },
-            {
-                "format": 321,
-                "name": "UHDBits",
-                "score": 0
-            },
-            {
-                "format": 318,
-                "name": "ATMOS (Missing)",
-                "score": 0
-            },
-            {
-                "format": 317,
-                "name": "TrueHD (Missing)",
-                "score": 0
-            },
-            {
-                "format": 316,
-                "name": "HDR10 (Missing)",
-                "score": -9999
-            },
-            {
-                "format": 315,
-                "name": "HDR10",
-                "score": -9999
-            },
-            {
-                "format": 314,
-                "name": "Dolby Vision",
-                "score": -9999
-            },
-            {
-                "format": 312,
-                "name": "HDR10+",
-                "score": -9999
-            },
-            {
-                "format": 308,
-                "name": "Stream Optimised",
-                "score": 80
-            },
-            {
-                "format": 307,
-                "name": "LoRD",
-                "score": 30
-            },
-            {
-                "format": 306,
-                "name": "Scene",
-                "score": 20
-            },
-            {
-                "format": 303,
-                "name": "mHD",
-                "score": -99999
-            },
-            {
-                "format": 302,
-                "name": "AV1",
-                "score": -9999
-            },
-            {
-                "format": 301,
-                "name": "VVC",
-                "score": -9999
-            },
-            {
-                "format": 300,
-                "name": "Extras",
-                "score": -9999
-            },
-            {
-                "format": 298,
-                "name": "480p",
-                "score": 0
-            },
-            {
-                "format": 297,
-                "name": "Dariush ",
-                "score": 30
-            },
-            {
-                "format": 296,
-                "name": "TBB SD",
-                "score": 30
-            },
-            {
-                "format": 295,
-                "name": "Xvid",
-                "score": 0
-            },
-            {
-                "format": 294,
-                "name": "DVD",
-                "score": 0
-            },
-            {
-                "format": 293,
-                "name": "DVD REMUX ",
-                "score": 40
-            },
-            {
-                "format": 292,
-                "name": "HANDJOB SD",
-                "score": 20
-            },
-            {
-                "format": 291,
-                "name": "iTunes (Missing)",
-                "score": 90
-            },
-            {
-                "format": 290,
-                "name": "ROKU",
-                "score": 190
-            },
-            {
-                "format": 289,
-                "name": "BeyondHD",
-                "score": -9999
-            },
-            {
-                "format": 288,
-                "name": "Disc ",
-                "score": -9999
-            },
-            {
-                "format": 287,
-                "name": "3D",
-                "score": -9999
-            },
-            {
-                "format": 286,
-                "name": "Unwanted",
-                "score": -9999
-            },
-            {
-                "format": 285,
-                "name": "HDBits Internal",
-                "score": 30
-            },
-            {
-                "format": 284,
-                "name": "RightSIZE",
-                "score": 30
-            },
-            {
-                "format": 283,
-                "name": "Black and White",
-                "score": -9999
-            },
-            {
-                "format": 281,
-                "name": "TrueHD",
-                "score": -9999
-            },
-            {
-                "format": 280,
-                "name": "DTS-X",
-                "score": -9999
-            },
-            {
-                "format": 279,
-                "name": "FLAC",
-                "score": 0
-            },
-            {
-                "format": 278,
-                "name": "DTS-HD MA",
-                "score": -9999
-            },
-            {
-                "format": 276,
-                "name": "x265",
-                "score": -500
-            },
-            {
-                "format": 275,
-                "name": "Golden Popcorn SD",
-                "score": 30
-            },
-            {
-                "format": 274,
-                "name": "Golden Popcorn 1080p",
-                "score": 80
-            },
-            {
-                "format": 273,
-                "name": "IMAX",
-                "score": 10
-            },
-            {
-                "format": 272,
-                "name": "ATMOS",
-                "score": 10
-            },
-            {
-                "format": 271,
-                "name": "DD",
-                "score": 0
-            },
-            {
-                "format": 270,
-                "name": "DTS",
-                "score": 0
-            },
-            {
-                "format": 269,
-                "name": "DD+",
-                "score": 0
-            },
-            {
-                "format": 268,
-                "name": "iTunes",
-                "score": 90
-            },
-            {
-                "format": 267,
-                "name": "Paramount+",
-                "score": 190
-            },
-            {
-                "format": 266,
-                "name": "Peacock TV",
-                "score": 190
-            },
-            {
-                "format": 265,
-                "name": "Hulu",
-                "score": 190
-            },
-            {
-                "format": 264,
-                "name": "Netflix",
-                "score": 200
-            },
-            {
-                "format": 263,
-                "name": "HBO Max",
-                "score": 200
-            },
-            {
-                "format": 262,
-                "name": "Disney+",
-                "score": 200
-            },
-            {
-                "format": 261,
-                "name": "Apple TV+",
-                "score": 210
-            },
-            {
-                "format": 260,
-                "name": "Movies Anywhere",
-                "score": 220
-            },
-            {
-                "format": 259,
-                "name": "Amazon Prime",
-                "score": 210
-            },
-            {
-                "format": 258,
-                "name": "REMUX",
-                "score": -9999
-            },
-            {
-                "format": 256,
-                "name": "x264",
-                "score": 10
-            },
-            {
-                "format": 255,
-                "name": "WEBRip",
-                "score": 10
-            },
-            {
-                "format": 254,
-                "name": "Blu-Ray",
-                "score": 10
-            },
-            {
-                "format": 253,
-                "name": "2160p",
-                "score": -9999
-            },
-            {
-                "format": 252,
-                "name": "720p",
-                "score": -9999
-            },
-            {
-                "format": 250,
-                "name": "1080p",
-                "score": 220
-            },
-            {
-                "format": 249,
-                "name": "BHDStudio",
-                "score": 90
-            },
-            {
-                "format": 248,
-                "name": "LEGi0N",
-                "score": 20
-            },
-            {
-                "format": 247,
-                "name": "FraMeSToR",
-                "score": 20
-            },
-            {
-                "format": 246,
-                "name": "iFT",
-                "score": 30
-            },
-            {
-                "format": 245,
-                "name": "MTeam",
-                "score": -9999
-            },
-            {
-                "format": 244,
-                "name": "EDPH",
-                "score": 20
-            },
-            {
-                "format": 243,
-                "name": "HANDJOB",
-                "score": 20
-            },
-            {
-                "format": 242,
-                "name": "c0ke",
-                "score": 70
-            },
-            {
-                "format": 241,
-                "name": "KASHMiR",
-                "score": 30
-            },
-            {
-                "format": 240,
-                "name": "WMING",
-                "score": 30
-            },
-            {
-                "format": 239,
-                "name": "playHD",
-                "score": 30
-            },
-            {
-                "format": 238,
-                "name": "E.N.D",
-                "score": 30
-            },
-            {
-                "format": 237,
-                "name": "GutS",
-                "score": 30
-            },
-            {
-                "format": 236,
-                "name": "BV",
-                "score": 30
-            },
-            {
-                "format": 235,
-                "name": "SiMPLE",
-                "score": 30
-            },
-            {
-                "format": 234,
-                "name": "W4NK3R",
-                "score": 30
-            },
-            {
-                "format": 233,
-                "name": "GS88",
-                "score": 30
-            },
-            {
-                "format": 232,
-                "name": "HiP",
-                "score": 40
-            },
-            {
-                "format": 231,
-                "name": "GALAXY",
-                "score": 30
-            },
-            {
-                "format": 230,
-                "name": "luvBB",
-                "score": 30
-            },
-            {
-                "format": 229,
-                "name": "NyHD",
-                "score": 30
-            },
-            {
-                "format": 228,
-                "name": "ZIMBO",
-                "score": 30
-            },
-            {
-                "format": 227,
-                "name": "ThD",
-                "score": 30
-            },
-            {
-                "format": 226,
-                "name": "SaNcTi",
-                "score": 30
-            },
-            {
-                "format": 225,
-                "name": "ORiGEN",
-                "score": 30
-            },
-            {
-                "format": 224,
-                "name": "Positive",
-                "score": 30
-            },
-            {
-                "format": 223,
-                "name": "ESiR",
-                "score": 30
-            },
-            {
-                "format": 222,
-                "name": "Chotab",
-                "score": 30
-            },
-            {
-                "format": 221,
-                "name": "xander",
-                "score": 30
-            },
-            {
-                "format": 220,
-                "name": "FTW-HD",
-                "score": 30
-            },
-            {
-                "format": 219,
-                "name": "Penumbra",
-                "score": 30
-            },
-            {
-                "format": 218,
-                "name": "TDD",
-                "score": 30
-            },
-            {
-                "format": 217,
-                "name": "Dariush SD",
-                "score": 30
-            },
-            {
-                "format": 216,
-                "name": "PTer",
-                "score": 30
-            },
-            {
-                "format": 215,
-                "name": "SbR",
-                "score": 30
-            },
-            {
-                "format": 214,
-                "name": "nmd",
-                "score": 30
-            },
-            {
-                "format": 213,
-                "name": "TBB",
-                "score": 30
-            },
-            {
-                "format": 212,
-                "name": "EA",
-                "score": 40
-            },
-            {
-                "format": 211,
-                "name": "BMF",
-                "score": 40
-            },
-            {
-                "format": 210,
-                "name": "LolHD",
-                "score": 40
-            },
-            {
-                "format": 209,
-                "name": "HDMaNiAcS",
-                "score": 40
-            },
-            {
-                "format": 208,
-                "name": "IDE",
-                "score": 40
-            },
-            {
-                "format": 207,
-                "name": "de[42]",
-                "score": 50
-            },
-            {
-                "format": 206,
-                "name": "NCmt",
-                "score": 60
-            },
-            {
-                "format": 205,
-                "name": "decibeL",
-                "score": 50
-            },
-            {
-                "format": 204,
-                "name": "NTb",
-                "score": 40
-            },
-            {
-                "format": 203,
-                "name": "CRiSC",
-                "score": 50
-            },
-            {
-                "format": 202,
-                "name": "SA89",
-                "score": 60
-            },
-            {
-                "format": 201,
-                "name": "HiDt",
-                "score": 60
-            },
-            {
-                "format": 200,
-                "name": "FoRM",
-                "score": 60
-            },
-            {
-                "format": 199,
-                "name": "HiFi",
-                "score": 60
-            },
-            {
-                "format": 198,
-                "name": "CtrlHD",
-                "score": 60
-            },
-            {
-                "format": 197,
-                "name": "VietHD",
-                "score": 70
-            },
-            {
-                "format": 196,
-                "name": "ZQ",
-                "score": 70
-            },
-            {
-                "format": 195,
-                "name": "TayTo",
-                "score": 70
-            },
-            {
-                "format": 194,
-                "name": "Geek",
-                "score": 70
-            },
-            {
-                "format": 193,
-                "name": "EbP",
-                "score": 80
-            },
-            {
-                "format": 192,
-                "name": "DON",
-                "score": 80
-            },
-            {
-                "format": 191,
-                "name": "D-Z0N3",
-                "score": 80
-            },
-            {
-                "format": 340,
-                "name": "Upscaled",
-                "score": -9999
-            }
+        "allowed": false,
+        "id": 1001
+      },
+      {
+        "quality": {
+          "id": 6,
+          "name": "Bluray-720p",
+          "source": "bluray",
+          "resolution": 720,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 0,
+          "name": "Unknown",
+          "source": "unknown",
+          "resolution": 0,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "name": "Else",
+        "items": [
+          {
+            "quality": {
+              "id": 25,
+              "name": "CAM",
+              "source": "cam",
+              "resolution": 0,
+              "modifier": "none"
+            },
+            "items": [],
+            "allowed": true
+          },
+          {
+            "quality": {
+              "id": 26,
+              "name": "TELESYNC",
+              "source": "telesync",
+              "resolution": 0,
+              "modifier": "none"
+            },
+            "items": [],
+            "allowed": true
+          },
+          {
+            "quality": {
+              "id": 27,
+              "name": "TELECINE",
+              "source": "telecine",
+              "resolution": 0,
+              "modifier": "none"
+            },
+            "items": [],
+            "allowed": true
+          },
+          {
+            "quality": {
+              "id": 2,
+              "name": "DVD",
+              "source": "dvd",
+              "resolution": 0,
+              "modifier": "none"
+            },
+            "items": [],
+            "allowed": true
+          },
+          {
+            "quality": {
+              "id": 23,
+              "name": "DVD-R",
+              "source": "dvd",
+              "resolution": 480,
+              "modifier": "remux"
+            },
+            "items": [],
+            "allowed": true
+          },
+          {
+            "quality": {
+              "id": 8,
+              "name": "WEBDL-480p",
+              "source": "webdl",
+              "resolution": 480,
+              "modifier": "none"
+            },
+            "items": [],
+            "allowed": true
+          },
+          {
+            "quality": {
+              "id": 20,
+              "name": "Bluray-480p",
+              "source": "bluray",
+              "resolution": 480,
+              "modifier": "none"
+            },
+            "items": [],
+            "allowed": true
+          },
+          {
+            "quality": {
+              "id": 21,
+              "name": "Bluray-576p",
+              "source": "bluray",
+              "resolution": 576,
+              "modifier": "none"
+            },
+            "items": [],
+            "allowed": true
+          },
+          {
+            "quality": {
+              "id": 9,
+              "name": "HDTV-1080p",
+              "source": "tv",
+              "resolution": 1080,
+              "modifier": "none"
+            },
+            "items": [],
+            "allowed": true
+          }
         ],
-        "language": {
-            "id": 1,
-            "name": "English"
-        }
+        "allowed": true,
+        "id": 1005
+      },
+      {
+        "quality": {
+          "id": 30,
+          "name": "Remux-1080p",
+          "source": "bluray",
+          "resolution": 1080,
+          "modifier": "remux"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "name": "Balanced Capable",
+        "items": [
+          {
+            "quality": {
+              "id": 15,
+              "name": "WEBRip-1080p",
+              "source": "webrip",
+              "resolution": 1080,
+              "modifier": "none"
+            },
+            "items": [],
+            "allowed": true
+          },
+          {
+            "quality": {
+              "id": 7,
+              "name": "Bluray-1080p",
+              "source": "bluray",
+              "resolution": 1080,
+              "modifier": "none"
+            },
+            "items": [],
+            "allowed": true
+          },
+          {
+            "quality": {
+              "id": 3,
+              "name": "WEBDL-1080p",
+              "source": "webdl",
+              "resolution": 1080,
+              "modifier": "none"
+            },
+            "items": [],
+            "allowed": true
+          }
+        ],
+        "allowed": true,
+        "id": 1004
+      },
+      {
+        "quality": {
+          "id": 16,
+          "name": "HDTV-2160p",
+          "source": "tv",
+          "resolution": 2160,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "name": "WEB 2160p",
+        "items": [
+          {
+            "quality": {
+              "id": 18,
+              "name": "WEBDL-2160p",
+              "source": "webdl",
+              "resolution": 2160,
+              "modifier": "none"
+            },
+            "items": [],
+            "allowed": false
+          },
+          {
+            "quality": {
+              "id": 17,
+              "name": "WEBRip-2160p",
+              "source": "webrip",
+              "resolution": 2160,
+              "modifier": "none"
+            },
+            "items": [],
+            "allowed": false
+          }
+        ],
+        "allowed": false,
+        "id": 1003
+      },
+      {
+        "quality": {
+          "id": 19,
+          "name": "Bluray-2160p",
+          "source": "bluray",
+          "resolution": 2160,
+          "modifier": "none"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 31,
+          "name": "Remux-2160p",
+          "source": "bluray",
+          "resolution": 2160,
+          "modifier": "remux"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 22,
+          "name": "BR-DISK",
+          "source": "bluray",
+          "resolution": 1080,
+          "modifier": "brdisk"
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 10,
+          "name": "Raw-HD",
+          "source": "tv",
+          "resolution": 1080,
+          "modifier": "rawhd"
+        },
+        "items": [],
+        "allowed": false
+      }
+    ],
+    "minFormatScore": 0,
+    "cutoffFormatScore": 520,
+    "minUpgradeFormatScore": 1,
+    "formatItems": [
+      {
+        "format": 373,
+        "name": "Tigole",
+        "score": 500
+      },
+      {
+        "format": 372,
+        "name": "x265 (Missing)",
+        "score": -500
+      },
+      {
+        "format": 371,
+        "name": "edge2020",
+        "score": 500
+      },
+      {
+        "format": 370,
+        "name": "x265 (Web)",
+        "score": -9999
+      },
+      {
+        "format": 369,
+        "name": "MainFrame",
+        "score": 700
+      },
+      {
+        "format": 368,
+        "name": "LEGi0N (x265)",
+        "score": 500
+      },
+      {
+        "format": 367,
+        "name": "SEV",
+        "score": 500
+      },
+      {
+        "format": 366,
+        "name": "LSt",
+        "score": 700
+      },
+      {
+        "format": 365,
+        "name": "AnoZu",
+        "score": 500
+      },
+      {
+        "format": 364,
+        "name": "dkore",
+        "score": 680
+      },
+      {
+        "format": 363,
+        "name": "R1GY3B / B3YG1R",
+        "score": -9999
+      },
+      {
+        "format": 362,
+        "name": "QxR",
+        "score": 680
+      },
+      {
+        "format": 361,
+        "name": "Ralphy",
+        "score": 680
+      },
+      {
+        "format": 360,
+        "name": "Vyndros",
+        "score": 680
+      },
+      {
+        "format": 359,
+        "name": "TAoE",
+        "score": 680
+      },
+      {
+        "format": 358,
+        "name": "GRiMM",
+        "score": 680
+      },
+      {
+        "format": 357,
+        "name": "Chivaman",
+        "score": 700
+      },
+      {
+        "format": 356,
+        "name": "TimeDistortion",
+        "score": 680
+      },
+      {
+        "format": 355,
+        "name": "NAN0",
+        "score": 780
+      },
+      {
+        "format": 354,
+        "name": "HONE",
+        "score": 780
+      },
+      {
+        "format": 353,
+        "name": "BHDStudio (1080p x265)",
+        "score": 0
+      },
+      {
+        "format": 352,
+        "name": "E1",
+        "score": 0
+      },
+      {
+        "format": 351,
+        "name": "2160p x265",
+        "score": 0
+      },
+      {
+        "format": 349,
+        "name": "EXCiSiON",
+        "score": 0
+      },
+      {
+        "format": 348,
+        "name": "Unwanted x265 Groups",
+        "score": 0
+      },
+      {
+        "format": 347,
+        "name": "CRX",
+        "score": 0
+      },
+      {
+        "format": 346,
+        "name": "HDR10 (Missing) (x265 HDR only)",
+        "score": 0
+      },
+      {
+        "format": 345,
+        "name": "UHD Bluray",
+        "score": 0
+      },
+      {
+        "format": 344,
+        "name": "jennaortegaUHD",
+        "score": 0
+      },
+      {
+        "format": 342,
+        "name": "Freeleech25",
+        "score": 0
+      },
+      {
+        "format": 341,
+        "name": "Freeleech50",
+        "score": 0
+      },
+      {
+        "format": 340,
+        "name": "Freeleech75",
+        "score": 0
+      },
+      {
+        "format": 339,
+        "name": "Freeleech100",
+        "score": 0
+      },
+      {
+        "format": 338,
+        "name": "TEST FLAC",
+        "score": 0
+      },
+      {
+        "format": 337,
+        "name": "h265 (4k)",
+        "score": 0
+      },
+      {
+        "format": 336,
+        "name": "MAX",
+        "score": 0
+      },
+      {
+        "format": 335,
+        "name": "Blu-Ray (Remux)",
+        "score": 0
+      },
+      {
+        "format": 334,
+        "name": "PCM",
+        "score": 0
+      },
+      {
+        "format": 333,
+        "name": "h265",
+        "score": 60
+      },
+      {
+        "format": 331,
+        "name": "Golden Popcorn 720p",
+        "score": 0
+      },
+      {
+        "format": 330,
+        "name": "LQ",
+        "score": 0
+      },
+      {
+        "format": 329,
+        "name": "EPSiLON",
+        "score": 0
+      },
+      {
+        "format": 328,
+        "name": "playBD",
+        "score": 0
+      },
+      {
+        "format": 327,
+        "name": "BLURANiUM",
+        "score": 0
+      },
+      {
+        "format": 326,
+        "name": "PmP",
+        "score": 0
+      },
+      {
+        "format": 325,
+        "name": "WiLDCAT",
+        "score": 0
+      },
+      {
+        "format": 324,
+        "name": "TRiToN",
+        "score": 0
+      },
+      {
+        "format": 323,
+        "name": "3L",
+        "score": 0
+      },
+      {
+        "format": 322,
+        "name": "Dolby Vision w/out Fallback",
+        "score": -9999
+      },
+      {
+        "format": 321,
+        "name": "UHDBits",
+        "score": 0
+      },
+      {
+        "format": 318,
+        "name": "ATMOS (Missing)",
+        "score": 0
+      },
+      {
+        "format": 317,
+        "name": "TrueHD (Missing)",
+        "score": 0
+      },
+      {
+        "format": 316,
+        "name": "HDR10 (Missing)",
+        "score": -9999
+      },
+      {
+        "format": 315,
+        "name": "HDR10",
+        "score": -9999
+      },
+      {
+        "format": 314,
+        "name": "Dolby Vision",
+        "score": -9999
+      },
+      {
+        "format": 312,
+        "name": "HDR10+",
+        "score": -9999
+      },
+      {
+        "format": 308,
+        "name": "Stream Optimised",
+        "score": 80
+      },
+      {
+        "format": 307,
+        "name": "LoRD",
+        "score": 30
+      },
+      {
+        "format": 306,
+        "name": "Scene",
+        "score": 20
+      },
+      {
+        "format": 303,
+        "name": "mHD",
+        "score": -99999
+      },
+      {
+        "format": 302,
+        "name": "AV1",
+        "score": -9999
+      },
+      {
+        "format": 301,
+        "name": "VVC",
+        "score": -9999
+      },
+      {
+        "format": 300,
+        "name": "Extras",
+        "score": -9999
+      },
+      {
+        "format": 298,
+        "name": "480p",
+        "score": 0
+      },
+      {
+        "format": 297,
+        "name": "Dariush ",
+        "score": 30
+      },
+      {
+        "format": 296,
+        "name": "TBB SD",
+        "score": 30
+      },
+      {
+        "format": 295,
+        "name": "Xvid",
+        "score": 0
+      },
+      {
+        "format": 294,
+        "name": "DVD",
+        "score": 0
+      },
+      {
+        "format": 293,
+        "name": "DVD REMUX ",
+        "score": 40
+      },
+      {
+        "format": 292,
+        "name": "HANDJOB SD",
+        "score": 20
+      },
+      {
+        "format": 291,
+        "name": "iTunes (Missing)",
+        "score": 90
+      },
+      {
+        "format": 290,
+        "name": "ROKU",
+        "score": 190
+      },
+      {
+        "format": 289,
+        "name": "BeyondHD",
+        "score": -9999
+      },
+      {
+        "format": 288,
+        "name": "Disc ",
+        "score": -9999
+      },
+      {
+        "format": 287,
+        "name": "3D",
+        "score": -9999
+      },
+      {
+        "format": 286,
+        "name": "Unwanted",
+        "score": -9999
+      },
+      {
+        "format": 285,
+        "name": "HDBits Internal",
+        "score": 30
+      },
+      {
+        "format": 284,
+        "name": "RightSIZE",
+        "score": 30
+      },
+      {
+        "format": 283,
+        "name": "Black and White",
+        "score": -9999
+      },
+      {
+        "format": 281,
+        "name": "TrueHD",
+        "score": -9999
+      },
+      {
+        "format": 280,
+        "name": "DTS-X",
+        "score": -9999
+      },
+      {
+        "format": 279,
+        "name": "FLAC",
+        "score": 0
+      },
+      {
+        "format": 278,
+        "name": "DTS-HD MA",
+        "score": -9999
+      },
+      {
+        "format": 276,
+        "name": "x265",
+        "score": -500
+      },
+      {
+        "format": 275,
+        "name": "Golden Popcorn SD",
+        "score": 30
+      },
+      {
+        "format": 274,
+        "name": "Golden Popcorn 1080p",
+        "score": 80
+      },
+      {
+        "format": 273,
+        "name": "IMAX",
+        "score": 10
+      },
+      {
+        "format": 272,
+        "name": "ATMOS",
+        "score": 10
+      },
+      {
+        "format": 271,
+        "name": "DD",
+        "score": 0
+      },
+      {
+        "format": 270,
+        "name": "DTS",
+        "score": 0
+      },
+      {
+        "format": 269,
+        "name": "DD+",
+        "score": 0
+      },
+      {
+        "format": 268,
+        "name": "iTunes",
+        "score": 90
+      },
+      {
+        "format": 267,
+        "name": "Paramount+",
+        "score": 190
+      },
+      {
+        "format": 266,
+        "name": "Peacock TV",
+        "score": 190
+      },
+      {
+        "format": 265,
+        "name": "Hulu",
+        "score": 190
+      },
+      {
+        "format": 264,
+        "name": "Netflix",
+        "score": 200
+      },
+      {
+        "format": 263,
+        "name": "HBO Max",
+        "score": 200
+      },
+      {
+        "format": 262,
+        "name": "Disney+",
+        "score": 200
+      },
+      {
+        "format": 261,
+        "name": "Apple TV+",
+        "score": 210
+      },
+      {
+        "format": 260,
+        "name": "Movies Anywhere",
+        "score": 220
+      },
+      {
+        "format": 259,
+        "name": "Amazon Prime",
+        "score": 210
+      },
+      {
+        "format": 258,
+        "name": "REMUX",
+        "score": -9999
+      },
+      {
+        "format": 256,
+        "name": "x264",
+        "score": 10
+      },
+      {
+        "format": 255,
+        "name": "WEBRip",
+        "score": 10
+      },
+      {
+        "format": 254,
+        "name": "Blu-Ray",
+        "score": 10
+      },
+      {
+        "format": 253,
+        "name": "2160p",
+        "score": -9999
+      },
+      {
+        "format": 252,
+        "name": "720p",
+        "score": -9999
+      },
+      {
+        "format": 250,
+        "name": "1080p",
+        "score": 220
+      },
+      {
+        "format": 249,
+        "name": "BHDStudio",
+        "score": 90
+      },
+      {
+        "format": 248,
+        "name": "LEGi0N",
+        "score": 20
+      },
+      {
+        "format": 247,
+        "name": "FraMeSToR",
+        "score": 20
+      },
+      {
+        "format": 246,
+        "name": "iFT",
+        "score": 30
+      },
+      {
+        "format": 245,
+        "name": "MTeam",
+        "score": -9999
+      },
+      {
+        "format": 244,
+        "name": "EDPH",
+        "score": 20
+      },
+      {
+        "format": 243,
+        "name": "HANDJOB",
+        "score": 20
+      },
+      {
+        "format": 242,
+        "name": "c0ke",
+        "score": 70
+      },
+      {
+        "format": 241,
+        "name": "KASHMiR",
+        "score": 30
+      },
+      {
+        "format": 240,
+        "name": "WMING",
+        "score": 30
+      },
+      {
+        "format": 239,
+        "name": "playHD",
+        "score": 30
+      },
+      {
+        "format": 238,
+        "name": "E.N.D",
+        "score": 30
+      },
+      {
+        "format": 237,
+        "name": "GutS",
+        "score": 30
+      },
+      {
+        "format": 236,
+        "name": "BV",
+        "score": 30
+      },
+      {
+        "format": 235,
+        "name": "SiMPLE",
+        "score": 30
+      },
+      {
+        "format": 234,
+        "name": "W4NK3R",
+        "score": 30
+      },
+      {
+        "format": 233,
+        "name": "GS88",
+        "score": 30
+      },
+      {
+        "format": 232,
+        "name": "HiP",
+        "score": 40
+      },
+      {
+        "format": 231,
+        "name": "GALAXY",
+        "score": 30
+      },
+      {
+        "format": 230,
+        "name": "luvBB",
+        "score": 30
+      },
+      {
+        "format": 229,
+        "name": "NyHD",
+        "score": 30
+      },
+      {
+        "format": 228,
+        "name": "ZIMBO",
+        "score": 30
+      },
+      {
+        "format": 227,
+        "name": "ThD",
+        "score": 30
+      },
+      {
+        "format": 226,
+        "name": "SaNcTi",
+        "score": 30
+      },
+      {
+        "format": 225,
+        "name": "ORiGEN",
+        "score": 30
+      },
+      {
+        "format": 224,
+        "name": "Positive",
+        "score": 30
+      },
+      {
+        "format": 223,
+        "name": "ESiR",
+        "score": 30
+      },
+      {
+        "format": 222,
+        "name": "Chotab",
+        "score": 30
+      },
+      {
+        "format": 221,
+        "name": "xander",
+        "score": 30
+      },
+      {
+        "format": 220,
+        "name": "FTW-HD",
+        "score": 30
+      },
+      {
+        "format": 219,
+        "name": "Penumbra",
+        "score": 30
+      },
+      {
+        "format": 218,
+        "name": "TDD",
+        "score": 30
+      },
+      {
+        "format": 217,
+        "name": "Dariush SD",
+        "score": 30
+      },
+      {
+        "format": 216,
+        "name": "PTer",
+        "score": 30
+      },
+      {
+        "format": 215,
+        "name": "SbR",
+        "score": 30
+      },
+      {
+        "format": 214,
+        "name": "nmd",
+        "score": 30
+      },
+      {
+        "format": 213,
+        "name": "TBB",
+        "score": 30
+      },
+      {
+        "format": 212,
+        "name": "EA",
+        "score": 40
+      },
+      {
+        "format": 211,
+        "name": "BMF",
+        "score": 40
+      },
+      {
+        "format": 210,
+        "name": "LolHD",
+        "score": 40
+      },
+      {
+        "format": 209,
+        "name": "HDMaNiAcS",
+        "score": 40
+      },
+      {
+        "format": 208,
+        "name": "IDE",
+        "score": 40
+      },
+      {
+        "format": 207,
+        "name": "de[42]",
+        "score": 50
+      },
+      {
+        "format": 206,
+        "name": "NCmt",
+        "score": 60
+      },
+      {
+        "format": 205,
+        "name": "decibeL",
+        "score": 50
+      },
+      {
+        "format": 204,
+        "name": "NTb",
+        "score": 40
+      },
+      {
+        "format": 203,
+        "name": "CRiSC",
+        "score": 50
+      },
+      {
+        "format": 202,
+        "name": "SA89",
+        "score": 60
+      },
+      {
+        "format": 201,
+        "name": "HiDt",
+        "score": 60
+      },
+      {
+        "format": 200,
+        "name": "FoRM",
+        "score": 60
+      },
+      {
+        "format": 199,
+        "name": "HiFi",
+        "score": 60
+      },
+      {
+        "format": 198,
+        "name": "CtrlHD",
+        "score": 60
+      },
+      {
+        "format": 197,
+        "name": "VietHD",
+        "score": 70
+      },
+      {
+        "format": 196,
+        "name": "ZQ",
+        "score": 70
+      },
+      {
+        "format": 195,
+        "name": "TayTo",
+        "score": 70
+      },
+      {
+        "format": 194,
+        "name": "Geek",
+        "score": 70
+      },
+      {
+        "format": 193,
+        "name": "EbP",
+        "score": 80
+      },
+      {
+        "format": 192,
+        "name": "DON",
+        "score": 80
+      },
+      {
+        "format": 191,
+        "name": "D-Z0N3",
+        "score": 80
+      },
+      {
+        "format": 340,
+        "name": "Upscaled",
+        "score": -9999
+      }
+    ],
+    "language": {
+      "id": 1,
+      "name": "English"
     }
+  }
 ]

--- a/imports/quality_profiles/sonarr/1080p Balanced (sonarr - master).json
+++ b/imports/quality_profiles/sonarr/1080p Balanced (sonarr - master).json
@@ -1,932 +1,933 @@
 [
-    {
-        "name": "1080p Balanced",
-        "upgradeAllowed": true,
-        "cutoff": 1001,
+  {
+    "name": "1080p Balanced",
+    "upgradeAllowed": true,
+    "cutoff": 1001,
+    "items": [
+      {
+        "quality": {
+          "id": 0,
+          "name": "Unknown",
+          "source": "unknown",
+          "resolution": 0
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 13,
+          "name": "Bluray-480p",
+          "source": "bluray",
+          "resolution": 480
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 4,
+          "name": "HDTV-720p",
+          "source": "television",
+          "resolution": 720
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 14,
+          "name": "WEBRip-720p",
+          "source": "webRip",
+          "resolution": 720
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 5,
+          "name": "WEBDL-720p",
+          "source": "web",
+          "resolution": 720
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 6,
+          "name": "Bluray-720p",
+          "source": "bluray",
+          "resolution": 720
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "name": "Else",
         "items": [
-            {
-                "quality": {
-                    "id": 0,
-                    "name": "Unknown",
-                    "source": "unknown",
-                    "resolution": 0
-                },
-                "items": [],
-                "allowed": false
+          {
+            "quality": {
+              "id": 1,
+              "name": "SDTV",
+              "source": "television",
+              "resolution": 480
             },
-            {
-                "quality": {
-                    "id": 13,
-                    "name": "Bluray-480p",
-                    "source": "bluray",
-                    "resolution": 480
-                },
-                "items": [],
-                "allowed": false
+            "items": [],
+            "allowed": true
+          },
+          {
+            "quality": {
+              "id": 12,
+              "name": "WEBRip-480p",
+              "source": "webRip",
+              "resolution": 480
             },
-            {
-                "quality": {
-                    "id": 4,
-                    "name": "HDTV-720p",
-                    "source": "television",
-                    "resolution": 720
-                },
-                "items": [],
-                "allowed": false
+            "items": [],
+            "allowed": true
+          },
+          {
+            "quality": {
+              "id": 8,
+              "name": "WEBDL-480p",
+              "source": "web",
+              "resolution": 480
             },
-            {
-                "quality": {
-                    "id": 14,
-                    "name": "WEBRip-720p",
-                    "source": "webRip",
-                    "resolution": 720
-                },
-                "items": [],
-                "allowed": false
+            "items": [],
+            "allowed": true
+          },
+          {
+            "quality": {
+              "id": 2,
+              "name": "DVD",
+              "source": "dvd",
+              "resolution": 480
             },
-            {
-                "quality": {
-                    "id": 5,
-                    "name": "WEBDL-720p",
-                    "source": "web",
-                    "resolution": 720
-                },
-                "items": [],
-                "allowed": false
+            "items": [],
+            "allowed": true
+          },
+          {
+            "quality": {
+              "id": 10,
+              "name": "Raw-HD",
+              "source": "televisionRaw",
+              "resolution": 1080
             },
-            {
-                "quality": {
-                    "id": 6,
-                    "name": "Bluray-720p",
-                    "source": "bluray",
-                    "resolution": 720
-                },
-                "items": [],
-                "allowed": false
+            "items": [],
+            "allowed": true
+          },
+          {
+            "quality": {
+              "id": 9,
+              "name": "HDTV-1080p",
+              "source": "television",
+              "resolution": 1080
             },
-            {
-                "name": "Else",
-                "items": [
-                    {
-                        "quality": {
-                            "id": 1,
-                            "name": "SDTV",
-                            "source": "television",
-                            "resolution": 480
-                        },
-                        "items": [],
-                        "allowed": true
-                    },
-                    {
-                        "quality": {
-                            "id": 12,
-                            "name": "WEBRip-480p",
-                            "source": "webRip",
-                            "resolution": 480
-                        },
-                        "items": [],
-                        "allowed": true
-                    },
-                    {
-                        "quality": {
-                            "id": 8,
-                            "name": "WEBDL-480p",
-                            "source": "web",
-                            "resolution": 480
-                        },
-                        "items": [],
-                        "allowed": true
-                    },
-                    {
-                        "quality": {
-                            "id": 2,
-                            "name": "DVD",
-                            "source": "dvd",
-                            "resolution": 480
-                        },
-                        "items": [],
-                        "allowed": true
-                    },
-                    {
-                        "quality": {
-                            "id": 10,
-                            "name": "Raw-HD",
-                            "source": "televisionRaw",
-                            "resolution": 1080
-                        },
-                        "items": [],
-                        "allowed": true
-                    },
-                    {
-                        "quality": {
-                            "id": 9,
-                            "name": "HDTV-1080p",
-                            "source": "television",
-                            "resolution": 1080
-                        },
-                        "items": [],
-                        "allowed": true
-                    }
-                ],
-                "allowed": true,
-                "id": 1002
-            },
-            {
-                "name": "Balanced Capable",
-                "items": [
-                    {
-                        "quality": {
-                            "id": 3,
-                            "name": "WEBDL-1080p",
-                            "source": "web",
-                            "resolution": 1080
-                        },
-                        "items": [],
-                        "allowed": true
-                    },
-                    {
-                        "quality": {
-                            "id": 15,
-                            "name": "WEBRip-1080p",
-                            "source": "webRip",
-                            "resolution": 1080
-                        },
-                        "items": [],
-                        "allowed": true
-                    },
-                    {
-                        "quality": {
-                            "id": 7,
-                            "name": "Bluray-1080p",
-                            "source": "bluray",
-                            "resolution": 1080
-                        },
-                        "items": [],
-                        "allowed": true
-                    }
-                ],
-                "allowed": true,
-                "id": 1001
-            },
-            {
-                "quality": {
-                    "id": 20,
-                    "name": "Bluray-1080p Remux",
-                    "source": "blurayRaw",
-                    "resolution": 1080
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 16,
-                    "name": "HDTV-2160p",
-                    "source": "television",
-                    "resolution": 2160
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 17,
-                    "name": "WEBRip-2160p",
-                    "source": "webRip",
-                    "resolution": 2160
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 19,
-                    "name": "Bluray-2160p",
-                    "source": "bluray",
-                    "resolution": 2160
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 18,
-                    "name": "WEBDL-2160p",
-                    "source": "web",
-                    "resolution": 2160
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 21,
-                    "name": "Bluray-2160p Remux",
-                    "source": "blurayRaw",
-                    "resolution": 2160
-                },
-                "items": [],
-                "allowed": false
-            }
+            "items": [],
+            "allowed": true
+          }
         ],
-        "minFormatScore": 0,
-        "cutoffFormatScore": 500,
-        "formatItems": [
-            {
-                "format": 229,
-                "name": "HR",
-                "score": 30
-            },
-            {
-                "format": 228,
-                "name": "MAX",
-                "score": 0
-            },
-            {
-                "format": 227,
-                "name": "h265 (4k)",
-                "score": 0
-            },
-            {
-                "format": 226,
-                "name": "PCM",
-                "score": 0
-            },
-            {
-                "format": 225,
-                "name": "Blu-Ray (Remux)",
-                "score": 0
-            },
-            {
-                "format": 224,
-                "name": "h265",
-                "score": -9999
-            },
-            {
-                "format": 214,
-                "name": "LQ",
-                "score": 0
-            },
-            {
-                "format": 213,
-                "name": "EPSiLON",
-                "score": 0
-            },
-            {
-                "format": 212,
-                "name": "playBD",
-                "score": 0
-            },
-            {
-                "format": 211,
-                "name": "BLURANiUM",
-                "score": 0
-            },
-            {
-                "format": 210,
-                "name": "PmP",
-                "score": 0
-            },
-            {
-                "format": 209,
-                "name": "WiLDCAT",
-                "score": 0
-            },
-            {
-                "format": 208,
-                "name": "TRiToN",
-                "score": 0
-            },
-            {
-                "format": 207,
-                "name": "3L",
-                "score": 0
-            },
-            {
-                "format": 206,
-                "name": "Dolby Vision w/out Fallback",
-                "score": 0
-            },
-            {
-                "format": 205,
-                "name": "UHDBits",
-                "score": 0
-            },
-            {
-                "format": 204,
-                "name": "ATMOS (Missing)",
-                "score": 0
-            },
-            {
-                "format": 203,
-                "name": "TrueHD (Missing)",
-                "score": 0
-            },
-            {
-                "format": 202,
-                "name": "HDR10 (Missing)",
-                "score": 0
-            },
-            {
-                "format": 201,
-                "name": "HDR10",
-                "score": 0
-            },
-            {
-                "format": 200,
-                "name": "Dolby Vision",
-                "score": 0
-            },
-            {
-                "format": 199,
-                "name": "HDR10+",
-                "score": 0
-            },
-            {
-                "format": 198,
-                "name": "Stream Optimised",
-                "score": 80
-            },
-            {
-                "format": 197,
-                "name": "LoRD",
-                "score": 30
-            },
-            {
-                "format": 196,
-                "name": "Scene",
-                "score": 20
-            },
-            {
-                "format": 195,
-                "name": "mHD",
-                "score": -99999
-            },
-            {
-                "format": 194,
-                "name": "AV1",
-                "score": -9999
-            },
-            {
-                "format": 193,
-                "name": "VVC",
-                "score": -9999
-            },
-            {
-                "format": 192,
-                "name": "Extras",
-                "score": -9999
-            },
-            {
-                "format": 191,
-                "name": "480p",
-                "score": 0
-            },
-            {
-                "format": 190,
-                "name": "Dariush ",
-                "score": 30
-            },
-            {
-                "format": 189,
-                "name": "TBB SD",
-                "score": 30
-            },
-            {
-                "format": 188,
-                "name": "Xvid",
-                "score": 0
-            },
-            {
-                "format": 187,
-                "name": "DVD",
-                "score": 0
-            },
-            {
-                "format": 186,
-                "name": "DVD REMUX ",
-                "score": 40
-            },
-            {
-                "format": 185,
-                "name": "HANDJOB SD",
-                "score": 20
-            },
-            {
-                "format": 184,
-                "name": "iTunes (Missing)",
-                "score": 90
-            },
-            {
-                "format": 183,
-                "name": "ROKU",
-                "score": 190
-            },
-            {
-                "format": 182,
-                "name": "BeyondHD",
-                "score": -9999
-            },
-            {
-                "format": 181,
-                "name": "Disc ",
-                "score": -9999
-            },
-            {
-                "format": 180,
-                "name": "3D",
-                "score": -9999
-            },
-            {
-                "format": 179,
-                "name": "Unwanted",
-                "score": -9999
-            },
-            {
-                "format": 178,
-                "name": "RightSIZE",
-                "score": 30
-            },
-            {
-                "format": 177,
-                "name": "Black and White",
-                "score": -9999
-            },
-            {
-                "format": 176,
-                "name": "TrueHD",
-                "score": -9999
-            },
-            {
-                "format": 175,
-                "name": "DTS-X",
-                "score": -9999
-            },
-            {
-                "format": 174,
-                "name": "FLAC",
-                "score": 0
-            },
-            {
-                "format": 173,
-                "name": "DTS-HD MA",
-                "score": -9999
-            },
-            {
-                "format": 172,
-                "name": "x265",
-                "score": -9999
-            },
-            {
-                "format": 171,
-                "name": "IMAX",
-                "score": 10
-            },
-            {
-                "format": 170,
-                "name": "ATMOS",
-                "score": 10
-            },
-            {
-                "format": 169,
-                "name": "DD",
-                "score": 0
-            },
-            {
-                "format": 168,
-                "name": "DTS",
-                "score": 0
-            },
-            {
-                "format": 167,
-                "name": "DD+",
-                "score": 0
-            },
-            {
-                "format": 166,
-                "name": "iTunes",
-                "score": 90
-            },
-            {
-                "format": 165,
-                "name": "Paramount+",
-                "score": 190
-            },
-            {
-                "format": 164,
-                "name": "Peacock TV",
-                "score": 190
-            },
-            {
-                "format": 163,
-                "name": "Hulu",
-                "score": 190
-            },
-            {
-                "format": 162,
-                "name": "Netflix",
-                "score": 200
-            },
-            {
-                "format": 161,
-                "name": "HBO Max",
-                "score": 200
-            },
-            {
-                "format": 160,
-                "name": "Disney+",
-                "score": 200
-            },
-            {
-                "format": 159,
-                "name": "Apple TV+",
-                "score": 210
-            },
-            {
-                "format": 158,
-                "name": "Movies Anywhere",
-                "score": 220
-            },
-            {
-                "format": 157,
-                "name": "Amazon Prime",
-                "score": 210
-            },
-            {
-                "format": 156,
-                "name": "REMUX",
-                "score": -9999
-            },
-            {
-                "format": 155,
-                "name": "x264",
-                "score": 10
-            },
-            {
-                "format": 154,
-                "name": "WEBRip",
-                "score": 10
-            },
-            {
-                "format": 153,
-                "name": "Blu-Ray",
-                "score": 10
-            },
-            {
-                "format": 152,
-                "name": "2160p",
-                "score": -9999
-            },
-            {
-                "format": 151,
-                "name": "720p",
-                "score": -9999
-            },
-            {
-                "format": 150,
-                "name": "1080p",
-                "score": 220
-            },
-            {
-                "format": 149,
-                "name": "BHDStudio",
-                "score": 90
-            },
-            {
-                "format": 148,
-                "name": "LEGi0N",
-                "score": 20
-            },
-            {
-                "format": 147,
-                "name": "FraMeSToR",
-                "score": 20
-            },
-            {
-                "format": 146,
-                "name": "iFT",
-                "score": 30
-            },
-            {
-                "format": 145,
-                "name": "MTeam",
-                "score": -9999
-            },
-            {
-                "format": 144,
-                "name": "EDPH",
-                "score": 20
-            },
-            {
-                "format": 143,
-                "name": "HANDJOB",
-                "score": 20
-            },
-            {
-                "format": 142,
-                "name": "c0ke",
-                "score": 70
-            },
-            {
-                "format": 141,
-                "name": "KASHMiR",
-                "score": 30
-            },
-            {
-                "format": 140,
-                "name": "WMING",
-                "score": 30
-            },
-            {
-                "format": 139,
-                "name": "playHD",
-                "score": 30
-            },
-            {
-                "format": 138,
-                "name": "E.N.D",
-                "score": 30
-            },
-            {
-                "format": 137,
-                "name": "GutS",
-                "score": 30
-            },
-            {
-                "format": 136,
-                "name": "BV",
-                "score": 30
-            },
-            {
-                "format": 135,
-                "name": "SiMPLE",
-                "score": 30
-            },
-            {
-                "format": 134,
-                "name": "W4NK3R",
-                "score": 30
-            },
-            {
-                "format": 133,
-                "name": "GS88",
-                "score": 30
-            },
-            {
-                "format": 132,
-                "name": "HiP",
-                "score": 40
-            },
-            {
-                "format": 131,
-                "name": "GALAXY",
-                "score": 30
-            },
-            {
-                "format": 130,
-                "name": "luvBB",
-                "score": 30
-            },
-            {
-                "format": 129,
-                "name": "NyHD",
-                "score": 30
-            },
-            {
-                "format": 128,
-                "name": "ZIMBO",
-                "score": 30
-            },
-            {
-                "format": 127,
-                "name": "ThD",
-                "score": 30
-            },
-            {
-                "format": 126,
-                "name": "SaNcTi",
-                "score": 30
-            },
-            {
-                "format": 125,
-                "name": "ORiGEN",
-                "score": 30
-            },
-            {
-                "format": 124,
-                "name": "Positive",
-                "score": 30
-            },
-            {
-                "format": 123,
-                "name": "ESiR",
-                "score": 30
-            },
-            {
-                "format": 122,
-                "name": "Chotab",
-                "score": 30
-            },
-            {
-                "format": 121,
-                "name": "xander",
-                "score": 30
-            },
-            {
-                "format": 120,
-                "name": "FTW-HD",
-                "score": 30
-            },
-            {
-                "format": 119,
-                "name": "Penumbra",
-                "score": 30
-            },
-            {
-                "format": 118,
-                "name": "TDD",
-                "score": 30
-            },
-            {
-                "format": 117,
-                "name": "Dariush SD",
-                "score": 30
-            },
-            {
-                "format": 116,
-                "name": "PTer",
-                "score": 30
-            },
-            {
-                "format": 115,
-                "name": "SbR",
-                "score": 30
-            },
-            {
-                "format": 114,
-                "name": "nmd",
-                "score": 30
-            },
-            {
-                "format": 113,
-                "name": "TBB",
-                "score": 30
-            },
-            {
-                "format": 112,
-                "name": "EA",
-                "score": 40
-            },
-            {
-                "format": 111,
-                "name": "BMF",
-                "score": 40
-            },
-            {
-                "format": 110,
-                "name": "LolHD",
-                "score": 40
-            },
-            {
-                "format": 109,
-                "name": "HDMaNiAcS",
-                "score": 40
-            },
-            {
-                "format": 108,
-                "name": "IDE",
-                "score": 40
-            },
-            {
-                "format": 107,
-                "name": "de[42]",
-                "score": 50
-            },
-            {
-                "format": 106,
-                "name": "NCmt",
-                "score": 60
-            },
-            {
-                "format": 105,
-                "name": "decibeL",
-                "score": 50
-            },
-            {
-                "format": 104,
-                "name": "NTb",
-                "score": 40
-            },
-            {
-                "format": 103,
-                "name": "CRiSC",
-                "score": 50
-            },
-            {
-                "format": 102,
-                "name": "SA89",
-                "score": 60
-            },
-            {
-                "format": 101,
-                "name": "HiDt",
-                "score": 60
-            },
-            {
-                "format": 100,
-                "name": "FoRM",
-                "score": 60
-            },
-            {
-                "format": 99,
-                "name": "HiFi",
-                "score": 60
-            },
-            {
-                "format": 98,
-                "name": "CtrlHD",
-                "score": 60
-            },
-            {
-                "format": 97,
-                "name": "VietHD",
-                "score": 70
-            },
-            {
-                "format": 96,
-                "name": "ZQ",
-                "score": 70
-            },
-            {
-                "format": 95,
-                "name": "TayTo",
-                "score": 70
-            },
-            {
-                "format": 94,
-                "name": "Geek",
-                "score": 70
-            },
-            {
-                "format": 93,
-                "name": "EbP",
-                "score": 80
-            },
-            {
-                "format": 92,
-                "name": "DON",
-                "score": 80
-            },
-            {
-                "format": 91,
-                "name": "D-Z0N3",
-                "score": 80
-            },
-            {
-                "format": 215,
-                "name": "CJ",
-                "score": 0
-            },
-            {
-                "format": 216,
-                "name": "pcroland",
-                "score": 0
-            },
-            {
-                "format": 217,
-                "name": "BTN",
-                "score": 0
-            },
-            {
-                "format": 218,
-                "name": "iON",
-                "score": 0
-            },
-            {
-                "format": 219,
-                "name": "AJP69",
-                "score": 0
-            },
-            {
-                "format": 220,
-                "name": "VLAD",
-                "score": 0
-            },
-            {
-                "format": 221,
-                "name": "hdalx",
-                "score": 0
-            },
-            {
-                "format": 223,
-                "name": "LiNG",
-                "score": 0
-            },
-            {
-                "format": 224,
-                "name": "Upscaled",
-                "score": -9999
-            }
-        ]
-    }
+        "allowed": true,
+        "id": 1002
+      },
+      {
+        "name": "Balanced Capable",
+        "items": [
+          {
+            "quality": {
+              "id": 3,
+              "name": "WEBDL-1080p",
+              "source": "web",
+              "resolution": 1080
+            },
+            "items": [],
+            "allowed": true
+          },
+          {
+            "quality": {
+              "id": 15,
+              "name": "WEBRip-1080p",
+              "source": "webRip",
+              "resolution": 1080
+            },
+            "items": [],
+            "allowed": true
+          },
+          {
+            "quality": {
+              "id": 7,
+              "name": "Bluray-1080p",
+              "source": "bluray",
+              "resolution": 1080
+            },
+            "items": [],
+            "allowed": true
+          }
+        ],
+        "allowed": true,
+        "id": 1001
+      },
+      {
+        "quality": {
+          "id": 20,
+          "name": "Bluray-1080p Remux",
+          "source": "blurayRaw",
+          "resolution": 1080
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 16,
+          "name": "HDTV-2160p",
+          "source": "television",
+          "resolution": 2160
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 17,
+          "name": "WEBRip-2160p",
+          "source": "webRip",
+          "resolution": 2160
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 19,
+          "name": "Bluray-2160p",
+          "source": "bluray",
+          "resolution": 2160
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 18,
+          "name": "WEBDL-2160p",
+          "source": "web",
+          "resolution": 2160
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 21,
+          "name": "Bluray-2160p Remux",
+          "source": "blurayRaw",
+          "resolution": 2160
+        },
+        "items": [],
+        "allowed": false
+      }
+    ],
+    "minFormatScore": 0,
+    "cutoffFormatScore": 500,
+    "minUpgradeFormatScore": 1,
+    "formatItems": [
+      {
+        "format": 229,
+        "name": "HR",
+        "score": 30
+      },
+      {
+        "format": 228,
+        "name": "MAX",
+        "score": 0
+      },
+      {
+        "format": 227,
+        "name": "h265 (4k)",
+        "score": 0
+      },
+      {
+        "format": 226,
+        "name": "PCM",
+        "score": 0
+      },
+      {
+        "format": 225,
+        "name": "Blu-Ray (Remux)",
+        "score": 0
+      },
+      {
+        "format": 224,
+        "name": "h265",
+        "score": -9999
+      },
+      {
+        "format": 214,
+        "name": "LQ",
+        "score": 0
+      },
+      {
+        "format": 213,
+        "name": "EPSiLON",
+        "score": 0
+      },
+      {
+        "format": 212,
+        "name": "playBD",
+        "score": 0
+      },
+      {
+        "format": 211,
+        "name": "BLURANiUM",
+        "score": 0
+      },
+      {
+        "format": 210,
+        "name": "PmP",
+        "score": 0
+      },
+      {
+        "format": 209,
+        "name": "WiLDCAT",
+        "score": 0
+      },
+      {
+        "format": 208,
+        "name": "TRiToN",
+        "score": 0
+      },
+      {
+        "format": 207,
+        "name": "3L",
+        "score": 0
+      },
+      {
+        "format": 206,
+        "name": "Dolby Vision w/out Fallback",
+        "score": 0
+      },
+      {
+        "format": 205,
+        "name": "UHDBits",
+        "score": 0
+      },
+      {
+        "format": 204,
+        "name": "ATMOS (Missing)",
+        "score": 0
+      },
+      {
+        "format": 203,
+        "name": "TrueHD (Missing)",
+        "score": 0
+      },
+      {
+        "format": 202,
+        "name": "HDR10 (Missing)",
+        "score": 0
+      },
+      {
+        "format": 201,
+        "name": "HDR10",
+        "score": 0
+      },
+      {
+        "format": 200,
+        "name": "Dolby Vision",
+        "score": 0
+      },
+      {
+        "format": 199,
+        "name": "HDR10+",
+        "score": 0
+      },
+      {
+        "format": 198,
+        "name": "Stream Optimised",
+        "score": 80
+      },
+      {
+        "format": 197,
+        "name": "LoRD",
+        "score": 30
+      },
+      {
+        "format": 196,
+        "name": "Scene",
+        "score": 20
+      },
+      {
+        "format": 195,
+        "name": "mHD",
+        "score": -99999
+      },
+      {
+        "format": 194,
+        "name": "AV1",
+        "score": -9999
+      },
+      {
+        "format": 193,
+        "name": "VVC",
+        "score": -9999
+      },
+      {
+        "format": 192,
+        "name": "Extras",
+        "score": -9999
+      },
+      {
+        "format": 191,
+        "name": "480p",
+        "score": 0
+      },
+      {
+        "format": 190,
+        "name": "Dariush ",
+        "score": 30
+      },
+      {
+        "format": 189,
+        "name": "TBB SD",
+        "score": 30
+      },
+      {
+        "format": 188,
+        "name": "Xvid",
+        "score": 0
+      },
+      {
+        "format": 187,
+        "name": "DVD",
+        "score": 0
+      },
+      {
+        "format": 186,
+        "name": "DVD REMUX ",
+        "score": 40
+      },
+      {
+        "format": 185,
+        "name": "HANDJOB SD",
+        "score": 20
+      },
+      {
+        "format": 184,
+        "name": "iTunes (Missing)",
+        "score": 90
+      },
+      {
+        "format": 183,
+        "name": "ROKU",
+        "score": 190
+      },
+      {
+        "format": 182,
+        "name": "BeyondHD",
+        "score": -9999
+      },
+      {
+        "format": 181,
+        "name": "Disc ",
+        "score": -9999
+      },
+      {
+        "format": 180,
+        "name": "3D",
+        "score": -9999
+      },
+      {
+        "format": 179,
+        "name": "Unwanted",
+        "score": -9999
+      },
+      {
+        "format": 178,
+        "name": "RightSIZE",
+        "score": 30
+      },
+      {
+        "format": 177,
+        "name": "Black and White",
+        "score": -9999
+      },
+      {
+        "format": 176,
+        "name": "TrueHD",
+        "score": -9999
+      },
+      {
+        "format": 175,
+        "name": "DTS-X",
+        "score": -9999
+      },
+      {
+        "format": 174,
+        "name": "FLAC",
+        "score": 0
+      },
+      {
+        "format": 173,
+        "name": "DTS-HD MA",
+        "score": -9999
+      },
+      {
+        "format": 172,
+        "name": "x265",
+        "score": -9999
+      },
+      {
+        "format": 171,
+        "name": "IMAX",
+        "score": 10
+      },
+      {
+        "format": 170,
+        "name": "ATMOS",
+        "score": 10
+      },
+      {
+        "format": 169,
+        "name": "DD",
+        "score": 0
+      },
+      {
+        "format": 168,
+        "name": "DTS",
+        "score": 0
+      },
+      {
+        "format": 167,
+        "name": "DD+",
+        "score": 0
+      },
+      {
+        "format": 166,
+        "name": "iTunes",
+        "score": 90
+      },
+      {
+        "format": 165,
+        "name": "Paramount+",
+        "score": 190
+      },
+      {
+        "format": 164,
+        "name": "Peacock TV",
+        "score": 190
+      },
+      {
+        "format": 163,
+        "name": "Hulu",
+        "score": 190
+      },
+      {
+        "format": 162,
+        "name": "Netflix",
+        "score": 200
+      },
+      {
+        "format": 161,
+        "name": "HBO Max",
+        "score": 200
+      },
+      {
+        "format": 160,
+        "name": "Disney+",
+        "score": 200
+      },
+      {
+        "format": 159,
+        "name": "Apple TV+",
+        "score": 210
+      },
+      {
+        "format": 158,
+        "name": "Movies Anywhere",
+        "score": 220
+      },
+      {
+        "format": 157,
+        "name": "Amazon Prime",
+        "score": 210
+      },
+      {
+        "format": 156,
+        "name": "REMUX",
+        "score": -9999
+      },
+      {
+        "format": 155,
+        "name": "x264",
+        "score": 10
+      },
+      {
+        "format": 154,
+        "name": "WEBRip",
+        "score": 10
+      },
+      {
+        "format": 153,
+        "name": "Blu-Ray",
+        "score": 10
+      },
+      {
+        "format": 152,
+        "name": "2160p",
+        "score": -9999
+      },
+      {
+        "format": 151,
+        "name": "720p",
+        "score": -9999
+      },
+      {
+        "format": 150,
+        "name": "1080p",
+        "score": 220
+      },
+      {
+        "format": 149,
+        "name": "BHDStudio",
+        "score": 90
+      },
+      {
+        "format": 148,
+        "name": "LEGi0N",
+        "score": 20
+      },
+      {
+        "format": 147,
+        "name": "FraMeSToR",
+        "score": 20
+      },
+      {
+        "format": 146,
+        "name": "iFT",
+        "score": 30
+      },
+      {
+        "format": 145,
+        "name": "MTeam",
+        "score": -9999
+      },
+      {
+        "format": 144,
+        "name": "EDPH",
+        "score": 20
+      },
+      {
+        "format": 143,
+        "name": "HANDJOB",
+        "score": 20
+      },
+      {
+        "format": 142,
+        "name": "c0ke",
+        "score": 70
+      },
+      {
+        "format": 141,
+        "name": "KASHMiR",
+        "score": 30
+      },
+      {
+        "format": 140,
+        "name": "WMING",
+        "score": 30
+      },
+      {
+        "format": 139,
+        "name": "playHD",
+        "score": 30
+      },
+      {
+        "format": 138,
+        "name": "E.N.D",
+        "score": 30
+      },
+      {
+        "format": 137,
+        "name": "GutS",
+        "score": 30
+      },
+      {
+        "format": 136,
+        "name": "BV",
+        "score": 30
+      },
+      {
+        "format": 135,
+        "name": "SiMPLE",
+        "score": 30
+      },
+      {
+        "format": 134,
+        "name": "W4NK3R",
+        "score": 30
+      },
+      {
+        "format": 133,
+        "name": "GS88",
+        "score": 30
+      },
+      {
+        "format": 132,
+        "name": "HiP",
+        "score": 40
+      },
+      {
+        "format": 131,
+        "name": "GALAXY",
+        "score": 30
+      },
+      {
+        "format": 130,
+        "name": "luvBB",
+        "score": 30
+      },
+      {
+        "format": 129,
+        "name": "NyHD",
+        "score": 30
+      },
+      {
+        "format": 128,
+        "name": "ZIMBO",
+        "score": 30
+      },
+      {
+        "format": 127,
+        "name": "ThD",
+        "score": 30
+      },
+      {
+        "format": 126,
+        "name": "SaNcTi",
+        "score": 30
+      },
+      {
+        "format": 125,
+        "name": "ORiGEN",
+        "score": 30
+      },
+      {
+        "format": 124,
+        "name": "Positive",
+        "score": 30
+      },
+      {
+        "format": 123,
+        "name": "ESiR",
+        "score": 30
+      },
+      {
+        "format": 122,
+        "name": "Chotab",
+        "score": 30
+      },
+      {
+        "format": 121,
+        "name": "xander",
+        "score": 30
+      },
+      {
+        "format": 120,
+        "name": "FTW-HD",
+        "score": 30
+      },
+      {
+        "format": 119,
+        "name": "Penumbra",
+        "score": 30
+      },
+      {
+        "format": 118,
+        "name": "TDD",
+        "score": 30
+      },
+      {
+        "format": 117,
+        "name": "Dariush SD",
+        "score": 30
+      },
+      {
+        "format": 116,
+        "name": "PTer",
+        "score": 30
+      },
+      {
+        "format": 115,
+        "name": "SbR",
+        "score": 30
+      },
+      {
+        "format": 114,
+        "name": "nmd",
+        "score": 30
+      },
+      {
+        "format": 113,
+        "name": "TBB",
+        "score": 30
+      },
+      {
+        "format": 112,
+        "name": "EA",
+        "score": 40
+      },
+      {
+        "format": 111,
+        "name": "BMF",
+        "score": 40
+      },
+      {
+        "format": 110,
+        "name": "LolHD",
+        "score": 40
+      },
+      {
+        "format": 109,
+        "name": "HDMaNiAcS",
+        "score": 40
+      },
+      {
+        "format": 108,
+        "name": "IDE",
+        "score": 40
+      },
+      {
+        "format": 107,
+        "name": "de[42]",
+        "score": 50
+      },
+      {
+        "format": 106,
+        "name": "NCmt",
+        "score": 60
+      },
+      {
+        "format": 105,
+        "name": "decibeL",
+        "score": 50
+      },
+      {
+        "format": 104,
+        "name": "NTb",
+        "score": 40
+      },
+      {
+        "format": 103,
+        "name": "CRiSC",
+        "score": 50
+      },
+      {
+        "format": 102,
+        "name": "SA89",
+        "score": 60
+      },
+      {
+        "format": 101,
+        "name": "HiDt",
+        "score": 60
+      },
+      {
+        "format": 100,
+        "name": "FoRM",
+        "score": 60
+      },
+      {
+        "format": 99,
+        "name": "HiFi",
+        "score": 60
+      },
+      {
+        "format": 98,
+        "name": "CtrlHD",
+        "score": 60
+      },
+      {
+        "format": 97,
+        "name": "VietHD",
+        "score": 70
+      },
+      {
+        "format": 96,
+        "name": "ZQ",
+        "score": 70
+      },
+      {
+        "format": 95,
+        "name": "TayTo",
+        "score": 70
+      },
+      {
+        "format": 94,
+        "name": "Geek",
+        "score": 70
+      },
+      {
+        "format": 93,
+        "name": "EbP",
+        "score": 80
+      },
+      {
+        "format": 92,
+        "name": "DON",
+        "score": 80
+      },
+      {
+        "format": 91,
+        "name": "D-Z0N3",
+        "score": 80
+      },
+      {
+        "format": 215,
+        "name": "CJ",
+        "score": 0
+      },
+      {
+        "format": 216,
+        "name": "pcroland",
+        "score": 0
+      },
+      {
+        "format": 217,
+        "name": "BTN",
+        "score": 0
+      },
+      {
+        "format": 218,
+        "name": "iON",
+        "score": 0
+      },
+      {
+        "format": 219,
+        "name": "AJP69",
+        "score": 0
+      },
+      {
+        "format": 220,
+        "name": "VLAD",
+        "score": 0
+      },
+      {
+        "format": 221,
+        "name": "hdalx",
+        "score": 0
+      },
+      {
+        "format": 223,
+        "name": "LiNG",
+        "score": 0
+      },
+      {
+        "format": 224,
+        "name": "Upscaled",
+        "score": -9999
+      }
+    ]
+  }
 ]

--- a/imports/quality_profiles/sonarr/1080p Optimal (sonarr - master).json
+++ b/imports/quality_profiles/sonarr/1080p Optimal (sonarr - master).json
@@ -1,918 +1,919 @@
 [
-    {
-        "name": "1080p Optimal",
-        "upgradeAllowed": true,
-        "cutoff": 20,
-        "items": [
-            {
-                "quality": {
-                    "id": 0,
-                    "name": "Unknown",
-                    "source": "unknown",
-                    "resolution": 0
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 13,
-                    "name": "Bluray-480p",
-                    "source": "bluray",
-                    "resolution": 480
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 4,
-                    "name": "HDTV-720p",
-                    "source": "television",
-                    "resolution": 720
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 14,
-                    "name": "WEBRip-720p",
-                    "source": "webRip",
-                    "resolution": 720
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 5,
-                    "name": "WEBDL-720p",
-                    "source": "web",
-                    "resolution": 720
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 6,
-                    "name": "Bluray-720p",
-                    "source": "bluray",
-                    "resolution": 720
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 1,
-                    "name": "SDTV",
-                    "source": "television",
-                    "resolution": 480
-                },
-                "items": [],
-                "allowed": true
-            },
-            {
-                "quality": {
-                    "id": 12,
-                    "name": "WEBRip-480p",
-                    "source": "webRip",
-                    "resolution": 480
-                },
-                "items": [],
-                "allowed": true
-            },
-            {
-                "quality": {
-                    "id": 8,
-                    "name": "WEBDL-480p",
-                    "source": "web",
-                    "resolution": 480
-                },
-                "items": [],
-                "allowed": true
-            },
-            {
-                "quality": {
-                    "id": 2,
-                    "name": "DVD",
-                    "source": "dvd",
-                    "resolution": 480
-                },
-                "items": [],
-                "allowed": true
-            },
-            {
-                "quality": {
-                    "id": 10,
-                    "name": "Raw-HD",
-                    "source": "televisionRaw",
-                    "resolution": 1080
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 9,
-                    "name": "HDTV-1080p",
-                    "source": "television",
-                    "resolution": 1080
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 15,
-                    "name": "WEBRip-1080p",
-                    "source": "webRip",
-                    "resolution": 1080
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 7,
-                    "name": "Bluray-1080p",
-                    "source": "bluray",
-                    "resolution": 1080
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 3,
-                    "name": "WEBDL-1080p",
-                    "source": "web",
-                    "resolution": 1080
-                },
-                "items": [],
-                "allowed": true
-            },
-            {
-                "quality": {
-                    "id": 20,
-                    "name": "Bluray-1080p Remux",
-                    "source": "blurayRaw",
-                    "resolution": 1080
-                },
-                "items": [],
-                "allowed": true
-            },
-            {
-                "quality": {
-                    "id": 16,
-                    "name": "HDTV-2160p",
-                    "source": "television",
-                    "resolution": 2160
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 17,
-                    "name": "WEBRip-2160p",
-                    "source": "webRip",
-                    "resolution": 2160
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 19,
-                    "name": "Bluray-2160p",
-                    "source": "bluray",
-                    "resolution": 2160
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 18,
-                    "name": "WEBDL-2160p",
-                    "source": "web",
-                    "resolution": 2160
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 21,
-                    "name": "Bluray-2160p Remux",
-                    "source": "blurayRaw",
-                    "resolution": 2160
-                },
-                "items": [],
-                "allowed": false
-            }
-        ],
-        "minFormatScore": 0,
-        "cutoffFormatScore": 1000,
-        "formatItems": [
-            {
-                "format": 229,
-                "name": "HR",
-                "score": 0
-            },
-            {
-                "format": 228,
-                "name": "MAX",
-                "score": 0
-            },
-            {
-                "format": 227,
-                "name": "h265 (4k)",
-                "score": 0
-            },
-            {
-                "format": 226,
-                "name": "PCM",
-                "score": 30
-            },
-            {
-                "format": 225,
-                "name": "Blu-Ray (Remux)",
-                "score": 60
-            },
-            {
-                "format": 224,
-                "name": "h265",
-                "score": -9999
-            },
-            {
-                "format": 214,
-                "name": "LQ",
-                "score": -9999
-            },
-            {
-                "format": 213,
-                "name": "EPSiLON",
-                "score": 0
-            },
-            {
-                "format": 212,
-                "name": "playBD",
-                "score": 0
-            },
-            {
-                "format": 211,
-                "name": "BLURANiUM",
-                "score": 0
-            },
-            {
-                "format": 210,
-                "name": "PmP",
-                "score": 0
-            },
-            {
-                "format": 209,
-                "name": "WiLDCAT",
-                "score": 0
-            },
-            {
-                "format": 208,
-                "name": "TRiToN",
-                "score": 0
-            },
-            {
-                "format": 207,
-                "name": "3L",
-                "score": 0
-            },
-            {
-                "format": 206,
-                "name": "Dolby Vision w/out Fallback",
-                "score": -9999
-            },
-            {
-                "format": 205,
-                "name": "UHDBits",
-                "score": -9999
-            },
-            {
-                "format": 204,
-                "name": "ATMOS (Missing)",
-                "score": 10
-            },
-            {
-                "format": 203,
-                "name": "TrueHD (Missing)",
-                "score": 50
-            },
-            {
-                "format": 202,
-                "name": "HDR10 (Missing)",
-                "score": -9999
-            },
-            {
-                "format": 201,
-                "name": "HDR10",
-                "score": -9999
-            },
-            {
-                "format": 200,
-                "name": "Dolby Vision",
-                "score": -9999
-            },
-            {
-                "format": 199,
-                "name": "HDR10+",
-                "score": -9999
-            },
-            {
-                "format": 198,
-                "name": "Stream Optimised",
-                "score": 0
-            },
-            {
-                "format": 197,
-                "name": "LoRD",
-                "score": 0
-            },
-            {
-                "format": 196,
-                "name": "Scene",
-                "score": 0
-            },
-            {
-                "format": 195,
-                "name": "mHD",
-                "score": 0
-            },
-            {
-                "format": 194,
-                "name": "AV1",
-                "score": -9999
-            },
-            {
-                "format": 193,
-                "name": "VVC",
-                "score": -9999
-            },
-            {
-                "format": 192,
-                "name": "Extras",
-                "score": -9999
-            },
-            {
-                "format": 191,
-                "name": "480p",
-                "score": 0
-            },
-            {
-                "format": 190,
-                "name": "Dariush ",
-                "score": 0
-            },
-            {
-                "format": 189,
-                "name": "TBB SD",
-                "score": 30
-            },
-            {
-                "format": 188,
-                "name": "Xvid",
-                "score": 0
-            },
-            {
-                "format": 187,
-                "name": "DVD",
-                "score": 0
-            },
-            {
-                "format": 186,
-                "name": "DVD REMUX ",
-                "score": 40
-            },
-            {
-                "format": 185,
-                "name": "HANDJOB SD",
-                "score": 20
-            },
-            {
-                "format": 184,
-                "name": "iTunes (Missing)",
-                "score": 10
-            },
-            {
-                "format": 183,
-                "name": "ROKU",
-                "score": 20
-            },
-            {
-                "format": 182,
-                "name": "BeyondHD",
-                "score": 0
-            },
-            {
-                "format": 181,
-                "name": "Disc ",
-                "score": -9999
-            },
-            {
-                "format": 180,
-                "name": "3D",
-                "score": -9999
-            },
-            {
-                "format": 179,
-                "name": "Unwanted",
-                "score": -9999
-            },
-            {
-                "format": 178,
-                "name": "RightSIZE",
-                "score": 0
-            },
-            {
-                "format": 177,
-                "name": "Black and White",
-                "score": -9999
-            },
-            {
-                "format": 176,
-                "name": "TrueHD",
-                "score": 50
-            },
-            {
-                "format": 175,
-                "name": "DTS-X",
-                "score": 60
-            },
-            {
-                "format": 174,
-                "name": "FLAC",
-                "score": 30
-            },
-            {
-                "format": 173,
-                "name": "DTS-HD MA",
-                "score": 50
-            },
-            {
-                "format": 172,
-                "name": "x265",
-                "score": -9999
-            },
-            {
-                "format": 171,
-                "name": "IMAX",
-                "score": 10
-            },
-            {
-                "format": 170,
-                "name": "ATMOS",
-                "score": 10
-            },
-            {
-                "format": 169,
-                "name": "DD",
-                "score": 0
-            },
-            {
-                "format": 168,
-                "name": "DTS",
-                "score": 0
-            },
-            {
-                "format": 167,
-                "name": "DD+",
-                "score": 0
-            },
-            {
-                "format": 166,
-                "name": "iTunes",
-                "score": 10
-            },
-            {
-                "format": 165,
-                "name": "Paramount+",
-                "score": 20
-            },
-            {
-                "format": 164,
-                "name": "Peacock TV",
-                "score": 20
-            },
-            {
-                "format": 163,
-                "name": "Hulu",
-                "score": 20
-            },
-            {
-                "format": 162,
-                "name": "Netflix",
-                "score": 30
-            },
-            {
-                "format": 161,
-                "name": "HBO Max",
-                "score": 30
-            },
-            {
-                "format": 160,
-                "name": "Disney+",
-                "score": 30
-            },
-            {
-                "format": 159,
-                "name": "Apple TV+",
-                "score": 40
-            },
-            {
-                "format": 158,
-                "name": "Movies Anywhere",
-                "score": 50
-            },
-            {
-                "format": 157,
-                "name": "Amazon Prime",
-                "score": 40
-            },
-            {
-                "format": 156,
-                "name": "REMUX",
-                "score": 60
-            },
-            {
-                "format": 155,
-                "name": "x264",
-                "score": 10
-            },
-            {
-                "format": 154,
-                "name": "WEBRip",
-                "score": -9999
-            },
-            {
-                "format": 153,
-                "name": "Blu-Ray",
-                "score": -9999
-            },
-            {
-                "format": 152,
-                "name": "2160p",
-                "score": -9999
-            },
-            {
-                "format": 151,
-                "name": "720p",
-                "score": -9999
-            },
-            {
-                "format": 150,
-                "name": "1080p",
-                "score": 60
-            },
-            {
-                "format": 149,
-                "name": "BHDStudio",
-                "score": 0
-            },
-            {
-                "format": 148,
-                "name": "LEGi0N",
-                "score": 0
-            },
-            {
-                "format": 147,
-                "name": "FraMeSToR",
-                "score": 0
-            },
-            {
-                "format": 146,
-                "name": "iFT",
-                "score": 0
-            },
-            {
-                "format": 145,
-                "name": "MTeam",
-                "score": 0
-            },
-            {
-                "format": 144,
-                "name": "EDPH",
-                "score": 0
-            },
-            {
-                "format": 143,
-                "name": "HANDJOB",
-                "score": 0
-            },
-            {
-                "format": 142,
-                "name": "c0ke",
-                "score": 0
-            },
-            {
-                "format": 141,
-                "name": "KASHMiR",
-                "score": 0
-            },
-            {
-                "format": 140,
-                "name": "WMING",
-                "score": 0
-            },
-            {
-                "format": 139,
-                "name": "playHD",
-                "score": 0
-            },
-            {
-                "format": 138,
-                "name": "E.N.D",
-                "score": 0
-            },
-            {
-                "format": 137,
-                "name": "GutS",
-                "score": 0
-            },
-            {
-                "format": 136,
-                "name": "BV",
-                "score": 0
-            },
-            {
-                "format": 135,
-                "name": "SiMPLE",
-                "score": 0
-            },
-            {
-                "format": 134,
-                "name": "W4NK3R",
-                "score": 0
-            },
-            {
-                "format": 133,
-                "name": "GS88",
-                "score": 0
-            },
-            {
-                "format": 132,
-                "name": "HiP",
-                "score": 0
-            },
-            {
-                "format": 131,
-                "name": "GALAXY",
-                "score": 0
-            },
-            {
-                "format": 130,
-                "name": "luvBB",
-                "score": 0
-            },
-            {
-                "format": 129,
-                "name": "NyHD",
-                "score": 0
-            },
-            {
-                "format": 128,
-                "name": "ZIMBO",
-                "score": 0
-            },
-            {
-                "format": 127,
-                "name": "ThD",
-                "score": 0
-            },
-            {
-                "format": 126,
-                "name": "SaNcTi",
-                "score": 0
-            },
-            {
-                "format": 125,
-                "name": "ORiGEN",
-                "score": 0
-            },
-            {
-                "format": 124,
-                "name": "Positive",
-                "score": 0
-            },
-            {
-                "format": 123,
-                "name": "ESiR",
-                "score": 0
-            },
-            {
-                "format": 122,
-                "name": "Chotab",
-                "score": 0
-            },
-            {
-                "format": 121,
-                "name": "xander",
-                "score": 0
-            },
-            {
-                "format": 120,
-                "name": "FTW-HD",
-                "score": 0
-            },
-            {
-                "format": 119,
-                "name": "Penumbra",
-                "score": 0
-            },
-            {
-                "format": 118,
-                "name": "TDD",
-                "score": 0
-            },
-            {
-                "format": 117,
-                "name": "Dariush SD",
-                "score": 30
-            },
-            {
-                "format": 116,
-                "name": "PTer",
-                "score": 0
-            },
-            {
-                "format": 115,
-                "name": "SbR",
-                "score": 0
-            },
-            {
-                "format": 114,
-                "name": "nmd",
-                "score": 0
-            },
-            {
-                "format": 113,
-                "name": "TBB",
-                "score": 0
-            },
-            {
-                "format": 112,
-                "name": "EA",
-                "score": 0
-            },
-            {
-                "format": 111,
-                "name": "BMF",
-                "score": 0
-            },
-            {
-                "format": 110,
-                "name": "LolHD",
-                "score": 0
-            },
-            {
-                "format": 109,
-                "name": "HDMaNiAcS",
-                "score": 0
-            },
-            {
-                "format": 108,
-                "name": "IDE",
-                "score": 0
-            },
-            {
-                "format": 107,
-                "name": "de[42]",
-                "score": 0
-            },
-            {
-                "format": 106,
-                "name": "NCmt",
-                "score": 0
-            },
-            {
-                "format": 105,
-                "name": "decibeL",
-                "score": 0
-            },
-            {
-                "format": 104,
-                "name": "NTb",
-                "score": 0
-            },
-            {
-                "format": 103,
-                "name": "CRiSC",
-                "score": 0
-            },
-            {
-                "format": 102,
-                "name": "SA89",
-                "score": 0
-            },
-            {
-                "format": 101,
-                "name": "HiDt",
-                "score": 0
-            },
-            {
-                "format": 100,
-                "name": "FoRM",
-                "score": 0
-            },
-            {
-                "format": 99,
-                "name": "HiFi",
-                "score": 0
-            },
-            {
-                "format": 98,
-                "name": "CtrlHD",
-                "score": 0
-            },
-            {
-                "format": 97,
-                "name": "VietHD",
-                "score": 0
-            },
-            {
-                "format": 96,
-                "name": "ZQ",
-                "score": 0
-            },
-            {
-                "format": 95,
-                "name": "TayTo",
-                "score": 0
-            },
-            {
-                "format": 94,
-                "name": "Geek",
-                "score": 0
-            },
-            {
-                "format": 93,
-                "name": "EbP",
-                "score": 0
-            },
-            {
-                "format": 92,
-                "name": "DON",
-                "score": 0
-            },
-            {
-                "format": 91,
-                "name": "D-Z0N3",
-                "score": 0
-            },
-            {
-                "format": 215,
-                "name": "CJ",
-                "score": 0
-            },
-            {
-                "format": 216,
-                "name": "pcroland",
-                "score": 0
-            },
-            {
-                "format": 217,
-                "name": "BTN",
-                "score": 0
-            },
-            {
-                "format": 218,
-                "name": "iON",
-                "score": 0
-            },
-            {
-                "format": 219,
-                "name": "AJP69",
-                "score": 0
-            },
-            {
-                "format": 220,
-                "name": "VLAD",
-                "score": 0
-            },
-            {
-                "format": 221,
-                "name": "hdalx",
-                "score": 0
-            },
-            {
-                "format": 223,
-                "name": "LiNG",
-                "score": 0
-            },
-            {
-                "format": 224,
-                "name": "Upscaled",
-                "score": -9999
-            }
-        ]
-    }
+  {
+    "name": "1080p Optimal",
+    "upgradeAllowed": true,
+    "cutoff": 20,
+    "items": [
+      {
+        "quality": {
+          "id": 0,
+          "name": "Unknown",
+          "source": "unknown",
+          "resolution": 0
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 13,
+          "name": "Bluray-480p",
+          "source": "bluray",
+          "resolution": 480
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 4,
+          "name": "HDTV-720p",
+          "source": "television",
+          "resolution": 720
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 14,
+          "name": "WEBRip-720p",
+          "source": "webRip",
+          "resolution": 720
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 5,
+          "name": "WEBDL-720p",
+          "source": "web",
+          "resolution": 720
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 6,
+          "name": "Bluray-720p",
+          "source": "bluray",
+          "resolution": 720
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 1,
+          "name": "SDTV",
+          "source": "television",
+          "resolution": 480
+        },
+        "items": [],
+        "allowed": true
+      },
+      {
+        "quality": {
+          "id": 12,
+          "name": "WEBRip-480p",
+          "source": "webRip",
+          "resolution": 480
+        },
+        "items": [],
+        "allowed": true
+      },
+      {
+        "quality": {
+          "id": 8,
+          "name": "WEBDL-480p",
+          "source": "web",
+          "resolution": 480
+        },
+        "items": [],
+        "allowed": true
+      },
+      {
+        "quality": {
+          "id": 2,
+          "name": "DVD",
+          "source": "dvd",
+          "resolution": 480
+        },
+        "items": [],
+        "allowed": true
+      },
+      {
+        "quality": {
+          "id": 10,
+          "name": "Raw-HD",
+          "source": "televisionRaw",
+          "resolution": 1080
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 9,
+          "name": "HDTV-1080p",
+          "source": "television",
+          "resolution": 1080
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 15,
+          "name": "WEBRip-1080p",
+          "source": "webRip",
+          "resolution": 1080
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 7,
+          "name": "Bluray-1080p",
+          "source": "bluray",
+          "resolution": 1080
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 3,
+          "name": "WEBDL-1080p",
+          "source": "web",
+          "resolution": 1080
+        },
+        "items": [],
+        "allowed": true
+      },
+      {
+        "quality": {
+          "id": 20,
+          "name": "Bluray-1080p Remux",
+          "source": "blurayRaw",
+          "resolution": 1080
+        },
+        "items": [],
+        "allowed": true
+      },
+      {
+        "quality": {
+          "id": 16,
+          "name": "HDTV-2160p",
+          "source": "television",
+          "resolution": 2160
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 17,
+          "name": "WEBRip-2160p",
+          "source": "webRip",
+          "resolution": 2160
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 19,
+          "name": "Bluray-2160p",
+          "source": "bluray",
+          "resolution": 2160
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 18,
+          "name": "WEBDL-2160p",
+          "source": "web",
+          "resolution": 2160
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 21,
+          "name": "Bluray-2160p Remux",
+          "source": "blurayRaw",
+          "resolution": 2160
+        },
+        "items": [],
+        "allowed": false
+      }
+    ],
+    "minFormatScore": 0,
+    "cutoffFormatScore": 1000,
+    "minUpgradeFormatScore": 1,
+    "formatItems": [
+      {
+        "format": 229,
+        "name": "HR",
+        "score": 0
+      },
+      {
+        "format": 228,
+        "name": "MAX",
+        "score": 0
+      },
+      {
+        "format": 227,
+        "name": "h265 (4k)",
+        "score": 0
+      },
+      {
+        "format": 226,
+        "name": "PCM",
+        "score": 30
+      },
+      {
+        "format": 225,
+        "name": "Blu-Ray (Remux)",
+        "score": 60
+      },
+      {
+        "format": 224,
+        "name": "h265",
+        "score": -9999
+      },
+      {
+        "format": 214,
+        "name": "LQ",
+        "score": -9999
+      },
+      {
+        "format": 213,
+        "name": "EPSiLON",
+        "score": 0
+      },
+      {
+        "format": 212,
+        "name": "playBD",
+        "score": 0
+      },
+      {
+        "format": 211,
+        "name": "BLURANiUM",
+        "score": 0
+      },
+      {
+        "format": 210,
+        "name": "PmP",
+        "score": 0
+      },
+      {
+        "format": 209,
+        "name": "WiLDCAT",
+        "score": 0
+      },
+      {
+        "format": 208,
+        "name": "TRiToN",
+        "score": 0
+      },
+      {
+        "format": 207,
+        "name": "3L",
+        "score": 0
+      },
+      {
+        "format": 206,
+        "name": "Dolby Vision w/out Fallback",
+        "score": -9999
+      },
+      {
+        "format": 205,
+        "name": "UHDBits",
+        "score": -9999
+      },
+      {
+        "format": 204,
+        "name": "ATMOS (Missing)",
+        "score": 10
+      },
+      {
+        "format": 203,
+        "name": "TrueHD (Missing)",
+        "score": 50
+      },
+      {
+        "format": 202,
+        "name": "HDR10 (Missing)",
+        "score": -9999
+      },
+      {
+        "format": 201,
+        "name": "HDR10",
+        "score": -9999
+      },
+      {
+        "format": 200,
+        "name": "Dolby Vision",
+        "score": -9999
+      },
+      {
+        "format": 199,
+        "name": "HDR10+",
+        "score": -9999
+      },
+      {
+        "format": 198,
+        "name": "Stream Optimised",
+        "score": 0
+      },
+      {
+        "format": 197,
+        "name": "LoRD",
+        "score": 0
+      },
+      {
+        "format": 196,
+        "name": "Scene",
+        "score": 0
+      },
+      {
+        "format": 195,
+        "name": "mHD",
+        "score": 0
+      },
+      {
+        "format": 194,
+        "name": "AV1",
+        "score": -9999
+      },
+      {
+        "format": 193,
+        "name": "VVC",
+        "score": -9999
+      },
+      {
+        "format": 192,
+        "name": "Extras",
+        "score": -9999
+      },
+      {
+        "format": 191,
+        "name": "480p",
+        "score": 0
+      },
+      {
+        "format": 190,
+        "name": "Dariush ",
+        "score": 0
+      },
+      {
+        "format": 189,
+        "name": "TBB SD",
+        "score": 30
+      },
+      {
+        "format": 188,
+        "name": "Xvid",
+        "score": 0
+      },
+      {
+        "format": 187,
+        "name": "DVD",
+        "score": 0
+      },
+      {
+        "format": 186,
+        "name": "DVD REMUX ",
+        "score": 40
+      },
+      {
+        "format": 185,
+        "name": "HANDJOB SD",
+        "score": 20
+      },
+      {
+        "format": 184,
+        "name": "iTunes (Missing)",
+        "score": 10
+      },
+      {
+        "format": 183,
+        "name": "ROKU",
+        "score": 20
+      },
+      {
+        "format": 182,
+        "name": "BeyondHD",
+        "score": 0
+      },
+      {
+        "format": 181,
+        "name": "Disc ",
+        "score": -9999
+      },
+      {
+        "format": 180,
+        "name": "3D",
+        "score": -9999
+      },
+      {
+        "format": 179,
+        "name": "Unwanted",
+        "score": -9999
+      },
+      {
+        "format": 178,
+        "name": "RightSIZE",
+        "score": 0
+      },
+      {
+        "format": 177,
+        "name": "Black and White",
+        "score": -9999
+      },
+      {
+        "format": 176,
+        "name": "TrueHD",
+        "score": 50
+      },
+      {
+        "format": 175,
+        "name": "DTS-X",
+        "score": 60
+      },
+      {
+        "format": 174,
+        "name": "FLAC",
+        "score": 30
+      },
+      {
+        "format": 173,
+        "name": "DTS-HD MA",
+        "score": 50
+      },
+      {
+        "format": 172,
+        "name": "x265",
+        "score": -9999
+      },
+      {
+        "format": 171,
+        "name": "IMAX",
+        "score": 10
+      },
+      {
+        "format": 170,
+        "name": "ATMOS",
+        "score": 10
+      },
+      {
+        "format": 169,
+        "name": "DD",
+        "score": 0
+      },
+      {
+        "format": 168,
+        "name": "DTS",
+        "score": 0
+      },
+      {
+        "format": 167,
+        "name": "DD+",
+        "score": 0
+      },
+      {
+        "format": 166,
+        "name": "iTunes",
+        "score": 10
+      },
+      {
+        "format": 165,
+        "name": "Paramount+",
+        "score": 20
+      },
+      {
+        "format": 164,
+        "name": "Peacock TV",
+        "score": 20
+      },
+      {
+        "format": 163,
+        "name": "Hulu",
+        "score": 20
+      },
+      {
+        "format": 162,
+        "name": "Netflix",
+        "score": 30
+      },
+      {
+        "format": 161,
+        "name": "HBO Max",
+        "score": 30
+      },
+      {
+        "format": 160,
+        "name": "Disney+",
+        "score": 30
+      },
+      {
+        "format": 159,
+        "name": "Apple TV+",
+        "score": 40
+      },
+      {
+        "format": 158,
+        "name": "Movies Anywhere",
+        "score": 50
+      },
+      {
+        "format": 157,
+        "name": "Amazon Prime",
+        "score": 40
+      },
+      {
+        "format": 156,
+        "name": "REMUX",
+        "score": 60
+      },
+      {
+        "format": 155,
+        "name": "x264",
+        "score": 10
+      },
+      {
+        "format": 154,
+        "name": "WEBRip",
+        "score": -9999
+      },
+      {
+        "format": 153,
+        "name": "Blu-Ray",
+        "score": -9999
+      },
+      {
+        "format": 152,
+        "name": "2160p",
+        "score": -9999
+      },
+      {
+        "format": 151,
+        "name": "720p",
+        "score": -9999
+      },
+      {
+        "format": 150,
+        "name": "1080p",
+        "score": 60
+      },
+      {
+        "format": 149,
+        "name": "BHDStudio",
+        "score": 0
+      },
+      {
+        "format": 148,
+        "name": "LEGi0N",
+        "score": 0
+      },
+      {
+        "format": 147,
+        "name": "FraMeSToR",
+        "score": 0
+      },
+      {
+        "format": 146,
+        "name": "iFT",
+        "score": 0
+      },
+      {
+        "format": 145,
+        "name": "MTeam",
+        "score": 0
+      },
+      {
+        "format": 144,
+        "name": "EDPH",
+        "score": 0
+      },
+      {
+        "format": 143,
+        "name": "HANDJOB",
+        "score": 0
+      },
+      {
+        "format": 142,
+        "name": "c0ke",
+        "score": 0
+      },
+      {
+        "format": 141,
+        "name": "KASHMiR",
+        "score": 0
+      },
+      {
+        "format": 140,
+        "name": "WMING",
+        "score": 0
+      },
+      {
+        "format": 139,
+        "name": "playHD",
+        "score": 0
+      },
+      {
+        "format": 138,
+        "name": "E.N.D",
+        "score": 0
+      },
+      {
+        "format": 137,
+        "name": "GutS",
+        "score": 0
+      },
+      {
+        "format": 136,
+        "name": "BV",
+        "score": 0
+      },
+      {
+        "format": 135,
+        "name": "SiMPLE",
+        "score": 0
+      },
+      {
+        "format": 134,
+        "name": "W4NK3R",
+        "score": 0
+      },
+      {
+        "format": 133,
+        "name": "GS88",
+        "score": 0
+      },
+      {
+        "format": 132,
+        "name": "HiP",
+        "score": 0
+      },
+      {
+        "format": 131,
+        "name": "GALAXY",
+        "score": 0
+      },
+      {
+        "format": 130,
+        "name": "luvBB",
+        "score": 0
+      },
+      {
+        "format": 129,
+        "name": "NyHD",
+        "score": 0
+      },
+      {
+        "format": 128,
+        "name": "ZIMBO",
+        "score": 0
+      },
+      {
+        "format": 127,
+        "name": "ThD",
+        "score": 0
+      },
+      {
+        "format": 126,
+        "name": "SaNcTi",
+        "score": 0
+      },
+      {
+        "format": 125,
+        "name": "ORiGEN",
+        "score": 0
+      },
+      {
+        "format": 124,
+        "name": "Positive",
+        "score": 0
+      },
+      {
+        "format": 123,
+        "name": "ESiR",
+        "score": 0
+      },
+      {
+        "format": 122,
+        "name": "Chotab",
+        "score": 0
+      },
+      {
+        "format": 121,
+        "name": "xander",
+        "score": 0
+      },
+      {
+        "format": 120,
+        "name": "FTW-HD",
+        "score": 0
+      },
+      {
+        "format": 119,
+        "name": "Penumbra",
+        "score": 0
+      },
+      {
+        "format": 118,
+        "name": "TDD",
+        "score": 0
+      },
+      {
+        "format": 117,
+        "name": "Dariush SD",
+        "score": 30
+      },
+      {
+        "format": 116,
+        "name": "PTer",
+        "score": 0
+      },
+      {
+        "format": 115,
+        "name": "SbR",
+        "score": 0
+      },
+      {
+        "format": 114,
+        "name": "nmd",
+        "score": 0
+      },
+      {
+        "format": 113,
+        "name": "TBB",
+        "score": 0
+      },
+      {
+        "format": 112,
+        "name": "EA",
+        "score": 0
+      },
+      {
+        "format": 111,
+        "name": "BMF",
+        "score": 0
+      },
+      {
+        "format": 110,
+        "name": "LolHD",
+        "score": 0
+      },
+      {
+        "format": 109,
+        "name": "HDMaNiAcS",
+        "score": 0
+      },
+      {
+        "format": 108,
+        "name": "IDE",
+        "score": 0
+      },
+      {
+        "format": 107,
+        "name": "de[42]",
+        "score": 0
+      },
+      {
+        "format": 106,
+        "name": "NCmt",
+        "score": 0
+      },
+      {
+        "format": 105,
+        "name": "decibeL",
+        "score": 0
+      },
+      {
+        "format": 104,
+        "name": "NTb",
+        "score": 0
+      },
+      {
+        "format": 103,
+        "name": "CRiSC",
+        "score": 0
+      },
+      {
+        "format": 102,
+        "name": "SA89",
+        "score": 0
+      },
+      {
+        "format": 101,
+        "name": "HiDt",
+        "score": 0
+      },
+      {
+        "format": 100,
+        "name": "FoRM",
+        "score": 0
+      },
+      {
+        "format": 99,
+        "name": "HiFi",
+        "score": 0
+      },
+      {
+        "format": 98,
+        "name": "CtrlHD",
+        "score": 0
+      },
+      {
+        "format": 97,
+        "name": "VietHD",
+        "score": 0
+      },
+      {
+        "format": 96,
+        "name": "ZQ",
+        "score": 0
+      },
+      {
+        "format": 95,
+        "name": "TayTo",
+        "score": 0
+      },
+      {
+        "format": 94,
+        "name": "Geek",
+        "score": 0
+      },
+      {
+        "format": 93,
+        "name": "EbP",
+        "score": 0
+      },
+      {
+        "format": 92,
+        "name": "DON",
+        "score": 0
+      },
+      {
+        "format": 91,
+        "name": "D-Z0N3",
+        "score": 0
+      },
+      {
+        "format": 215,
+        "name": "CJ",
+        "score": 0
+      },
+      {
+        "format": 216,
+        "name": "pcroland",
+        "score": 0
+      },
+      {
+        "format": 217,
+        "name": "BTN",
+        "score": 0
+      },
+      {
+        "format": 218,
+        "name": "iON",
+        "score": 0
+      },
+      {
+        "format": 219,
+        "name": "AJP69",
+        "score": 0
+      },
+      {
+        "format": 220,
+        "name": "VLAD",
+        "score": 0
+      },
+      {
+        "format": 221,
+        "name": "hdalx",
+        "score": 0
+      },
+      {
+        "format": 223,
+        "name": "LiNG",
+        "score": 0
+      },
+      {
+        "format": 224,
+        "name": "Upscaled",
+        "score": -9999
+      }
+    ]
+  }
 ]

--- a/imports/quality_profiles/sonarr/1080p Transparent (Double Grab) (sonarr - master).json
+++ b/imports/quality_profiles/sonarr/1080p Transparent (Double Grab) (sonarr - master).json
@@ -1,939 +1,940 @@
 [
-    {
-        "name": "1080p Transparent (Double Grab)",
-        "upgradeAllowed": true,
-        "cutoff": 1001,
+  {
+    "name": "1080p Transparent (Double Grab)",
+    "upgradeAllowed": true,
+    "cutoff": 1001,
+    "items": [
+      {
+        "quality": {
+          "id": 0,
+          "name": "Unknown",
+          "source": "unknown",
+          "resolution": 0
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 13,
+          "name": "Bluray-480p",
+          "source": "bluray",
+          "resolution": 480
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 4,
+          "name": "HDTV-720p",
+          "source": "television",
+          "resolution": 720
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 14,
+          "name": "WEBRip-720p",
+          "source": "webRip",
+          "resolution": 720
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 5,
+          "name": "WEBDL-720p",
+          "source": "web",
+          "resolution": 720
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 6,
+          "name": "Bluray-720p",
+          "source": "bluray",
+          "resolution": 720
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "name": "Fallback SD",
         "items": [
-            {
-                "quality": {
-                    "id": 0,
-                    "name": "Unknown",
-                    "source": "unknown",
-                    "resolution": 0
-                },
-                "items": [],
-                "allowed": false
+          {
+            "quality": {
+              "id": 1,
+              "name": "SDTV",
+              "source": "television",
+              "resolution": 480
             },
-            {
-                "quality": {
-                    "id": 13,
-                    "name": "Bluray-480p",
-                    "source": "bluray",
-                    "resolution": 480
-                },
-                "items": [],
-                "allowed": false
+            "items": [],
+            "allowed": true
+          },
+          {
+            "quality": {
+              "id": 12,
+              "name": "WEBRip-480p",
+              "source": "webRip",
+              "resolution": 480
             },
-            {
-                "quality": {
-                    "id": 4,
-                    "name": "HDTV-720p",
-                    "source": "television",
-                    "resolution": 720
-                },
-                "items": [],
-                "allowed": false
+            "items": [],
+            "allowed": true
+          },
+          {
+            "quality": {
+              "id": 8,
+              "name": "WEBDL-480p",
+              "source": "web",
+              "resolution": 480
             },
-            {
-                "quality": {
-                    "id": 14,
-                    "name": "WEBRip-720p",
-                    "source": "webRip",
-                    "resolution": 720
-                },
-                "items": [],
-                "allowed": false
+            "items": [],
+            "allowed": true
+          },
+          {
+            "quality": {
+              "id": 2,
+              "name": "DVD",
+              "source": "dvd",
+              "resolution": 480
             },
-            {
-                "quality": {
-                    "id": 5,
-                    "name": "WEBDL-720p",
-                    "source": "web",
-                    "resolution": 720
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 6,
-                    "name": "Bluray-720p",
-                    "source": "bluray",
-                    "resolution": 720
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "name": "Fallback SD",
-                "items": [
-                    {
-                        "quality": {
-                            "id": 1,
-                            "name": "SDTV",
-                            "source": "television",
-                            "resolution": 480
-                        },
-                        "items": [],
-                        "allowed": true
-                    },
-                    {
-                        "quality": {
-                            "id": 12,
-                            "name": "WEBRip-480p",
-                            "source": "webRip",
-                            "resolution": 480
-                        },
-                        "items": [],
-                        "allowed": true
-                    },
-                    {
-                        "quality": {
-                            "id": 8,
-                            "name": "WEBDL-480p",
-                            "source": "web",
-                            "resolution": 480
-                        },
-                        "items": [],
-                        "allowed": true
-                    },
-                    {
-                        "quality": {
-                            "id": 2,
-                            "name": "DVD",
-                            "source": "dvd",
-                            "resolution": 480
-                        },
-                        "items": [],
-                        "allowed": true
-                    }
-                ],
-                "allowed": true,
-                "id": 1003
-            },
-            {
-                "name": "Fallback 1080p",
-                "items": [
-                    {
-                        "quality": {
-                            "id": 10,
-                            "name": "Raw-HD",
-                            "source": "televisionRaw",
-                            "resolution": 1080
-                        },
-                        "items": [],
-                        "allowed": true
-                    },
-                    {
-                        "quality": {
-                            "id": 9,
-                            "name": "HDTV-1080p",
-                            "source": "television",
-                            "resolution": 1080
-                        },
-                        "items": [],
-                        "allowed": true
-                    }
-                ],
-                "allowed": true,
-                "id": 1002
-            },
-            {
-                "name": "Transparent Capable",
-                "items": [
-                    {
-                        "quality": {
-                            "id": 3,
-                            "name": "WEBDL-1080p",
-                            "source": "web",
-                            "resolution": 1080
-                        },
-                        "items": [],
-                        "allowed": true
-                    },
-                    {
-                        "quality": {
-                            "id": 15,
-                            "name": "WEBRip-1080p",
-                            "source": "webRip",
-                            "resolution": 1080
-                        },
-                        "items": [],
-                        "allowed": true
-                    },
-                    {
-                        "quality": {
-                            "id": 7,
-                            "name": "Bluray-1080p",
-                            "source": "bluray",
-                            "resolution": 1080
-                        },
-                        "items": [],
-                        "allowed": true
-                    }
-                ],
-                "allowed": true,
-                "id": 1001
-            },
-            {
-                "quality": {
-                    "id": 20,
-                    "name": "Bluray-1080p Remux",
-                    "source": "blurayRaw",
-                    "resolution": 1080
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 16,
-                    "name": "HDTV-2160p",
-                    "source": "television",
-                    "resolution": 2160
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 17,
-                    "name": "WEBRip-2160p",
-                    "source": "webRip",
-                    "resolution": 2160
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 18,
-                    "name": "WEBDL-2160p",
-                    "source": "web",
-                    "resolution": 2160
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 19,
-                    "name": "Bluray-2160p",
-                    "source": "bluray",
-                    "resolution": 2160
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 21,
-                    "name": "Bluray-2160p Remux",
-                    "source": "blurayRaw",
-                    "resolution": 2160
-                },
-                "items": [],
-                "allowed": false
-            }
+            "items": [],
+            "allowed": true
+          }
         ],
-        "minFormatScore": 0,
-        "cutoffFormatScore": 140,
-        "formatItems": [
-            {
-                "format": 229,
-                "name": "HR",
-                "score": 30
-            },
-            {
-                "format": 228,
-                "name": "MAX",
-                "score": 0
-            },
-            {
-                "format": 227,
-                "name": "h265 (4k)",
-                "score": 0
-            },
-            {
-                "format": 226,
-                "name": "PCM",
-                "score": 0
-            },
-            {
-                "format": 225,
-                "name": "Blu-Ray (Remux)",
-                "score": 0
-            },
-            {
-                "format": 224,
-                "name": "h265",
-                "score": -9999
-            },
-            {
-                "format": 223,
-                "name": "LiNG",
-                "score": 80
-            },
-            {
-                "format": 221,
-                "name": "hdalx",
-                "score": 80
-            },
-            {
-                "format": 220,
-                "name": "VLAD",
-                "score": 80
-            },
-            {
-                "format": 219,
-                "name": "AJP69",
-                "score": 80
-            },
-            {
-                "format": 218,
-                "name": "iON",
-                "score": 80
-            },
-            {
-                "format": 217,
-                "name": "BTN",
-                "score": 30
-            },
-            {
-                "format": 216,
-                "name": "pcroland",
-                "score": 80
-            },
-            {
-                "format": 215,
-                "name": "CJ",
-                "score": 80
-            },
-            {
-                "format": 214,
-                "name": "LQ",
-                "score": -9999
-            },
-            {
-                "format": 213,
-                "name": "EPSiLON",
-                "score": 0
-            },
-            {
-                "format": 212,
-                "name": "playBD",
-                "score": 0
-            },
-            {
-                "format": 211,
-                "name": "BLURANiUM",
-                "score": 0
-            },
-            {
-                "format": 210,
-                "name": "PmP",
-                "score": 0
-            },
-            {
-                "format": 209,
-                "name": "WiLDCAT",
-                "score": 0
-            },
-            {
-                "format": 208,
-                "name": "TRiToN",
-                "score": 0
-            },
-            {
-                "format": 207,
-                "name": "3L",
-                "score": 0
-            },
-            {
-                "format": 206,
-                "name": "Dolby Vision w/out Fallback",
-                "score": -9999
-            },
-            {
-                "format": 205,
-                "name": "UHDBits",
-                "score": 0
-            },
-            {
-                "format": 204,
-                "name": "ATMOS (Missing)",
-                "score": 0
-            },
-            {
-                "format": 203,
-                "name": "TrueHD (Missing)",
-                "score": -9999
-            },
-            {
-                "format": 202,
-                "name": "HDR10 (Missing)",
-                "score": -9999
-            },
-            {
-                "format": 201,
-                "name": "HDR10",
-                "score": -9999
-            },
-            {
-                "format": 200,
-                "name": "Dolby Vision",
-                "score": -9999
-            },
-            {
-                "format": 199,
-                "name": "HDR10+",
-                "score": -9999
-            },
-            {
-                "format": 198,
-                "name": "Stream Optimised",
-                "score": 0
-            },
-            {
-                "format": 197,
-                "name": "LoRD",
-                "score": 70
-            },
-            {
-                "format": 196,
-                "name": "Scene",
-                "score": 30
-            },
-            {
-                "format": 195,
-                "name": "mHD",
-                "score": -999999
-            },
-            {
-                "format": 194,
-                "name": "AV1",
-                "score": -9999
-            },
-            {
-                "format": 193,
-                "name": "VVC",
-                "score": -9999
-            },
-            {
-                "format": 192,
-                "name": "Extras",
-                "score": -9999
-            },
-            {
-                "format": 191,
-                "name": "480p",
-                "score": 0
-            },
-            {
-                "format": 190,
-                "name": "Dariush ",
-                "score": 20
-            },
-            {
-                "format": 189,
-                "name": "TBB SD",
-                "score": 30
-            },
-            {
-                "format": 188,
-                "name": "Xvid",
-                "score": 0
-            },
-            {
-                "format": 187,
-                "name": "DVD",
-                "score": 0
-            },
-            {
-                "format": 186,
-                "name": "DVD REMUX ",
-                "score": 40
-            },
-            {
-                "format": 185,
-                "name": "HANDJOB SD",
-                "score": 20
-            },
-            {
-                "format": 184,
-                "name": "iTunes (Missing)",
-                "score": 60
-            },
-            {
-                "format": 183,
-                "name": "ROKU",
-                "score": 60
-            },
-            {
-                "format": 182,
-                "name": "BeyondHD",
-                "score": -10000
-            },
-            {
-                "format": 181,
-                "name": "Disc ",
-                "score": -9999
-            },
-            {
-                "format": 180,
-                "name": "3D",
-                "score": -9999
-            },
-            {
-                "format": 179,
-                "name": "Unwanted",
-                "score": -9999
-            },
-            {
-                "format": 178,
-                "name": "RightSIZE",
-                "score": 70
-            },
-            {
-                "format": 177,
-                "name": "Black and White",
-                "score": -9999
-            },
-            {
-                "format": 176,
-                "name": "TrueHD",
-                "score": -9999
-            },
-            {
-                "format": 175,
-                "name": "DTS-X",
-                "score": -9999
-            },
-            {
-                "format": 174,
-                "name": "FLAC",
-                "score": 0
-            },
-            {
-                "format": 173,
-                "name": "DTS-HD MA",
-                "score": -9999
-            },
-            {
-                "format": 172,
-                "name": "x265",
-                "score": -9999
-            },
-            {
-                "format": 171,
-                "name": "IMAX",
-                "score": 0
-            },
-            {
-                "format": 170,
-                "name": "ATMOS",
-                "score": 0
-            },
-            {
-                "format": 169,
-                "name": "DD",
-                "score": 0
-            },
-            {
-                "format": 168,
-                "name": "DTS",
-                "score": 0
-            },
-            {
-                "format": 167,
-                "name": "DD+",
-                "score": 0
-            },
-            {
-                "format": 166,
-                "name": "iTunes",
-                "score": 60
-            },
-            {
-                "format": 165,
-                "name": "Paramount+",
-                "score": 60
-            },
-            {
-                "format": 164,
-                "name": "Peacock TV",
-                "score": 60
-            },
-            {
-                "format": 163,
-                "name": "Hulu",
-                "score": 60
-            },
-            {
-                "format": 162,
-                "name": "Netflix",
-                "score": 60
-            },
-            {
-                "format": 161,
-                "name": "HBO Max",
-                "score": 60
-            },
-            {
-                "format": 160,
-                "name": "Disney+",
-                "score": 60
-            },
-            {
-                "format": 159,
-                "name": "Apple TV+",
-                "score": 60
-            },
-            {
-                "format": 158,
-                "name": "Movies Anywhere",
-                "score": 60
-            },
-            {
-                "format": 157,
-                "name": "Amazon Prime",
-                "score": 60
-            },
-            {
-                "format": 156,
-                "name": "REMUX",
-                "score": -9999
-            },
-            {
-                "format": 155,
-                "name": "x264",
-                "score": 10
-            },
-            {
-                "format": 154,
-                "name": "WEBRip",
-                "score": 0
-            },
-            {
-                "format": 153,
-                "name": "Blu-Ray",
-                "score": 0
-            },
-            {
-                "format": 152,
-                "name": "2160p",
-                "score": -9999
-            },
-            {
-                "format": 151,
-                "name": "720p",
-                "score": -10000
-            },
-            {
-                "format": 150,
-                "name": "1080p",
-                "score": 60
-            },
-            {
-                "format": 149,
-                "name": "BHDStudio",
-                "score": 50
-            },
-            {
-                "format": 148,
-                "name": "LEGi0N",
-                "score": 30
-            },
-            {
-                "format": 147,
-                "name": "FraMeSToR",
-                "score": 30
-            },
-            {
-                "format": 146,
-                "name": "iFT",
-                "score": 70
-            },
-            {
-                "format": 145,
-                "name": "MTeam",
-                "score": -9999
-            },
-            {
-                "format": 144,
-                "name": "EDPH",
-                "score": 30
-            },
-            {
-                "format": 143,
-                "name": "HANDJOB",
-                "score": 30
-            },
-            {
-                "format": 142,
-                "name": "c0ke",
-                "score": 110
-            },
-            {
-                "format": 141,
-                "name": "KASHMiR",
-                "score": 70
-            },
-            {
-                "format": 140,
-                "name": "WMING",
-                "score": 70
-            },
-            {
-                "format": 139,
-                "name": "playHD",
-                "score": 70
-            },
-            {
-                "format": 138,
-                "name": "E.N.D",
-                "score": 70
-            },
-            {
-                "format": 137,
-                "name": "GutS",
-                "score": 70
-            },
-            {
-                "format": 136,
-                "name": "BV",
-                "score": 70
-            },
-            {
-                "format": 135,
-                "name": "SiMPLE",
-                "score": 70
-            },
-            {
-                "format": 134,
-                "name": "W4NK3R",
-                "score": 70
-            },
-            {
-                "format": 133,
-                "name": "GS88",
-                "score": 70
-            },
-            {
-                "format": 132,
-                "name": "HiP",
-                "score": 80
-            },
-            {
-                "format": 131,
-                "name": "GALAXY",
-                "score": 70
-            },
-            {
-                "format": 130,
-                "name": "luvBB",
-                "score": 70
-            },
-            {
-                "format": 129,
-                "name": "NyHD",
-                "score": 70
-            },
-            {
-                "format": 128,
-                "name": "ZIMBO",
-                "score": 70
-            },
-            {
-                "format": 127,
-                "name": "ThD",
-                "score": 70
-            },
-            {
-                "format": 126,
-                "name": "SaNcTi",
-                "score": 70
-            },
-            {
-                "format": 125,
-                "name": "ORiGEN",
-                "score": 70
-            },
-            {
-                "format": 124,
-                "name": "Positive",
-                "score": 70
-            },
-            {
-                "format": 123,
-                "name": "ESiR",
-                "score": 70
-            },
-            {
-                "format": 122,
-                "name": "Chotab",
-                "score": 70
-            },
-            {
-                "format": 121,
-                "name": "xander",
-                "score": 70
-            },
-            {
-                "format": 120,
-                "name": "FTW-HD",
-                "score": 70
-            },
-            {
-                "format": 119,
-                "name": "Penumbra",
-                "score": 70
-            },
-            {
-                "format": 118,
-                "name": "TDD",
-                "score": 70
-            },
-            {
-                "format": 117,
-                "name": "Dariush SD",
-                "score": 70
-            },
-            {
-                "format": 116,
-                "name": "PTer",
-                "score": 70
-            },
-            {
-                "format": 115,
-                "name": "SbR",
-                "score": 70
-            },
-            {
-                "format": 114,
-                "name": "nmd",
-                "score": 70
-            },
-            {
-                "format": 113,
-                "name": "TBB",
-                "score": 70
-            },
-            {
-                "format": 112,
-                "name": "EA",
-                "score": 80
-            },
-            {
-                "format": 111,
-                "name": "BMF",
-                "score": 80
-            },
-            {
-                "format": 110,
-                "name": "LolHD",
-                "score": 80
-            },
-            {
-                "format": 109,
-                "name": "HDMaNiAcS",
-                "score": 80
-            },
-            {
-                "format": 108,
-                "name": "IDE",
-                "score": 80
-            },
-            {
-                "format": 107,
-                "name": "de[42]",
-                "score": 90
-            },
-            {
-                "format": 106,
-                "name": "NCmt",
-                "score": 100
-            },
-            {
-                "format": 105,
-                "name": "decibeL",
-                "score": 90
-            },
-            {
-                "format": 104,
-                "name": "NTb",
-                "score": 80
-            },
-            {
-                "format": 103,
-                "name": "CRiSC",
-                "score": 90
-            },
-            {
-                "format": 102,
-                "name": "SA89",
-                "score": 100
-            },
-            {
-                "format": 101,
-                "name": "HiDt",
-                "score": 100
-            },
-            {
-                "format": 100,
-                "name": "FoRM",
-                "score": 100
-            },
-            {
-                "format": 99,
-                "name": "HiFi",
-                "score": 100
-            },
-            {
-                "format": 98,
-                "name": "CtrlHD",
-                "score": 100
-            },
-            {
-                "format": 97,
-                "name": "VietHD",
-                "score": 110
-            },
-            {
-                "format": 96,
-                "name": "ZQ",
-                "score": 110
-            },
-            {
-                "format": 95,
-                "name": "TayTo",
-                "score": 110
-            },
-            {
-                "format": 94,
-                "name": "Geek",
-                "score": 110
-            },
-            {
-                "format": 93,
-                "name": "EbP",
-                "score": 120
-            },
-            {
-                "format": 92,
-                "name": "DON",
-                "score": 120
-            },
-            {
-                "format": 91,
-                "name": "D-Z0N3",
-                "score": 120
-            },
-            {
-                "format": 92,
-                "name": "Upscaled",
-                "score": -9999
-            }
-        ]
-    }
+        "allowed": true,
+        "id": 1003
+      },
+      {
+        "name": "Fallback 1080p",
+        "items": [
+          {
+            "quality": {
+              "id": 10,
+              "name": "Raw-HD",
+              "source": "televisionRaw",
+              "resolution": 1080
+            },
+            "items": [],
+            "allowed": true
+          },
+          {
+            "quality": {
+              "id": 9,
+              "name": "HDTV-1080p",
+              "source": "television",
+              "resolution": 1080
+            },
+            "items": [],
+            "allowed": true
+          }
+        ],
+        "allowed": true,
+        "id": 1002
+      },
+      {
+        "name": "Transparent Capable",
+        "items": [
+          {
+            "quality": {
+              "id": 3,
+              "name": "WEBDL-1080p",
+              "source": "web",
+              "resolution": 1080
+            },
+            "items": [],
+            "allowed": true
+          },
+          {
+            "quality": {
+              "id": 15,
+              "name": "WEBRip-1080p",
+              "source": "webRip",
+              "resolution": 1080
+            },
+            "items": [],
+            "allowed": true
+          },
+          {
+            "quality": {
+              "id": 7,
+              "name": "Bluray-1080p",
+              "source": "bluray",
+              "resolution": 1080
+            },
+            "items": [],
+            "allowed": true
+          }
+        ],
+        "allowed": true,
+        "id": 1001
+      },
+      {
+        "quality": {
+          "id": 20,
+          "name": "Bluray-1080p Remux",
+          "source": "blurayRaw",
+          "resolution": 1080
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 16,
+          "name": "HDTV-2160p",
+          "source": "television",
+          "resolution": 2160
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 17,
+          "name": "WEBRip-2160p",
+          "source": "webRip",
+          "resolution": 2160
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 18,
+          "name": "WEBDL-2160p",
+          "source": "web",
+          "resolution": 2160
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 19,
+          "name": "Bluray-2160p",
+          "source": "bluray",
+          "resolution": 2160
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 21,
+          "name": "Bluray-2160p Remux",
+          "source": "blurayRaw",
+          "resolution": 2160
+        },
+        "items": [],
+        "allowed": false
+      }
+    ],
+    "minFormatScore": 0,
+    "cutoffFormatScore": 140,
+    "minUpgradeFormatScore": 1,
+    "formatItems": [
+      {
+        "format": 229,
+        "name": "HR",
+        "score": 30
+      },
+      {
+        "format": 228,
+        "name": "MAX",
+        "score": 0
+      },
+      {
+        "format": 227,
+        "name": "h265 (4k)",
+        "score": 0
+      },
+      {
+        "format": 226,
+        "name": "PCM",
+        "score": 0
+      },
+      {
+        "format": 225,
+        "name": "Blu-Ray (Remux)",
+        "score": 0
+      },
+      {
+        "format": 224,
+        "name": "h265",
+        "score": -9999
+      },
+      {
+        "format": 223,
+        "name": "LiNG",
+        "score": 80
+      },
+      {
+        "format": 221,
+        "name": "hdalx",
+        "score": 80
+      },
+      {
+        "format": 220,
+        "name": "VLAD",
+        "score": 80
+      },
+      {
+        "format": 219,
+        "name": "AJP69",
+        "score": 80
+      },
+      {
+        "format": 218,
+        "name": "iON",
+        "score": 80
+      },
+      {
+        "format": 217,
+        "name": "BTN",
+        "score": 30
+      },
+      {
+        "format": 216,
+        "name": "pcroland",
+        "score": 80
+      },
+      {
+        "format": 215,
+        "name": "CJ",
+        "score": 80
+      },
+      {
+        "format": 214,
+        "name": "LQ",
+        "score": -9999
+      },
+      {
+        "format": 213,
+        "name": "EPSiLON",
+        "score": 0
+      },
+      {
+        "format": 212,
+        "name": "playBD",
+        "score": 0
+      },
+      {
+        "format": 211,
+        "name": "BLURANiUM",
+        "score": 0
+      },
+      {
+        "format": 210,
+        "name": "PmP",
+        "score": 0
+      },
+      {
+        "format": 209,
+        "name": "WiLDCAT",
+        "score": 0
+      },
+      {
+        "format": 208,
+        "name": "TRiToN",
+        "score": 0
+      },
+      {
+        "format": 207,
+        "name": "3L",
+        "score": 0
+      },
+      {
+        "format": 206,
+        "name": "Dolby Vision w/out Fallback",
+        "score": -9999
+      },
+      {
+        "format": 205,
+        "name": "UHDBits",
+        "score": 0
+      },
+      {
+        "format": 204,
+        "name": "ATMOS (Missing)",
+        "score": 0
+      },
+      {
+        "format": 203,
+        "name": "TrueHD (Missing)",
+        "score": -9999
+      },
+      {
+        "format": 202,
+        "name": "HDR10 (Missing)",
+        "score": -9999
+      },
+      {
+        "format": 201,
+        "name": "HDR10",
+        "score": -9999
+      },
+      {
+        "format": 200,
+        "name": "Dolby Vision",
+        "score": -9999
+      },
+      {
+        "format": 199,
+        "name": "HDR10+",
+        "score": -9999
+      },
+      {
+        "format": 198,
+        "name": "Stream Optimised",
+        "score": 0
+      },
+      {
+        "format": 197,
+        "name": "LoRD",
+        "score": 70
+      },
+      {
+        "format": 196,
+        "name": "Scene",
+        "score": 30
+      },
+      {
+        "format": 195,
+        "name": "mHD",
+        "score": -999999
+      },
+      {
+        "format": 194,
+        "name": "AV1",
+        "score": -9999
+      },
+      {
+        "format": 193,
+        "name": "VVC",
+        "score": -9999
+      },
+      {
+        "format": 192,
+        "name": "Extras",
+        "score": -9999
+      },
+      {
+        "format": 191,
+        "name": "480p",
+        "score": 0
+      },
+      {
+        "format": 190,
+        "name": "Dariush ",
+        "score": 20
+      },
+      {
+        "format": 189,
+        "name": "TBB SD",
+        "score": 30
+      },
+      {
+        "format": 188,
+        "name": "Xvid",
+        "score": 0
+      },
+      {
+        "format": 187,
+        "name": "DVD",
+        "score": 0
+      },
+      {
+        "format": 186,
+        "name": "DVD REMUX ",
+        "score": 40
+      },
+      {
+        "format": 185,
+        "name": "HANDJOB SD",
+        "score": 20
+      },
+      {
+        "format": 184,
+        "name": "iTunes (Missing)",
+        "score": 60
+      },
+      {
+        "format": 183,
+        "name": "ROKU",
+        "score": 60
+      },
+      {
+        "format": 182,
+        "name": "BeyondHD",
+        "score": -10000
+      },
+      {
+        "format": 181,
+        "name": "Disc ",
+        "score": -9999
+      },
+      {
+        "format": 180,
+        "name": "3D",
+        "score": -9999
+      },
+      {
+        "format": 179,
+        "name": "Unwanted",
+        "score": -9999
+      },
+      {
+        "format": 178,
+        "name": "RightSIZE",
+        "score": 70
+      },
+      {
+        "format": 177,
+        "name": "Black and White",
+        "score": -9999
+      },
+      {
+        "format": 176,
+        "name": "TrueHD",
+        "score": -9999
+      },
+      {
+        "format": 175,
+        "name": "DTS-X",
+        "score": -9999
+      },
+      {
+        "format": 174,
+        "name": "FLAC",
+        "score": 0
+      },
+      {
+        "format": 173,
+        "name": "DTS-HD MA",
+        "score": -9999
+      },
+      {
+        "format": 172,
+        "name": "x265",
+        "score": -9999
+      },
+      {
+        "format": 171,
+        "name": "IMAX",
+        "score": 0
+      },
+      {
+        "format": 170,
+        "name": "ATMOS",
+        "score": 0
+      },
+      {
+        "format": 169,
+        "name": "DD",
+        "score": 0
+      },
+      {
+        "format": 168,
+        "name": "DTS",
+        "score": 0
+      },
+      {
+        "format": 167,
+        "name": "DD+",
+        "score": 0
+      },
+      {
+        "format": 166,
+        "name": "iTunes",
+        "score": 60
+      },
+      {
+        "format": 165,
+        "name": "Paramount+",
+        "score": 60
+      },
+      {
+        "format": 164,
+        "name": "Peacock TV",
+        "score": 60
+      },
+      {
+        "format": 163,
+        "name": "Hulu",
+        "score": 60
+      },
+      {
+        "format": 162,
+        "name": "Netflix",
+        "score": 60
+      },
+      {
+        "format": 161,
+        "name": "HBO Max",
+        "score": 60
+      },
+      {
+        "format": 160,
+        "name": "Disney+",
+        "score": 60
+      },
+      {
+        "format": 159,
+        "name": "Apple TV+",
+        "score": 60
+      },
+      {
+        "format": 158,
+        "name": "Movies Anywhere",
+        "score": 60
+      },
+      {
+        "format": 157,
+        "name": "Amazon Prime",
+        "score": 60
+      },
+      {
+        "format": 156,
+        "name": "REMUX",
+        "score": -9999
+      },
+      {
+        "format": 155,
+        "name": "x264",
+        "score": 10
+      },
+      {
+        "format": 154,
+        "name": "WEBRip",
+        "score": 0
+      },
+      {
+        "format": 153,
+        "name": "Blu-Ray",
+        "score": 0
+      },
+      {
+        "format": 152,
+        "name": "2160p",
+        "score": -9999
+      },
+      {
+        "format": 151,
+        "name": "720p",
+        "score": -10000
+      },
+      {
+        "format": 150,
+        "name": "1080p",
+        "score": 60
+      },
+      {
+        "format": 149,
+        "name": "BHDStudio",
+        "score": 50
+      },
+      {
+        "format": 148,
+        "name": "LEGi0N",
+        "score": 30
+      },
+      {
+        "format": 147,
+        "name": "FraMeSToR",
+        "score": 30
+      },
+      {
+        "format": 146,
+        "name": "iFT",
+        "score": 70
+      },
+      {
+        "format": 145,
+        "name": "MTeam",
+        "score": -9999
+      },
+      {
+        "format": 144,
+        "name": "EDPH",
+        "score": 30
+      },
+      {
+        "format": 143,
+        "name": "HANDJOB",
+        "score": 30
+      },
+      {
+        "format": 142,
+        "name": "c0ke",
+        "score": 110
+      },
+      {
+        "format": 141,
+        "name": "KASHMiR",
+        "score": 70
+      },
+      {
+        "format": 140,
+        "name": "WMING",
+        "score": 70
+      },
+      {
+        "format": 139,
+        "name": "playHD",
+        "score": 70
+      },
+      {
+        "format": 138,
+        "name": "E.N.D",
+        "score": 70
+      },
+      {
+        "format": 137,
+        "name": "GutS",
+        "score": 70
+      },
+      {
+        "format": 136,
+        "name": "BV",
+        "score": 70
+      },
+      {
+        "format": 135,
+        "name": "SiMPLE",
+        "score": 70
+      },
+      {
+        "format": 134,
+        "name": "W4NK3R",
+        "score": 70
+      },
+      {
+        "format": 133,
+        "name": "GS88",
+        "score": 70
+      },
+      {
+        "format": 132,
+        "name": "HiP",
+        "score": 80
+      },
+      {
+        "format": 131,
+        "name": "GALAXY",
+        "score": 70
+      },
+      {
+        "format": 130,
+        "name": "luvBB",
+        "score": 70
+      },
+      {
+        "format": 129,
+        "name": "NyHD",
+        "score": 70
+      },
+      {
+        "format": 128,
+        "name": "ZIMBO",
+        "score": 70
+      },
+      {
+        "format": 127,
+        "name": "ThD",
+        "score": 70
+      },
+      {
+        "format": 126,
+        "name": "SaNcTi",
+        "score": 70
+      },
+      {
+        "format": 125,
+        "name": "ORiGEN",
+        "score": 70
+      },
+      {
+        "format": 124,
+        "name": "Positive",
+        "score": 70
+      },
+      {
+        "format": 123,
+        "name": "ESiR",
+        "score": 70
+      },
+      {
+        "format": 122,
+        "name": "Chotab",
+        "score": 70
+      },
+      {
+        "format": 121,
+        "name": "xander",
+        "score": 70
+      },
+      {
+        "format": 120,
+        "name": "FTW-HD",
+        "score": 70
+      },
+      {
+        "format": 119,
+        "name": "Penumbra",
+        "score": 70
+      },
+      {
+        "format": 118,
+        "name": "TDD",
+        "score": 70
+      },
+      {
+        "format": 117,
+        "name": "Dariush SD",
+        "score": 70
+      },
+      {
+        "format": 116,
+        "name": "PTer",
+        "score": 70
+      },
+      {
+        "format": 115,
+        "name": "SbR",
+        "score": 70
+      },
+      {
+        "format": 114,
+        "name": "nmd",
+        "score": 70
+      },
+      {
+        "format": 113,
+        "name": "TBB",
+        "score": 70
+      },
+      {
+        "format": 112,
+        "name": "EA",
+        "score": 80
+      },
+      {
+        "format": 111,
+        "name": "BMF",
+        "score": 80
+      },
+      {
+        "format": 110,
+        "name": "LolHD",
+        "score": 80
+      },
+      {
+        "format": 109,
+        "name": "HDMaNiAcS",
+        "score": 80
+      },
+      {
+        "format": 108,
+        "name": "IDE",
+        "score": 80
+      },
+      {
+        "format": 107,
+        "name": "de[42]",
+        "score": 90
+      },
+      {
+        "format": 106,
+        "name": "NCmt",
+        "score": 100
+      },
+      {
+        "format": 105,
+        "name": "decibeL",
+        "score": 90
+      },
+      {
+        "format": 104,
+        "name": "NTb",
+        "score": 80
+      },
+      {
+        "format": 103,
+        "name": "CRiSC",
+        "score": 90
+      },
+      {
+        "format": 102,
+        "name": "SA89",
+        "score": 100
+      },
+      {
+        "format": 101,
+        "name": "HiDt",
+        "score": 100
+      },
+      {
+        "format": 100,
+        "name": "FoRM",
+        "score": 100
+      },
+      {
+        "format": 99,
+        "name": "HiFi",
+        "score": 100
+      },
+      {
+        "format": 98,
+        "name": "CtrlHD",
+        "score": 100
+      },
+      {
+        "format": 97,
+        "name": "VietHD",
+        "score": 110
+      },
+      {
+        "format": 96,
+        "name": "ZQ",
+        "score": 110
+      },
+      {
+        "format": 95,
+        "name": "TayTo",
+        "score": 110
+      },
+      {
+        "format": 94,
+        "name": "Geek",
+        "score": 110
+      },
+      {
+        "format": 93,
+        "name": "EbP",
+        "score": 120
+      },
+      {
+        "format": 92,
+        "name": "DON",
+        "score": 120
+      },
+      {
+        "format": 91,
+        "name": "D-Z0N3",
+        "score": 120
+      },
+      {
+        "format": 92,
+        "name": "Upscaled",
+        "score": -9999
+      }
+    ]
+  }
 ]

--- a/imports/quality_profiles/sonarr/1080p Transparent (sonarr - master).json
+++ b/imports/quality_profiles/sonarr/1080p Transparent (sonarr - master).json
@@ -1,939 +1,940 @@
 [
-    {
-        "name": "1080p Transparent",
-        "upgradeAllowed": true,
-        "cutoff": 1001,
+  {
+    "name": "1080p Transparent",
+    "upgradeAllowed": true,
+    "cutoff": 1001,
+    "items": [
+      {
+        "quality": {
+          "id": 0,
+          "name": "Unknown",
+          "source": "unknown",
+          "resolution": 0
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 13,
+          "name": "Bluray-480p",
+          "source": "bluray",
+          "resolution": 480
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 4,
+          "name": "HDTV-720p",
+          "source": "television",
+          "resolution": 720
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 14,
+          "name": "WEBRip-720p",
+          "source": "webRip",
+          "resolution": 720
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 5,
+          "name": "WEBDL-720p",
+          "source": "web",
+          "resolution": 720
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 6,
+          "name": "Bluray-720p",
+          "source": "bluray",
+          "resolution": 720
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "name": "Fallback SD",
         "items": [
-            {
-                "quality": {
-                    "id": 0,
-                    "name": "Unknown",
-                    "source": "unknown",
-                    "resolution": 0
-                },
-                "items": [],
-                "allowed": false
+          {
+            "quality": {
+              "id": 1,
+              "name": "SDTV",
+              "source": "television",
+              "resolution": 480
             },
-            {
-                "quality": {
-                    "id": 13,
-                    "name": "Bluray-480p",
-                    "source": "bluray",
-                    "resolution": 480
-                },
-                "items": [],
-                "allowed": false
+            "items": [],
+            "allowed": true
+          },
+          {
+            "quality": {
+              "id": 12,
+              "name": "WEBRip-480p",
+              "source": "webRip",
+              "resolution": 480
             },
-            {
-                "quality": {
-                    "id": 4,
-                    "name": "HDTV-720p",
-                    "source": "television",
-                    "resolution": 720
-                },
-                "items": [],
-                "allowed": false
+            "items": [],
+            "allowed": true
+          },
+          {
+            "quality": {
+              "id": 8,
+              "name": "WEBDL-480p",
+              "source": "web",
+              "resolution": 480
             },
-            {
-                "quality": {
-                    "id": 14,
-                    "name": "WEBRip-720p",
-                    "source": "webRip",
-                    "resolution": 720
-                },
-                "items": [],
-                "allowed": false
+            "items": [],
+            "allowed": true
+          },
+          {
+            "quality": {
+              "id": 2,
+              "name": "DVD",
+              "source": "dvd",
+              "resolution": 480
             },
-            {
-                "quality": {
-                    "id": 5,
-                    "name": "WEBDL-720p",
-                    "source": "web",
-                    "resolution": 720
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 6,
-                    "name": "Bluray-720p",
-                    "source": "bluray",
-                    "resolution": 720
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "name": "Fallback SD",
-                "items": [
-                    {
-                        "quality": {
-                            "id": 1,
-                            "name": "SDTV",
-                            "source": "television",
-                            "resolution": 480
-                        },
-                        "items": [],
-                        "allowed": true
-                    },
-                    {
-                        "quality": {
-                            "id": 12,
-                            "name": "WEBRip-480p",
-                            "source": "webRip",
-                            "resolution": 480
-                        },
-                        "items": [],
-                        "allowed": true
-                    },
-                    {
-                        "quality": {
-                            "id": 8,
-                            "name": "WEBDL-480p",
-                            "source": "web",
-                            "resolution": 480
-                        },
-                        "items": [],
-                        "allowed": true
-                    },
-                    {
-                        "quality": {
-                            "id": 2,
-                            "name": "DVD",
-                            "source": "dvd",
-                            "resolution": 480
-                        },
-                        "items": [],
-                        "allowed": true
-                    }
-                ],
-                "allowed": true,
-                "id": 1003
-            },
-            {
-                "name": "Fallback 1080p",
-                "items": [
-                    {
-                        "quality": {
-                            "id": 10,
-                            "name": "Raw-HD",
-                            "source": "televisionRaw",
-                            "resolution": 1080
-                        },
-                        "items": [],
-                        "allowed": true
-                    },
-                    {
-                        "quality": {
-                            "id": 9,
-                            "name": "HDTV-1080p",
-                            "source": "television",
-                            "resolution": 1080
-                        },
-                        "items": [],
-                        "allowed": true
-                    }
-                ],
-                "allowed": true,
-                "id": 1002
-            },
-            {
-                "name": "Transparent Capable",
-                "items": [
-                    {
-                        "quality": {
-                            "id": 3,
-                            "name": "WEBDL-1080p",
-                            "source": "web",
-                            "resolution": 1080
-                        },
-                        "items": [],
-                        "allowed": true
-                    },
-                    {
-                        "quality": {
-                            "id": 15,
-                            "name": "WEBRip-1080p",
-                            "source": "webRip",
-                            "resolution": 1080
-                        },
-                        "items": [],
-                        "allowed": true
-                    },
-                    {
-                        "quality": {
-                            "id": 7,
-                            "name": "Bluray-1080p",
-                            "source": "bluray",
-                            "resolution": 1080
-                        },
-                        "items": [],
-                        "allowed": true
-                    }
-                ],
-                "allowed": true,
-                "id": 1001
-            },
-            {
-                "quality": {
-                    "id": 20,
-                    "name": "Bluray-1080p Remux",
-                    "source": "blurayRaw",
-                    "resolution": 1080
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 16,
-                    "name": "HDTV-2160p",
-                    "source": "television",
-                    "resolution": 2160
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 17,
-                    "name": "WEBRip-2160p",
-                    "source": "webRip",
-                    "resolution": 2160
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 18,
-                    "name": "WEBDL-2160p",
-                    "source": "web",
-                    "resolution": 2160
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 19,
-                    "name": "Bluray-2160p",
-                    "source": "bluray",
-                    "resolution": 2160
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 21,
-                    "name": "Bluray-2160p Remux",
-                    "source": "blurayRaw",
-                    "resolution": 2160
-                },
-                "items": [],
-                "allowed": false
-            }
+            "items": [],
+            "allowed": true
+          }
         ],
-        "minFormatScore": 0,
-        "cutoffFormatScore": 500,
-        "formatItems": [
-            {
-                "format": 229,
-                "name": "HR",
-                "score": 30
-            },
-            {
-                "format": 228,
-                "name": "MAX",
-                "score": 0
-            },
-            {
-                "format": 227,
-                "name": "h265 (4k)",
-                "score": 0
-            },
-            {
-                "format": 226,
-                "name": "PCM",
-                "score": 0
-            },
-            {
-                "format": 225,
-                "name": "Blu-Ray (Remux)",
-                "score": 0
-            },
-            {
-                "format": 224,
-                "name": "h265",
-                "score": -9999
-            },
-            {
-                "format": 223,
-                "name": "LiNG",
-                "score": 80
-            },
-            {
-                "format": 221,
-                "name": "hdalx",
-                "score": 80
-            },
-            {
-                "format": 220,
-                "name": "VLAD",
-                "score": 80
-            },
-            {
-                "format": 219,
-                "name": "AJP69",
-                "score": 80
-            },
-            {
-                "format": 218,
-                "name": "iON",
-                "score": 80
-            },
-            {
-                "format": 217,
-                "name": "BTN",
-                "score": 30
-            },
-            {
-                "format": 216,
-                "name": "pcroland",
-                "score": 80
-            },
-            {
-                "format": 215,
-                "name": "CJ",
-                "score": 80
-            },
-            {
-                "format": 214,
-                "name": "LQ",
-                "score": -9999
-            },
-            {
-                "format": 213,
-                "name": "EPSiLON",
-                "score": 0
-            },
-            {
-                "format": 212,
-                "name": "playBD",
-                "score": 0
-            },
-            {
-                "format": 211,
-                "name": "BLURANiUM",
-                "score": 0
-            },
-            {
-                "format": 210,
-                "name": "PmP",
-                "score": 0
-            },
-            {
-                "format": 209,
-                "name": "WiLDCAT",
-                "score": 0
-            },
-            {
-                "format": 208,
-                "name": "TRiToN",
-                "score": 0
-            },
-            {
-                "format": 207,
-                "name": "3L",
-                "score": 0
-            },
-            {
-                "format": 206,
-                "name": "Dolby Vision w/out Fallback",
-                "score": -9999
-            },
-            {
-                "format": 205,
-                "name": "UHDBits",
-                "score": 0
-            },
-            {
-                "format": 204,
-                "name": "ATMOS (Missing)",
-                "score": 0
-            },
-            {
-                "format": 203,
-                "name": "TrueHD (Missing)",
-                "score": -9999
-            },
-            {
-                "format": 202,
-                "name": "HDR10 (Missing)",
-                "score": -9999
-            },
-            {
-                "format": 201,
-                "name": "HDR10",
-                "score": -9999
-            },
-            {
-                "format": 200,
-                "name": "Dolby Vision",
-                "score": -9999
-            },
-            {
-                "format": 199,
-                "name": "HDR10+",
-                "score": -9999
-            },
-            {
-                "format": 198,
-                "name": "Stream Optimised",
-                "score": 0
-            },
-            {
-                "format": 197,
-                "name": "LoRD",
-                "score": 70
-            },
-            {
-                "format": 196,
-                "name": "Scene",
-                "score": 30
-            },
-            {
-                "format": 195,
-                "name": "mHD",
-                "score": -999999
-            },
-            {
-                "format": 194,
-                "name": "AV1",
-                "score": -9999
-            },
-            {
-                "format": 193,
-                "name": "VVC",
-                "score": -9999
-            },
-            {
-                "format": 192,
-                "name": "Extras",
-                "score": -9999
-            },
-            {
-                "format": 191,
-                "name": "480p",
-                "score": 0
-            },
-            {
-                "format": 190,
-                "name": "Dariush ",
-                "score": 20
-            },
-            {
-                "format": 189,
-                "name": "TBB SD",
-                "score": 30
-            },
-            {
-                "format": 188,
-                "name": "Xvid",
-                "score": 0
-            },
-            {
-                "format": 187,
-                "name": "DVD",
-                "score": 0
-            },
-            {
-                "format": 186,
-                "name": "DVD REMUX ",
-                "score": 40
-            },
-            {
-                "format": 185,
-                "name": "HANDJOB SD",
-                "score": 20
-            },
-            {
-                "format": 184,
-                "name": "iTunes (Missing)",
-                "score": 20
-            },
-            {
-                "format": 183,
-                "name": "ROKU",
-                "score": 30
-            },
-            {
-                "format": 182,
-                "name": "BeyondHD",
-                "score": -10000
-            },
-            {
-                "format": 181,
-                "name": "Disc ",
-                "score": -9999
-            },
-            {
-                "format": 180,
-                "name": "3D",
-                "score": -9999
-            },
-            {
-                "format": 179,
-                "name": "Unwanted",
-                "score": -9999
-            },
-            {
-                "format": 178,
-                "name": "RightSIZE",
-                "score": 70
-            },
-            {
-                "format": 177,
-                "name": "Black and White",
-                "score": -9999
-            },
-            {
-                "format": 176,
-                "name": "TrueHD",
-                "score": -9999
-            },
-            {
-                "format": 175,
-                "name": "DTS-X",
-                "score": -9999
-            },
-            {
-                "format": 174,
-                "name": "FLAC",
-                "score": 0
-            },
-            {
-                "format": 173,
-                "name": "DTS-HD MA",
-                "score": -9999
-            },
-            {
-                "format": 172,
-                "name": "x265",
-                "score": -9999
-            },
-            {
-                "format": 171,
-                "name": "IMAX",
-                "score": 10
-            },
-            {
-                "format": 170,
-                "name": "ATMOS",
-                "score": 5
-            },
-            {
-                "format": 169,
-                "name": "DD",
-                "score": 0
-            },
-            {
-                "format": 168,
-                "name": "DTS",
-                "score": 0
-            },
-            {
-                "format": 167,
-                "name": "DD+",
-                "score": 0
-            },
-            {
-                "format": 166,
-                "name": "iTunes",
-                "score": 20
-            },
-            {
-                "format": 165,
-                "name": "Paramount+",
-                "score": 30
-            },
-            {
-                "format": 164,
-                "name": "Peacock TV",
-                "score": 30
-            },
-            {
-                "format": 163,
-                "name": "Hulu",
-                "score": 30
-            },
-            {
-                "format": 162,
-                "name": "Netflix",
-                "score": 40
-            },
-            {
-                "format": 161,
-                "name": "HBO Max",
-                "score": 40
-            },
-            {
-                "format": 160,
-                "name": "Disney+",
-                "score": 40
-            },
-            {
-                "format": 159,
-                "name": "Apple TV+",
-                "score": 50
-            },
-            {
-                "format": 158,
-                "name": "Movies Anywhere",
-                "score": 60
-            },
-            {
-                "format": 157,
-                "name": "Amazon Prime",
-                "score": 50
-            },
-            {
-                "format": 156,
-                "name": "REMUX",
-                "score": -9999
-            },
-            {
-                "format": 155,
-                "name": "x264",
-                "score": 10
-            },
-            {
-                "format": 154,
-                "name": "WEBRip",
-                "score": 0
-            },
-            {
-                "format": 153,
-                "name": "Blu-Ray",
-                "score": 0
-            },
-            {
-                "format": 152,
-                "name": "2160p",
-                "score": -9999
-            },
-            {
-                "format": 151,
-                "name": "720p",
-                "score": -10000
-            },
-            {
-                "format": 150,
-                "name": "1080p",
-                "score": 60
-            },
-            {
-                "format": 149,
-                "name": "BHDStudio",
-                "score": 30
-            },
-            {
-                "format": 148,
-                "name": "LEGi0N",
-                "score": 30
-            },
-            {
-                "format": 147,
-                "name": "FraMeSToR",
-                "score": 30
-            },
-            {
-                "format": 146,
-                "name": "iFT",
-                "score": 70
-            },
-            {
-                "format": 145,
-                "name": "MTeam",
-                "score": -9999
-            },
-            {
-                "format": 144,
-                "name": "EDPH",
-                "score": 30
-            },
-            {
-                "format": 143,
-                "name": "HANDJOB",
-                "score": 30
-            },
-            {
-                "format": 142,
-                "name": "c0ke",
-                "score": 110
-            },
-            {
-                "format": 141,
-                "name": "KASHMiR",
-                "score": 70
-            },
-            {
-                "format": 140,
-                "name": "WMING",
-                "score": 70
-            },
-            {
-                "format": 139,
-                "name": "playHD",
-                "score": 70
-            },
-            {
-                "format": 138,
-                "name": "E.N.D",
-                "score": 70
-            },
-            {
-                "format": 137,
-                "name": "GutS",
-                "score": 70
-            },
-            {
-                "format": 136,
-                "name": "BV",
-                "score": 70
-            },
-            {
-                "format": 135,
-                "name": "SiMPLE",
-                "score": 70
-            },
-            {
-                "format": 134,
-                "name": "W4NK3R",
-                "score": 70
-            },
-            {
-                "format": 133,
-                "name": "GS88",
-                "score": 70
-            },
-            {
-                "format": 132,
-                "name": "HiP",
-                "score": 80
-            },
-            {
-                "format": 131,
-                "name": "GALAXY",
-                "score": 70
-            },
-            {
-                "format": 130,
-                "name": "luvBB",
-                "score": 70
-            },
-            {
-                "format": 129,
-                "name": "NyHD",
-                "score": 70
-            },
-            {
-                "format": 128,
-                "name": "ZIMBO",
-                "score": 70
-            },
-            {
-                "format": 127,
-                "name": "ThD",
-                "score": 70
-            },
-            {
-                "format": 126,
-                "name": "SaNcTi",
-                "score": 70
-            },
-            {
-                "format": 125,
-                "name": "ORiGEN",
-                "score": 70
-            },
-            {
-                "format": 124,
-                "name": "Positive",
-                "score": 70
-            },
-            {
-                "format": 123,
-                "name": "ESiR",
-                "score": 70
-            },
-            {
-                "format": 122,
-                "name": "Chotab",
-                "score": 70
-            },
-            {
-                "format": 121,
-                "name": "xander",
-                "score": 70
-            },
-            {
-                "format": 120,
-                "name": "FTW-HD",
-                "score": 70
-            },
-            {
-                "format": 119,
-                "name": "Penumbra",
-                "score": 70
-            },
-            {
-                "format": 118,
-                "name": "TDD",
-                "score": 70
-            },
-            {
-                "format": 117,
-                "name": "Dariush SD",
-                "score": 70
-            },
-            {
-                "format": 116,
-                "name": "PTer",
-                "score": 70
-            },
-            {
-                "format": 115,
-                "name": "SbR",
-                "score": 70
-            },
-            {
-                "format": 114,
-                "name": "nmd",
-                "score": 70
-            },
-            {
-                "format": 113,
-                "name": "TBB",
-                "score": 70
-            },
-            {
-                "format": 112,
-                "name": "EA",
-                "score": 80
-            },
-            {
-                "format": 111,
-                "name": "BMF",
-                "score": 80
-            },
-            {
-                "format": 110,
-                "name": "LolHD",
-                "score": 80
-            },
-            {
-                "format": 109,
-                "name": "HDMaNiAcS",
-                "score": 80
-            },
-            {
-                "format": 108,
-                "name": "IDE",
-                "score": 80
-            },
-            {
-                "format": 107,
-                "name": "de[42]",
-                "score": 90
-            },
-            {
-                "format": 106,
-                "name": "NCmt",
-                "score": 100
-            },
-            {
-                "format": 105,
-                "name": "decibeL",
-                "score": 90
-            },
-            {
-                "format": 104,
-                "name": "NTb",
-                "score": 80
-            },
-            {
-                "format": 103,
-                "name": "CRiSC",
-                "score": 90
-            },
-            {
-                "format": 102,
-                "name": "SA89",
-                "score": 100
-            },
-            {
-                "format": 101,
-                "name": "HiDt",
-                "score": 100
-            },
-            {
-                "format": 100,
-                "name": "FoRM",
-                "score": 100
-            },
-            {
-                "format": 99,
-                "name": "HiFi",
-                "score": 100
-            },
-            {
-                "format": 98,
-                "name": "CtrlHD",
-                "score": 100
-            },
-            {
-                "format": 97,
-                "name": "VietHD",
-                "score": 110
-            },
-            {
-                "format": 96,
-                "name": "ZQ",
-                "score": 110
-            },
-            {
-                "format": 95,
-                "name": "TayTo",
-                "score": 110
-            },
-            {
-                "format": 94,
-                "name": "Geek",
-                "score": 110
-            },
-            {
-                "format": 93,
-                "name": "EbP",
-                "score": 120
-            },
-            {
-                "format": 92,
-                "name": "DON",
-                "score": 120
-            },
-            {
-                "format": 91,
-                "name": "D-Z0N3",
-                "score": 120
-            },
-            {
-                "format": 92,
-                "name": "Upscaled",
-                "score": -9999
-            }
-        ]
-    }
+        "allowed": true,
+        "id": 1003
+      },
+      {
+        "name": "Fallback 1080p",
+        "items": [
+          {
+            "quality": {
+              "id": 10,
+              "name": "Raw-HD",
+              "source": "televisionRaw",
+              "resolution": 1080
+            },
+            "items": [],
+            "allowed": true
+          },
+          {
+            "quality": {
+              "id": 9,
+              "name": "HDTV-1080p",
+              "source": "television",
+              "resolution": 1080
+            },
+            "items": [],
+            "allowed": true
+          }
+        ],
+        "allowed": true,
+        "id": 1002
+      },
+      {
+        "name": "Transparent Capable",
+        "items": [
+          {
+            "quality": {
+              "id": 3,
+              "name": "WEBDL-1080p",
+              "source": "web",
+              "resolution": 1080
+            },
+            "items": [],
+            "allowed": true
+          },
+          {
+            "quality": {
+              "id": 15,
+              "name": "WEBRip-1080p",
+              "source": "webRip",
+              "resolution": 1080
+            },
+            "items": [],
+            "allowed": true
+          },
+          {
+            "quality": {
+              "id": 7,
+              "name": "Bluray-1080p",
+              "source": "bluray",
+              "resolution": 1080
+            },
+            "items": [],
+            "allowed": true
+          }
+        ],
+        "allowed": true,
+        "id": 1001
+      },
+      {
+        "quality": {
+          "id": 20,
+          "name": "Bluray-1080p Remux",
+          "source": "blurayRaw",
+          "resolution": 1080
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 16,
+          "name": "HDTV-2160p",
+          "source": "television",
+          "resolution": 2160
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 17,
+          "name": "WEBRip-2160p",
+          "source": "webRip",
+          "resolution": 2160
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 18,
+          "name": "WEBDL-2160p",
+          "source": "web",
+          "resolution": 2160
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 19,
+          "name": "Bluray-2160p",
+          "source": "bluray",
+          "resolution": 2160
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 21,
+          "name": "Bluray-2160p Remux",
+          "source": "blurayRaw",
+          "resolution": 2160
+        },
+        "items": [],
+        "allowed": false
+      }
+    ],
+    "minFormatScore": 0,
+    "cutoffFormatScore": 500,
+    "minUpgradeFormatScore": 1,
+    "formatItems": [
+      {
+        "format": 229,
+        "name": "HR",
+        "score": 30
+      },
+      {
+        "format": 228,
+        "name": "MAX",
+        "score": 0
+      },
+      {
+        "format": 227,
+        "name": "h265 (4k)",
+        "score": 0
+      },
+      {
+        "format": 226,
+        "name": "PCM",
+        "score": 0
+      },
+      {
+        "format": 225,
+        "name": "Blu-Ray (Remux)",
+        "score": 0
+      },
+      {
+        "format": 224,
+        "name": "h265",
+        "score": -9999
+      },
+      {
+        "format": 223,
+        "name": "LiNG",
+        "score": 80
+      },
+      {
+        "format": 221,
+        "name": "hdalx",
+        "score": 80
+      },
+      {
+        "format": 220,
+        "name": "VLAD",
+        "score": 80
+      },
+      {
+        "format": 219,
+        "name": "AJP69",
+        "score": 80
+      },
+      {
+        "format": 218,
+        "name": "iON",
+        "score": 80
+      },
+      {
+        "format": 217,
+        "name": "BTN",
+        "score": 30
+      },
+      {
+        "format": 216,
+        "name": "pcroland",
+        "score": 80
+      },
+      {
+        "format": 215,
+        "name": "CJ",
+        "score": 80
+      },
+      {
+        "format": 214,
+        "name": "LQ",
+        "score": -9999
+      },
+      {
+        "format": 213,
+        "name": "EPSiLON",
+        "score": 0
+      },
+      {
+        "format": 212,
+        "name": "playBD",
+        "score": 0
+      },
+      {
+        "format": 211,
+        "name": "BLURANiUM",
+        "score": 0
+      },
+      {
+        "format": 210,
+        "name": "PmP",
+        "score": 0
+      },
+      {
+        "format": 209,
+        "name": "WiLDCAT",
+        "score": 0
+      },
+      {
+        "format": 208,
+        "name": "TRiToN",
+        "score": 0
+      },
+      {
+        "format": 207,
+        "name": "3L",
+        "score": 0
+      },
+      {
+        "format": 206,
+        "name": "Dolby Vision w/out Fallback",
+        "score": -9999
+      },
+      {
+        "format": 205,
+        "name": "UHDBits",
+        "score": 0
+      },
+      {
+        "format": 204,
+        "name": "ATMOS (Missing)",
+        "score": 0
+      },
+      {
+        "format": 203,
+        "name": "TrueHD (Missing)",
+        "score": -9999
+      },
+      {
+        "format": 202,
+        "name": "HDR10 (Missing)",
+        "score": -9999
+      },
+      {
+        "format": 201,
+        "name": "HDR10",
+        "score": -9999
+      },
+      {
+        "format": 200,
+        "name": "Dolby Vision",
+        "score": -9999
+      },
+      {
+        "format": 199,
+        "name": "HDR10+",
+        "score": -9999
+      },
+      {
+        "format": 198,
+        "name": "Stream Optimised",
+        "score": 0
+      },
+      {
+        "format": 197,
+        "name": "LoRD",
+        "score": 70
+      },
+      {
+        "format": 196,
+        "name": "Scene",
+        "score": 30
+      },
+      {
+        "format": 195,
+        "name": "mHD",
+        "score": -999999
+      },
+      {
+        "format": 194,
+        "name": "AV1",
+        "score": -9999
+      },
+      {
+        "format": 193,
+        "name": "VVC",
+        "score": -9999
+      },
+      {
+        "format": 192,
+        "name": "Extras",
+        "score": -9999
+      },
+      {
+        "format": 191,
+        "name": "480p",
+        "score": 0
+      },
+      {
+        "format": 190,
+        "name": "Dariush ",
+        "score": 20
+      },
+      {
+        "format": 189,
+        "name": "TBB SD",
+        "score": 30
+      },
+      {
+        "format": 188,
+        "name": "Xvid",
+        "score": 0
+      },
+      {
+        "format": 187,
+        "name": "DVD",
+        "score": 0
+      },
+      {
+        "format": 186,
+        "name": "DVD REMUX ",
+        "score": 40
+      },
+      {
+        "format": 185,
+        "name": "HANDJOB SD",
+        "score": 20
+      },
+      {
+        "format": 184,
+        "name": "iTunes (Missing)",
+        "score": 20
+      },
+      {
+        "format": 183,
+        "name": "ROKU",
+        "score": 30
+      },
+      {
+        "format": 182,
+        "name": "BeyondHD",
+        "score": -10000
+      },
+      {
+        "format": 181,
+        "name": "Disc ",
+        "score": -9999
+      },
+      {
+        "format": 180,
+        "name": "3D",
+        "score": -9999
+      },
+      {
+        "format": 179,
+        "name": "Unwanted",
+        "score": -9999
+      },
+      {
+        "format": 178,
+        "name": "RightSIZE",
+        "score": 70
+      },
+      {
+        "format": 177,
+        "name": "Black and White",
+        "score": -9999
+      },
+      {
+        "format": 176,
+        "name": "TrueHD",
+        "score": -9999
+      },
+      {
+        "format": 175,
+        "name": "DTS-X",
+        "score": -9999
+      },
+      {
+        "format": 174,
+        "name": "FLAC",
+        "score": 0
+      },
+      {
+        "format": 173,
+        "name": "DTS-HD MA",
+        "score": -9999
+      },
+      {
+        "format": 172,
+        "name": "x265",
+        "score": -9999
+      },
+      {
+        "format": 171,
+        "name": "IMAX",
+        "score": 10
+      },
+      {
+        "format": 170,
+        "name": "ATMOS",
+        "score": 5
+      },
+      {
+        "format": 169,
+        "name": "DD",
+        "score": 0
+      },
+      {
+        "format": 168,
+        "name": "DTS",
+        "score": 0
+      },
+      {
+        "format": 167,
+        "name": "DD+",
+        "score": 0
+      },
+      {
+        "format": 166,
+        "name": "iTunes",
+        "score": 20
+      },
+      {
+        "format": 165,
+        "name": "Paramount+",
+        "score": 30
+      },
+      {
+        "format": 164,
+        "name": "Peacock TV",
+        "score": 30
+      },
+      {
+        "format": 163,
+        "name": "Hulu",
+        "score": 30
+      },
+      {
+        "format": 162,
+        "name": "Netflix",
+        "score": 40
+      },
+      {
+        "format": 161,
+        "name": "HBO Max",
+        "score": 40
+      },
+      {
+        "format": 160,
+        "name": "Disney+",
+        "score": 40
+      },
+      {
+        "format": 159,
+        "name": "Apple TV+",
+        "score": 50
+      },
+      {
+        "format": 158,
+        "name": "Movies Anywhere",
+        "score": 60
+      },
+      {
+        "format": 157,
+        "name": "Amazon Prime",
+        "score": 50
+      },
+      {
+        "format": 156,
+        "name": "REMUX",
+        "score": -9999
+      },
+      {
+        "format": 155,
+        "name": "x264",
+        "score": 10
+      },
+      {
+        "format": 154,
+        "name": "WEBRip",
+        "score": 0
+      },
+      {
+        "format": 153,
+        "name": "Blu-Ray",
+        "score": 0
+      },
+      {
+        "format": 152,
+        "name": "2160p",
+        "score": -9999
+      },
+      {
+        "format": 151,
+        "name": "720p",
+        "score": -10000
+      },
+      {
+        "format": 150,
+        "name": "1080p",
+        "score": 60
+      },
+      {
+        "format": 149,
+        "name": "BHDStudio",
+        "score": 30
+      },
+      {
+        "format": 148,
+        "name": "LEGi0N",
+        "score": 30
+      },
+      {
+        "format": 147,
+        "name": "FraMeSToR",
+        "score": 30
+      },
+      {
+        "format": 146,
+        "name": "iFT",
+        "score": 70
+      },
+      {
+        "format": 145,
+        "name": "MTeam",
+        "score": -9999
+      },
+      {
+        "format": 144,
+        "name": "EDPH",
+        "score": 30
+      },
+      {
+        "format": 143,
+        "name": "HANDJOB",
+        "score": 30
+      },
+      {
+        "format": 142,
+        "name": "c0ke",
+        "score": 110
+      },
+      {
+        "format": 141,
+        "name": "KASHMiR",
+        "score": 70
+      },
+      {
+        "format": 140,
+        "name": "WMING",
+        "score": 70
+      },
+      {
+        "format": 139,
+        "name": "playHD",
+        "score": 70
+      },
+      {
+        "format": 138,
+        "name": "E.N.D",
+        "score": 70
+      },
+      {
+        "format": 137,
+        "name": "GutS",
+        "score": 70
+      },
+      {
+        "format": 136,
+        "name": "BV",
+        "score": 70
+      },
+      {
+        "format": 135,
+        "name": "SiMPLE",
+        "score": 70
+      },
+      {
+        "format": 134,
+        "name": "W4NK3R",
+        "score": 70
+      },
+      {
+        "format": 133,
+        "name": "GS88",
+        "score": 70
+      },
+      {
+        "format": 132,
+        "name": "HiP",
+        "score": 80
+      },
+      {
+        "format": 131,
+        "name": "GALAXY",
+        "score": 70
+      },
+      {
+        "format": 130,
+        "name": "luvBB",
+        "score": 70
+      },
+      {
+        "format": 129,
+        "name": "NyHD",
+        "score": 70
+      },
+      {
+        "format": 128,
+        "name": "ZIMBO",
+        "score": 70
+      },
+      {
+        "format": 127,
+        "name": "ThD",
+        "score": 70
+      },
+      {
+        "format": 126,
+        "name": "SaNcTi",
+        "score": 70
+      },
+      {
+        "format": 125,
+        "name": "ORiGEN",
+        "score": 70
+      },
+      {
+        "format": 124,
+        "name": "Positive",
+        "score": 70
+      },
+      {
+        "format": 123,
+        "name": "ESiR",
+        "score": 70
+      },
+      {
+        "format": 122,
+        "name": "Chotab",
+        "score": 70
+      },
+      {
+        "format": 121,
+        "name": "xander",
+        "score": 70
+      },
+      {
+        "format": 120,
+        "name": "FTW-HD",
+        "score": 70
+      },
+      {
+        "format": 119,
+        "name": "Penumbra",
+        "score": 70
+      },
+      {
+        "format": 118,
+        "name": "TDD",
+        "score": 70
+      },
+      {
+        "format": 117,
+        "name": "Dariush SD",
+        "score": 70
+      },
+      {
+        "format": 116,
+        "name": "PTer",
+        "score": 70
+      },
+      {
+        "format": 115,
+        "name": "SbR",
+        "score": 70
+      },
+      {
+        "format": 114,
+        "name": "nmd",
+        "score": 70
+      },
+      {
+        "format": 113,
+        "name": "TBB",
+        "score": 70
+      },
+      {
+        "format": 112,
+        "name": "EA",
+        "score": 80
+      },
+      {
+        "format": 111,
+        "name": "BMF",
+        "score": 80
+      },
+      {
+        "format": 110,
+        "name": "LolHD",
+        "score": 80
+      },
+      {
+        "format": 109,
+        "name": "HDMaNiAcS",
+        "score": 80
+      },
+      {
+        "format": 108,
+        "name": "IDE",
+        "score": 80
+      },
+      {
+        "format": 107,
+        "name": "de[42]",
+        "score": 90
+      },
+      {
+        "format": 106,
+        "name": "NCmt",
+        "score": 100
+      },
+      {
+        "format": 105,
+        "name": "decibeL",
+        "score": 90
+      },
+      {
+        "format": 104,
+        "name": "NTb",
+        "score": 80
+      },
+      {
+        "format": 103,
+        "name": "CRiSC",
+        "score": 90
+      },
+      {
+        "format": 102,
+        "name": "SA89",
+        "score": 100
+      },
+      {
+        "format": 101,
+        "name": "HiDt",
+        "score": 100
+      },
+      {
+        "format": 100,
+        "name": "FoRM",
+        "score": 100
+      },
+      {
+        "format": 99,
+        "name": "HiFi",
+        "score": 100
+      },
+      {
+        "format": 98,
+        "name": "CtrlHD",
+        "score": 100
+      },
+      {
+        "format": 97,
+        "name": "VietHD",
+        "score": 110
+      },
+      {
+        "format": 96,
+        "name": "ZQ",
+        "score": 110
+      },
+      {
+        "format": 95,
+        "name": "TayTo",
+        "score": 110
+      },
+      {
+        "format": 94,
+        "name": "Geek",
+        "score": 110
+      },
+      {
+        "format": 93,
+        "name": "EbP",
+        "score": 120
+      },
+      {
+        "format": 92,
+        "name": "DON",
+        "score": 120
+      },
+      {
+        "format": 91,
+        "name": "D-Z0N3",
+        "score": 120
+      },
+      {
+        "format": 92,
+        "name": "Upscaled",
+        "score": -9999
+      }
+    ]
+  }
 ]

--- a/imports/quality_profiles/sonarr/2160p Optimal (sonarr - master).json
+++ b/imports/quality_profiles/sonarr/2160p Optimal (sonarr - master).json
@@ -1,939 +1,940 @@
 [
-    {
-        "name": "2160p Optimal",
-        "upgradeAllowed": true,
-        "cutoff": 21,
+  {
+    "name": "2160p Optimal",
+    "upgradeAllowed": true,
+    "cutoff": 21,
+    "items": [
+      {
+        "quality": {
+          "id": 0,
+          "name": "Unknown",
+          "source": "unknown",
+          "resolution": 0
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 13,
+          "name": "Bluray-480p",
+          "source": "bluray",
+          "resolution": 480
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 4,
+          "name": "HDTV-720p",
+          "source": "television",
+          "resolution": 720
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 14,
+          "name": "WEBRip-720p",
+          "source": "webRip",
+          "resolution": 720
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 5,
+          "name": "WEBDL-720p",
+          "source": "web",
+          "resolution": 720
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 6,
+          "name": "Bluray-720p",
+          "source": "bluray",
+          "resolution": 720
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "name": "Fallback SD",
         "items": [
-            {
-                "quality": {
-                    "id": 0,
-                    "name": "Unknown",
-                    "source": "unknown",
-                    "resolution": 0
-                },
-                "items": [],
-                "allowed": false
+          {
+            "quality": {
+              "id": 1,
+              "name": "SDTV",
+              "source": "television",
+              "resolution": 480
             },
-            {
-                "quality": {
-                    "id": 13,
-                    "name": "Bluray-480p",
-                    "source": "bluray",
-                    "resolution": 480
-                },
-                "items": [],
-                "allowed": false
+            "items": [],
+            "allowed": false
+          },
+          {
+            "quality": {
+              "id": 12,
+              "name": "WEBRip-480p",
+              "source": "webRip",
+              "resolution": 480
             },
-            {
-                "quality": {
-                    "id": 4,
-                    "name": "HDTV-720p",
-                    "source": "television",
-                    "resolution": 720
-                },
-                "items": [],
-                "allowed": false
+            "items": [],
+            "allowed": false
+          },
+          {
+            "quality": {
+              "id": 8,
+              "name": "WEBDL-480p",
+              "source": "web",
+              "resolution": 480
             },
-            {
-                "quality": {
-                    "id": 14,
-                    "name": "WEBRip-720p",
-                    "source": "webRip",
-                    "resolution": 720
-                },
-                "items": [],
-                "allowed": false
+            "items": [],
+            "allowed": false
+          },
+          {
+            "quality": {
+              "id": 2,
+              "name": "DVD",
+              "source": "dvd",
+              "resolution": 480
             },
-            {
-                "quality": {
-                    "id": 5,
-                    "name": "WEBDL-720p",
-                    "source": "web",
-                    "resolution": 720
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 6,
-                    "name": "Bluray-720p",
-                    "source": "bluray",
-                    "resolution": 720
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "name": "Fallback SD",
-                "items": [
-                    {
-                        "quality": {
-                            "id": 1,
-                            "name": "SDTV",
-                            "source": "television",
-                            "resolution": 480
-                        },
-                        "items": [],
-                        "allowed": false
-                    },
-                    {
-                        "quality": {
-                            "id": 12,
-                            "name": "WEBRip-480p",
-                            "source": "webRip",
-                            "resolution": 480
-                        },
-                        "items": [],
-                        "allowed": false
-                    },
-                    {
-                        "quality": {
-                            "id": 8,
-                            "name": "WEBDL-480p",
-                            "source": "web",
-                            "resolution": 480
-                        },
-                        "items": [],
-                        "allowed": false
-                    },
-                    {
-                        "quality": {
-                            "id": 2,
-                            "name": "DVD",
-                            "source": "dvd",
-                            "resolution": 480
-                        },
-                        "items": [],
-                        "allowed": false
-                    }
-                ],
-                "allowed": false,
-                "id": 1003
-            },
-            {
-                "name": "Fallback 1080p",
-                "items": [
-                    {
-                        "quality": {
-                            "id": 10,
-                            "name": "Raw-HD",
-                            "source": "televisionRaw",
-                            "resolution": 1080
-                        },
-                        "items": [],
-                        "allowed": false
-                    },
-                    {
-                        "quality": {
-                            "id": 9,
-                            "name": "HDTV-1080p",
-                            "source": "television",
-                            "resolution": 1080
-                        },
-                        "items": [],
-                        "allowed": false
-                    }
-                ],
-                "allowed": false,
-                "id": 1002
-            },
-            {
-                "name": "Transparent Capable",
-                "items": [
-                    {
-                        "quality": {
-                            "id": 3,
-                            "name": "WEBDL-1080p",
-                            "source": "web",
-                            "resolution": 1080
-                        },
-                        "items": [],
-                        "allowed": false
-                    },
-                    {
-                        "quality": {
-                            "id": 15,
-                            "name": "WEBRip-1080p",
-                            "source": "webRip",
-                            "resolution": 1080
-                        },
-                        "items": [],
-                        "allowed": false
-                    },
-                    {
-                        "quality": {
-                            "id": 7,
-                            "name": "Bluray-1080p",
-                            "source": "bluray",
-                            "resolution": 1080
-                        },
-                        "items": [],
-                        "allowed": false
-                    }
-                ],
-                "allowed": false,
-                "id": 1001
-            },
-            {
-                "quality": {
-                    "id": 20,
-                    "name": "Bluray-1080p Remux",
-                    "source": "blurayRaw",
-                    "resolution": 1080
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 16,
-                    "name": "HDTV-2160p",
-                    "source": "television",
-                    "resolution": 2160
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 17,
-                    "name": "WEBRip-2160p",
-                    "source": "webRip",
-                    "resolution": 2160
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 19,
-                    "name": "Bluray-2160p",
-                    "source": "bluray",
-                    "resolution": 2160
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 18,
-                    "name": "WEBDL-2160p",
-                    "source": "web",
-                    "resolution": 2160
-                },
-                "items": [],
-                "allowed": true
-            },
-            {
-                "quality": {
-                    "id": 21,
-                    "name": "Bluray-2160p Remux",
-                    "source": "blurayRaw",
-                    "resolution": 2160
-                },
-                "items": [],
-                "allowed": true
-            }
+            "items": [],
+            "allowed": false
+          }
         ],
-        "minFormatScore": 0,
-        "cutoffFormatScore": 320,
-        "formatItems": [
-            {
-                "format": 229,
-                "name": "HR",
-                "score": 0
-            },
-            {
-                "format": 228,
-                "name": "MAX",
-                "score": 0
-            },
-            {
-                "format": 227,
-                "name": "h265 (4k)",
-                "score": 0
-            },
-            {
-                "format": 226,
-                "name": "PCM",
-                "score": 0
-            },
-            {
-                "format": 225,
-                "name": "Blu-Ray (Remux)",
-                "score": 60
-            },
-            {
-                "format": 224,
-                "name": "h265",
-                "score": 0
-            },
-            {
-                "format": 223,
-                "name": "LiNG",
-                "score": 0
-            },
-            {
-                "format": 214,
-                "name": "LQ",
-                "score": -9999
-            },
-            {
-                "format": 213,
-                "name": "EPSiLON",
-                "score": 0
-            },
-            {
-                "format": 212,
-                "name": "playBD",
-                "score": 0
-            },
-            {
-                "format": 211,
-                "name": "BLURANiUM",
-                "score": 0
-            },
-            {
-                "format": 210,
-                "name": "PmP",
-                "score": 0
-            },
-            {
-                "format": 209,
-                "name": "WiLDCAT",
-                "score": 0
-            },
-            {
-                "format": 208,
-                "name": "TRiToN",
-                "score": 0
-            },
-            {
-                "format": 207,
-                "name": "3L",
-                "score": 0
-            },
-            {
-                "format": 206,
-                "name": "Dolby Vision w/out Fallback",
-                "score": -9999
-            },
-            {
-                "format": 205,
-                "name": "UHDBits",
-                "score": -9999
-            },
-            {
-                "format": 204,
-                "name": "ATMOS (Missing)",
-                "score": 10
-            },
-            {
-                "format": 203,
-                "name": "TrueHD (Missing)",
-                "score": 50
-            },
-            {
-                "format": 202,
-                "name": "HDR10 (Missing)",
-                "score": 10
-            },
-            {
-                "format": 201,
-                "name": "HDR10",
-                "score": 10
-            },
-            {
-                "format": 200,
-                "name": "Dolby Vision",
-                "score": 30
-            },
-            {
-                "format": 199,
-                "name": "HDR10+",
-                "score": 20
-            },
-            {
-                "format": 198,
-                "name": "Stream Optimised",
-                "score": 0
-            },
-            {
-                "format": 197,
-                "name": "LoRD",
-                "score": 0
-            },
-            {
-                "format": 196,
-                "name": "Scene",
-                "score": 0
-            },
-            {
-                "format": 195,
-                "name": "mHD",
-                "score": 0
-            },
-            {
-                "format": 194,
-                "name": "AV1",
-                "score": -9999
-            },
-            {
-                "format": 193,
-                "name": "VVC",
-                "score": -9999
-            },
-            {
-                "format": 192,
-                "name": "Extras",
-                "score": -9999
-            },
-            {
-                "format": 191,
-                "name": "480p",
-                "score": -9999
-            },
-            {
-                "format": 190,
-                "name": "Dariush ",
-                "score": 0
-            },
-            {
-                "format": 189,
-                "name": "TBB SD",
-                "score": 0
-            },
-            {
-                "format": 188,
-                "name": "Xvid",
-                "score": -9999
-            },
-            {
-                "format": 187,
-                "name": "DVD",
-                "score": -9999
-            },
-            {
-                "format": 186,
-                "name": "DVD REMUX ",
-                "score": -9999
-            },
-            {
-                "format": 185,
-                "name": "HANDJOB SD",
-                "score": 0
-            },
-            {
-                "format": 184,
-                "name": "iTunes (Missing)",
-                "score": 10
-            },
-            {
-                "format": 183,
-                "name": "ROKU",
-                "score": 20
-            },
-            {
-                "format": 182,
-                "name": "BeyondHD",
-                "score": 0
-            },
-            {
-                "format": 181,
-                "name": "Disc ",
-                "score": -9999
-            },
-            {
-                "format": 180,
-                "name": "3D",
-                "score": -9999
-            },
-            {
-                "format": 179,
-                "name": "Unwanted",
-                "score": -9999
-            },
-            {
-                "format": 178,
-                "name": "RightSIZE",
-                "score": 0
-            },
-            {
-                "format": 177,
-                "name": "Black and White",
-                "score": 0
-            },
-            {
-                "format": 176,
-                "name": "TrueHD",
-                "score": 50
-            },
-            {
-                "format": 175,
-                "name": "DTS-X",
-                "score": 60
-            },
-            {
-                "format": 174,
-                "name": "FLAC",
-                "score": 40
-            },
-            {
-                "format": 173,
-                "name": "DTS-HD MA",
-                "score": 40
-            },
-            {
-                "format": 172,
-                "name": "x265",
-                "score": -9999
-            },
-            {
-                "format": 171,
-                "name": "IMAX",
-                "score": 0
-            },
-            {
-                "format": 170,
-                "name": "ATMOS",
-                "score": 10
-            },
-            {
-                "format": 169,
-                "name": "DD",
-                "score": 0
-            },
-            {
-                "format": 168,
-                "name": "DTS",
-                "score": 0
-            },
-            {
-                "format": 167,
-                "name": "DD+",
-                "score": 0
-            },
-            {
-                "format": 166,
-                "name": "iTunes",
-                "score": 10
-            },
-            {
-                "format": 165,
-                "name": "Paramount+",
-                "score": 20
-            },
-            {
-                "format": 164,
-                "name": "Peacock TV",
-                "score": 20
-            },
-            {
-                "format": 163,
-                "name": "Hulu",
-                "score": 20
-            },
-            {
-                "format": 162,
-                "name": "Netflix",
-                "score": 30
-            },
-            {
-                "format": 161,
-                "name": "HBO Max",
-                "score": 30
-            },
-            {
-                "format": 160,
-                "name": "Disney+",
-                "score": 30
-            },
-            {
-                "format": 159,
-                "name": "Apple TV+",
-                "score": 40
-            },
-            {
-                "format": 158,
-                "name": "Movies Anywhere",
-                "score": 50
-            },
-            {
-                "format": 157,
-                "name": "Amazon Prime",
-                "score": 40
-            },
-            {
-                "format": 156,
-                "name": "REMUX",
-                "score": 60
-            },
-            {
-                "format": 155,
-                "name": "x264",
-                "score": -9999
-            },
-            {
-                "format": 154,
-                "name": "WEBRip",
-                "score": -9999
-            },
-            {
-                "format": 153,
-                "name": "Blu-Ray",
-                "score": 60
-            },
-            {
-                "format": 152,
-                "name": "2160p",
-                "score": 60
-            },
-            {
-                "format": 151,
-                "name": "720p",
-                "score": -9999
-            },
-            {
-                "format": 150,
-                "name": "1080p",
-                "score": -9999
-            },
-            {
-                "format": 149,
-                "name": "BHDStudio",
-                "score": 0
-            },
-            {
-                "format": 148,
-                "name": "LEGi0N",
-                "score": 0
-            },
-            {
-                "format": 147,
-                "name": "FraMeSToR",
-                "score": 0
-            },
-            {
-                "format": 146,
-                "name": "iFT",
-                "score": 0
-            },
-            {
-                "format": 145,
-                "name": "MTeam",
-                "score": 0
-            },
-            {
-                "format": 144,
-                "name": "EDPH",
-                "score": 0
-            },
-            {
-                "format": 143,
-                "name": "HANDJOB",
-                "score": 0
-            },
-            {
-                "format": 142,
-                "name": "c0ke",
-                "score": 0
-            },
-            {
-                "format": 141,
-                "name": "KASHMiR",
-                "score": 0
-            },
-            {
-                "format": 140,
-                "name": "WMING",
-                "score": 0
-            },
-            {
-                "format": 139,
-                "name": "playHD",
-                "score": 0
-            },
-            {
-                "format": 138,
-                "name": "E.N.D",
-                "score": 0
-            },
-            {
-                "format": 137,
-                "name": "GutS",
-                "score": 0
-            },
-            {
-                "format": 136,
-                "name": "BV",
-                "score": 0
-            },
-            {
-                "format": 135,
-                "name": "SiMPLE",
-                "score": 0
-            },
-            {
-                "format": 134,
-                "name": "W4NK3R",
-                "score": 0
-            },
-            {
-                "format": 133,
-                "name": "GS88",
-                "score": 0
-            },
-            {
-                "format": 132,
-                "name": "HiP",
-                "score": 0
-            },
-            {
-                "format": 131,
-                "name": "GALAXY",
-                "score": 0
-            },
-            {
-                "format": 130,
-                "name": "luvBB",
-                "score": 0
-            },
-            {
-                "format": 129,
-                "name": "NyHD",
-                "score": 0
-            },
-            {
-                "format": 128,
-                "name": "ZIMBO",
-                "score": 0
-            },
-            {
-                "format": 127,
-                "name": "ThD",
-                "score": 0
-            },
-            {
-                "format": 126,
-                "name": "SaNcTi",
-                "score": 0
-            },
-            {
-                "format": 125,
-                "name": "ORiGEN",
-                "score": 0
-            },
-            {
-                "format": 124,
-                "name": "Positive",
-                "score": 0
-            },
-            {
-                "format": 123,
-                "name": "ESiR",
-                "score": 0
-            },
-            {
-                "format": 122,
-                "name": "Chotab",
-                "score": 0
-            },
-            {
-                "format": 121,
-                "name": "xander",
-                "score": 0
-            },
-            {
-                "format": 120,
-                "name": "FTW-HD",
-                "score": 0
-            },
-            {
-                "format": 119,
-                "name": "Penumbra",
-                "score": 0
-            },
-            {
-                "format": 118,
-                "name": "TDD",
-                "score": 0
-            },
-            {
-                "format": 117,
-                "name": "Dariush SD",
-                "score": 0
-            },
-            {
-                "format": 116,
-                "name": "PTer",
-                "score": 0
-            },
-            {
-                "format": 115,
-                "name": "SbR",
-                "score": 0
-            },
-            {
-                "format": 114,
-                "name": "nmd",
-                "score": 0
-            },
-            {
-                "format": 113,
-                "name": "TBB",
-                "score": 0
-            },
-            {
-                "format": 112,
-                "name": "EA",
-                "score": 0
-            },
-            {
-                "format": 111,
-                "name": "BMF",
-                "score": 0
-            },
-            {
-                "format": 110,
-                "name": "LolHD",
-                "score": 0
-            },
-            {
-                "format": 109,
-                "name": "HDMaNiAcS",
-                "score": 0
-            },
-            {
-                "format": 108,
-                "name": "IDE",
-                "score": 0
-            },
-            {
-                "format": 107,
-                "name": "de[42]",
-                "score": 0
-            },
-            {
-                "format": 106,
-                "name": "NCmt",
-                "score": 0
-            },
-            {
-                "format": 105,
-                "name": "decibeL",
-                "score": 0
-            },
-            {
-                "format": 104,
-                "name": "NTb",
-                "score": 0
-            },
-            {
-                "format": 103,
-                "name": "CRiSC",
-                "score": 0
-            },
-            {
-                "format": 102,
-                "name": "SA89",
-                "score": 0
-            },
-            {
-                "format": 101,
-                "name": "HiDt",
-                "score": 0
-            },
-            {
-                "format": 100,
-                "name": "FoRM",
-                "score": 0
-            },
-            {
-                "format": 99,
-                "name": "HiFi",
-                "score": 0
-            },
-            {
-                "format": 98,
-                "name": "CtrlHD",
-                "score": 0
-            },
-            {
-                "format": 97,
-                "name": "VietHD",
-                "score": 0
-            },
-            {
-                "format": 96,
-                "name": "ZQ",
-                "score": 0
-            },
-            {
-                "format": 95,
-                "name": "TayTo",
-                "score": 0
-            },
-            {
-                "format": 94,
-                "name": "Geek",
-                "score": 0
-            },
-            {
-                "format": 93,
-                "name": "EbP",
-                "score": 0
-            },
-            {
-                "format": 92,
-                "name": "DON",
-                "score": 0
-            },
-            {
-                "format": 91,
-                "name": "D-Z0N3",
-                "score": 0
-            },
-            {
-                "format": 215,
-                "name": "CJ",
-                "score": 0
-            },
-            {
-                "format": 216,
-                "name": "pcroland",
-                "score": 0
-            },
-            {
-                "format": 217,
-                "name": "BTN",
-                "score": 0
-            },
-            {
-                "format": 218,
-                "name": "iON",
-                "score": 0
-            },
-            {
-                "format": 219,
-                "name": "AJP69",
-                "score": 0
-            },
-            {
-                "format": 220,
-                "name": "VLAD",
-                "score": 0
-            },
-            {
-                "format": 221,
-                "name": "hdalx",
-                "score": 0
-            },
-            {
-                "format": 222,
-                "name": "Upscaled",
-                "score": -9999
-            }
-        ]
-    }
+        "allowed": false,
+        "id": 1003
+      },
+      {
+        "name": "Fallback 1080p",
+        "items": [
+          {
+            "quality": {
+              "id": 10,
+              "name": "Raw-HD",
+              "source": "televisionRaw",
+              "resolution": 1080
+            },
+            "items": [],
+            "allowed": false
+          },
+          {
+            "quality": {
+              "id": 9,
+              "name": "HDTV-1080p",
+              "source": "television",
+              "resolution": 1080
+            },
+            "items": [],
+            "allowed": false
+          }
+        ],
+        "allowed": false,
+        "id": 1002
+      },
+      {
+        "name": "Transparent Capable",
+        "items": [
+          {
+            "quality": {
+              "id": 3,
+              "name": "WEBDL-1080p",
+              "source": "web",
+              "resolution": 1080
+            },
+            "items": [],
+            "allowed": false
+          },
+          {
+            "quality": {
+              "id": 15,
+              "name": "WEBRip-1080p",
+              "source": "webRip",
+              "resolution": 1080
+            },
+            "items": [],
+            "allowed": false
+          },
+          {
+            "quality": {
+              "id": 7,
+              "name": "Bluray-1080p",
+              "source": "bluray",
+              "resolution": 1080
+            },
+            "items": [],
+            "allowed": false
+          }
+        ],
+        "allowed": false,
+        "id": 1001
+      },
+      {
+        "quality": {
+          "id": 20,
+          "name": "Bluray-1080p Remux",
+          "source": "blurayRaw",
+          "resolution": 1080
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 16,
+          "name": "HDTV-2160p",
+          "source": "television",
+          "resolution": 2160
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 17,
+          "name": "WEBRip-2160p",
+          "source": "webRip",
+          "resolution": 2160
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 19,
+          "name": "Bluray-2160p",
+          "source": "bluray",
+          "resolution": 2160
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 18,
+          "name": "WEBDL-2160p",
+          "source": "web",
+          "resolution": 2160
+        },
+        "items": [],
+        "allowed": true
+      },
+      {
+        "quality": {
+          "id": 21,
+          "name": "Bluray-2160p Remux",
+          "source": "blurayRaw",
+          "resolution": 2160
+        },
+        "items": [],
+        "allowed": true
+      }
+    ],
+    "minFormatScore": 0,
+    "cutoffFormatScore": 320,
+    "minUpgradeFormatScore": 1,
+    "formatItems": [
+      {
+        "format": 229,
+        "name": "HR",
+        "score": 0
+      },
+      {
+        "format": 228,
+        "name": "MAX",
+        "score": 0
+      },
+      {
+        "format": 227,
+        "name": "h265 (4k)",
+        "score": 0
+      },
+      {
+        "format": 226,
+        "name": "PCM",
+        "score": 0
+      },
+      {
+        "format": 225,
+        "name": "Blu-Ray (Remux)",
+        "score": 60
+      },
+      {
+        "format": 224,
+        "name": "h265",
+        "score": 0
+      },
+      {
+        "format": 223,
+        "name": "LiNG",
+        "score": 0
+      },
+      {
+        "format": 214,
+        "name": "LQ",
+        "score": -9999
+      },
+      {
+        "format": 213,
+        "name": "EPSiLON",
+        "score": 0
+      },
+      {
+        "format": 212,
+        "name": "playBD",
+        "score": 0
+      },
+      {
+        "format": 211,
+        "name": "BLURANiUM",
+        "score": 0
+      },
+      {
+        "format": 210,
+        "name": "PmP",
+        "score": 0
+      },
+      {
+        "format": 209,
+        "name": "WiLDCAT",
+        "score": 0
+      },
+      {
+        "format": 208,
+        "name": "TRiToN",
+        "score": 0
+      },
+      {
+        "format": 207,
+        "name": "3L",
+        "score": 0
+      },
+      {
+        "format": 206,
+        "name": "Dolby Vision w/out Fallback",
+        "score": -9999
+      },
+      {
+        "format": 205,
+        "name": "UHDBits",
+        "score": -9999
+      },
+      {
+        "format": 204,
+        "name": "ATMOS (Missing)",
+        "score": 10
+      },
+      {
+        "format": 203,
+        "name": "TrueHD (Missing)",
+        "score": 50
+      },
+      {
+        "format": 202,
+        "name": "HDR10 (Missing)",
+        "score": 10
+      },
+      {
+        "format": 201,
+        "name": "HDR10",
+        "score": 10
+      },
+      {
+        "format": 200,
+        "name": "Dolby Vision",
+        "score": 30
+      },
+      {
+        "format": 199,
+        "name": "HDR10+",
+        "score": 20
+      },
+      {
+        "format": 198,
+        "name": "Stream Optimised",
+        "score": 0
+      },
+      {
+        "format": 197,
+        "name": "LoRD",
+        "score": 0
+      },
+      {
+        "format": 196,
+        "name": "Scene",
+        "score": 0
+      },
+      {
+        "format": 195,
+        "name": "mHD",
+        "score": 0
+      },
+      {
+        "format": 194,
+        "name": "AV1",
+        "score": -9999
+      },
+      {
+        "format": 193,
+        "name": "VVC",
+        "score": -9999
+      },
+      {
+        "format": 192,
+        "name": "Extras",
+        "score": -9999
+      },
+      {
+        "format": 191,
+        "name": "480p",
+        "score": -9999
+      },
+      {
+        "format": 190,
+        "name": "Dariush ",
+        "score": 0
+      },
+      {
+        "format": 189,
+        "name": "TBB SD",
+        "score": 0
+      },
+      {
+        "format": 188,
+        "name": "Xvid",
+        "score": -9999
+      },
+      {
+        "format": 187,
+        "name": "DVD",
+        "score": -9999
+      },
+      {
+        "format": 186,
+        "name": "DVD REMUX ",
+        "score": -9999
+      },
+      {
+        "format": 185,
+        "name": "HANDJOB SD",
+        "score": 0
+      },
+      {
+        "format": 184,
+        "name": "iTunes (Missing)",
+        "score": 10
+      },
+      {
+        "format": 183,
+        "name": "ROKU",
+        "score": 20
+      },
+      {
+        "format": 182,
+        "name": "BeyondHD",
+        "score": 0
+      },
+      {
+        "format": 181,
+        "name": "Disc ",
+        "score": -9999
+      },
+      {
+        "format": 180,
+        "name": "3D",
+        "score": -9999
+      },
+      {
+        "format": 179,
+        "name": "Unwanted",
+        "score": -9999
+      },
+      {
+        "format": 178,
+        "name": "RightSIZE",
+        "score": 0
+      },
+      {
+        "format": 177,
+        "name": "Black and White",
+        "score": 0
+      },
+      {
+        "format": 176,
+        "name": "TrueHD",
+        "score": 50
+      },
+      {
+        "format": 175,
+        "name": "DTS-X",
+        "score": 60
+      },
+      {
+        "format": 174,
+        "name": "FLAC",
+        "score": 40
+      },
+      {
+        "format": 173,
+        "name": "DTS-HD MA",
+        "score": 40
+      },
+      {
+        "format": 172,
+        "name": "x265",
+        "score": -9999
+      },
+      {
+        "format": 171,
+        "name": "IMAX",
+        "score": 0
+      },
+      {
+        "format": 170,
+        "name": "ATMOS",
+        "score": 10
+      },
+      {
+        "format": 169,
+        "name": "DD",
+        "score": 0
+      },
+      {
+        "format": 168,
+        "name": "DTS",
+        "score": 0
+      },
+      {
+        "format": 167,
+        "name": "DD+",
+        "score": 0
+      },
+      {
+        "format": 166,
+        "name": "iTunes",
+        "score": 10
+      },
+      {
+        "format": 165,
+        "name": "Paramount+",
+        "score": 20
+      },
+      {
+        "format": 164,
+        "name": "Peacock TV",
+        "score": 20
+      },
+      {
+        "format": 163,
+        "name": "Hulu",
+        "score": 20
+      },
+      {
+        "format": 162,
+        "name": "Netflix",
+        "score": 30
+      },
+      {
+        "format": 161,
+        "name": "HBO Max",
+        "score": 30
+      },
+      {
+        "format": 160,
+        "name": "Disney+",
+        "score": 30
+      },
+      {
+        "format": 159,
+        "name": "Apple TV+",
+        "score": 40
+      },
+      {
+        "format": 158,
+        "name": "Movies Anywhere",
+        "score": 50
+      },
+      {
+        "format": 157,
+        "name": "Amazon Prime",
+        "score": 40
+      },
+      {
+        "format": 156,
+        "name": "REMUX",
+        "score": 60
+      },
+      {
+        "format": 155,
+        "name": "x264",
+        "score": -9999
+      },
+      {
+        "format": 154,
+        "name": "WEBRip",
+        "score": -9999
+      },
+      {
+        "format": 153,
+        "name": "Blu-Ray",
+        "score": 60
+      },
+      {
+        "format": 152,
+        "name": "2160p",
+        "score": 60
+      },
+      {
+        "format": 151,
+        "name": "720p",
+        "score": -9999
+      },
+      {
+        "format": 150,
+        "name": "1080p",
+        "score": -9999
+      },
+      {
+        "format": 149,
+        "name": "BHDStudio",
+        "score": 0
+      },
+      {
+        "format": 148,
+        "name": "LEGi0N",
+        "score": 0
+      },
+      {
+        "format": 147,
+        "name": "FraMeSToR",
+        "score": 0
+      },
+      {
+        "format": 146,
+        "name": "iFT",
+        "score": 0
+      },
+      {
+        "format": 145,
+        "name": "MTeam",
+        "score": 0
+      },
+      {
+        "format": 144,
+        "name": "EDPH",
+        "score": 0
+      },
+      {
+        "format": 143,
+        "name": "HANDJOB",
+        "score": 0
+      },
+      {
+        "format": 142,
+        "name": "c0ke",
+        "score": 0
+      },
+      {
+        "format": 141,
+        "name": "KASHMiR",
+        "score": 0
+      },
+      {
+        "format": 140,
+        "name": "WMING",
+        "score": 0
+      },
+      {
+        "format": 139,
+        "name": "playHD",
+        "score": 0
+      },
+      {
+        "format": 138,
+        "name": "E.N.D",
+        "score": 0
+      },
+      {
+        "format": 137,
+        "name": "GutS",
+        "score": 0
+      },
+      {
+        "format": 136,
+        "name": "BV",
+        "score": 0
+      },
+      {
+        "format": 135,
+        "name": "SiMPLE",
+        "score": 0
+      },
+      {
+        "format": 134,
+        "name": "W4NK3R",
+        "score": 0
+      },
+      {
+        "format": 133,
+        "name": "GS88",
+        "score": 0
+      },
+      {
+        "format": 132,
+        "name": "HiP",
+        "score": 0
+      },
+      {
+        "format": 131,
+        "name": "GALAXY",
+        "score": 0
+      },
+      {
+        "format": 130,
+        "name": "luvBB",
+        "score": 0
+      },
+      {
+        "format": 129,
+        "name": "NyHD",
+        "score": 0
+      },
+      {
+        "format": 128,
+        "name": "ZIMBO",
+        "score": 0
+      },
+      {
+        "format": 127,
+        "name": "ThD",
+        "score": 0
+      },
+      {
+        "format": 126,
+        "name": "SaNcTi",
+        "score": 0
+      },
+      {
+        "format": 125,
+        "name": "ORiGEN",
+        "score": 0
+      },
+      {
+        "format": 124,
+        "name": "Positive",
+        "score": 0
+      },
+      {
+        "format": 123,
+        "name": "ESiR",
+        "score": 0
+      },
+      {
+        "format": 122,
+        "name": "Chotab",
+        "score": 0
+      },
+      {
+        "format": 121,
+        "name": "xander",
+        "score": 0
+      },
+      {
+        "format": 120,
+        "name": "FTW-HD",
+        "score": 0
+      },
+      {
+        "format": 119,
+        "name": "Penumbra",
+        "score": 0
+      },
+      {
+        "format": 118,
+        "name": "TDD",
+        "score": 0
+      },
+      {
+        "format": 117,
+        "name": "Dariush SD",
+        "score": 0
+      },
+      {
+        "format": 116,
+        "name": "PTer",
+        "score": 0
+      },
+      {
+        "format": 115,
+        "name": "SbR",
+        "score": 0
+      },
+      {
+        "format": 114,
+        "name": "nmd",
+        "score": 0
+      },
+      {
+        "format": 113,
+        "name": "TBB",
+        "score": 0
+      },
+      {
+        "format": 112,
+        "name": "EA",
+        "score": 0
+      },
+      {
+        "format": 111,
+        "name": "BMF",
+        "score": 0
+      },
+      {
+        "format": 110,
+        "name": "LolHD",
+        "score": 0
+      },
+      {
+        "format": 109,
+        "name": "HDMaNiAcS",
+        "score": 0
+      },
+      {
+        "format": 108,
+        "name": "IDE",
+        "score": 0
+      },
+      {
+        "format": 107,
+        "name": "de[42]",
+        "score": 0
+      },
+      {
+        "format": 106,
+        "name": "NCmt",
+        "score": 0
+      },
+      {
+        "format": 105,
+        "name": "decibeL",
+        "score": 0
+      },
+      {
+        "format": 104,
+        "name": "NTb",
+        "score": 0
+      },
+      {
+        "format": 103,
+        "name": "CRiSC",
+        "score": 0
+      },
+      {
+        "format": 102,
+        "name": "SA89",
+        "score": 0
+      },
+      {
+        "format": 101,
+        "name": "HiDt",
+        "score": 0
+      },
+      {
+        "format": 100,
+        "name": "FoRM",
+        "score": 0
+      },
+      {
+        "format": 99,
+        "name": "HiFi",
+        "score": 0
+      },
+      {
+        "format": 98,
+        "name": "CtrlHD",
+        "score": 0
+      },
+      {
+        "format": 97,
+        "name": "VietHD",
+        "score": 0
+      },
+      {
+        "format": 96,
+        "name": "ZQ",
+        "score": 0
+      },
+      {
+        "format": 95,
+        "name": "TayTo",
+        "score": 0
+      },
+      {
+        "format": 94,
+        "name": "Geek",
+        "score": 0
+      },
+      {
+        "format": 93,
+        "name": "EbP",
+        "score": 0
+      },
+      {
+        "format": 92,
+        "name": "DON",
+        "score": 0
+      },
+      {
+        "format": 91,
+        "name": "D-Z0N3",
+        "score": 0
+      },
+      {
+        "format": 215,
+        "name": "CJ",
+        "score": 0
+      },
+      {
+        "format": 216,
+        "name": "pcroland",
+        "score": 0
+      },
+      {
+        "format": 217,
+        "name": "BTN",
+        "score": 0
+      },
+      {
+        "format": 218,
+        "name": "iON",
+        "score": 0
+      },
+      {
+        "format": 219,
+        "name": "AJP69",
+        "score": 0
+      },
+      {
+        "format": 220,
+        "name": "VLAD",
+        "score": 0
+      },
+      {
+        "format": 221,
+        "name": "hdalx",
+        "score": 0
+      },
+      {
+        "format": 222,
+        "name": "Upscaled",
+        "score": -9999
+      }
+    ]
+  }
 ]

--- a/imports/quality_profiles/sonarr/Balanced (HEVC) (sonarr - master).json
+++ b/imports/quality_profiles/sonarr/Balanced (HEVC) (sonarr - master).json
@@ -1,1032 +1,1033 @@
 [
-    {
-        "name": "Balanced (HEVC)",
-        "upgradeAllowed": true,
-        "cutoff": 1001,
+  {
+    "name": "Balanced (HEVC)",
+    "upgradeAllowed": true,
+    "cutoff": 1001,
+    "items": [
+      {
+        "quality": {
+          "id": 0,
+          "name": "Unknown",
+          "source": "unknown",
+          "resolution": 0
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 13,
+          "name": "Bluray-480p",
+          "source": "bluray",
+          "resolution": 480
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 4,
+          "name": "HDTV-720p",
+          "source": "television",
+          "resolution": 720
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 14,
+          "name": "WEBRip-720p",
+          "source": "webRip",
+          "resolution": 720
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 5,
+          "name": "WEBDL-720p",
+          "source": "web",
+          "resolution": 720
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 6,
+          "name": "Bluray-720p",
+          "source": "bluray",
+          "resolution": 720
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "name": "Else",
         "items": [
-            {
-                "quality": {
-                    "id": 0,
-                    "name": "Unknown",
-                    "source": "unknown",
-                    "resolution": 0
-                },
-                "items": [],
-                "allowed": false
+          {
+            "quality": {
+              "id": 1,
+              "name": "SDTV",
+              "source": "television",
+              "resolution": 480
             },
-            {
-                "quality": {
-                    "id": 13,
-                    "name": "Bluray-480p",
-                    "source": "bluray",
-                    "resolution": 480
-                },
-                "items": [],
-                "allowed": false
+            "items": [],
+            "allowed": true
+          },
+          {
+            "quality": {
+              "id": 12,
+              "name": "WEBRip-480p",
+              "source": "webRip",
+              "resolution": 480
             },
-            {
-                "quality": {
-                    "id": 4,
-                    "name": "HDTV-720p",
-                    "source": "television",
-                    "resolution": 720
-                },
-                "items": [],
-                "allowed": false
+            "items": [],
+            "allowed": true
+          },
+          {
+            "quality": {
+              "id": 8,
+              "name": "WEBDL-480p",
+              "source": "web",
+              "resolution": 480
             },
-            {
-                "quality": {
-                    "id": 14,
-                    "name": "WEBRip-720p",
-                    "source": "webRip",
-                    "resolution": 720
-                },
-                "items": [],
-                "allowed": false
+            "items": [],
+            "allowed": true
+          },
+          {
+            "quality": {
+              "id": 2,
+              "name": "DVD",
+              "source": "dvd",
+              "resolution": 480
             },
-            {
-                "quality": {
-                    "id": 5,
-                    "name": "WEBDL-720p",
-                    "source": "web",
-                    "resolution": 720
-                },
-                "items": [],
-                "allowed": false
+            "items": [],
+            "allowed": true
+          },
+          {
+            "quality": {
+              "id": 10,
+              "name": "Raw-HD",
+              "source": "televisionRaw",
+              "resolution": 1080
             },
-            {
-                "quality": {
-                    "id": 6,
-                    "name": "Bluray-720p",
-                    "source": "bluray",
-                    "resolution": 720
-                },
-                "items": [],
-                "allowed": false
+            "items": [],
+            "allowed": true
+          },
+          {
+            "quality": {
+              "id": 9,
+              "name": "HDTV-1080p",
+              "source": "television",
+              "resolution": 1080
             },
-            {
-                "name": "Else",
-                "items": [
-                    {
-                        "quality": {
-                            "id": 1,
-                            "name": "SDTV",
-                            "source": "television",
-                            "resolution": 480
-                        },
-                        "items": [],
-                        "allowed": true
-                    },
-                    {
-                        "quality": {
-                            "id": 12,
-                            "name": "WEBRip-480p",
-                            "source": "webRip",
-                            "resolution": 480
-                        },
-                        "items": [],
-                        "allowed": true
-                    },
-                    {
-                        "quality": {
-                            "id": 8,
-                            "name": "WEBDL-480p",
-                            "source": "web",
-                            "resolution": 480
-                        },
-                        "items": [],
-                        "allowed": true
-                    },
-                    {
-                        "quality": {
-                            "id": 2,
-                            "name": "DVD",
-                            "source": "dvd",
-                            "resolution": 480
-                        },
-                        "items": [],
-                        "allowed": true
-                    },
-                    {
-                        "quality": {
-                            "id": 10,
-                            "name": "Raw-HD",
-                            "source": "televisionRaw",
-                            "resolution": 1080
-                        },
-                        "items": [],
-                        "allowed": true
-                    },
-                    {
-                        "quality": {
-                            "id": 9,
-                            "name": "HDTV-1080p",
-                            "source": "television",
-                            "resolution": 1080
-                        },
-                        "items": [],
-                        "allowed": true
-                    }
-                ],
-                "allowed": true,
-                "id": 1002
-            },
-            {
-                "name": "Balanced Capable",
-                "items": [
-                    {
-                        "quality": {
-                            "id": 3,
-                            "name": "WEBDL-1080p",
-                            "source": "web",
-                            "resolution": 1080
-                        },
-                        "items": [],
-                        "allowed": true
-                    },
-                    {
-                        "quality": {
-                            "id": 15,
-                            "name": "WEBRip-1080p",
-                            "source": "webRip",
-                            "resolution": 1080
-                        },
-                        "items": [],
-                        "allowed": true
-                    },
-                    {
-                        "quality": {
-                            "id": 7,
-                            "name": "Bluray-1080p",
-                            "source": "bluray",
-                            "resolution": 1080
-                        },
-                        "items": [],
-                        "allowed": true
-                    }
-                ],
-                "allowed": true,
-                "id": 1001
-            },
-            {
-                "quality": {
-                    "id": 20,
-                    "name": "Bluray-1080p Remux",
-                    "source": "blurayRaw",
-                    "resolution": 1080
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 16,
-                    "name": "HDTV-2160p",
-                    "source": "television",
-                    "resolution": 2160
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 17,
-                    "name": "WEBRip-2160p",
-                    "source": "webRip",
-                    "resolution": 2160
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 19,
-                    "name": "Bluray-2160p",
-                    "source": "bluray",
-                    "resolution": 2160
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 18,
-                    "name": "WEBDL-2160p",
-                    "source": "web",
-                    "resolution": 2160
-                },
-                "items": [],
-                "allowed": false
-            },
-            {
-                "quality": {
-                    "id": 21,
-                    "name": "Bluray-2160p Remux",
-                    "source": "blurayRaw",
-                    "resolution": 2160
-                },
-                "items": [],
-                "allowed": false
-            }
+            "items": [],
+            "allowed": true
+          }
         ],
-        "minFormatScore": 0,
-        "cutoffFormatScore": 520,
-        "formatItems": [
-            {
-                "format": 250,
-                "name": "R1GY3B / B3YG1R",
-                "score": 0
-            },
-            {
-                "format": 249,
-                "name": "LEGi0N (x265)",
-                "score": 500
-            },
-            {
-                "format": 248,
-                "name": "SEV",
-                "score": 500
-            },
-            {
-                "format": 247,
-                "name": "AnoZu",
-                "score": 500
-            },
-            {
-                "format": 246,
-                "name": "edge2020",
-                "score": 500
-            },
-            {
-                "format": 245,
-                "name": "Tigole",
-                "score": 500
-            },
-            {
-                "format": 244,
-                "name": "dkore",
-                "score": 720
-            },
-            {
-                "format": 243,
-                "name": "QxR",
-                "score": 710
-            },
-            {
-                "format": 242,
-                "name": "Ralphy",
-                "score": 720
-            },
-            {
-                "format": 241,
-                "name": "Vyndros",
-                "score": 720
-            },
-            {
-                "format": 240,
-                "name": "TAoE",
-                "score": 720
-            },
-            {
-                "format": 239,
-                "name": "GRiMM",
-                "score": 720
-            },
-            {
-                "format": 238,
-                "name": "MainFrame",
-                "score": 750
-            },
-            {
-                "format": 237,
-                "name": "Chivaman",
-                "score": 700
-            },
-            {
-                "format": 236,
-                "name": "TimeDistortion",
-                "score": 720
-            },
-            {
-                "format": 235,
-                "name": "LSt",
-                "score": 750
-            },
-            {
-                "format": 234,
-                "name": "NAN0",
-                "score": 780
-            },
-            {
-                "format": 233,
-                "name": "HONE",
-                "score": 780
-            },
-            {
-                "format": 232,
-                "name": "x265 (Web)",
-                "score": -500
-            },
-            {
-                "format": 231,
-                "name": "x265 (Missing)",
-                "score": -500
-            },
-            {
-                "format": 229,
-                "name": "HR",
-                "score": 30
-            },
-            {
-                "format": 228,
-                "name": "MAX",
-                "score": 0
-            },
-            {
-                "format": 227,
-                "name": "h265 (4k)",
-                "score": 0
-            },
-            {
-                "format": 226,
-                "name": "PCM",
-                "score": 0
-            },
-            {
-                "format": 225,
-                "name": "Blu-Ray (Remux)",
-                "score": 0
-            },
-            {
-                "format": 224,
-                "name": "h265",
-                "score": 60
-            },
-            {
-                "format": 214,
-                "name": "LQ",
-                "score": -9999
-            },
-            {
-                "format": 213,
-                "name": "EPSiLON",
-                "score": 0
-            },
-            {
-                "format": 212,
-                "name": "playBD",
-                "score": 0
-            },
-            {
-                "format": 211,
-                "name": "BLURANiUM",
-                "score": 0
-            },
-            {
-                "format": 210,
-                "name": "PmP",
-                "score": 0
-            },
-            {
-                "format": 209,
-                "name": "WiLDCAT",
-                "score": 0
-            },
-            {
-                "format": 208,
-                "name": "TRiToN",
-                "score": 0
-            },
-            {
-                "format": 207,
-                "name": "3L",
-                "score": 0
-            },
-            {
-                "format": 206,
-                "name": "Dolby Vision w/out Fallback",
-                "score": -9999
-            },
-            {
-                "format": 205,
-                "name": "UHDBits",
-                "score": 0
-            },
-            {
-                "format": 204,
-                "name": "ATMOS (Missing)",
-                "score": 0
-            },
-            {
-                "format": 203,
-                "name": "TrueHD (Missing)",
-                "score": 0
-            },
-            {
-                "format": 202,
-                "name": "HDR10 (Missing)",
-                "score": -9999
-            },
-            {
-                "format": 201,
-                "name": "HDR10",
-                "score": -9999
-            },
-            {
-                "format": 200,
-                "name": "Dolby Vision",
-                "score": -9999
-            },
-            {
-                "format": 199,
-                "name": "HDR10+",
-                "score": -9999
-            },
-            {
-                "format": 198,
-                "name": "Stream Optimised",
-                "score": 80
-            },
-            {
-                "format": 197,
-                "name": "LoRD",
-                "score": 30
-            },
-            {
-                "format": 196,
-                "name": "Scene",
-                "score": 20
-            },
-            {
-                "format": 195,
-                "name": "mHD",
-                "score": -9999
-            },
-            {
-                "format": 194,
-                "name": "AV1",
-                "score": -9999
-            },
-            {
-                "format": 193,
-                "name": "VVC",
-                "score": -9999
-            },
-            {
-                "format": 192,
-                "name": "Extras",
-                "score": -9999
-            },
-            {
-                "format": 191,
-                "name": "480p",
-                "score": 0
-            },
-            {
-                "format": 190,
-                "name": "Dariush ",
-                "score": 30
-            },
-            {
-                "format": 189,
-                "name": "TBB SD",
-                "score": 30
-            },
-            {
-                "format": 188,
-                "name": "Xvid",
-                "score": 0
-            },
-            {
-                "format": 187,
-                "name": "DVD",
-                "score": 0
-            },
-            {
-                "format": 186,
-                "name": "DVD REMUX ",
-                "score": 40
-            },
-            {
-                "format": 185,
-                "name": "HANDJOB SD",
-                "score": 20
-            },
-            {
-                "format": 184,
-                "name": "iTunes (Missing)",
-                "score": 90
-            },
-            {
-                "format": 183,
-                "name": "ROKU",
-                "score": 190
-            },
-            {
-                "format": 182,
-                "name": "BeyondHD",
-                "score": -9999
-            },
-            {
-                "format": 181,
-                "name": "Disc ",
-                "score": -9999
-            },
-            {
-                "format": 180,
-                "name": "3D",
-                "score": -9999
-            },
-            {
-                "format": 179,
-                "name": "Unwanted",
-                "score": -9999
-            },
-            {
-                "format": 178,
-                "name": "RightSIZE",
-                "score": 30
-            },
-            {
-                "format": 177,
-                "name": "Black and White",
-                "score": -9999
-            },
-            {
-                "format": 176,
-                "name": "TrueHD",
-                "score": -9999
-            },
-            {
-                "format": 175,
-                "name": "DTS-X",
-                "score": -9999
-            },
-            {
-                "format": 174,
-                "name": "FLAC",
-                "score": 0
-            },
-            {
-                "format": 173,
-                "name": "DTS-HD MA",
-                "score": -9999
-            },
-            {
-                "format": 172,
-                "name": "x265",
-                "score": -500
-            },
-            {
-                "format": 171,
-                "name": "IMAX",
-                "score": 10
-            },
-            {
-                "format": 170,
-                "name": "ATMOS",
-                "score": 10
-            },
-            {
-                "format": 169,
-                "name": "DD",
-                "score": 0
-            },
-            {
-                "format": 168,
-                "name": "DTS",
-                "score": 0
-            },
-            {
-                "format": 167,
-                "name": "DD+",
-                "score": 0
-            },
-            {
-                "format": 166,
-                "name": "iTunes",
-                "score": 90
-            },
-            {
-                "format": 165,
-                "name": "Paramount+",
-                "score": 190
-            },
-            {
-                "format": 164,
-                "name": "Peacock TV",
-                "score": 190
-            },
-            {
-                "format": 163,
-                "name": "Hulu",
-                "score": 190
-            },
-            {
-                "format": 162,
-                "name": "Netflix",
-                "score": 200
-            },
-            {
-                "format": 161,
-                "name": "HBO Max",
-                "score": 200
-            },
-            {
-                "format": 160,
-                "name": "Disney+",
-                "score": 200
-            },
-            {
-                "format": 159,
-                "name": "Apple TV+",
-                "score": 210
-            },
-            {
-                "format": 158,
-                "name": "Movies Anywhere",
-                "score": 220
-            },
-            {
-                "format": 157,
-                "name": "Amazon Prime",
-                "score": 210
-            },
-            {
-                "format": 156,
-                "name": "REMUX",
-                "score": -9999
-            },
-            {
-                "format": 155,
-                "name": "x264",
-                "score": 10
-            },
-            {
-                "format": 154,
-                "name": "WEBRip",
-                "score": 10
-            },
-            {
-                "format": 153,
-                "name": "Blu-Ray",
-                "score": 10
-            },
-            {
-                "format": 152,
-                "name": "2160p",
-                "score": -9999
-            },
-            {
-                "format": 151,
-                "name": "720p",
-                "score": -9999
-            },
-            {
-                "format": 150,
-                "name": "1080p",
-                "score": 220
-            },
-            {
-                "format": 149,
-                "name": "BHDStudio",
-                "score": 90
-            },
-            {
-                "format": 148,
-                "name": "LEGi0N",
-                "score": 20
-            },
-            {
-                "format": 147,
-                "name": "FraMeSToR",
-                "score": 20
-            },
-            {
-                "format": 146,
-                "name": "iFT",
-                "score": 30
-            },
-            {
-                "format": 145,
-                "name": "MTeam",
-                "score": -9999
-            },
-            {
-                "format": 144,
-                "name": "EDPH",
-                "score": 20
-            },
-            {
-                "format": 143,
-                "name": "HANDJOB",
-                "score": 20
-            },
-            {
-                "format": 142,
-                "name": "c0ke",
-                "score": 70
-            },
-            {
-                "format": 141,
-                "name": "KASHMiR",
-                "score": 30
-            },
-            {
-                "format": 140,
-                "name": "WMING",
-                "score": 30
-            },
-            {
-                "format": 139,
-                "name": "playHD",
-                "score": 30
-            },
-            {
-                "format": 138,
-                "name": "E.N.D",
-                "score": 30
-            },
-            {
-                "format": 137,
-                "name": "GutS",
-                "score": 30
-            },
-            {
-                "format": 136,
-                "name": "BV",
-                "score": 30
-            },
-            {
-                "format": 135,
-                "name": "SiMPLE",
-                "score": 30
-            },
-            {
-                "format": 134,
-                "name": "W4NK3R",
-                "score": 30
-            },
-            {
-                "format": 133,
-                "name": "GS88",
-                "score": 30
-            },
-            {
-                "format": 132,
-                "name": "HiP",
-                "score": 40
-            },
-            {
-                "format": 131,
-                "name": "GALAXY",
-                "score": 30
-            },
-            {
-                "format": 130,
-                "name": "luvBB",
-                "score": 30
-            },
-            {
-                "format": 129,
-                "name": "NyHD",
-                "score": 30
-            },
-            {
-                "format": 128,
-                "name": "ZIMBO",
-                "score": 30
-            },
-            {
-                "format": 127,
-                "name": "ThD",
-                "score": 30
-            },
-            {
-                "format": 126,
-                "name": "SaNcTi",
-                "score": 30
-            },
-            {
-                "format": 125,
-                "name": "ORiGEN",
-                "score": 30
-            },
-            {
-                "format": 124,
-                "name": "Positive",
-                "score": 30
-            },
-            {
-                "format": 123,
-                "name": "ESiR",
-                "score": 30
-            },
-            {
-                "format": 122,
-                "name": "Chotab",
-                "score": 30
-            },
-            {
-                "format": 121,
-                "name": "xander",
-                "score": 30
-            },
-            {
-                "format": 120,
-                "name": "FTW-HD",
-                "score": 30
-            },
-            {
-                "format": 119,
-                "name": "Penumbra",
-                "score": 30
-            },
-            {
-                "format": 118,
-                "name": "TDD",
-                "score": 30
-            },
-            {
-                "format": 117,
-                "name": "Dariush SD",
-                "score": 30
-            },
-            {
-                "format": 116,
-                "name": "PTer",
-                "score": 30
-            },
-            {
-                "format": 115,
-                "name": "SbR",
-                "score": 30
-            },
-            {
-                "format": 114,
-                "name": "nmd",
-                "score": 30
-            },
-            {
-                "format": 113,
-                "name": "TBB",
-                "score": 30
-            },
-            {
-                "format": 112,
-                "name": "EA",
-                "score": 40
-            },
-            {
-                "format": 111,
-                "name": "BMF",
-                "score": 40
-            },
-            {
-                "format": 110,
-                "name": "LolHD",
-                "score": 40
-            },
-            {
-                "format": 109,
-                "name": "HDMaNiAcS",
-                "score": 40
-            },
-            {
-                "format": 108,
-                "name": "IDE",
-                "score": 40
-            },
-            {
-                "format": 107,
-                "name": "de[42]",
-                "score": 50
-            },
-            {
-                "format": 106,
-                "name": "NCmt",
-                "score": 60
-            },
-            {
-                "format": 105,
-                "name": "decibeL",
-                "score": 50
-            },
-            {
-                "format": 104,
-                "name": "NTb",
-                "score": 40
-            },
-            {
-                "format": 103,
-                "name": "CRiSC",
-                "score": 50
-            },
-            {
-                "format": 102,
-                "name": "SA89",
-                "score": 60
-            },
-            {
-                "format": 101,
-                "name": "HiDt",
-                "score": 60
-            },
-            {
-                "format": 100,
-                "name": "FoRM",
-                "score": 60
-            },
-            {
-                "format": 99,
-                "name": "HiFi",
-                "score": 60
-            },
-            {
-                "format": 98,
-                "name": "CtrlHD",
-                "score": 60
-            },
-            {
-                "format": 97,
-                "name": "VietHD",
-                "score": 70
-            },
-            {
-                "format": 96,
-                "name": "ZQ",
-                "score": 70
-            },
-            {
-                "format": 95,
-                "name": "TayTo",
-                "score": 70
-            },
-            {
-                "format": 94,
-                "name": "Geek",
-                "score": 70
-            },
-            {
-                "format": 93,
-                "name": "EbP",
-                "score": 80
-            },
-            {
-                "format": 92,
-                "name": "DON",
-                "score": 80
-            },
-            {
-                "format": 91,
-                "name": "D-Z0N3",
-                "score": 80
-            },
-            {
-                "format": 215,
-                "name": "CJ",
-                "score": 0
-            },
-            {
-                "format": 216,
-                "name": "pcroland",
-                "score": 0
-            },
-            {
-                "format": 217,
-                "name": "BTN",
-                "score": 0
-            },
-            {
-                "format": 218,
-                "name": "iON",
-                "score": 0
-            },
-            {
-                "format": 219,
-                "name": "AJP69",
-                "score": 0
-            },
-            {
-                "format": 220,
-                "name": "VLAD",
-                "score": 0
-            },
-            {
-                "format": 221,
-                "name": "hdalx",
-                "score": 0
-            },
-            {
-                "format": 223,
-                "name": "LiNG",
-                "score": 0
-            },
-            {
-                "format": 224,
-                "name": "Upscaled",
-                "score": -9999
-            }
-        ]
-    }
+        "allowed": true,
+        "id": 1002
+      },
+      {
+        "name": "Balanced Capable",
+        "items": [
+          {
+            "quality": {
+              "id": 3,
+              "name": "WEBDL-1080p",
+              "source": "web",
+              "resolution": 1080
+            },
+            "items": [],
+            "allowed": true
+          },
+          {
+            "quality": {
+              "id": 15,
+              "name": "WEBRip-1080p",
+              "source": "webRip",
+              "resolution": 1080
+            },
+            "items": [],
+            "allowed": true
+          },
+          {
+            "quality": {
+              "id": 7,
+              "name": "Bluray-1080p",
+              "source": "bluray",
+              "resolution": 1080
+            },
+            "items": [],
+            "allowed": true
+          }
+        ],
+        "allowed": true,
+        "id": 1001
+      },
+      {
+        "quality": {
+          "id": 20,
+          "name": "Bluray-1080p Remux",
+          "source": "blurayRaw",
+          "resolution": 1080
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 16,
+          "name": "HDTV-2160p",
+          "source": "television",
+          "resolution": 2160
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 17,
+          "name": "WEBRip-2160p",
+          "source": "webRip",
+          "resolution": 2160
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 19,
+          "name": "Bluray-2160p",
+          "source": "bluray",
+          "resolution": 2160
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 18,
+          "name": "WEBDL-2160p",
+          "source": "web",
+          "resolution": 2160
+        },
+        "items": [],
+        "allowed": false
+      },
+      {
+        "quality": {
+          "id": 21,
+          "name": "Bluray-2160p Remux",
+          "source": "blurayRaw",
+          "resolution": 2160
+        },
+        "items": [],
+        "allowed": false
+      }
+    ],
+    "minFormatScore": 0,
+    "cutoffFormatScore": 520,
+    "minUpgradeFormatScore": 1,
+    "formatItems": [
+      {
+        "format": 250,
+        "name": "R1GY3B / B3YG1R",
+        "score": 0
+      },
+      {
+        "format": 249,
+        "name": "LEGi0N (x265)",
+        "score": 500
+      },
+      {
+        "format": 248,
+        "name": "SEV",
+        "score": 500
+      },
+      {
+        "format": 247,
+        "name": "AnoZu",
+        "score": 500
+      },
+      {
+        "format": 246,
+        "name": "edge2020",
+        "score": 500
+      },
+      {
+        "format": 245,
+        "name": "Tigole",
+        "score": 500
+      },
+      {
+        "format": 244,
+        "name": "dkore",
+        "score": 720
+      },
+      {
+        "format": 243,
+        "name": "QxR",
+        "score": 710
+      },
+      {
+        "format": 242,
+        "name": "Ralphy",
+        "score": 720
+      },
+      {
+        "format": 241,
+        "name": "Vyndros",
+        "score": 720
+      },
+      {
+        "format": 240,
+        "name": "TAoE",
+        "score": 720
+      },
+      {
+        "format": 239,
+        "name": "GRiMM",
+        "score": 720
+      },
+      {
+        "format": 238,
+        "name": "MainFrame",
+        "score": 750
+      },
+      {
+        "format": 237,
+        "name": "Chivaman",
+        "score": 700
+      },
+      {
+        "format": 236,
+        "name": "TimeDistortion",
+        "score": 720
+      },
+      {
+        "format": 235,
+        "name": "LSt",
+        "score": 750
+      },
+      {
+        "format": 234,
+        "name": "NAN0",
+        "score": 780
+      },
+      {
+        "format": 233,
+        "name": "HONE",
+        "score": 780
+      },
+      {
+        "format": 232,
+        "name": "x265 (Web)",
+        "score": -500
+      },
+      {
+        "format": 231,
+        "name": "x265 (Missing)",
+        "score": -500
+      },
+      {
+        "format": 229,
+        "name": "HR",
+        "score": 30
+      },
+      {
+        "format": 228,
+        "name": "MAX",
+        "score": 0
+      },
+      {
+        "format": 227,
+        "name": "h265 (4k)",
+        "score": 0
+      },
+      {
+        "format": 226,
+        "name": "PCM",
+        "score": 0
+      },
+      {
+        "format": 225,
+        "name": "Blu-Ray (Remux)",
+        "score": 0
+      },
+      {
+        "format": 224,
+        "name": "h265",
+        "score": 60
+      },
+      {
+        "format": 214,
+        "name": "LQ",
+        "score": -9999
+      },
+      {
+        "format": 213,
+        "name": "EPSiLON",
+        "score": 0
+      },
+      {
+        "format": 212,
+        "name": "playBD",
+        "score": 0
+      },
+      {
+        "format": 211,
+        "name": "BLURANiUM",
+        "score": 0
+      },
+      {
+        "format": 210,
+        "name": "PmP",
+        "score": 0
+      },
+      {
+        "format": 209,
+        "name": "WiLDCAT",
+        "score": 0
+      },
+      {
+        "format": 208,
+        "name": "TRiToN",
+        "score": 0
+      },
+      {
+        "format": 207,
+        "name": "3L",
+        "score": 0
+      },
+      {
+        "format": 206,
+        "name": "Dolby Vision w/out Fallback",
+        "score": -9999
+      },
+      {
+        "format": 205,
+        "name": "UHDBits",
+        "score": 0
+      },
+      {
+        "format": 204,
+        "name": "ATMOS (Missing)",
+        "score": 0
+      },
+      {
+        "format": 203,
+        "name": "TrueHD (Missing)",
+        "score": 0
+      },
+      {
+        "format": 202,
+        "name": "HDR10 (Missing)",
+        "score": -9999
+      },
+      {
+        "format": 201,
+        "name": "HDR10",
+        "score": -9999
+      },
+      {
+        "format": 200,
+        "name": "Dolby Vision",
+        "score": -9999
+      },
+      {
+        "format": 199,
+        "name": "HDR10+",
+        "score": -9999
+      },
+      {
+        "format": 198,
+        "name": "Stream Optimised",
+        "score": 80
+      },
+      {
+        "format": 197,
+        "name": "LoRD",
+        "score": 30
+      },
+      {
+        "format": 196,
+        "name": "Scene",
+        "score": 20
+      },
+      {
+        "format": 195,
+        "name": "mHD",
+        "score": -9999
+      },
+      {
+        "format": 194,
+        "name": "AV1",
+        "score": -9999
+      },
+      {
+        "format": 193,
+        "name": "VVC",
+        "score": -9999
+      },
+      {
+        "format": 192,
+        "name": "Extras",
+        "score": -9999
+      },
+      {
+        "format": 191,
+        "name": "480p",
+        "score": 0
+      },
+      {
+        "format": 190,
+        "name": "Dariush ",
+        "score": 30
+      },
+      {
+        "format": 189,
+        "name": "TBB SD",
+        "score": 30
+      },
+      {
+        "format": 188,
+        "name": "Xvid",
+        "score": 0
+      },
+      {
+        "format": 187,
+        "name": "DVD",
+        "score": 0
+      },
+      {
+        "format": 186,
+        "name": "DVD REMUX ",
+        "score": 40
+      },
+      {
+        "format": 185,
+        "name": "HANDJOB SD",
+        "score": 20
+      },
+      {
+        "format": 184,
+        "name": "iTunes (Missing)",
+        "score": 90
+      },
+      {
+        "format": 183,
+        "name": "ROKU",
+        "score": 190
+      },
+      {
+        "format": 182,
+        "name": "BeyondHD",
+        "score": -9999
+      },
+      {
+        "format": 181,
+        "name": "Disc ",
+        "score": -9999
+      },
+      {
+        "format": 180,
+        "name": "3D",
+        "score": -9999
+      },
+      {
+        "format": 179,
+        "name": "Unwanted",
+        "score": -9999
+      },
+      {
+        "format": 178,
+        "name": "RightSIZE",
+        "score": 30
+      },
+      {
+        "format": 177,
+        "name": "Black and White",
+        "score": -9999
+      },
+      {
+        "format": 176,
+        "name": "TrueHD",
+        "score": -9999
+      },
+      {
+        "format": 175,
+        "name": "DTS-X",
+        "score": -9999
+      },
+      {
+        "format": 174,
+        "name": "FLAC",
+        "score": 0
+      },
+      {
+        "format": 173,
+        "name": "DTS-HD MA",
+        "score": -9999
+      },
+      {
+        "format": 172,
+        "name": "x265",
+        "score": -500
+      },
+      {
+        "format": 171,
+        "name": "IMAX",
+        "score": 10
+      },
+      {
+        "format": 170,
+        "name": "ATMOS",
+        "score": 10
+      },
+      {
+        "format": 169,
+        "name": "DD",
+        "score": 0
+      },
+      {
+        "format": 168,
+        "name": "DTS",
+        "score": 0
+      },
+      {
+        "format": 167,
+        "name": "DD+",
+        "score": 0
+      },
+      {
+        "format": 166,
+        "name": "iTunes",
+        "score": 90
+      },
+      {
+        "format": 165,
+        "name": "Paramount+",
+        "score": 190
+      },
+      {
+        "format": 164,
+        "name": "Peacock TV",
+        "score": 190
+      },
+      {
+        "format": 163,
+        "name": "Hulu",
+        "score": 190
+      },
+      {
+        "format": 162,
+        "name": "Netflix",
+        "score": 200
+      },
+      {
+        "format": 161,
+        "name": "HBO Max",
+        "score": 200
+      },
+      {
+        "format": 160,
+        "name": "Disney+",
+        "score": 200
+      },
+      {
+        "format": 159,
+        "name": "Apple TV+",
+        "score": 210
+      },
+      {
+        "format": 158,
+        "name": "Movies Anywhere",
+        "score": 220
+      },
+      {
+        "format": 157,
+        "name": "Amazon Prime",
+        "score": 210
+      },
+      {
+        "format": 156,
+        "name": "REMUX",
+        "score": -9999
+      },
+      {
+        "format": 155,
+        "name": "x264",
+        "score": 10
+      },
+      {
+        "format": 154,
+        "name": "WEBRip",
+        "score": 10
+      },
+      {
+        "format": 153,
+        "name": "Blu-Ray",
+        "score": 10
+      },
+      {
+        "format": 152,
+        "name": "2160p",
+        "score": -9999
+      },
+      {
+        "format": 151,
+        "name": "720p",
+        "score": -9999
+      },
+      {
+        "format": 150,
+        "name": "1080p",
+        "score": 220
+      },
+      {
+        "format": 149,
+        "name": "BHDStudio",
+        "score": 90
+      },
+      {
+        "format": 148,
+        "name": "LEGi0N",
+        "score": 20
+      },
+      {
+        "format": 147,
+        "name": "FraMeSToR",
+        "score": 20
+      },
+      {
+        "format": 146,
+        "name": "iFT",
+        "score": 30
+      },
+      {
+        "format": 145,
+        "name": "MTeam",
+        "score": -9999
+      },
+      {
+        "format": 144,
+        "name": "EDPH",
+        "score": 20
+      },
+      {
+        "format": 143,
+        "name": "HANDJOB",
+        "score": 20
+      },
+      {
+        "format": 142,
+        "name": "c0ke",
+        "score": 70
+      },
+      {
+        "format": 141,
+        "name": "KASHMiR",
+        "score": 30
+      },
+      {
+        "format": 140,
+        "name": "WMING",
+        "score": 30
+      },
+      {
+        "format": 139,
+        "name": "playHD",
+        "score": 30
+      },
+      {
+        "format": 138,
+        "name": "E.N.D",
+        "score": 30
+      },
+      {
+        "format": 137,
+        "name": "GutS",
+        "score": 30
+      },
+      {
+        "format": 136,
+        "name": "BV",
+        "score": 30
+      },
+      {
+        "format": 135,
+        "name": "SiMPLE",
+        "score": 30
+      },
+      {
+        "format": 134,
+        "name": "W4NK3R",
+        "score": 30
+      },
+      {
+        "format": 133,
+        "name": "GS88",
+        "score": 30
+      },
+      {
+        "format": 132,
+        "name": "HiP",
+        "score": 40
+      },
+      {
+        "format": 131,
+        "name": "GALAXY",
+        "score": 30
+      },
+      {
+        "format": 130,
+        "name": "luvBB",
+        "score": 30
+      },
+      {
+        "format": 129,
+        "name": "NyHD",
+        "score": 30
+      },
+      {
+        "format": 128,
+        "name": "ZIMBO",
+        "score": 30
+      },
+      {
+        "format": 127,
+        "name": "ThD",
+        "score": 30
+      },
+      {
+        "format": 126,
+        "name": "SaNcTi",
+        "score": 30
+      },
+      {
+        "format": 125,
+        "name": "ORiGEN",
+        "score": 30
+      },
+      {
+        "format": 124,
+        "name": "Positive",
+        "score": 30
+      },
+      {
+        "format": 123,
+        "name": "ESiR",
+        "score": 30
+      },
+      {
+        "format": 122,
+        "name": "Chotab",
+        "score": 30
+      },
+      {
+        "format": 121,
+        "name": "xander",
+        "score": 30
+      },
+      {
+        "format": 120,
+        "name": "FTW-HD",
+        "score": 30
+      },
+      {
+        "format": 119,
+        "name": "Penumbra",
+        "score": 30
+      },
+      {
+        "format": 118,
+        "name": "TDD",
+        "score": 30
+      },
+      {
+        "format": 117,
+        "name": "Dariush SD",
+        "score": 30
+      },
+      {
+        "format": 116,
+        "name": "PTer",
+        "score": 30
+      },
+      {
+        "format": 115,
+        "name": "SbR",
+        "score": 30
+      },
+      {
+        "format": 114,
+        "name": "nmd",
+        "score": 30
+      },
+      {
+        "format": 113,
+        "name": "TBB",
+        "score": 30
+      },
+      {
+        "format": 112,
+        "name": "EA",
+        "score": 40
+      },
+      {
+        "format": 111,
+        "name": "BMF",
+        "score": 40
+      },
+      {
+        "format": 110,
+        "name": "LolHD",
+        "score": 40
+      },
+      {
+        "format": 109,
+        "name": "HDMaNiAcS",
+        "score": 40
+      },
+      {
+        "format": 108,
+        "name": "IDE",
+        "score": 40
+      },
+      {
+        "format": 107,
+        "name": "de[42]",
+        "score": 50
+      },
+      {
+        "format": 106,
+        "name": "NCmt",
+        "score": 60
+      },
+      {
+        "format": 105,
+        "name": "decibeL",
+        "score": 50
+      },
+      {
+        "format": 104,
+        "name": "NTb",
+        "score": 40
+      },
+      {
+        "format": 103,
+        "name": "CRiSC",
+        "score": 50
+      },
+      {
+        "format": 102,
+        "name": "SA89",
+        "score": 60
+      },
+      {
+        "format": 101,
+        "name": "HiDt",
+        "score": 60
+      },
+      {
+        "format": 100,
+        "name": "FoRM",
+        "score": 60
+      },
+      {
+        "format": 99,
+        "name": "HiFi",
+        "score": 60
+      },
+      {
+        "format": 98,
+        "name": "CtrlHD",
+        "score": 60
+      },
+      {
+        "format": 97,
+        "name": "VietHD",
+        "score": 70
+      },
+      {
+        "format": 96,
+        "name": "ZQ",
+        "score": 70
+      },
+      {
+        "format": 95,
+        "name": "TayTo",
+        "score": 70
+      },
+      {
+        "format": 94,
+        "name": "Geek",
+        "score": 70
+      },
+      {
+        "format": 93,
+        "name": "EbP",
+        "score": 80
+      },
+      {
+        "format": 92,
+        "name": "DON",
+        "score": 80
+      },
+      {
+        "format": 91,
+        "name": "D-Z0N3",
+        "score": 80
+      },
+      {
+        "format": 215,
+        "name": "CJ",
+        "score": 0
+      },
+      {
+        "format": 216,
+        "name": "pcroland",
+        "score": 0
+      },
+      {
+        "format": 217,
+        "name": "BTN",
+        "score": 0
+      },
+      {
+        "format": 218,
+        "name": "iON",
+        "score": 0
+      },
+      {
+        "format": 219,
+        "name": "AJP69",
+        "score": 0
+      },
+      {
+        "format": 220,
+        "name": "VLAD",
+        "score": 0
+      },
+      {
+        "format": 221,
+        "name": "hdalx",
+        "score": 0
+      },
+      {
+        "format": 223,
+        "name": "LiNG",
+        "score": 0
+      },
+      {
+        "format": 224,
+        "name": "Upscaled",
+        "score": -9999
+      }
+    ]
+  }
 ]


### PR DESCRIPTION
added new field inside each quality profile: minUpgradeFormatScore
- not currently used by profilarr, but needed for compatability