### PR TITLE
Allow running docker image as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 # Dockerfile
 FROM python:3.9-slim
 WORKDIR /app
+RUN groupadd appgroup && useradd -m -d /home/appuser -s /bin/bash  -g appgroup appuser
+RUN mkdir -p /home/appuser
 # Install git and gosu for user switching
-RUN apt-get update && apt-get install -y git gosu && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
 # Copy pre-built files from dist directory
 COPY dist/backend/app ./app
 COPY dist/static ./app/static
@@ -17,5 +19,6 @@ LABEL org.opencontainers.image.source="https://github.com/Dictionarry-Hub/profil
 LABEL org.opencontainers.image.title="Profilarr"
 LABEL org.opencontainers.image.version="beta"
 EXPOSE 6868
+USER appuser
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["gunicorn", "--bind", "0.0.0.0:6868", "--timeout", "600", "app.main:create_app()"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,34 +1,22 @@
 #!/bin/bash
 set -e
 
-# Default to UID/GID 1000 if not provided
-PUID=${PUID:-1000}
-PGID=${PGID:-1000}
+GID=$(id -g)
 # Default umask to 022 if not provided
 UMASK=${UMASK:-022}
 
-echo "Starting with UID: $PUID, GID: $PGID, UMASK: $UMASK"
+echo "Starting with UID: $UID, GID: $GID, UMASK: $UMASK"
 
 umask "$UMASK"
-
-# Create group with specified GID
-groupadd -g "$PGID" appgroup 2>/dev/null || true
-
-# Create user with specified UID and GID
-useradd -u "$PUID" -g "$PGID" -d /home/appuser -s /bin/bash appuser 2>/dev/null || true
-
-# Create home directory if it doesn't exist
-mkdir -p /home/appuser
-chown "$PUID:$PGID" /home/appuser
 
 # Fix permissions on /config if it exists
 if [ -d "/config" ]; then
     echo "Setting up /config directory permissions"
     # Change ownership of /config and all its contents to PUID:PGID
     # This ensures files created by different UIDs are accessible
-    chown -R "$PUID:$PGID" /config
+    chown -R "$UID:$GID" /config
 fi
 
 # Execute the main command as the specified user
-echo "Starting application as user $PUID:$PGID"
-exec gosu "$PUID:$PGID" "$@"
+echo "Starting application as user $UID:$GID"
+exec "$@"


### PR DESCRIPTION
The docker image expected to be root as it was doing operations that require root permissions in the entrypoint.sh (so at runtime).

Some users might want to run the entire container as a non-root user, so let's cater for both scenarios by adding a USER instruction in the Dockerfile and adding the group/user there as well.

By default this will mean we now run the container as a non-root user, but if a user still wants to run as root that is possible by specifying `--user root` using docker cli or whichever equivalent in other container runtimes.

This also means we don't need the gosu command in the entrypoint anymore.

Fixes #231