### PR TITLE
GitHub Workflow: Add arm64 to platforms

### DIFF
--- a/.github/workflows/beta-build.yml
+++ b/.github/workflows/beta-build.yml
@@ -14,7 +14,12 @@ jobs:
         steps:
             - name: Checkout code
               uses: actions/checkout@v4
-
+              
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@v3
+              with:
+                platforms: linux/amd64,linux/arm64/v8
+                
             - name: Set up Node.js
               uses: actions/setup-node@v4
               with:
@@ -46,6 +51,7 @@ jobs:
             - name: Build and push
               uses: docker/build-push-action@v5
               with:
+                  platforms: linux/amd64,linux/arm64/v8
                   context: .
                   push: ${{ github.event_name != 'pull_request' }}
-                  tags: santiagosayshey/profilarr:beta
+                  tags: 123marvin123/profilarr:beta

--- a/.github/workflows/beta-build.yml
+++ b/.github/workflows/beta-build.yml
@@ -54,4 +54,4 @@ jobs:
                   platforms: linux/amd64,linux/arm64/v8
                   context: .
                   push: ${{ github.event_name != 'pull_request' }}
-                  tags: 123marvin123/profilarr:beta
+                  tags: santiagosayshey/profilarr:beta

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -16,6 +16,11 @@ jobs:
               id: tag
               run: echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@v3
+              with:
+                platforms: linux/amd64,linux/arm64/v8
+
             - name: Set up Node.js
               uses: actions/setup-node@v4
               with:
@@ -47,7 +52,8 @@ jobs:
               uses: docker/build-push-action@v5
               with:
                   context: .
+                  platforms: linux/amd64,linux/arm64/v8
                   push: true
                   tags: |
-                      santiagosayshey/profilarr:latest
-                      santiagosayshey/profilarr:${{ steps.tag.outputs.tag }}
+                      123marvin123/profilarr:latest
+                      123marvin123/profilarr:${{ steps.tag.outputs.tag }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -55,5 +55,5 @@ jobs:
                   platforms: linux/amd64,linux/arm64/v8
                   push: true
                   tags: |
-                      123marvin123/profilarr:latest
-                      123marvin123/profilarr:${{ steps.tag.outputs.tag }}
+                      santiagosayshey/profilarr:latest
+                      santiagosayshey/profilarr:${{ steps.tag.outputs.tag }}

--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@ Configuration management tool for Radarr/Sonarr that automates importing and ver
 
 ## Getting Started
 
+### Compatibility
+
+| Architecture                   | Support      |
+| ------------------------------ | ------------ |
+| amd64 (x86_64)                 | ✅ Supported |
+| arm64 (Apple Silicon, RPi 4/5) | ✅ Supported |
+
 ### Quick Installation (Docker Compose)
 
 ```yaml
@@ -70,13 +77,15 @@ Detailed contributing guidelines will be available soon. Join our Discord to dis
 
 ## Status
 
-Currently in beta. Part of the [Dictionarry](https://github.com/Dictionarry-Hub) project to simplify media automation. 
+Currently in beta. Part of the [Dictionarry](https://github.com/Dictionarry-Hub) project to simplify media automation.
 
 ### Known Issues
-- Light Mode is not working
-- Renaming / Deleting files can be a little wonky - if you expect to stay connected with a database, try to limit deleting / renaming files.
-- State management for custom format conditions is also a little wonky on chromium based browsers
+
+-   Light Mode is not working
+-   Renaming / Deleting files can be a little wonky - if you expect to stay connected with a database, try to limit deleting / renaming files.
+-   State management for custom format conditions is also a little wonky on chromium based browsers
 
 ### Development
-- Currently focused on fixing bugs found in open beta
-- 1.1 will focus on improving the 'setup' side of profilarr - adding media management / quality settings syncs
+
+-   Currently focused on fixing bugs found in open beta
+-   1.1 will focus on improving the 'setup' side of profilarr - adding media management / quality settings syncs


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflows to support multi-platform builds. The changes involve setting up QEMU and specifying platforms for Docker build and push actions.

This will automatically build and push the image for `linux/amd64` and `linux/arm64/v8`.