### PR TITLE
feat: live job status indicator in sidebar via SSE

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -1645,7 +1645,7 @@
         "npm:@types/deno@^2.5.0",
         "npm:@types/node@22",
         "npm:better-sqlite3@^12.6.2",
-        "npm:croner@^9.1.0",
+        "npm:croner@^10.0.1",
         "npm:esbuild@0.24",
         "npm:jose@^6.2.0",
         "npm:kysely@0.27.6",

--- a/docs/architecture/jobs.md
+++ b/docs/architecture/jobs.md
@@ -51,20 +51,20 @@ concurrency and makes the system deterministic.
 
 ## Job Types
 
-| Job Type | Purpose | Payload | Scheduled |
-|----------|---------|---------|-----------|
-| `arr.sync` | Combined sync (legacy) | `{ instanceId }` | Yes |
-| `arr.sync.qualityProfiles` | Sync quality profiles to Arr | `{ instanceId }` | Yes |
-| `arr.sync.delayProfiles` | Sync delay profiles to Arr | `{ instanceId }` | Yes |
-| `arr.sync.mediaManagement` | Sync media management to Arr | `{ instanceId }` | Yes |
-| `arr.upgrade` | Automated quality upgrades | `{ instanceId }` | Yes |
-| `arr.rename` | Bulk file/folder rename | `{ instanceId }` | Yes |
-| `arr.cleanup` | Remove stale configs from Arr | `{ instanceId }` | Yes |
-| `arr.library.refresh` | Refresh cached library data | `{ instanceId }` | Yes |
-| `pcd.sync` | Check/pull PCD database updates | `{ databaseId }` | Yes |
-| `backup.create` | Create backup archive | `{}` | Yes |
-| `backup.cleanup` | Delete old backups past retention | `{}` | Yes |
-| `logs.cleanup` | Delete old log files past retention | `{}` | Yes |
+| Job Type                   | Purpose                             | Payload          | Scheduled |
+| -------------------------- | ----------------------------------- | ---------------- | --------- |
+| `arr.sync`                 | Combined sync (legacy)              | `{ instanceId }` | Yes       |
+| `arr.sync.qualityProfiles` | Sync quality profiles to Arr        | `{ instanceId }` | Yes       |
+| `arr.sync.delayProfiles`   | Sync delay profiles to Arr          | `{ instanceId }` | Yes       |
+| `arr.sync.mediaManagement` | Sync media management to Arr        | `{ instanceId }` | Yes       |
+| `arr.upgrade`              | Automated quality upgrades          | `{ instanceId }` | Yes       |
+| `arr.rename`               | Bulk file/folder rename             | `{ instanceId }` | Yes       |
+| `arr.cleanup`              | Remove stale configs from Arr       | `{ instanceId }` | Yes       |
+| `arr.library.refresh`      | Refresh cached library data         | `{ instanceId }` | Yes       |
+| `pcd.sync`                 | Check/pull PCD database updates     | `{ databaseId }` | Yes       |
+| `backup.create`            | Create backup archive               | `{}`             | Yes       |
+| `backup.cleanup`           | Delete old backups past retention   | `{}`             | Yes       |
+| `logs.cleanup`             | Delete old log files past retention | `{}`             | Yes       |
 
 ## Lifecycle
 
@@ -118,12 +118,12 @@ The execution loop (`runDueJobs`) runs until no more due jobs remain:
 
 Handlers return one of four statuses:
 
-| Status | Meaning | Queue Status |
-|--------|---------|-------------|
-| `success` | Job completed normally | `success` |
-| `skipped` | Job had nothing to do (e.g. no old backups) | `success` |
-| `failure` | Job encountered an error | `failed` |
-| `cancelled` | Job was skipped due to config (e.g. backups disabled) | `cancelled` |
+| Status      | Meaning                                               | Queue Status |
+| ----------- | ----------------------------------------------------- | ------------ |
+| `success`   | Job completed normally                                | `success`    |
+| `skipped`   | Job had nothing to do (e.g. no old backups)           | `success`    |
+| `failure`   | Job encountered an error                              | `failed`     |
+| `cancelled` | Job was skipped due to config (e.g. backups disabled) | `cancelled`  |
 
 If the handler returns a `rescheduleAt` timestamp and the job source is
 `schedule`, the job is reset to `queued` with the new `run_at` instead of being
@@ -158,11 +158,11 @@ Used by backup and log cleanup jobs. The schedule is a keyword (`daily`,
 `hourly`, `weekly`, `monthly`) or a cron expression. Named schedules map to
 fixed times:
 
-| Schedule | Next Run |
-|----------|----------|
-| `daily` | Midnight tomorrow |
-| `hourly` | Next hour at :00 |
-| `weekly` | 7 days from now at midnight |
+| Schedule  | Next Run                      |
+| --------- | ----------------------------- |
+| `daily`   | Midnight tomorrow             |
+| `hourly`  | Next hour at :00              |
+| `weekly`  | 7 days from now at midnight   |
 | `monthly` | 1st of next month at midnight |
 
 ### Manual Triggers
@@ -230,19 +230,19 @@ that fail still reschedule their next occurrence.
 
 The source of truth for all jobs, both active and completed.
 
-| Column | Type | Description |
-|--------|------|-------------|
-| `id` | INTEGER PK | Auto-increment ID |
-| `job_type` | TEXT | Job type identifier |
-| `status` | TEXT | `queued`, `running`, `success`, `failed`, `cancelled` |
-| `run_at` | TEXT | ISO timestamp when the job should execute |
-| `payload` | TEXT | JSON object with job-specific data |
-| `source` | TEXT | `schedule`, `manual`, or `system` |
-| `dedupe_key` | TEXT | Unique key for scheduled jobs (nullable) |
-| `cooldown_until` | TEXT | Reserved for future cooldown mechanism |
-| `attempts` | INTEGER | Incremented each time the job is claimed |
-| `started_at` | TEXT | Set when claimed by dispatcher |
-| `finished_at` | TEXT | Set when execution completes |
+| Column           | Type       | Description                                           |
+| ---------------- | ---------- | ----------------------------------------------------- |
+| `id`             | INTEGER PK | Auto-increment ID                                     |
+| `job_type`       | TEXT       | Job type identifier                                   |
+| `status`         | TEXT       | `queued`, `running`, `success`, `failed`, `cancelled` |
+| `run_at`         | TEXT       | ISO timestamp when the job should execute             |
+| `payload`        | TEXT       | JSON object with job-specific data                    |
+| `source`         | TEXT       | `schedule`, `manual`, or `system`                     |
+| `dedupe_key`     | TEXT       | Unique key for scheduled jobs (nullable)              |
+| `cooldown_until` | TEXT       | Reserved for future cooldown mechanism                |
+| `attempts`       | INTEGER    | Incremented each time the job is claimed              |
+| `started_at`     | TEXT       | Set when claimed by dispatcher                        |
+| `finished_at`    | TEXT       | Set when execution completes                          |
 
 Key indexes:
 
@@ -254,17 +254,17 @@ Key indexes:
 
 Immutable log of every job execution.
 
-| Column | Type | Description |
-|--------|------|-------------|
-| `id` | INTEGER PK | Auto-increment ID |
-| `queue_id` | INTEGER | FK to job_queue (SET NULL on delete) |
-| `job_type` | TEXT | Job type (denormalized for orphan safety) |
-| `status` | TEXT | `success`, `failure`, `skipped`, `cancelled` |
-| `started_at` | TEXT | When execution began |
-| `finished_at` | TEXT | When execution ended |
-| `duration_ms` | INTEGER | Wall-clock execution time |
-| `error` | TEXT | Error message if failed |
-| `output` | TEXT | Handler's human-readable summary |
+| Column        | Type       | Description                                  |
+| ------------- | ---------- | -------------------------------------------- |
+| `id`          | INTEGER PK | Auto-increment ID                            |
+| `queue_id`    | INTEGER    | FK to job_queue (SET NULL on delete)         |
+| `job_type`    | TEXT       | Job type (denormalized for orphan safety)    |
+| `status`      | TEXT       | `success`, `failure`, `skipped`, `cancelled` |
+| `started_at`  | TEXT       | When execution began                         |
+| `finished_at` | TEXT       | When execution ended                         |
+| `duration_ms` | INTEGER    | Wall-clock execution time                    |
+| `error`       | TEXT       | Error message if failed                      |
+| `output`      | TEXT       | Handler's human-readable summary             |
 
 ## Real-Time Updates (SSE)
 
@@ -334,6 +334,7 @@ combined `arr.sync` type (legacy, runs all sections) and individual section
 types (`arr.sync.qualityProfiles`, etc.).
 
 Per section:
+
 1. Check if the section has config for this instance.
 2. Claim the sync lock (`pending` to `in_progress`).
 3. Create a syncer and execute.
@@ -416,4 +417,3 @@ dispatcher.
 **Job History** - a table of recent `job_run_history` entries showing job name,
 status, start time, duration, and output/error. Skipped runs are hidden by
 default.
-

--- a/docs/architecture/jobs.md
+++ b/docs/architecture/jobs.md
@@ -1,0 +1,419 @@
+# Job System
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Job Types](#job-types)
+- [Lifecycle](#lifecycle)
+  - [Initialization](#initialization)
+  - [Scheduling](#scheduling)
+  - [Dispatch](#dispatch)
+  - [Execution](#execution)
+  - [Completion](#completion)
+- [Scheduling Mechanisms](#scheduling-mechanisms)
+  - [Cron](#cron)
+  - [Fixed Interval](#fixed-interval)
+  - [Named Schedules](#named-schedules)
+  - [Manual Triggers](#manual-triggers)
+- [Deduplication & Locking](#deduplication--locking)
+- [Error Handling & Recovery](#error-handling--recovery)
+- [Database Schema](#database-schema)
+- [Real-Time Updates (SSE)](#real-time-updates-sse)
+  - [Server Side](#server-side)
+  - [Client Side](#client-side)
+- [Handlers](#handlers)
+  - [Arr Sync](#arr-sync)
+  - [Arr Upgrade](#arr-upgrade)
+  - [Arr Rename](#arr-rename)
+  - [Arr Cleanup](#arr-cleanup)
+  - [Arr Library Refresh](#arr-library-refresh)
+  - [PCD Sync](#pcd-sync)
+  - [Backup Create](#backup-create)
+  - [Backup Cleanup](#backup-cleanup)
+  - [Logs Cleanup](#logs-cleanup)
+- [Settings UI](#settings-ui)
+
+## Overview
+
+Profilarr uses an event-driven job queue for background tasks: syncing
+configuration to Arr instances, creating backups, running upgrades, renaming
+files, and cleaning up old data. The system is built around a SQLite-backed
+queue with a single-threaded dispatcher that processes jobs sequentially.
+
+The dispatcher does not poll. It calculates the delay until the next job is due
+and sets a timeout. When a new job is enqueued, the dispatcher is notified and
+recalculates if needed. This means zero CPU usage when idle and immediate
+execution when jobs are due.
+
+Jobs are strictly serial: one job runs at a time. The dispatcher claims and
+executes jobs in a loop, only sleeping when no jobs are due. This simplifies
+concurrency and makes the system deterministic.
+
+## Job Types
+
+| Job Type | Purpose | Payload | Scheduled |
+|----------|---------|---------|-----------|
+| `arr.sync` | Combined sync (legacy) | `{ instanceId }` | Yes |
+| `arr.sync.qualityProfiles` | Sync quality profiles to Arr | `{ instanceId }` | Yes |
+| `arr.sync.delayProfiles` | Sync delay profiles to Arr | `{ instanceId }` | Yes |
+| `arr.sync.mediaManagement` | Sync media management to Arr | `{ instanceId }` | Yes |
+| `arr.upgrade` | Automated quality upgrades | `{ instanceId }` | Yes |
+| `arr.rename` | Bulk file/folder rename | `{ instanceId }` | Yes |
+| `arr.cleanup` | Remove stale configs from Arr | `{ instanceId }` | Yes |
+| `arr.library.refresh` | Refresh cached library data | `{ instanceId }` | Yes |
+| `pcd.sync` | Check/pull PCD database updates | `{ databaseId }` | Yes |
+| `backup.create` | Create backup archive | `{}` | Yes |
+| `backup.cleanup` | Delete old backups past retention | `{}` | Yes |
+| `logs.cleanup` | Delete old log files past retention | `{}` | Yes |
+
+## Lifecycle
+
+### Initialization
+
+On server startup (`hooks.server.ts`), `initializeJobs()` runs:
+
+1. **Recovery** - any jobs stuck in `running` (from a crash) are reset to
+   `queued` so they can retry.
+2. **Schedule rebuild** - all scheduled jobs are created or updated from current
+   config (instances, databases, settings).
+3. **Dispatcher start** - the dispatcher begins watching for due jobs.
+
+### Scheduling
+
+Schedule functions read config from the database (sync triggers, cron
+expressions, intervals) and create or update queue entries using
+`upsertScheduled()`. Each scheduled job has a `dedupeKey` that prevents
+duplicates. When config changes (user saves settings), the relevant schedule
+function runs again to update the job's `run_at`.
+
+### Dispatch
+
+The dispatcher uses timeout-based scheduling:
+
+1. Query the next queued job (earliest `run_at`).
+2. Calculate delay: `max(0, run_at - now)`.
+3. Set a `setTimeout` for that delay.
+4. When the timeout fires, enter the execution loop.
+
+If a new job is enqueued with an earlier `run_at` than the current timeout, the
+dispatcher is notified via `notifyJobEnqueued()` and recalculates.
+
+### Execution
+
+The execution loop (`runDueJobs`) runs until no more due jobs remain:
+
+1. **Claim** - `claimNextDue()` atomically finds the next due job and sets its
+   status to `running`. This is a conditional UPDATE (WHERE status = 'queued')
+   to prevent double-claiming.
+2. **Lookup** - find the handler function in the registry by job type.
+3. **Run** - call the handler with the full job record. The handler is async and
+   returns a `JobHandlerResult`.
+4. **Emit** - push SSE events to connected browsers (sync jobs only).
+5. **Record** - write a `job_run_history` row with status, duration, output, and
+   error.
+6. **Finish** - either reschedule (if handler returned `rescheduleAt`) or mark
+   the job as success/failed/cancelled.
+
+### Completion
+
+Handlers return one of four statuses:
+
+| Status | Meaning | Queue Status |
+|--------|---------|-------------|
+| `success` | Job completed normally | `success` |
+| `skipped` | Job had nothing to do (e.g. no old backups) | `success` |
+| `failure` | Job encountered an error | `failed` |
+| `cancelled` | Job was skipped due to config (e.g. backups disabled) | `cancelled` |
+
+If the handler returns a `rescheduleAt` timestamp and the job source is
+`schedule`, the job is reset to `queued` with the new `run_at` instead of being
+marked finished. This creates the recurring loop for scheduled jobs.
+
+## Scheduling Mechanisms
+
+### Cron
+
+Used by sync, upgrade, rename, and cleanup jobs. The cron expression is stored
+in the config table for each instance. `calculateNextRun()` uses the `croner`
+library to compute the next occurrence.
+
+Cron expressions are validated with a minimum interval check to prevent
+accidental sub-minute schedules. For simple `*/N * * * *` patterns, the interval
+is checked directly. For complex expressions, the validator runs the cron 3
+times and measures the gaps.
+
+### Fixed Interval
+
+Used by library refresh and PCD sync. The interval is stored in minutes. Next
+run is calculated as `lastRunAt + intervalMinutes`. If there's no previous run,
+the job runs immediately.
+
+Handlers for interval-based jobs include a "not due yet" guard: if the
+scheduler fires early (e.g. after a restart), the handler checks whether the
+actual due time has passed and reschedules if not.
+
+### Named Schedules
+
+Used by backup and log cleanup jobs. The schedule is a keyword (`daily`,
+`hourly`, `weekly`, `monthly`) or a cron expression. Named schedules map to
+fixed times:
+
+| Schedule | Next Run |
+|----------|----------|
+| `daily` | Midnight tomorrow |
+| `hourly` | Next hour at :00 |
+| `weekly` | 7 days from now at midnight |
+| `monthly` | 1st of next month at midnight |
+
+### Manual Triggers
+
+Any job can be triggered manually via "Run now" in the settings UI or via API.
+Manual jobs use `source: 'manual'` and `run_at: now`. They execute immediately
+(the dispatcher is notified) and do not reschedule after completion.
+
+## Deduplication & Locking
+
+### Queue Deduplication
+
+Every scheduled job has a unique `dedupeKey` (e.g.
+`arr.sync.qualityProfiles:123`). A unique partial index ensures only one job
+per key can exist. When `upsertScheduled()` is called:
+
+- If no job exists with that key, create one.
+- If a queued job exists, update its `run_at` and payload.
+- If a running job exists, leave it alone (never overwrite a running job).
+
+This prevents duplicate jobs from accumulating when config is saved multiple
+times or when `scheduleAllJobs()` runs on startup.
+
+### Sync Locking
+
+Arr sync jobs use a separate locking mechanism via the `sync_status` column on
+sync config tables (`arr_sync_quality_profiles_config`, etc.):
+
+- `idle` - no sync running
+- `pending` - job enqueued, waiting to start
+- `in_progress` - handler claimed the lock, sync executing
+- `failed` - sync encountered an error
+
+The handler calls `claimSync()` which atomically moves `pending` to
+`in_progress`. If already `in_progress`, the claim fails and the job is
+skipped. This prevents concurrent syncs to the same instance for the same
+section.
+
+## Error Handling & Recovery
+
+### Handler Errors
+
+If a handler throws an exception, the dispatcher catches it and converts it to
+a failure result. The error message is recorded in job run history. The job is
+marked as `failed` in the queue.
+
+If no handler is registered for a job type, the job is immediately marked as
+`failed` with "Handler not found" recorded in history.
+
+### Startup Recovery
+
+On init, `recoverRunning()` resets any jobs stuck in `running` to `queued`.
+This handles the case where the process was killed while a job was executing.
+The job will retry on next dispatch.
+
+### No Auto-Retry
+
+Failed jobs do not automatically retry. They remain in the queue with status
+`failed`. Users can manually re-trigger via the settings UI. Scheduled jobs
+that fail still reschedule their next occurrence.
+
+## Database Schema
+
+### job_queue
+
+The source of truth for all jobs, both active and completed.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `id` | INTEGER PK | Auto-increment ID |
+| `job_type` | TEXT | Job type identifier |
+| `status` | TEXT | `queued`, `running`, `success`, `failed`, `cancelled` |
+| `run_at` | TEXT | ISO timestamp when the job should execute |
+| `payload` | TEXT | JSON object with job-specific data |
+| `source` | TEXT | `schedule`, `manual`, or `system` |
+| `dedupe_key` | TEXT | Unique key for scheduled jobs (nullable) |
+| `cooldown_until` | TEXT | Reserved for future cooldown mechanism |
+| `attempts` | INTEGER | Incremented each time the job is claimed |
+| `started_at` | TEXT | Set when claimed by dispatcher |
+| `finished_at` | TEXT | Set when execution completes |
+
+Key indexes:
+
+- `idx_job_queue_dedupe_key` - unique partial index on `dedupe_key` WHERE NOT
+  NULL
+- `idx_job_queue_status_run_at` - composite for efficient claim queries
+
+### job_run_history
+
+Immutable log of every job execution.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `id` | INTEGER PK | Auto-increment ID |
+| `queue_id` | INTEGER | FK to job_queue (SET NULL on delete) |
+| `job_type` | TEXT | Job type (denormalized for orphan safety) |
+| `status` | TEXT | `success`, `failure`, `skipped`, `cancelled` |
+| `started_at` | TEXT | When execution began |
+| `finished_at` | TEXT | When execution ended |
+| `duration_ms` | INTEGER | Wall-clock execution time |
+| `error` | TEXT | Error message if failed |
+| `output` | TEXT | Handler's human-readable summary |
+
+## Real-Time Updates (SSE)
+
+The job system pushes real-time status updates to connected browsers via
+Server-Sent Events. Currently limited to sync job types (`arr.sync.*`).
+
+### Server Side
+
+**Event emitter** (`src/lib/server/jobs/jobEvents.ts`): A callback-based
+pub/sub singleton. The dispatcher calls `emit()` on job start and finish. The
+emitter filters by job type internally, so non-sync jobs are silently ignored.
+
+Two event types:
+
+- `job.started` - emitted after the handler is resolved, before execution. Includes
+  `jobId`, `jobType`, and a short `displayLabel` (e.g. "Syncing Quality
+  Profiles...").
+- `job.finished` - emitted after history is recorded, before reschedule. Includes
+  `jobId`, `jobType`, `displayLabel` (e.g. "Quality Profiles sync"), `status`,
+  and `durationMs`.
+
+**SSE endpoint** (`src/routes/jobs/events/+server.ts`): A GET handler that
+returns a `Response` with a `ReadableStream` body. On stream start, it
+subscribes to the event emitter. Each event is written as SSE-formatted text.
+A keepalive comment (`: keepalive`) is sent every 30 seconds to prevent proxy
+timeouts. On client disconnect, the subscription is cleaned up.
+
+The endpoint is a web app route (not under `/api/`), so it uses session-only
+auth. API keys cannot access it.
+
+### Client Side
+
+**Store** (`src/lib/client/stores/jobStatus.ts`): A Svelte writable store that
+manages an `EventSource` connection and a three-state machine:
+
+- `idle` - no job activity, version block shows normally
+- `running` - job in progress, shows spinner and label
+- `completed` - job finished, shows result for 6 seconds then returns to idle
+
+The store includes holdoff logic: if a new `job.started` arrives within 5
+seconds of entering `completed`, the completion message is held for the
+remaining time before transitioning. This prevents flickering during
+back-to-back jobs.
+
+The `EventSource` connects on app load (from `+layout.svelte`) and stays open
+for the session. It auto-reconnects on network drops.
+
+**Desktop UI** (`src/lib/client/ui/navigation/pageNav/jobStatus.svelte`): A
+card component that appears above the version block in the sidebar when a job
+is active. Uses Svelte's `fade` transition.
+
+**Mobile UI** (`src/lib/client/ui/navigation/bottomNav/BottomNav.svelte`): A
+compact status strip that slides in above the bottom navigation tabs. Uses
+Svelte's `slide` transition.
+
+## Handlers
+
+All handlers live in `src/lib/server/jobs/handlers/` and are registered in
+`index.ts` on import.
+
+### Arr Sync
+
+**Handler:** `arrSync.ts`
+
+Syncs configuration from the PCD cache into Arr instances. Handles both the
+combined `arr.sync` type (legacy, runs all sections) and individual section
+types (`arr.sync.qualityProfiles`, etc.).
+
+Per section:
+1. Check if the section has config for this instance.
+2. Claim the sync lock (`pending` to `in_progress`).
+3. Create a syncer and execute.
+4. On success, mark `idle` and record `last_synced_at`.
+5. On failure, mark `failed` and record `last_error`.
+6. Calculate next cron run and reschedule if scheduled.
+
+### Arr Upgrade
+
+**Handler:** `arrUpgrade.ts`
+
+Runs the upgrade engine for Radarr instances: evaluates filter rules against
+the library, selects items for search, and triggers interactive or live
+searches. Supports round-robin and random filter modes. Rotates the filter
+index after each run.
+
+### Arr Rename
+
+**Handler:** `arrRename.ts`
+
+Scans Arr libraries for files/folders that don't match the current naming
+config and triggers rename commands. Supports dry-run mode and folder renaming.
+
+### Arr Cleanup
+
+**Handler:** `arrCleanup.ts`
+
+Scans Arr instances for stale custom formats and quality profiles that exist in
+the Arr but are no longer in the PCD config, then deletes them. Also scans for
+removed entities (TMDB/TVDB items no longer in the database).
+
+### Arr Library Refresh
+
+**Handler:** `arrLibraryRefresh.ts`
+
+Fetches the library from an Arr instance and caches it. Includes a "not due
+yet" guard to avoid unnecessary fetches when the scheduler fires early after a
+restart.
+
+### PCD Sync
+
+**Handler:** `pcdSync.ts`
+
+Checks a PCD database repository for upstream changes. If `auto_pull` is
+enabled and updates are found, pulls them automatically. Includes the same
+"not due yet" guard as library refresh.
+
+### Backup Create
+
+**Handler:** `backupCreate.ts`
+
+Creates a compressed backup archive of the data directory. The database copy
+inside the archive is sanitized: API keys, tokens, webhook URLs, user
+credentials, and sessions are all stripped. See the security doc for details on
+secret stripping.
+
+### Backup Cleanup
+
+**Handler:** `backupCleanup.ts`
+
+Scans the backups directory and deletes files older than the configured
+retention period. Reschedules daily.
+
+### Logs Cleanup
+
+**Handler:** `logsCleanup.ts`
+
+Scans the logs directory for dated log files (`YYYY-MM-DD.log`) and deletes
+those older than the configured retention period. Reschedules daily.
+
+## Settings UI
+
+The jobs settings page (`src/routes/settings/jobs/`) shows two views:
+
+**Scheduled Jobs** - a table of all jobs with a `dedupeKey` (one row per
+scheduled task). Shows status, last run time and result, and next run time.
+Users can trigger "Run now" which sets `run_at` to now and wakes the
+dispatcher.
+
+**Job History** - a table of recent `job_run_history` entries showing job name,
+status, start time, duration, and output/error. Skipped runs are hidden by
+default.
+

--- a/src/lib/client/stores/jobStatus.ts
+++ b/src/lib/client/stores/jobStatus.ts
@@ -24,7 +24,7 @@ export type JobStatusState =
 			displayLabel: string;
 			status: string;
 			durationMs: number;
-		};
+	  };
 
 const COMPLETED_DISPLAY_MS = 6_000;
 const COMPLETED_HOLDOFF_MS = 5_000;

--- a/src/lib/client/stores/jobStatus.ts
+++ b/src/lib/client/stores/jobStatus.ts
@@ -1,0 +1,146 @@
+/**
+ * Job status store with SSE connection.
+ *
+ * Manages the state machine for the sidebar job status indicator.
+ * Connects to /jobs/events via EventSource on app load.
+ *
+ * States: idle → running → completed → idle
+ *
+ * Timer rules:
+ * - completed → idle after 10 seconds
+ * - If job.started arrives during completed and < 5s elapsed, hold
+ *   the completion message until 5s pass, then transition to running
+ */
+
+import { writable } from 'svelte/store';
+import { browser } from '$app/environment';
+
+export type JobStatusState =
+	| { state: 'idle' }
+	| { state: 'running'; jobType: string; displayLabel: string }
+	| {
+			state: 'completed';
+			jobType: string;
+			displayLabel: string;
+			status: string;
+			durationMs: number;
+		};
+
+const COMPLETED_DISPLAY_MS = 6_000;
+const COMPLETED_HOLDOFF_MS = 5_000;
+
+function createJobStatusStore() {
+	const { subscribe, set } = writable<JobStatusState>({ state: 'idle' });
+
+	let eventSource: EventSource | null = null;
+	let resetTimer: ReturnType<typeof setTimeout> | null = null;
+	let holdoffTimer: ReturnType<typeof setTimeout> | null = null;
+	let completedAt = 0;
+	let pendingStartEvent: { jobType: string; displayLabel: string } | null = null;
+
+	function clearTimers() {
+		if (resetTimer) {
+			clearTimeout(resetTimer);
+			resetTimer = null;
+		}
+		if (holdoffTimer) {
+			clearTimeout(holdoffTimer);
+			holdoffTimer = null;
+		}
+		pendingStartEvent = null;
+	}
+
+	function handleStarted(data: { jobType: string; displayLabel: string }) {
+		// Clear the idle reset timer if running
+		if (resetTimer) {
+			clearTimeout(resetTimer);
+			resetTimer = null;
+		}
+
+		const elapsed = Date.now() - completedAt;
+
+		// If in completed state within holdoff window, delay the transition
+		if (completedAt > 0 && elapsed < COMPLETED_HOLDOFF_MS) {
+			pendingStartEvent = data;
+			if (holdoffTimer) clearTimeout(holdoffTimer);
+			holdoffTimer = setTimeout(() => {
+				if (pendingStartEvent) {
+					set({
+						state: 'running',
+						jobType: pendingStartEvent.jobType,
+						displayLabel: pendingStartEvent.displayLabel
+					});
+					pendingStartEvent = null;
+				}
+				completedAt = 0;
+				holdoffTimer = null;
+			}, COMPLETED_HOLDOFF_MS - elapsed);
+			return;
+		}
+
+		// Transition immediately
+		completedAt = 0;
+		pendingStartEvent = null;
+		if (holdoffTimer) {
+			clearTimeout(holdoffTimer);
+			holdoffTimer = null;
+		}
+		set({ state: 'running', jobType: data.jobType, displayLabel: data.displayLabel });
+	}
+
+	function handleFinished(data: {
+		jobType: string;
+		displayLabel: string;
+		status: string;
+		durationMs: number;
+	}) {
+		clearTimers();
+		completedAt = Date.now();
+		set({
+			state: 'completed',
+			jobType: data.jobType,
+			displayLabel: data.displayLabel,
+			status: data.status,
+			durationMs: data.durationMs
+		});
+		resetTimer = setTimeout(() => {
+			set({ state: 'idle' });
+			completedAt = 0;
+			resetTimer = null;
+		}, COMPLETED_DISPLAY_MS);
+	}
+
+	function connect() {
+		if (!browser || eventSource) return;
+
+		eventSource = new EventSource('/jobs/events');
+
+		eventSource.addEventListener('job.started', (e) => {
+			try {
+				handleStarted(JSON.parse(e.data));
+			} catch {
+				// Invalid event data
+			}
+		});
+
+		eventSource.addEventListener('job.finished', (e) => {
+			try {
+				handleFinished(JSON.parse(e.data));
+			} catch {
+				// Invalid event data
+			}
+		});
+	}
+
+	function disconnect() {
+		eventSource?.close();
+		eventSource = null;
+		clearTimers();
+		completedAt = 0;
+		set({ state: 'idle' });
+	}
+
+	return { subscribe, connect, disconnect };
+}
+
+export const jobStatus = createJobStatusStore();

--- a/src/lib/client/ui/navigation/bottomNav/BottomNav.svelte
+++ b/src/lib/client/ui/navigation/bottomNav/BottomNav.svelte
@@ -8,8 +8,19 @@
 		Settings,
 		Microscope,
 		Tag,
-		Clock
+		Clock,
+		Loader2,
+		CheckCircle2,
+		XCircle
 	} from 'lucide-svelte';
+	import { jobStatus } from '$stores/jobStatus';
+	import { slide } from 'svelte/transition';
+
+	function formatDuration(ms: number): string {
+		if (ms < 1000) return `${ms}ms`;
+		if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+		return `${(ms / 60_000).toFixed(1)}m`;
+	}
 
 	type NavItem = {
 		href: string;
@@ -54,6 +65,35 @@
 <nav
 	class="fixed right-0 bottom-0 left-0 z-50 border-t border-neutral-200 bg-neutral-50 pb-[env(safe-area-inset-bottom)] md:hidden dark:border-neutral-800 dark:bg-neutral-900"
 >
+	{#if $jobStatus.state !== 'idle'}
+		<div
+			class="flex items-center justify-center gap-2 border-b border-neutral-200 px-3 py-1.5 dark:border-neutral-800"
+			transition:slide={{ duration: 200 }}
+		>
+			{#if $jobStatus.state === 'running'}
+				<Loader2 size={14} class="flex-shrink-0 animate-spin text-blue-500 dark:text-blue-400" />
+				<span class="text-xs font-medium text-neutral-700 dark:text-neutral-300">
+					{$jobStatus.displayLabel}
+				</span>
+			{:else if $jobStatus.state === 'completed'}
+				{#if $jobStatus.status === 'success' || $jobStatus.status === 'skipped'}
+					<CheckCircle2 size={14} class="flex-shrink-0 text-emerald-600 dark:text-emerald-400" />
+				{:else}
+					<XCircle size={14} class="flex-shrink-0 text-red-600 dark:text-red-400" />
+				{/if}
+				<span class="text-xs font-medium text-neutral-700 dark:text-neutral-300">
+					{$jobStatus.displayLabel}
+					{$jobStatus.status === 'success' || $jobStatus.status === 'skipped'
+						? 'complete'
+						: 'failed'}
+				</span>
+				<span class="font-mono text-[10px] text-neutral-500 dark:text-neutral-500">
+					{formatDuration($jobStatus.durationMs)}
+				</span>
+			{/if}
+		</div>
+	{/if}
+
 	<div class="flex items-center justify-around px-1">
 		{#each items as item}
 			{@const active = isActive(item.href, pathname)}

--- a/src/lib/client/ui/navigation/pageNav/jobStatus.svelte
+++ b/src/lib/client/ui/navigation/pageNav/jobStatus.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+	import { Loader2, CheckCircle2, XCircle } from 'lucide-svelte';
+	import { jobStatus } from '$stores/jobStatus';
+	import Card from '$ui/card/Card.svelte';
+
+	function formatDuration(ms: number): string {
+		if (ms < 1000) return `${ms}ms`;
+		if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+		return `${(ms / 60_000).toFixed(1)}m`;
+	}
+</script>
+
+<Card padding="sm" flush className="mt-2">
+	<div class="flex items-center gap-2.5">
+		{#if $jobStatus.state === 'running'}
+			<Loader2 size={16} class="flex-shrink-0 animate-spin text-blue-500 dark:text-blue-400" />
+			<div class="flex-1">
+				<div class="text-xs font-semibold text-neutral-900 dark:text-neutral-50">
+					{$jobStatus.displayLabel}
+				</div>
+			</div>
+		{:else if $jobStatus.state === 'completed'}
+			{#if $jobStatus.status === 'success' || $jobStatus.status === 'skipped'}
+				<CheckCircle2
+					size={16}
+					class="flex-shrink-0 text-emerald-600 dark:text-emerald-400"
+				/>
+			{:else}
+				<XCircle size={16} class="flex-shrink-0 text-red-600 dark:text-red-400" />
+			{/if}
+			<div class="flex-1">
+				<div class="text-xs font-semibold text-neutral-900 dark:text-neutral-50">
+					{$jobStatus.displayLabel}
+					{$jobStatus.status === 'success' || $jobStatus.status === 'skipped'
+						? 'complete'
+						: 'failed'}
+				</div>
+				<div class="font-mono text-[10px] text-neutral-600 dark:text-neutral-400">
+					{formatDuration($jobStatus.durationMs)}
+				</div>
+			</div>
+		{/if}
+	</div>
+</Card>

--- a/src/lib/client/ui/navigation/pageNav/jobStatus.svelte
+++ b/src/lib/client/ui/navigation/pageNav/jobStatus.svelte
@@ -21,10 +21,7 @@
 			</div>
 		{:else if $jobStatus.state === 'completed'}
 			{#if $jobStatus.status === 'success' || $jobStatus.status === 'skipped'}
-				<CheckCircle2
-					size={16}
-					class="flex-shrink-0 text-emerald-600 dark:text-emerald-400"
-				/>
+				<CheckCircle2 size={16} class="flex-shrink-0 text-emerald-600 dark:text-emerald-400" />
 			{:else}
 				<XCircle size={16} class="flex-shrink-0 text-red-600 dark:text-red-400" />
 			{/if}

--- a/src/lib/client/ui/navigation/pageNav/pageNav.svelte
+++ b/src/lib/client/ui/navigation/pageNav/pageNav.svelte
@@ -2,6 +2,9 @@
 	import Group from './group.svelte';
 	import GroupItem from './groupItem.svelte';
 	import Version from './version.svelte';
+	import JobStatus from './jobStatus.svelte';
+	import { jobStatus } from '$stores/jobStatus';
+	import { fade } from 'svelte/transition';
 	import {
 		FolderTree,
 		Link,
@@ -197,14 +200,19 @@
 			/>
 		</Group>
 
-		<!-- Version scrolls with content on mobile -->
+		<!-- Version scrolls with content on mobile (job status shown in bottom nav) -->
 		<div class="mt-2 md:hidden">
 			<Version {version} />
 		</div>
 	</div>
 
-	<!-- Version pinned to bottom on desktop only -->
+	<!-- Version + job status pinned to bottom on desktop only -->
 	<div class="hidden shrink-0 p-4 md:block">
+		{#if $jobStatus.state !== 'idle'}
+			<div transition:fade={{ duration: 150 }}>
+				<JobStatus />
+			</div>
+		{/if}
 		<Version {version} />
 	</div>
 </nav>

--- a/src/lib/client/ui/navigation/pageNav/version.svelte
+++ b/src/lib/client/ui/navigation/pageNav/version.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { getPlatformLabel, getChannelLabel, shouldShowVersion } from '$shared/utils/version.ts';
 	import logo from '$assets/logo-512.png';
+	import Card from '$ui/card/Card.svelte';
 
 	export let version: string = '';
 
@@ -9,16 +10,16 @@
 	const showVersion = shouldShowVersion();
 </script>
 
-<div
-	class="mt-2 flex items-center gap-2.5 rounded-lg border border-neutral-300 px-3 py-2 dark:border-neutral-700"
->
-	<img src={logo} alt="Profilarr logo" class="h-5 w-5 flex-shrink-0" />
+<Card padding="sm" flush className="mt-2">
+	<div class="flex items-center gap-2.5">
+		<img src={logo} alt="Profilarr logo" class="h-5 w-5 flex-shrink-0" />
 
-	<div class="flex-1">
-		<div class="text-xs font-semibold text-neutral-900 dark:text-neutral-50">profilarr</div>
-		<div class="font-mono text-[10px] text-neutral-600 dark:text-neutral-400">
-			{platform} · {channel}{#if showVersion && version}
-				· {version}{/if}
+		<div class="flex-1">
+			<div class="text-xs font-semibold text-neutral-900 dark:text-neutral-50">profilarr</div>
+			<div class="font-mono text-[10px] text-neutral-600 dark:text-neutral-400">
+				{platform} · {channel}{#if showVersion && version}
+					· {version}{/if}
+			</div>
 		</div>
 	</div>
-</div>
+</Card>

--- a/src/lib/server/jobs/dispatcher.ts
+++ b/src/lib/server/jobs/dispatcher.ts
@@ -4,6 +4,7 @@ import { buildJobDisplayName } from './display.ts';
 import { jobQueueRegistry } from './queueRegistry.ts';
 import type { JobHandlerResult, JobQueueRecord, JobStatus } from './queueTypes.ts';
 import { logger } from '$logger/logger.ts';
+import { jobEvents, getSyncRunningLabel, getSyncCompletedLabel } from './jobEvents.ts';
 import './handlers/index.ts';
 
 class JobDispatcher {
@@ -102,6 +103,13 @@ class JobDispatcher {
 			}
 		});
 
+		jobEvents.emit({
+			type: 'job.started',
+			jobId: job.id,
+			jobType: job.jobType,
+			displayLabel: getSyncRunningLabel(job.jobType)
+		});
+
 		let result: JobHandlerResult;
 		try {
 			result = await handler(job);
@@ -125,6 +133,15 @@ class JobDispatcher {
 			result.error,
 			result.output
 		);
+
+		jobEvents.emit({
+			type: 'job.finished',
+			jobId: job.id,
+			jobType: job.jobType,
+			displayLabel: getSyncCompletedLabel(job.jobType),
+			status: result.status,
+			durationMs
+		});
 
 		await logger.debug(`Job finished: ${job.jobType} (${result.status})`, {
 			source: 'JobDispatcher',

--- a/src/lib/server/jobs/jobEvents.ts
+++ b/src/lib/server/jobs/jobEvents.ts
@@ -1,0 +1,86 @@
+/**
+ * Job event emitter singleton.
+ *
+ * The dispatcher emits events here; SSE streams subscribe to fan them
+ * out to connected browser clients. Only sync job types are emitted.
+ */
+
+import type { JobType, JobRunStatus } from './queueTypes.ts';
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface JobStartedEvent {
+	type: 'job.started';
+	jobId: number;
+	jobType: JobType;
+	displayLabel: string;
+}
+
+export interface JobFinishedEvent {
+	type: 'job.finished';
+	jobId: number;
+	jobType: JobType;
+	displayLabel: string;
+	status: JobRunStatus;
+	durationMs: number;
+}
+
+export type JobEvent = JobStartedEvent | JobFinishedEvent;
+
+type JobEventCallback = (event: JobEvent) => void;
+
+// ─── Display Labels ──────────────────────────────────────────────────────────
+
+const SYNC_RUNNING_LABELS: Partial<Record<JobType, string>> = {
+	'arr.sync': 'Syncing...',
+	'arr.sync.qualityProfiles': 'Syncing Quality Profiles...',
+	'arr.sync.delayProfiles': 'Syncing Delay Profiles...',
+	'arr.sync.mediaManagement': 'Syncing Media Management...'
+};
+
+const SYNC_COMPLETED_LABELS: Partial<Record<JobType, string>> = {
+	'arr.sync': 'Sync',
+	'arr.sync.qualityProfiles': 'Quality Profiles sync',
+	'arr.sync.delayProfiles': 'Delay Profiles sync',
+	'arr.sync.mediaManagement': 'Media Management sync'
+};
+
+const SYNC_JOB_TYPES = new Set(Object.keys(SYNC_RUNNING_LABELS));
+
+export function getSyncRunningLabel(jobType: JobType): string {
+	return SYNC_RUNNING_LABELS[jobType] ?? jobType;
+}
+
+export function getSyncCompletedLabel(jobType: JobType): string {
+	return SYNC_COMPLETED_LABELS[jobType] ?? jobType;
+}
+
+// ─── Emitter ─────────────────────────────────────────────────────────────────
+
+const subscribers = new Set<JobEventCallback>();
+
+/**
+ * Subscribe to job events. Returns an unsubscribe function.
+ */
+export function subscribe(callback: JobEventCallback): () => void {
+	subscribers.add(callback);
+	return () => subscribers.delete(callback);
+}
+
+/**
+ * Emit a job event to all subscribers.
+ * Silently ignores non-sync job types.
+ */
+export function emit(event: JobEvent): void {
+	if (!SYNC_JOB_TYPES.has(event.jobType)) return;
+
+	for (const callback of subscribers) {
+		try {
+			callback(event);
+		} catch {
+			// Don't let a broken subscriber kill the dispatcher
+		}
+	}
+}
+
+export const jobEvents = { subscribe, emit };

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -6,11 +6,21 @@
 	import BottomNav from '$ui/navigation/bottomNav/BottomNav.svelte';
 	import AlertContainer from '$alerts/AlertContainer.svelte';
 	import { page } from '$app/stores';
+	import { onMount, onDestroy } from 'svelte';
+	import { jobStatus } from '$stores/jobStatus';
 
 	export let data;
 
 	// Hide navigation on auth pages (login, setup, etc.)
 	$: isAuthPage = $page.url.pathname.startsWith('/auth/');
+
+	onMount(() => {
+		if (!isAuthPage) jobStatus.connect();
+	});
+
+	onDestroy(() => {
+		jobStatus.disconnect();
+	});
 </script>
 
 <svelte:head>

--- a/src/routes/arr/[id]/sync/components/DelayProfiles.svelte
+++ b/src/routes/arr/[id]/sync/components/DelayProfiles.svelte
@@ -90,9 +90,7 @@
 			});
 
 			const result = deserialize(await response.text());
-			if (result.type === 'success') {
-				alertStore.add('success', (result.data?.message as string) ?? 'Sync queued');
-			} else if (result.type === 'failure') {
+			if (result.type === 'failure') {
 				alertStore.add('warning', (result.data?.error as string) ?? 'Sync failed');
 			}
 		} catch {

--- a/src/routes/arr/[id]/sync/components/MediaManagement.svelte
+++ b/src/routes/arr/[id]/sync/components/MediaManagement.svelte
@@ -197,9 +197,7 @@
 			});
 
 			const result = deserialize(await response.text());
-			if (result.type === 'success') {
-				alertStore.add('success', (result.data?.message as string) ?? 'Sync queued');
-			} else if (result.type === 'failure') {
+			if (result.type === 'failure') {
 				alertStore.add('warning', (result.data?.error as string) ?? 'Sync failed');
 			}
 		} catch {

--- a/src/routes/arr/[id]/sync/components/QualityProfiles.svelte
+++ b/src/routes/arr/[id]/sync/components/QualityProfiles.svelte
@@ -131,9 +131,7 @@
 			});
 
 			const result = deserialize(await response.text());
-			if (result.type === 'success') {
-				alertStore.add('success', (result.data?.message as string) ?? 'Sync queued');
-			} else if (result.type === 'failure') {
+			if (result.type === 'failure') {
 				alertStore.add('warning', (result.data?.error as string) ?? 'Sync failed');
 			}
 		} catch {

--- a/src/routes/jobs/events/+server.ts
+++ b/src/routes/jobs/events/+server.ts
@@ -1,0 +1,52 @@
+import type { RequestHandler } from '@sveltejs/kit';
+import { jobEvents } from '$jobs/jobEvents.ts';
+
+/**
+ * GET /jobs/events
+ *
+ * Server-Sent Events endpoint for live job status updates.
+ * Session-only auth (enforced by hooks.server.ts for non-/api/ routes).
+ *
+ * Streams job.started and job.finished events as they occur.
+ * Sends keepalive comments every 30s to prevent proxy timeouts.
+ */
+export const GET: RequestHandler = () => {
+	const encoder = new TextEncoder();
+
+	let unsubscribe: (() => void) | undefined;
+	let keepalive: ReturnType<typeof setInterval> | undefined;
+
+	const stream = new ReadableStream({
+		start(controller) {
+			unsubscribe = jobEvents.subscribe((event) => {
+				const line = `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`;
+				try {
+					controller.enqueue(encoder.encode(line));
+				} catch {
+					// Stream closed
+				}
+			});
+
+			keepalive = setInterval(() => {
+				try {
+					controller.enqueue(encoder.encode(': keepalive\n\n'));
+				} catch {
+					clearInterval(keepalive);
+				}
+			}, 30_000);
+		},
+		cancel() {
+			unsubscribe?.();
+			if (keepalive) clearInterval(keepalive);
+		}
+	});
+
+	return new Response(stream, {
+		headers: {
+			'Content-Type': 'text/event-stream',
+			'Cache-Control': 'no-cache, no-transform',
+			'Connection': 'keep-alive',
+			'X-Accel-Buffering': 'no'
+		}
+	});
+};

--- a/src/routes/jobs/events/+server.ts
+++ b/src/routes/jobs/events/+server.ts
@@ -45,7 +45,7 @@ export const GET: RequestHandler = () => {
 		headers: {
 			'Content-Type': 'text/event-stream',
 			'Cache-Control': 'no-cache, no-transform',
-			'Connection': 'keep-alive',
+			Connection: 'keep-alive',
 			'X-Accel-Buffering': 'no'
 		}
 	});


### PR DESCRIPTION
## What does this PR do?
- Add real-time job status updates using Server-Sent Events
- Dispatcher emits events when sync jobs start/finish, streamed to browsers via `/jobs/events`
- Sidebar shows status card (desktop) with spinner while running, result + duration on completion
- Mobile bottom nav shows a compact status strip that slides in above the tabs
- Remove redundant "sync queued" success alerts from sync components
- Version and job status components refactored to use Card base component

## Related issues

Closes #331 
