### PR TITLE
feat: add webhook notification service

### DIFF
--- a/docs/architecture/notifications.md
+++ b/docs/architecture/notifications.md
@@ -11,6 +11,7 @@
 - [Notifiers](#notifiers)
   - [Discord (Detail Tier)](#discord-detail-tier)
   - [Ntfy (Summary Tier)](#ntfy-summary-tier)
+  - [Webhook (Passthrough Tier)](#webhook-passthrough-tier)
 - [Service Tiers](#service-tiers)
 - [Testing](#testing)
 - [Adding a New Service](#adding-a-new-service)
@@ -53,10 +54,12 @@ flowchart TD
 
     FACTORY -->|discord| DISCORD[DiscordNotifier]
     FACTORY -->|ntfy| NTFY[NtfyNotifier]
+    FACTORY -->|webhook| WEBHOOK[WebhookNotifier]
     FACTORY -->|future| OTHER[...]
 
     DISCORD -->|renders to embeds| WEBHOOK_D[Discord Webhook]
     NTFY -->|renders to ntfy JSON| WEBHOOK_N[Ntfy Server]
+    WEBHOOK -->|raw JSON| WEBHOOK_W[Webhook Endpoint]
     OTHER -->|renders| WEBHOOK_O[...]
 
     NM -->|record result| HISTORY[(notification_history)]
@@ -106,6 +109,7 @@ Each notifier maps severity to its platform's concept:
 | -------- | -------------------- | ------------------- | ----------------- | -------------------- |
 | Discord  | Green embed          | Red embed           | Yellow embed      | Blue embed           |
 | Ntfy     | Priority 3 (default) | Priority 5 (urgent) | Priority 4 (high) | Priority 3 (default) |
+| Webhook  | No mapping           | No mapping          | No mapping        | No mapping           |
 
 ## Definitions
 
@@ -173,6 +177,13 @@ POSTs JSON to the server root with `topic` in the payload. Maps severity to
 priority (3/4/5) and emoji tags. Optional `Authorization: Bearer` header for
 authenticated topics.
 
+### Webhook (Passthrough Tier)
+
+POSTs the raw `Notification` object as JSON to a user-configured URL. No
+rendering, no severity mapping, no block filtering — the payload is the
+notification. Optional `Authorization` header for authenticated endpoints
+(user provides the full header value, e.g. `Bearer token` or `Basic base64`).
+
 ## Service Tiers
 
 Not every service renders the same content. The tier determines what the notifier
@@ -197,6 +208,7 @@ tests/integration/notifications/
     upgrade.test.ts      - upgrade notification (definition + Discord + real webhook)
     rename.test.ts       - rename notification (definition + Discord + real webhook)
     ntfy.test.ts         - ntfy rendering + auth + real webhook
+    webhook.test.ts      - webhook passthrough + auth + real webhook
 ```
 
 Tests are organized by notification type. Each spec covers definition output,
@@ -205,6 +217,7 @@ notifier rendering via mock server, and optionally a real webhook send.
 ```bash
 deno task test integration notifications              # all
 deno task test integration notifications ntfy         # ntfy only
+deno task test integration notifications webhook      # webhook only
 deno task test integration notifications upgrade      # upgrade only
 ```
 

--- a/src/lib/server/notifications/NotificationManager.ts
+++ b/src/lib/server/notifications/NotificationManager.ts
@@ -2,9 +2,10 @@ import { logger } from '$logger/logger.ts';
 import { notificationServicesQueries } from '$db/queries/notificationServices.ts';
 import { notificationHistoryQueries } from '$db/queries/notificationHistory.ts';
 import type { Notifier } from './base/Notifier.ts';
-import type { Notification, DiscordConfig, NtfyConfig } from './types.ts';
+import type { Notification, DiscordConfig, NtfyConfig, WebhookConfig } from './types.ts';
 import { DiscordNotifier } from './notifiers/discord/DiscordNotifier.ts';
 import { NtfyNotifier } from './notifiers/ntfy/NtfyNotifier.ts';
+import { WebhookNotifier } from './notifiers/webhook/WebhookNotifier.ts';
 
 /**
  * Central notification manager
@@ -156,6 +157,8 @@ export class NotificationManager {
 					return new DiscordNotifier(config as DiscordConfig);
 				case 'ntfy':
 					return new NtfyNotifier(config as NtfyConfig);
+				case 'webhook':
+					return new WebhookNotifier(config as WebhookConfig);
 				default:
 					return null;
 			}

--- a/src/lib/server/notifications/notifiers/discord/DiscordNotifier.ts
+++ b/src/lib/server/notifications/notifiers/discord/DiscordNotifier.ts
@@ -1,4 +1,3 @@
-import { logger } from '$logger/logger.ts';
 import type { DiscordConfig, Notification, NotificationSeverity } from '../../types.ts';
 import { Colors, type DiscordEmbed } from './embed.ts';
 import { getWebhookClient } from '../../base/webhookClient.ts';
@@ -245,24 +244,7 @@ export class DiscordNotifier {
 	 * Send a single webhook request
 	 */
 	private async sendWebhook(payload: unknown): Promise<void> {
-		const payloadObj = payload as { embeds?: unknown[] };
-
-		try {
-			await getWebhookClient().sendWebhook(this.config.webhook_url, payload);
-		} catch (error) {
-			const embedCharCounts =
-				payloadObj.embeds
-					?.map((e, i) => `${i}:${getEmbedCharCount(e as DiscordEmbed)}`)
-					.join(', ') || 'none';
-			await logger.error('Failed to send notification', {
-				source: this.getName(),
-				meta: {
-					error: error instanceof Error ? error.message : String(error),
-					embedCharCounts
-				}
-			});
-			throw error;
-		}
+		await getWebhookClient().sendWebhook(this.config.webhook_url, payload);
 	}
 
 	private sleep(ms: number): Promise<void> {

--- a/src/lib/server/notifications/notifiers/index.ts
+++ b/src/lib/server/notifications/notifiers/index.ts
@@ -4,3 +4,4 @@
 
 export { DiscordNotifier } from './discord/DiscordNotifier.ts';
 export { NtfyNotifier } from './ntfy/NtfyNotifier.ts';
+export { WebhookNotifier } from './webhook/WebhookNotifier.ts';

--- a/src/lib/server/notifications/notifiers/ntfy/NtfyNotifier.ts
+++ b/src/lib/server/notifications/notifiers/ntfy/NtfyNotifier.ts
@@ -1,4 +1,3 @@
-import { logger } from '$logger/logger.ts';
 import type { NtfyConfig, Notification, NotificationSeverity } from '../../types.ts';
 import { getWebhookClient } from '../../base/webhookClient.ts';
 
@@ -23,24 +22,7 @@ export class NtfyNotifier {
 			headers['Authorization'] = `Bearer ${this.config.access_token}`;
 		}
 
-		try {
-			await getWebhookClient().post(url, payload, { headers });
-
-			await logger.debug('Notification sent', {
-				source: this.getName(),
-				meta: { type: notification.type }
-			});
-		} catch (error) {
-			await logger.error('Failed to send notification', {
-				source: this.getName(),
-				meta: {
-					type: notification.type,
-					title: notification.title,
-					error: error instanceof Error ? error.message : String(error)
-				}
-			});
-			throw error;
-		}
+		await getWebhookClient().post(url, payload, { headers });
 	}
 
 	private formatPayload(notification: Notification): unknown {

--- a/src/lib/server/notifications/notifiers/webhook/WebhookNotifier.ts
+++ b/src/lib/server/notifications/notifiers/webhook/WebhookNotifier.ts
@@ -1,0 +1,26 @@
+import type { WebhookConfig, Notification } from '../../types.ts';
+import { getWebhookClient } from '../../base/webhookClient.ts';
+
+/**
+ * Webhook notification service implementation.
+ * Passthrough tier: sends the raw Notification object as JSON with no rendering.
+ */
+export class WebhookNotifier {
+	constructor(private config: WebhookConfig) {}
+
+	getName(): string {
+		return 'Webhook';
+	}
+
+	async notify(notification: Notification): Promise<void> {
+		const headers: Record<string, string> = {};
+		if (this.config.auth_header) {
+			headers['Authorization'] = this.config.auth_header;
+		}
+
+		await getWebhookClient().post(this.config.webhook_url, notification, {
+			headers,
+			responseType: 'text'
+		});
+	}
+}

--- a/src/lib/server/notifications/types.ts
+++ b/src/lib/server/notifications/types.ts
@@ -98,11 +98,19 @@ export interface NtfyConfig {
 }
 
 /**
+ * Configuration for Webhook notifications
+ */
+export interface WebhookConfig {
+	webhook_url: string;
+	auth_header?: string;
+}
+
+/**
  * Union type for all notification service configs
  */
-export type NotificationServiceConfig = DiscordConfig | NtfyConfig;
+export type NotificationServiceConfig = DiscordConfig | NtfyConfig | WebhookConfig;
 
 /**
  * Service types supported
  */
-export type NotificationServiceType = 'discord' | 'ntfy';
+export type NotificationServiceType = 'discord' | 'ntfy' | 'webhook';

--- a/src/routes/settings/notifications/+page.server.ts
+++ b/src/routes/settings/notifications/+page.server.ts
@@ -21,7 +21,7 @@ export const load = () => {
 		let safeConfig = service.config;
 		try {
 			const parsed = JSON.parse(service.config);
-			const { webhook_url: _, access_token: __, ...rest } = parsed;
+			const { webhook_url: _, access_token: __, auth_header: ___, ...rest } = parsed;
 			safeConfig = JSON.stringify(rest);
 		} catch {
 			// If config isn't valid JSON, send as-is (no secret to strip)

--- a/src/routes/settings/notifications/components/NotificationServiceForm.svelte
+++ b/src/routes/settings/notifications/components/NotificationServiceForm.svelte
@@ -135,10 +135,10 @@
 			name="service_name"
 			value={serviceName}
 			placeholder={selectedType === 'ntfy'
-			? 'e.g., Phone Alerts'
-			: selectedType === 'webhook'
-				? 'e.g., Home Assistant'
-				: 'e.g., Main Discord Server'}
+				? 'e.g., Phone Alerts'
+				: selectedType === 'webhook'
+					? 'e.g., Home Assistant'
+					: 'e.g., Main Discord Server'}
 			description="A friendly name to identify this notification service"
 			required
 			on:input={(e) => (serviceName = e.detail)}

--- a/src/routes/settings/notifications/components/NotificationServiceForm.svelte
+++ b/src/routes/settings/notifications/components/NotificationServiceForm.svelte
@@ -3,6 +3,7 @@
 	import { alertStore } from '$alerts/store';
 	import DiscordConfiguration from './DiscordConfiguration.svelte';
 	import NtfyConfiguration from './NtfyConfiguration.svelte';
+	import WebhookConfiguration from './WebhookConfiguration.svelte';
 	import { groupNotificationTypesByCategory } from '$shared/notifications/types';
 	import { Plus, Save } from 'lucide-svelte';
 	import Toggle from '$ui/toggle/Toggle.svelte';
@@ -19,8 +20,8 @@
 		enabledTypes?: string[];
 	} = {};
 
-	let selectedType: 'discord' | 'ntfy' =
-		(initialData.serviceType as 'discord' | 'ntfy') || 'discord';
+	let selectedType: 'discord' | 'ntfy' | 'webhook' =
+		(initialData.serviceType as 'discord' | 'ntfy' | 'webhook') || 'discord';
 	let serviceName = initialData.name || '';
 
 	// Group notification types by category
@@ -42,7 +43,8 @@
 
 	const typeOptions = [
 		{ value: 'discord', label: 'Discord' },
-		{ value: 'ntfy', label: 'Ntfy' }
+		{ value: 'ntfy', label: 'Ntfy' },
+		{ value: 'webhook', label: 'Webhook' }
 	];
 
 	$: title = mode === 'create' ? 'New Notification Service' : 'Edit Notification Service';
@@ -132,7 +134,11 @@
 			label="Service Name"
 			name="service_name"
 			value={serviceName}
-			placeholder={selectedType === 'ntfy' ? 'e.g., Phone Alerts' : 'e.g., Main Discord Server'}
+			placeholder={selectedType === 'ntfy'
+			? 'e.g., Phone Alerts'
+			: selectedType === 'webhook'
+				? 'e.g., Home Assistant'
+				: 'e.g., Main Discord Server'}
 			description="A friendly name to identify this notification service"
 			required
 			on:input={(e) => (serviceName = e.detail)}
@@ -143,6 +149,8 @@
 			<DiscordConfiguration config={initialData.config} {mode} />
 		{:else if selectedType === 'ntfy'}
 			<NtfyConfiguration config={initialData.config} {mode} />
+		{:else if selectedType === 'webhook'}
+			<WebhookConfiguration config={initialData.config} {mode} />
 		{/if}
 
 		<!-- Notification Types -->

--- a/src/routes/settings/notifications/components/WebhookConfiguration.svelte
+++ b/src/routes/settings/notifications/components/WebhookConfiguration.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+	import FormInput from '$ui/form/FormInput.svelte';
+	export let config: Record<string, unknown> = {};
+	export let mode: 'create' | 'edit' = 'create';
+
+	let webhookUrl = (config.webhook_url as string) || '';
+	let authHeader = (config.auth_header as string) || '';
+</script>
+
+<div class="space-y-4">
+	<h3 class="text-sm font-semibold text-neutral-900 dark:text-neutral-100">
+		Webhook Configuration
+	</h3>
+
+	<!-- Webhook URL -->
+	<FormInput
+		label="Webhook URL"
+		name="webhook_url"
+		type="url"
+		value={webhookUrl}
+		placeholder={mode === 'edit' ? '••••••••••••••••' : 'https://example.com/webhook'}
+		description={mode === 'edit'
+			? 'Leave blank to keep existing URL'
+			: 'The URL to POST notification JSON to'}
+		required={mode === 'create'}
+		private_
+		on:input={(e) => (webhookUrl = e.detail)}
+	/>
+
+	<!-- Authorization Header -->
+	<FormInput
+		label="Authorization Header"
+		name="auth_header"
+		value={authHeader}
+		placeholder={mode === 'edit' ? '••••••••••••••••' : 'Bearer your-token'}
+		description={mode === 'edit'
+			? 'Leave blank to keep existing value'
+			: 'Raw value for the Authorization header (e.g., Bearer token, Basic base64). Optional'}
+		private_
+		on:input={(e) => (authHeader = e.detail)}
+	/>
+</div>

--- a/src/routes/settings/notifications/edit/[id]/+page.server.ts
+++ b/src/routes/settings/notifications/edit/[id]/+page.server.ts
@@ -22,7 +22,12 @@ export const load = ({ params }: { params: { id: string } }) => {
 	const enabledTypes = JSON.parse(service.enabled_types);
 
 	// Strip secrets from config before sending to frontend
-	const { webhook_url: _webhookUrl, access_token: _accessToken, ...safeConfig } = config;
+	const {
+		webhook_url: _webhookUrl,
+		access_token: _accessToken,
+		auth_header: _authHeader,
+		...safeConfig
+	} = config;
 
 	return {
 		service: {
@@ -100,6 +105,20 @@ export const actions: Actions = {
 					? { access_token: accessToken }
 					: existingConfig.access_token
 						? { access_token: existingConfig.access_token }
+						: {})
+			};
+		} else if (service.service_type === 'webhook') {
+			const webhookUrl = formData.get('webhook_url') as string;
+			const authHeader = formData.get('auth_header') as string;
+
+			config = {
+				// Keep existing webhook_url if new one not provided
+				webhook_url: webhookUrl || existingConfig.webhook_url,
+				// Keep existing auth_header if new one not provided
+				...(authHeader
+					? { auth_header: authHeader }
+					: existingConfig.auth_header
+						? { auth_header: existingConfig.auth_header }
 						: {})
 			};
 		}

--- a/src/routes/settings/notifications/new/+page.server.ts
+++ b/src/routes/settings/notifications/new/+page.server.ts
@@ -53,6 +53,18 @@ export const actions: Actions = {
 				topic,
 				...(accessToken && { access_token: accessToken })
 			};
+		} else if (serviceType === 'webhook') {
+			const webhookUrl = formData.get('webhook_url') as string;
+			const authHeader = formData.get('auth_header') as string;
+
+			if (!webhookUrl) {
+				return fail(400, { error: 'Webhook URL is required' });
+			}
+
+			config = {
+				webhook_url: webhookUrl,
+				...(authHeader && { auth_header: authHeader })
+			};
 		}
 
 		// Get enabled notification types dynamically from all available types

--- a/tests/integration/notifications/.env.example
+++ b/tests/integration/notifications/.env.example
@@ -3,3 +3,4 @@
 TEST_DISCORD_WEBHOOK=https://discord.com/api/webhooks/...
 TEST_NTFY_URL=https://ntfy.sh
 TEST_NTFY_TOPIC=profilarr-test
+TEST_WEBHOOK_URL=https://example.com/webhook

--- a/tests/integration/notifications/specs/webhook.test.ts
+++ b/tests/integration/notifications/specs/webhook.test.ts
@@ -229,22 +229,19 @@ function makeUpgradeLog(): UpgradeJobLog {
 					},
 					upgrades: [
 						{
-							release:
-								'Interstellar.2014.2160p.UHD.BluRay.Remux.HDR.HEVC.Atmos-EPSiLON.mkv',
+							release: 'Interstellar.2014.2160p.UHD.BluRay.Remux.HDR.HEVC.Atmos-EPSiLON.mkv',
 							formats: ['Remux', 'x265', '2160p', 'HDR', 'Atmos'],
 							score: 145
 						}
 					],
-					imageUrl:
-						'https://image.tmdb.org/t/p/w500/gEU2QniE6E77NI6lCU6MxlNBvIx.jpg'
+					imageUrl: 'https://image.tmdb.org/t/p/w500/gEU2QniE6E77NI6lCU6MxlNBvIx.jpg'
 				},
 				{
 					id: 102,
 					title: 'The Grand Budapest Hotel',
 					original: {
 						type: 'movie',
-						fileName:
-							'The.Grand.Budapest.Hotel.2014.720p.BluRay.x264-SPARKS.mkv',
+						fileName: 'The.Grand.Budapest.Hotel.2014.720p.BluRay.x264-SPARKS.mkv',
 						formats: ['Bluray', 'x264', '720p'],
 						score: 48
 					},
@@ -256,8 +253,7 @@ function makeUpgradeLog(): UpgradeJobLog {
 							score: 112
 						}
 					],
-					imageUrl:
-						'https://image.tmdb.org/t/p/w1280/eWdyYQreja6JGCzqHWXpWHDrrPo.jpg'
+					imageUrl: 'https://image.tmdb.org/t/p/w1280/eWdyYQreja6JGCzqHWXpWHDrrPo.jpg'
 				}
 			]
 		},
@@ -296,14 +292,11 @@ function makeRenameLog(): RenameJobLog {
 				},
 				files: [
 					{
-						existingPath:
-							'/movies/Interstellar (2014)/Interstellar.2014.1080p.BluRay.mkv',
-						newPath:
-							'/movies/Interstellar (2014)/Interstellar (2014) [Bluray-1080p].mkv'
+						existingPath: '/movies/Interstellar (2014)/Interstellar.2014.1080p.BluRay.mkv',
+						newPath: '/movies/Interstellar (2014)/Interstellar (2014) [Bluray-1080p].mkv'
 					}
 				],
-				imageUrl:
-					'https://image.tmdb.org/t/p/w500/gEU2QniE6E77NI6lCU6MxlNBvIx.jpg'
+				imageUrl: 'https://image.tmdb.org/t/p/w500/gEU2QniE6E77NI6lCU6MxlNBvIx.jpg'
 			}
 		]
 	};

--- a/tests/integration/notifications/specs/webhook.test.ts
+++ b/tests/integration/notifications/specs/webhook.test.ts
@@ -1,0 +1,325 @@
+/**
+ * Webhook notification - passthrough tier + auth + real webhook.
+ * Passthrough tier: entire Notification object sent as-is (all blocks included).
+ */
+
+import { assertEquals } from '@std/assert';
+import { setup, teardown, test, run } from '$test-harness/runner.ts';
+import { createMockServer, type CapturedRequest } from '../harness/mock-server.ts';
+import { WebhookNotifier } from '$notifications/notifiers/webhook/WebhookNotifier.ts';
+import { upgrade } from '$notifications/definitions/upgrade.ts';
+import { rename } from '$notifications/definitions/rename.ts';
+import type { Notification } from '$notifications/types.ts';
+import type { UpgradeJobLog } from '$lib/server/upgrades/types.ts';
+import type { RenameJobLog } from '$lib/server/rename/types.ts';
+
+const MOCK_PORT = 7136;
+let captured: CapturedRequest[];
+let mockServer: Deno.HttpServer;
+
+let REAL_WEBHOOK_URL: string | undefined;
+try {
+	const envPath = new URL('../.env', import.meta.url).pathname;
+	const content = await Deno.readTextFile(envPath);
+	for (const line of content.split('\n')) {
+		const trimmed = line.trim();
+		if (!trimmed || trimmed.startsWith('#')) continue;
+		const eqIdx = trimmed.indexOf('=');
+		if (eqIdx > 0) {
+			const key = trimmed.slice(0, eqIdx);
+			const value = trimmed.slice(eqIdx + 1);
+			if (key === 'TEST_WEBHOOK_URL') REAL_WEBHOOK_URL = value;
+		}
+	}
+} catch {
+	/* no .env */
+}
+
+setup(() => {
+	const mock = createMockServer(MOCK_PORT);
+	captured = mock.captured;
+	mockServer = mock.server;
+});
+
+teardown(async () => {
+	await mockServer.shutdown();
+});
+
+function getPayload(): Record<string, unknown> {
+	return captured[0]?.body as Record<string, unknown>;
+}
+
+function getHeaders(): Record<string, string> {
+	return captured[0]?.headers ?? {};
+}
+
+function makeNotifier(authHeader?: string): WebhookNotifier {
+	return new WebhookNotifier({
+		webhook_url: `http://localhost:${MOCK_PORT}/webhook`,
+		...(authHeader ? { auth_header: authHeader } : {})
+	});
+}
+
+function simpleNotification(
+	severity: Notification['severity'],
+	blocks?: Notification['blocks']
+): Notification {
+	return {
+		type: 'test',
+		severity,
+		title: 'Test Title',
+		message: 'Test message body',
+		blocks
+	};
+}
+
+// =========================================================================
+// Payload structure (passthrough)
+// =========================================================================
+
+test('sends notification type in payload', async () => {
+	captured.length = 0;
+	await makeNotifier().notify(simpleNotification('info'));
+	assertEquals(getPayload()?.type, 'test');
+});
+
+test('sends severity in payload', async () => {
+	captured.length = 0;
+	await makeNotifier().notify(simpleNotification('error'));
+	assertEquals(getPayload()?.severity, 'error');
+});
+
+test('sends title in payload', async () => {
+	captured.length = 0;
+	await makeNotifier().notify(simpleNotification('info'));
+	assertEquals(getPayload()?.title, 'Test Title');
+});
+
+test('sends message in payload', async () => {
+	captured.length = 0;
+	await makeNotifier().notify(simpleNotification('info'));
+	assertEquals(getPayload()?.message, 'Test message body');
+});
+
+test('includes field blocks in payload', async () => {
+	captured.length = 0;
+	const blocks: Notification['blocks'] = [
+		{ kind: 'field', label: 'Files', value: '5/5', inline: true },
+		{ kind: 'field', label: 'Mode', value: 'Live', inline: true }
+	];
+	await makeNotifier().notify(simpleNotification('info', blocks));
+	const payload = getPayload();
+	const payloadBlocks = payload?.blocks as Notification['blocks'];
+	assertEquals(payloadBlocks?.length, 2);
+	assertEquals(payloadBlocks?.[0], { kind: 'field', label: 'Files', value: '5/5', inline: true });
+	assertEquals(payloadBlocks?.[1], { kind: 'field', label: 'Mode', value: 'Live', inline: true });
+});
+
+test('includes section blocks in payload (unlike summary tier)', async () => {
+	captured.length = 0;
+	const blocks: Notification['blocks'] = [
+		{ kind: 'field', label: 'Count', value: '3' },
+		{
+			kind: 'section',
+			title: 'Interstellar',
+			content: 'Release\nInterstellar.2014.2160p.mkv'
+		},
+		{
+			kind: 'section',
+			title: 'Grand Budapest',
+			content: 'Release\nGrand.Budapest.2014.1080p.mkv'
+		}
+	];
+	await makeNotifier().notify(simpleNotification('info', blocks));
+	const payload = getPayload();
+	const payloadBlocks = payload?.blocks as Notification['blocks'];
+	assertEquals(payloadBlocks?.length, 3);
+	assertEquals(payloadBlocks?.[1]?.kind, 'section');
+	assertEquals((payloadBlocks?.[1] as { title: string }).title, 'Interstellar');
+	assertEquals(payloadBlocks?.[2]?.kind, 'section');
+	assertEquals((payloadBlocks?.[2] as { title: string }).title, 'Grand Budapest');
+});
+
+test('sends no blocks key when notification has no blocks', async () => {
+	captured.length = 0;
+	await makeNotifier().notify({
+		type: 'test',
+		severity: 'info',
+		title: 'No blocks',
+		message: 'Simple notification'
+	});
+	const payload = getPayload();
+	assertEquals(payload?.blocks, undefined);
+});
+
+// =========================================================================
+// HTTP behavior
+// =========================================================================
+
+test('POSTs to the configured webhook URL path', async () => {
+	captured.length = 0;
+	await makeNotifier().notify(simpleNotification('info'));
+	assertEquals(captured[0]?.method, 'POST');
+	assertEquals(captured[0]?.path, '/webhook');
+});
+
+test('sets Content-Type to application/json', async () => {
+	captured.length = 0;
+	await makeNotifier().notify(simpleNotification('info'));
+	assertEquals(getHeaders()['content-type'], 'application/json');
+});
+
+// =========================================================================
+// Auth header
+// =========================================================================
+
+test('sends Authorization header when auth_header configured', async () => {
+	captured.length = 0;
+	await makeNotifier('Bearer my-secret-token').notify(simpleNotification('info'));
+	assertEquals(getHeaders()['authorization'], 'Bearer my-secret-token');
+});
+
+test('sends no Authorization header when auth_header absent', async () => {
+	captured.length = 0;
+	await makeNotifier().notify(simpleNotification('info'));
+	assertEquals(getHeaders()['authorization'], undefined);
+});
+
+// =========================================================================
+// Real webhook (skipped without .env)
+// =========================================================================
+
+function makeUpgradeLog(): UpgradeJobLog {
+	return {
+		id: crypto.randomUUID(),
+		configId: 1,
+		instanceId: 1,
+		instanceName: 'Movies',
+		startedAt: '2026-03-17T04:00:00.000Z',
+		completedAt: '2026-03-17T04:05:00.000Z',
+		status: 'success',
+		config: {
+			cron: '0 */6 * * *',
+			filterMode: 'sequential',
+			selectedFilter: 'quality-upgrade',
+			dryRun: false
+		},
+		library: { totalItems: 847, fetchedFromCache: false, fetchDurationMs: 2100 },
+		filter: {
+			id: 'f-quality',
+			name: 'Quality Upgrade',
+			rules: { type: 'group', match: 'all', children: [] },
+			matchedCount: 312,
+			afterCooldown: 198,
+			dryRunExcluded: 0
+		},
+		selection: {
+			method: 'random',
+			requestedCount: 5,
+			actualCount: 3,
+			items: [
+				{
+					id: 101,
+					title: 'Interstellar',
+					original: {
+						type: 'movie',
+						fileName: 'Interstellar.2014.1080p.BluRay.x264-SPARKS.mkv',
+						formats: ['Bluray', 'x264', '1080p'],
+						score: 72
+					},
+					upgrades: [
+						{
+							release:
+								'Interstellar.2014.2160p.UHD.BluRay.Remux.HDR.HEVC.Atmos-EPSiLON.mkv',
+							formats: ['Remux', 'x265', '2160p', 'HDR', 'Atmos'],
+							score: 145
+						}
+					],
+					imageUrl:
+						'https://image.tmdb.org/t/p/w500/gEU2QniE6E77NI6lCU6MxlNBvIx.jpg'
+				},
+				{
+					id: 102,
+					title: 'The Grand Budapest Hotel',
+					original: {
+						type: 'movie',
+						fileName:
+							'The.Grand.Budapest.Hotel.2014.720p.BluRay.x264-SPARKS.mkv',
+						formats: ['Bluray', 'x264', '720p'],
+						score: 48
+					},
+					upgrades: [
+						{
+							release:
+								'The.Grand.Budapest.Hotel.2014.1080p.BluRay.Remux.AVC.DTS-HD.MA.5.1-RARBG.mkv',
+							formats: ['Remux', 'AVC', '1080p', 'DTS-HD MA'],
+							score: 112
+						}
+					],
+					imageUrl:
+						'https://image.tmdb.org/t/p/w1280/eWdyYQreja6JGCzqHWXpWHDrrPo.jpg'
+				}
+			]
+		},
+		results: { searchesTriggered: 5, successful: 2, failed: 0, errors: [] }
+	};
+}
+
+function makeRenameLog(): RenameJobLog {
+	return {
+		id: crypto.randomUUID(),
+		instanceId: 1,
+		instanceName: 'Movies',
+		instanceType: 'radarr',
+		startedAt: '2026-03-17T04:00:00.000Z',
+		completedAt: '2026-03-17T04:01:00.000Z',
+		status: 'success',
+		config: { dryRun: false, renameFolders: true, ignoreTag: null, manual: false },
+		library: { totalItems: 500, fetchDurationMs: 800 },
+		filtering: { afterIgnoreTag: 500, skippedByTag: 0 },
+		results: {
+			filesNeedingRename: 3,
+			filesRenamed: 3,
+			foldersRenamed: 1,
+			commandsTriggered: 3,
+			commandsCompleted: 3,
+			commandsFailed: 0,
+			errors: []
+		},
+		renamedItems: [
+			{
+				id: 1,
+				title: 'Interstellar',
+				folder: {
+					existingPath: '/movies/Interstellar (2014)',
+					newPath: '/movies/Interstellar (2014) {imdb-tt0816692}'
+				},
+				files: [
+					{
+						existingPath:
+							'/movies/Interstellar (2014)/Interstellar.2014.1080p.BluRay.mkv',
+						newPath:
+							'/movies/Interstellar (2014)/Interstellar (2014) [Bluray-1080p].mkv'
+					}
+				],
+				imageUrl:
+					'https://image.tmdb.org/t/p/w500/gEU2QniE6E77NI6lCU6MxlNBvIx.jpg'
+			}
+		]
+	};
+}
+
+test('real: sends upgrade notification to webhook', async () => {
+	if (!REAL_WEBHOOK_URL) return;
+	const notifier = new WebhookNotifier({ webhook_url: REAL_WEBHOOK_URL });
+	await notifier.notify(upgrade({ log: makeUpgradeLog() }));
+});
+
+test('real: sends rename notification to webhook', async () => {
+	if (!REAL_WEBHOOK_URL) return;
+	await new Promise((r) => setTimeout(r, 2000));
+	const notifier = new WebhookNotifier({ webhook_url: REAL_WEBHOOK_URL });
+	await notifier.notify(rename({ log: makeRenameLog() }));
+});
+
+await run();


### PR DESCRIPTION
## What does this PR do?

- Adds a generic webhook notification service (passthrough tier). POSTs the raw Notification JSON to a user-configured URL with optional Authorization header.
- Also removes duplicate error logging from all notifiers.

## Related issues

Related to #334
