### PR TITLE
Allow `CONFIG_DIR` to be set via an environment variable

### DIFF
--- a/backend/app/config/config.py
+++ b/backend/app/config/config.py
@@ -4,7 +4,7 @@ import logging
 
 class Config:
     # Base Paths
-    CONFIG_DIR = '/config'
+    CONFIG_DIR = os.getenv('CONFIG_DIR', '/config')
     DB_PATH = os.path.join(CONFIG_DIR, 'profilarr.db')
     DB_DIR = os.path.join(CONFIG_DIR, 'db')
 


### PR DESCRIPTION
Other options would include a way to set it via a flag on the command line.

This allows Profilarr to be used outside a container, where `/config` probably can't be used to store Profilarr's configuration.