### PR TITLE
Add: `HOST` & `PORT` env vars for profilarr.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && apt-get install -y git gosu && rm -rf /var/lib/apt/lists/*
 COPY dist/backend/app ./app
 COPY dist/static ./app/static
 COPY dist/requirements.txt .
+COPY gunicorn.conf.py .
 RUN pip install --no-cache-dir -r requirements.txt
 # Copy and setup entrypoint script
 COPY entrypoint.sh /entrypoint.sh
@@ -18,4 +19,4 @@ LABEL org.opencontainers.image.title="Profilarr"
 LABEL org.opencontainers.image.version="beta"
 EXPOSE 6868
 ENTRYPOINT ["/entrypoint.sh"]
-CMD ["gunicorn", "--bind", "0.0.0.0:6868", "--timeout", "600", "app.main:create_app()"]
+CMD ["gunicorn", "--config", "gunicorn.conf.py", --timeout", "600", "app.main:create_app()"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ LABEL org.opencontainers.image.title="Profilarr"
 LABEL org.opencontainers.image.version="beta"
 EXPOSE 6868
 ENTRYPOINT ["/entrypoint.sh"]
-CMD ["gunicorn", "--config", "gunicorn.conf.py", --timeout", "600", "app.main:create_app()"]
+CMD ["gunicorn", "--config", "gunicorn.conf.py", "--timeout", "600", "app.main:create_app()"]

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,0 +1,6 @@
+import os
+
+# Make host and port configurable
+host  = os.getenv("HOST", "0.0.0.0")
+port  = os.getenv("PORT", "6868")
+bind  = f"{host}:{port}"


### PR DESCRIPTION
This lets users override the address on which gunicorn binds. fixes #257