### PR TITLE
sytle: number input / tab viewer

### DIFF
--- a/frontend/src/components/profile/scoring/AdvancedView.jsx
+++ b/frontend/src/components/profile/scoring/AdvancedView.jsx
@@ -71,6 +71,7 @@ const AdvancedView = ({formats, onScoreChange, onFormatRemove, showRemoveButton}
                                                 onChange={value =>
                                                     onScoreChange(format.id, value)
                                                 }
+                                                className="w-24"
                                             />
                                             {showRemoveButton && (
                                                 <button

--- a/frontend/src/components/profile/scoring/BasicView.jsx
+++ b/frontend/src/components/profile/scoring/BasicView.jsx
@@ -55,6 +55,7 @@ const BasicView = ({formats, onScoreChange, onFormatRemove, showRemoveButton}) =
                                     onChange={value =>
                                         onScoreChange(format.id, value)
                                     }
+                                    className="w-24"
                                 />
                                 {showRemoveButton && (
                                     <button

--- a/frontend/src/components/profile/scoring/UpgradeSettings.jsx
+++ b/frontend/src/components/profile/scoring/UpgradeSettings.jsx
@@ -27,6 +27,7 @@ const UpgradeSettings = ({
                     <NumberInput
                         value={minCustomFormatScore}
                         onChange={onMinScoreChange}
+                        className="w-20"
                     />
                 </div>
 
@@ -49,6 +50,7 @@ const UpgradeSettings = ({
                                 value={upgradeUntilScore}
                                 onChange={onUpgradeUntilScoreChange}
                                 min={0}
+                                className="w-20"
                             />
                         </div>
 
@@ -68,6 +70,7 @@ const UpgradeSettings = ({
                                 value={minScoreIncrement}
                                 onChange={onMinIncrementChange}
                                 min={0}
+                                className="w-20"
                             />
                         </div>
                     </>

--- a/frontend/src/components/ui/Modal.jsx
+++ b/frontend/src/components/ui/Modal.jsx
@@ -140,7 +140,7 @@ const Modal = ({
                         {title}
                     </h3>
                     {tabs && (
-                        <div className='ml-auto mr-3'>
+                        <div className='ml-auto mr-3 md:ml-4 md:mr-auto'>
                             <TabViewer
                                 tabs={tabs}
                                 activeTab={activeTab}
@@ -150,7 +150,7 @@ const Modal = ({
                     )}
                     <button
                         onClick={handleClose}
-                        className={`${tabs ? '' : 'ml-auto'} text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors`}>
+                        className='text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors'>
                         <svg
                             className='w-6 h-6'
                             fill='none'


### PR DESCRIPTION
- revert desktop tabs to be left aligned
- reduce number input size in profile scoring tab