### PR TITLE
Fix link to Official Dictionarry database in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 **Core**
 
 - **Link** - Connect to configuration databases like the
-  [Dictionarry database](https://github.com/Dictionarry-Hub/db) or any Profilarr
+  [Dictionarry database](https://github.com/Dictionarry-Hub/database) or any Profilarr
   Compliant Database (PCD)
 - **Bridge** - Add your Radarr and Sonarr instances by URL and API key
 - **Sync** - Push configurations to your instances. Profilarr compiles


### PR DESCRIPTION
Corrected the link to the Official Dictionarry database in the README.