### PR TITLE
Changed to use CSafeLoader if available

### DIFF
--- a/backend/app/data/utils.py
+++ b/backend/app/data/utils.py
@@ -14,6 +14,8 @@ logger.setLevel(logging.INFO)
 
 from ..config.config import config
 
+_YAML_LOADER = getattr(yaml, 'CSafeLoader', yaml.SafeLoader)
+
 # Directory constants
 REPO_PATH = config.DB_DIR
 REGEX_DIR = config.REGEX_DIR
@@ -102,7 +104,7 @@ def load_yaml_file(file_path: str) -> Dict[str, Any]:
 
     try:
         with open(file_path, 'r') as f:
-            content = yaml.safe_load(f)
+            content = yaml.load(f, Loader=_YAML_LOADER)
             return content
 
     except yaml.YAMLError as e:


### PR DESCRIPTION
I noticed the `api/data/profile` and `api/data/custom_format` endpoints were quite slow on my machine (~2900ms each).

I changed `load_yaml_file` to use `CSafeLoader` if available. Falling back to `yaml.SafeLoader` when it is not.

The runtime on my machine is now 80ms for `profile` and 370ms for `custom_format` when using the default dictionary.