### PR TITLE
Gh 240 add alpine image

### DIFF
--- a/.github/workflows/beta-build.yml
+++ b/.github/workflows/beta-build.yml
@@ -11,15 +11,23 @@ on:
 jobs:
     build:
         runs-on: ubuntu-latest
+        strategy:
+          fail-fast: false
+          matrix:
+            include:
+              - dockerfile: Dockerfile
+                suffix:
+              - dockerfile: Dockerfile.alpine
+                suffix: -alpine
         steps:
             - name: Checkout code
               uses: actions/checkout@v4
-              
+
             - name: Set up QEMU
               uses: docker/setup-qemu-action@v3
               with:
                 platforms: linux/amd64,linux/arm64/v8
-                
+
             - name: Set up Node.js
               uses: actions/setup-node@v4
               with:
@@ -48,10 +56,26 @@ jobs:
                   username: ${{ secrets.DOCKERHUB_USERNAME }}
                   password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+            - name: Extract metadata (tags, labels) for Docker
+              id: meta
+              uses: docker/metadata-action@v5.10.0
+              with:
+                images: santiagosayshey/profillar
+                flavor: |
+                  suffix=${{ matrix.suffix }}
+                tags: beta
+
             - name: Build and push
               uses: docker/build-push-action@v5
               with:
                   platforms: linux/amd64,linux/arm64/v8
                   context: .
+                  file: ${{ matrix.dockerfile }}
                   push: ${{ github.event_name != 'pull_request' }}
-                  tags: santiagosayshey/profilarr:beta
+                  tags: ${{ steps.meta.outputs.tags }}
+                  labels: |
+                      ${{ steps.meta.outputs.labels }}
+                      org.opencontainers.image.authors="Dictionarry dictionarry@pm.me"
+                      org.opencontainers.image.description="Profilarr - Profile manager for *arr apps"
+                      org.opencontainers.image.source="https://github.com/Dictionarry-Hub/profilarr"
+                      org.opencontainers.image.title="Profilarr"

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -8,13 +8,19 @@ on:
 jobs:
     build:
         runs-on: ubuntu-latest
+        strategy:
+          fail-fast: false
+          matrix:
+            include:
+              - dockerfile: Dockerfile
+                suffix:
+                use_latest: true
+              - dockerfile: Dockerfile.alpine
+                suffix: -alpine
+                use_latest: false
         steps:
             - name: Checkout code
               uses: actions/checkout@v4
-
-            - name: Get tag
-              id: tag
-              run: echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
             - name: Set up QEMU
               uses: docker/setup-qemu-action@v3
@@ -48,12 +54,29 @@ jobs:
                   username: ${{ secrets.DOCKERHUB_USERNAME }}
                   password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+            - name: Extract metadata (tags, labels) for Docker
+              id: meta
+              uses: docker/metadata-action@v5.10.0
+              with:
+                images: santiagosayshey/profillar
+                flavor: |
+                  latest=${{ matrix.use_latest }}
+                  suffix=${{ matrix.suffix }}
+                tags: |
+                  type=ref,event=tag
+                  type=raw,value=alpine,suffix=,enable=${{ matrix.suffix == '-alpine' }}
+
             - name: Build and push
               uses: docker/build-push-action@v5
               with:
                   context: .
                   platforms: linux/amd64,linux/arm64/v8
+                  file: ${{ matrix.dockerfile }}
                   push: true
-                  tags: |
-                      santiagosayshey/profilarr:latest
-                      santiagosayshey/profilarr:${{ steps.tag.outputs.tag }}
+                  tags: ${{ steps.meta.outputs.tags }}
+                  labels: |
+                      ${{ steps.meta.outputs.labels }}
+                      org.opencontainers.image.authors="Dictionarry dictionarry@pm.me"
+                      org.opencontainers.image.description="Profilarr - Profile manager for *arr apps"
+                      org.opencontainers.image.source="https://github.com/Dictionarry-Hub/profilarr"
+                      org.opencontainers.image.title="Profilarr"

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,13 +1,17 @@
 # Dockerfile
-FROM python:3.9-slim
+FROM python:3.9-alpine3.22
 WORKDIR /app
 # Install git (for app) and gosu for user switching (in entrypoint)
-RUN apt-get update && apt-get install -y git gosu && rm -rf /var/lib/apt/lists/*
+RUN apk add -U --update --no-cache \
+    git \
+    gosu
 # Copy pre-built files from dist directory
 COPY dist/backend/app ./app
 COPY dist/static ./app/static
 COPY dist/requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install -U --no-cache-dir -r requirements.txt \
+    # add --no-build-isolation, because PyYaml always fail building without it. Remove with >6.0.1
+    --no-build-isolation
 # Copy and setup entrypoint script
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh


### PR DESCRIPTION
This will resolve parts of #240 

I know you are working on a rewrite in c# and this will probably lead to a linuxserver image with a single binary at some point, but until then we could have an addtional image, that is just less than half the size of the current one.

I saw that you have added powershell in the  `dev` branch, but I ignored that for now, since I am not sure what is happening there :P But I tried it out and you can basically copy&paste the code from your `Dockerfile` there and adjust the urls to be the correct one for alpine.

I will leave some remarks in the code to further explain what happened in there.