### PR TITLE
feat: add Telegram notification service

### DIFF
--- a/docs/architecture/notifications.md
+++ b/docs/architecture/notifications.md
@@ -12,6 +12,7 @@
   - [Discord (Detail Tier)](#discord-detail-tier)
   - [Ntfy (Summary Tier)](#ntfy-summary-tier)
   - [Webhook (Passthrough Tier)](#webhook-passthrough-tier)
+  - [Telegram (Summary Tier)](#telegram-summary-tier)
 - [Service Tiers](#service-tiers)
 - [Testing](#testing)
 - [Adding a New Service](#adding-a-new-service)
@@ -55,11 +56,13 @@ flowchart TD
     FACTORY -->|discord| DISCORD[DiscordNotifier]
     FACTORY -->|ntfy| NTFY[NtfyNotifier]
     FACTORY -->|webhook| WEBHOOK[WebhookNotifier]
+    FACTORY -->|telegram| TELEGRAM[TelegramNotifier]
     FACTORY -->|future| OTHER[...]
 
     DISCORD -->|renders to embeds| WEBHOOK_D[Discord Webhook]
     NTFY -->|renders to ntfy JSON| WEBHOOK_N[Ntfy Server]
     WEBHOOK -->|raw JSON| WEBHOOK_W[Webhook Endpoint]
+    TELEGRAM -->|renders to HTML| WEBHOOK_T[Telegram Bot API]
     OTHER -->|renders| WEBHOOK_O[...]
 
     NM -->|record result| HISTORY[(notification_history)]
@@ -109,6 +112,7 @@ Each notifier maps severity to its platform's concept:
 | -------- | -------------------- | ------------------- | ----------------- | -------------------- |
 | Discord  | Green embed          | Red embed           | Yellow embed      | Blue embed           |
 | Ntfy     | Priority 3 (default) | Priority 5 (urgent) | Priority 4 (high) | Priority 3 (default) |
+| Telegram | ✅ prefix            | ❌ prefix           | ⚠️ prefix         | ℹ️ prefix            |
 | Webhook  | No mapping           | No mapping          | No mapping        | No mapping           |
 
 ## Definitions
@@ -184,16 +188,24 @@ rendering, no severity mapping, no block filtering — the payload is the
 notification. Optional `Authorization` header for authenticated endpoints
 (user provides the full header value, e.g. `Bearer token` or `Basic base64`).
 
+### Telegram (Summary Tier)
+
+Quick ping via the Telegram Bot API. Title, message, and field blocks only.
+Section blocks are omitted. POSTs to
+`https://api.telegram.org/bot{token}/sendMessage` with HTML parse mode. Severity
+mapped to emoji prefix (✅/❌/⚠️/ℹ️). Messages truncated at 4096 chars.
+Config: `bot_token` (secret), `chat_id`.
+
 ## Service Tiers
 
 Not every service renders the same content. The tier determines what the notifier
 includes from the structured payload.
 
-| Tier        | Renders                              | Drops                  | Example |
-| ----------- | ------------------------------------ | ---------------------- | ------- |
-| Detail      | Everything: fields, sections, images | Nothing                | Discord |
-| Summary     | Title, message, field blocks         | Section blocks, images | Ntfy    |
-| Passthrough | Raw `Notification` JSON              | Nothing (no rendering) | Webhook |
+| Tier        | Renders                              | Drops                  | Example        |
+| ----------- | ------------------------------------ | ---------------------- | -------------- |
+| Detail      | Everything: fields, sections, images | Nothing                | Discord        |
+| Summary     | Title, message, field blocks         | Section blocks, images | Ntfy, Telegram |
+| Passthrough | Raw `Notification` JSON              | Nothing (no rendering) | Webhook        |
 
 The tier is a design-time decision baked into the renderer, not a runtime config.
 
@@ -204,25 +216,27 @@ tests/integration/notifications/
   harness/
     mock-server.ts       - Deno.serve() that captures HTTP requests
   specs/
-    test.test.ts         - test notification (definition + Discord + real webhook)
-    upgrade.test.ts      - upgrade notification (definition + Discord + real webhook)
-    rename.test.ts       - rename notification (definition + Discord + real webhook)
-    ntfy.test.ts         - ntfy rendering + auth + real webhook
-    webhook.test.ts      - webhook passthrough + auth + real webhook
+    test.test.ts         - test notification (definition + all notifiers)
+    upgrade.test.ts      - upgrade notification (definition + all notifiers)
+    rename.test.ts       - rename notification (definition + all notifiers)
+    arrSync.test.ts      - arr sync notification (definition + all notifiers)
+    pcdSync.test.ts      - PCD sync notification (definition + all notifiers)
 ```
 
-Tests are organized by notification type. Each spec covers definition output,
-notifier rendering via mock server, and optionally a real webhook send.
+Tests are organized by event, not by notifier. Each spec covers definition
+output, rendering for all notifiers (Discord, Ntfy, Webhook, Telegram) via
+mock server, and optionally real sends.
 
 ```bash
 deno task test integration notifications              # all
-deno task test integration notifications ntfy         # ntfy only
-deno task test integration notifications webhook      # webhook only
+deno task test integration notifications test         # test event only
 deno task test integration notifications upgrade      # upgrade only
+deno task test integration notifications telegram     # (no standalone file — telegram tests are in each event spec)
 ```
 
-Real webhook tests are skipped without `.env`. Copy `.env.example` and fill in
-values for visual verification. Not part of CI.
+Real send tests are skipped without `.env`. Copy `.env.example` and fill in
+values for visual verification. Not part of CI. Telegram requires
+`TEST_TELEGRAM_BOT_TOKEN` and `TEST_TELEGRAM_CHAT_ID`.
 
 ## Adding a New Service
 
@@ -236,9 +250,10 @@ provide? Which fields are secrets? How does severity map? Document this in
 > **Config:** `server_url`, `topic`, `access_token` (secret).
 > **Severity:** success/info → priority 3, warning → 4, error → 5.
 
-**2. Write tests.** Create `specs/{service}.test.ts` with mock tests (severity
-mapping, payload structure, auth headers, block rendering per tier) and real
-webhook tests (skipped without `.env`). This is the contract.
+**2. Write tests.** Add a section for the new notifier to each existing event
+spec (`test.test.ts`, `rename.test.ts`, etc.) with mock tests (severity mapping,
+payload structure, block rendering per tier) and real send tests (skipped without
+`.env`). Tests are organized by event, not by notifier.
 
 **3. Build the UI.** Config form component, add to type dropdown in
 `NotificationServiceForm.svelte`, add config parsing in `new/` and `edit/` page

--- a/src/lib/client/ui/button/Button.svelte
+++ b/src/lib/client/ui/button/Button.svelte
@@ -9,6 +9,7 @@
 	export let size: 'xs' | 'sm' | 'md' = 'sm';
 	export let disabled: boolean = false;
 	export let icon: ComponentType | null = null;
+	export let leadingIcon: ComponentType | { path: string } | null = null;
 	export let iconColor: string = '';
 	export let textColor: string = '';
 	export let iconPosition: 'left' | 'right' = 'left';
@@ -85,7 +86,8 @@
 		iconColor || (variant === 'ghost' ? 'text-neutral-500 dark:text-neutral-400' : '');
 	$: effectiveIcon = loading ? Loader2 : icon;
 	$: effectiveIconColor = loading ? baseIconColor + ' animate-spin' : baseIconColor;
-	$: isIconOnly = icon && !text;
+	$: isLeadingSvg = leadingIcon && typeof leadingIcon === 'object' && 'path' in leadingIcon;
+	$: isIconOnly = icon && !text && !leadingIcon;
 	$: activeSizeClasses = isIconOnly ? iconOnlySizeClasses : sizeClasses;
 	$: classes = `group ${baseClasses} ${activeSizeClasses[effectiveSize]} ${variantClasses[variant]} ${widthClass}`;
 	$: iconSize = effectiveSize === 'xs' ? 12 : effectiveSize === 'sm' ? 14 : 16;
@@ -105,7 +107,26 @@
 			{#if effectiveIcon && iconPosition === 'left'}
 				<svelte:component this={effectiveIcon} size={iconSize} class={effectiveIconColor} />
 			{/if}
-			{#if text}
+			{#if leadingIcon}
+				<span class="inline-flex items-center gap-1.5">
+					{#if isLeadingSvg}
+						<svg
+							role="img"
+							viewBox="0 0 24 24"
+							fill="currentColor"
+							width={iconSize}
+							height={iconSize}
+						>
+							<path d={(leadingIcon as { path: string }).path} />
+						</svg>
+					{:else}
+						<svelte:component this={leadingIcon} size={iconSize} />
+					{/if}
+					{#if text}
+						<span class="{baseTextColor} {hideTextOnMobile ? 'hidden md:inline' : ''}">{text}</span>
+					{/if}
+				</span>
+			{:else if text}
 				<span class="{baseTextColor} {hideTextOnMobile ? 'hidden md:inline' : ''}">{text}</span>
 			{/if}
 			<slot />
@@ -125,7 +146,26 @@
 			{#if effectiveIcon && iconPosition === 'left'}
 				<svelte:component this={effectiveIcon} size={iconSize} class={effectiveIconColor} />
 			{/if}
-			{#if text}
+			{#if leadingIcon}
+				<span class="inline-flex items-center gap-1.5">
+					{#if isLeadingSvg}
+						<svg
+							role="img"
+							viewBox="0 0 24 24"
+							fill="currentColor"
+							width={iconSize}
+							height={iconSize}
+						>
+							<path d={(leadingIcon as { path: string }).path} />
+						</svg>
+					{:else}
+						<svelte:component this={leadingIcon} size={iconSize} />
+					{/if}
+					{#if text}
+						<span class="{baseTextColor} {hideTextOnMobile ? 'hidden md:inline' : ''}">{text}</span>
+					{/if}
+				</span>
+			{:else if text}
 				<span class="{baseTextColor} {hideTextOnMobile ? 'hidden md:inline' : ''}">{text}</span>
 			{/if}
 			<slot />

--- a/src/lib/client/ui/button/Button.svelte
+++ b/src/lib/client/ui/button/Button.svelte
@@ -120,7 +120,7 @@
 							<path d={(leadingIcon as { path: string }).path} />
 						</svg>
 					{:else}
-						<svelte:component this={leadingIcon} size={iconSize} />
+						<svelte:component this={leadingIcon as ComponentType} size={iconSize} />
 					{/if}
 					{#if text}
 						<span class="{baseTextColor} {hideTextOnMobile ? 'hidden md:inline' : ''}">{text}</span>
@@ -159,7 +159,7 @@
 							<path d={(leadingIcon as { path: string }).path} />
 						</svg>
 					{:else}
-						<svelte:component this={leadingIcon} size={iconSize} />
+						<svelte:component this={leadingIcon as ComponentType} size={iconSize} />
 					{/if}
 					{#if text}
 						<span class="{baseTextColor} {hideTextOnMobile ? 'hidden md:inline' : ''}">{text}</span>

--- a/src/lib/client/ui/dropdown/DropdownItem.svelte
+++ b/src/lib/client/ui/dropdown/DropdownItem.svelte
@@ -1,8 +1,11 @@
 <script lang="ts">
 	import type { ComponentType } from 'svelte';
 	import { Check } from 'lucide-svelte';
+	import IconCheckbox from '$ui/form/IconCheckbox.svelte';
 
-	export let icon: ComponentType | undefined = undefined;
+	export let icon: ComponentType | { path: string } | undefined = undefined;
+
+	$: isSvgIcon = icon && typeof icon === 'object' && 'path' in icon;
 	export let label: string;
 	export let disabled: boolean = false;
 	export let danger: boolean = false;
@@ -30,10 +33,14 @@
 	on:click
 >
 	{#if icon}
-		<svelte:component this={icon} size={iconSize} />
+		{#if isSvgIcon}
+			<svg role="img" viewBox="0 0 24 24" fill="currentColor" width={iconSize} height={iconSize}>
+				<path d={(icon as { path: string }).path} />
+			</svg>
+		{:else}
+			<svelte:component this={icon} size={iconSize} />
+		{/if}
 	{/if}
 	<span class="flex-1">{label}</span>
-	{#if selected}
-		<Check size={iconSize} class="text-accent-600 dark:text-accent-400" />
-	{/if}
+	<IconCheckbox icon={Check} checked={selected} shape="circle" color="accent" />
 </button>

--- a/src/lib/client/ui/dropdown/DropdownItem.svelte
+++ b/src/lib/client/ui/dropdown/DropdownItem.svelte
@@ -38,7 +38,7 @@
 				<path d={(icon as { path: string }).path} />
 			</svg>
 		{:else}
-			<svelte:component this={icon} size={iconSize} />
+			<svelte:component this={icon as ComponentType} size={iconSize} />
 		{/if}
 	{/if}
 	<span class="flex-1">{label}</span>

--- a/src/lib/client/ui/dropdown/DropdownSelect.svelte
+++ b/src/lib/client/ui/dropdown/DropdownSelect.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import type { ComponentType } from 'svelte';
 	import { onMount, onDestroy, createEventDispatcher } from 'svelte';
 	import { clickOutside } from '$lib/client/utils/clickOutside';
 	import { ChevronDown } from 'lucide-svelte';
@@ -8,7 +9,13 @@
 
 	export let label: string | undefined = undefined;
 	export let value: string;
-	export let options: { value: string; label: string; shortLabel?: string; description?: string }[];
+	export let options: {
+		value: string;
+		label: string;
+		shortLabel?: string;
+		description?: string;
+		icon?: ComponentType | { path: string };
+	}[];
 	export let placeholder: string = 'Select...';
 	export let minWidth: string = '8rem';
 	export let position: 'left' | 'right' | 'middle' = 'left';
@@ -59,6 +66,7 @@
 	}
 
 	$: matchedOption = options.find((o) => o.value === value);
+	$: currentIcon = matchedOption?.icon ?? null;
 	$: currentLabel = matchedOption?.shortLabel
 		? matchedOption.shortLabel
 		: matchedOption?.label || placeholder;
@@ -96,6 +104,7 @@
 			text={currentLabel}
 			icon={ChevronDown}
 			iconPosition="right"
+			leadingIcon={currentIcon}
 			size={resolvedButtonSize}
 			{fullWidth}
 			{disabled}
@@ -115,6 +124,7 @@
 				{#each options as option}
 					<DropdownItem
 						label={option.label}
+						icon={option.icon}
 						selected={value === option.value}
 						compact={isCompactDropdown}
 						on:click={() => select(option.value)}

--- a/src/lib/server/notifications/NotificationManager.ts
+++ b/src/lib/server/notifications/NotificationManager.ts
@@ -2,10 +2,17 @@ import { logger } from '$logger/logger.ts';
 import { notificationServicesQueries } from '$db/queries/notificationServices.ts';
 import { notificationHistoryQueries } from '$db/queries/notificationHistory.ts';
 import type { Notifier } from './base/Notifier.ts';
-import type { Notification, DiscordConfig, NtfyConfig, WebhookConfig } from './types.ts';
+import type {
+	Notification,
+	DiscordConfig,
+	NtfyConfig,
+	WebhookConfig,
+	TelegramConfig
+} from './types.ts';
 import { DiscordNotifier } from './notifiers/discord/DiscordNotifier.ts';
 import { NtfyNotifier } from './notifiers/ntfy/NtfyNotifier.ts';
 import { WebhookNotifier } from './notifiers/webhook/WebhookNotifier.ts';
+import { TelegramNotifier } from './notifiers/telegram/TelegramNotifier.ts';
 
 /**
  * Central notification manager
@@ -159,6 +166,8 @@ export class NotificationManager {
 					return new NtfyNotifier(config as NtfyConfig);
 				case 'webhook':
 					return new WebhookNotifier(config as WebhookConfig);
+				case 'telegram':
+					return new TelegramNotifier(config as TelegramConfig);
 				default:
 					return null;
 			}

--- a/src/lib/server/notifications/notifiers/telegram/TelegramNotifier.ts
+++ b/src/lib/server/notifications/notifiers/telegram/TelegramNotifier.ts
@@ -1,0 +1,68 @@
+import type { TelegramConfig, Notification, NotificationSeverity } from '../../types.ts';
+import { getWebhookClient } from '../../base/webhookClient.ts';
+
+const TELEGRAM_API = 'https://api.telegram.org';
+const MAX_MESSAGE_LENGTH = 4096;
+
+/**
+ * Telegram notification service implementation.
+ * Summary tier: renders title, message, and field blocks only.
+ * Section blocks are omitted — Telegram is for quick pings, not full detail.
+ */
+export class TelegramNotifier {
+	constructor(private config: TelegramConfig) {}
+
+	getName(): string {
+		return 'Telegram';
+	}
+
+	async notify(notification: Notification): Promise<void> {
+		const base = this.config.api_base_url ?? TELEGRAM_API;
+		const url = `${base}/bot${this.config.bot_token}/sendMessage`;
+		const payload = this.formatPayload(notification);
+
+		await getWebhookClient().post(url, payload);
+	}
+
+	private formatPayload(notification: Notification): unknown {
+		const emoji = this.getEmoji(notification.severity);
+		const blocks = notification.blocks ?? [];
+		const parts: string[] = [];
+
+		parts.push(`${emoji} <b>${notification.title}</b>`);
+		parts.push(notification.message);
+
+		for (const block of blocks) {
+			if (block.kind === 'field') {
+				parts.push(`<b>${block.label}:</b> ${block.value}`);
+			}
+			// Section blocks omitted (summary tier)
+		}
+
+		let text = parts.join('\n\n');
+		if (text.length > MAX_MESSAGE_LENGTH) {
+			text = text.slice(0, MAX_MESSAGE_LENGTH - 1) + '\u2026';
+		}
+
+		return {
+			chat_id: this.config.chat_id,
+			text,
+			parse_mode: 'HTML'
+		};
+	}
+
+	private getEmoji(severity: NotificationSeverity): string {
+		switch (severity) {
+			case 'success':
+				return '\u2705';
+			case 'error':
+				return '\u274C';
+			case 'warning':
+				return '\u26A0\uFE0F';
+			case 'info':
+				return '\u2139\uFE0F';
+			default:
+				return '\u2139\uFE0F';
+		}
+	}
+}

--- a/src/lib/server/notifications/notifiers/telegram/index.ts
+++ b/src/lib/server/notifications/notifiers/telegram/index.ts
@@ -1,0 +1,1 @@
+export { TelegramNotifier } from './TelegramNotifier.ts';

--- a/src/lib/server/notifications/types.ts
+++ b/src/lib/server/notifications/types.ts
@@ -120,11 +120,20 @@ export interface WebhookConfig {
 }
 
 /**
+ * Configuration for Telegram notifications
+ */
+export interface TelegramConfig {
+	bot_token: string;
+	chat_id: string;
+	api_base_url?: string;
+}
+
+/**
  * Union type for all notification service configs
  */
-export type NotificationServiceConfig = DiscordConfig | NtfyConfig | WebhookConfig;
+export type NotificationServiceConfig = DiscordConfig | NtfyConfig | WebhookConfig | TelegramConfig;
 
 /**
  * Service types supported
  */
-export type NotificationServiceType = 'discord' | 'ntfy' | 'webhook';
+export type NotificationServiceType = 'discord' | 'ntfy' | 'webhook' | 'telegram';

--- a/src/routes/settings/notifications/+page.svelte
+++ b/src/routes/settings/notifications/+page.svelte
@@ -134,7 +134,7 @@
 							class="h-4 w-4 text-neutral-600 dark:text-neutral-400"
 							fill="currentColor"
 						>
-							<path d={serviceInfo[row.service_type].icon.path} />
+							<path d={serviceInfo[row.service_type]!.icon!.path} />
 						</svg>
 					{:else}
 						<Rss size={16} class="text-neutral-600 dark:text-neutral-400" />

--- a/src/routes/settings/notifications/+page.svelte
+++ b/src/routes/settings/notifications/+page.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
 	import { enhance } from '$app/forms';
 	import { alertStore } from '$alerts/store';
-	import { Plus, Trash2, Bell, BellOff, MessageSquare, Send, Pencil } from 'lucide-svelte';
+	import { Plus, Trash2, Bell, BellOff, Rss, Send, Pencil } from 'lucide-svelte';
 	import Modal from '$ui/modal/Modal.svelte';
 	import NotificationHistory from './components/NotificationHistory.svelte';
 	import Table from '$ui/table/Table.svelte';
 	import Badge from '$ui/badge/Badge.svelte';
 	import type { Column } from '$ui/table/types';
-	import { siDiscord } from 'simple-icons';
+	import { siDiscord, siNtfy, siTelegram } from 'simple-icons';
 	import Button from '$ui/button/Button.svelte';
 	import type { PageData } from './$types';
 
@@ -55,26 +55,15 @@
 		deleteFormRef = null;
 	}
 
-	function getServiceIcon(serviceType: string) {
-		switch (serviceType) {
-			case 'discord':
-				return MessageSquare;
-			default:
-				return Bell;
-		}
-	}
+	const serviceInfo: Record<string, { label: string; icon: { path: string } | null }> = {
+		discord: { label: 'Discord', icon: siDiscord },
+		ntfy: { label: 'Ntfy', icon: siNtfy },
+		webhook: { label: 'Webhook', icon: null },
+		telegram: { label: 'Telegram', icon: siTelegram }
+	};
 
 	function getServiceTypeName(serviceType: string): string {
-		switch (serviceType) {
-			case 'discord':
-				return 'Discord';
-			case 'slack':
-				return 'Slack';
-			case 'email':
-				return 'Email';
-			default:
-				return serviceType;
-		}
+		return serviceInfo[serviceType]?.label ?? serviceType;
 	}
 
 	function formatSuccessRate(rate: number): string {
@@ -138,21 +127,17 @@
 				<span class="font-medium">{row.name}</span>
 			{:else if column.key === 'service_type'}
 				<div class="flex items-center gap-2">
-					{#if row.service_type === 'discord'}
+					{#if serviceInfo[row.service_type]?.icon}
 						<svg
 							role="img"
 							viewBox="0 0 24 24"
 							class="h-4 w-4 text-neutral-600 dark:text-neutral-400"
 							fill="currentColor"
 						>
-							<path d={siDiscord.path} />
+							<path d={serviceInfo[row.service_type].icon.path} />
 						</svg>
 					{:else}
-						<svelte:component
-							this={getServiceIcon(row.service_type)}
-							size={16}
-							class="text-neutral-600 dark:text-neutral-400"
-						/>
+						<Rss size={16} class="text-neutral-600 dark:text-neutral-400" />
 					{/if}
 					<span>{getServiceTypeName(row.service_type)}</span>
 				</div>

--- a/src/routes/settings/notifications/components/NotificationServiceForm.svelte
+++ b/src/routes/settings/notifications/components/NotificationServiceForm.svelte
@@ -4,8 +4,10 @@
 	import DiscordConfiguration from './DiscordConfiguration.svelte';
 	import NtfyConfiguration from './NtfyConfiguration.svelte';
 	import WebhookConfiguration from './WebhookConfiguration.svelte';
+	import TelegramConfiguration from './TelegramConfiguration.svelte';
 	import { groupNotificationTypesByCategory } from '$shared/notifications/types';
-	import { Plus, Save, ListChecks, CheckCircle, XCircle } from 'lucide-svelte';
+	import { Plus, Save, ListChecks, CheckCircle, XCircle, Rss } from 'lucide-svelte';
+	import { siDiscord, siNtfy, siTelegram } from 'simple-icons';
 	import Toggle from '$ui/toggle/Toggle.svelte';
 	import FormInput from '$ui/form/FormInput.svelte';
 	import DropdownSelect from '$ui/dropdown/DropdownSelect.svelte';
@@ -22,8 +24,8 @@
 		enabledTypes?: string[];
 	} = {};
 
-	let selectedType: 'discord' | 'ntfy' | 'webhook' =
-		(initialData.serviceType as 'discord' | 'ntfy' | 'webhook') || 'discord';
+	let selectedType: 'discord' | 'ntfy' | 'webhook' | 'telegram' =
+		(initialData.serviceType as 'discord' | 'ntfy' | 'webhook' | 'telegram') || 'discord';
 	let serviceName = initialData.name || '';
 
 	// Group notification types by category
@@ -78,9 +80,10 @@
 	}
 
 	const typeOptions = [
-		{ value: 'discord', label: 'Discord' },
-		{ value: 'ntfy', label: 'Ntfy' },
-		{ value: 'webhook', label: 'Webhook' }
+		{ value: 'discord', label: 'Discord', icon: siDiscord },
+		{ value: 'ntfy', label: 'Ntfy', icon: siNtfy },
+		{ value: 'webhook', label: 'Webhook', icon: Rss },
+		{ value: 'telegram', label: 'Telegram', icon: siTelegram }
 	];
 
 	$: title = mode === 'create' ? 'New Notification Service' : 'Edit Notification Service';
@@ -146,39 +149,46 @@
 	<input type="hidden" name="name" value={serviceName} />
 
 	<div class="space-y-6 md:px-4">
-		<!-- Service Type -->
-		<div class="space-y-2">
-			<span class="block text-sm font-semibold text-neutral-900 dark:text-neutral-100">
-				Service Type
-			</span>
-			{#if mode === 'edit'}
+		<!-- Service Type + Service Name -->
+		<div class="grid grid-cols-8 gap-4">
+			<div class="col-span-2 space-y-2">
+				<span class="block text-sm font-semibold text-neutral-900 dark:text-neutral-100">
+					Service Type
+				</span>
 				<p class="text-xs text-neutral-500 dark:text-neutral-400">
-					Type cannot be changed after creation
+					{#if mode === 'edit'}
+						Type cannot be changed after creation
+					{:else}
+						The platform to send notifications to
+					{/if}
 				</p>
-			{/if}
-			<DropdownSelect
-				value={selectedType}
-				options={typeOptions}
-				disabled={mode === 'edit'}
-				fullWidth
-				on:change={(e) => (selectedType = e.detail as typeof selectedType)}
-			/>
-		</div>
+				<DropdownSelect
+					value={selectedType}
+					options={typeOptions}
+					disabled={mode === 'edit'}
+					fullWidth
+					on:change={(e) => (selectedType = e.detail as typeof selectedType)}
+				/>
+			</div>
 
-		<!-- Service Name -->
-		<FormInput
-			label="Service Name"
-			name="service_name"
-			value={serviceName}
-			placeholder={selectedType === 'ntfy'
-				? 'e.g., Phone Alerts'
-				: selectedType === 'webhook'
-					? 'e.g., Home Assistant'
-					: 'e.g., Main Discord Server'}
-			description="A friendly name to identify this notification service"
-			required
-			on:input={(e) => (serviceName = e.detail)}
-		/>
+			<div class="col-span-6">
+				<FormInput
+					label="Service Name"
+					name="service_name"
+					value={serviceName}
+					placeholder={selectedType === 'ntfy'
+						? 'e.g., Phone Alerts'
+						: selectedType === 'webhook'
+							? 'e.g., Home Assistant'
+							: selectedType === 'telegram'
+								? 'e.g., Personal Bot'
+								: 'e.g., Main Discord Server'}
+					description="A friendly name to identify this notification service"
+					required
+					on:input={(e) => (serviceName = e.detail)}
+				/>
+			</div>
+		</div>
 
 		<!-- Service Configuration -->
 		{#if selectedType === 'discord'}
@@ -187,6 +197,8 @@
 			<NtfyConfiguration config={initialData.config} {mode} />
 		{:else if selectedType === 'webhook'}
 			<WebhookConfiguration config={initialData.config} {mode} />
+		{:else if selectedType === 'telegram'}
+			<TelegramConfiguration config={initialData.config} {mode} />
 		{/if}
 
 		<!-- Notification Types -->

--- a/src/routes/settings/notifications/components/TelegramConfiguration.svelte
+++ b/src/routes/settings/notifications/components/TelegramConfiguration.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+	import FormInput from '$ui/form/FormInput.svelte';
+	export let config: Record<string, unknown> = {};
+	export let mode: 'create' | 'edit' = 'create';
+
+	let botToken = (config.bot_token as string) || '';
+	let chatId = (config.chat_id as string) || '';
+</script>
+
+<div class="space-y-4">
+	<h3 class="text-sm font-semibold text-neutral-900 dark:text-neutral-100">
+		Telegram Configuration
+	</h3>
+
+	<!-- Bot Token -->
+	<FormInput
+		label="Bot Token"
+		name="bot_token"
+		value={botToken}
+		placeholder={mode === 'edit' ? '••••••••••••••••' : '123456789:ABCdefGHI...'}
+		description={mode === 'edit'
+			? 'Leave blank to keep existing token'
+			: 'Create a bot via @BotFather on Telegram to get a token'}
+		private_
+		on:input={(e) => (botToken = e.detail)}
+	/>
+
+	<!-- Chat ID -->
+	<FormInput
+		label="Chat ID"
+		name="chat_id"
+		value={chatId}
+		placeholder="e.g., 123456789"
+		description="Your user or group chat ID. Message @userinfobot on Telegram to find yours"
+		required
+		on:input={(e) => (chatId = e.detail)}
+	/>
+</div>

--- a/src/routes/settings/notifications/edit/[id]/+page.server.ts
+++ b/src/routes/settings/notifications/edit/[id]/+page.server.ts
@@ -26,6 +26,7 @@ export const load = ({ params }: { params: { id: string } }) => {
 		webhook_url: _webhookUrl,
 		access_token: _accessToken,
 		auth_header: _authHeader,
+		bot_token: _botToken,
 		...safeConfig
 	} = config;
 
@@ -120,6 +121,19 @@ export const actions: Actions = {
 					: existingConfig.auth_header
 						? { auth_header: existingConfig.auth_header }
 						: {})
+			};
+		} else if (service.service_type === 'telegram') {
+			const botToken = formData.get('bot_token') as string;
+			const chatId = formData.get('chat_id') as string;
+
+			if (!chatId) {
+				return fail(400, { error: 'Chat ID is required for Telegram' });
+			}
+
+			config = {
+				// Keep existing bot_token if new one not provided
+				bot_token: botToken || existingConfig.bot_token,
+				chat_id: chatId
 			};
 		}
 

--- a/src/routes/settings/notifications/new/+page.server.ts
+++ b/src/routes/settings/notifications/new/+page.server.ts
@@ -65,6 +65,18 @@ export const actions: Actions = {
 				webhook_url: webhookUrl,
 				...(authHeader && { auth_header: authHeader })
 			};
+		} else if (serviceType === 'telegram') {
+			const botToken = formData.get('bot_token') as string;
+			const chatId = formData.get('chat_id') as string;
+
+			if (!botToken || !chatId) {
+				return fail(400, { error: 'Bot token and chat ID are required for Telegram' });
+			}
+
+			config = {
+				bot_token: botToken,
+				chat_id: chatId
+			};
 		}
 
 		// Get enabled notification types dynamically from all available types

--- a/tests/integration/notifications/.env.example
+++ b/tests/integration/notifications/.env.example
@@ -4,3 +4,5 @@ TEST_DISCORD_WEBHOOK=https://discord.com/api/webhooks/...
 TEST_NTFY_URL=https://ntfy.sh
 TEST_NTFY_TOPIC=profilarr-test
 TEST_WEBHOOK_URL=https://example.com/webhook
+TEST_TELEGRAM_BOT_TOKEN=123456789:ABCdefGHIjklMNOpqrsTUVwxYz
+TEST_TELEGRAM_CHAT_ID=123456789

--- a/tests/integration/notifications/specs/arrSync.test.ts
+++ b/tests/integration/notifications/specs/arrSync.test.ts
@@ -1,5 +1,5 @@
 /**
- * Arr sync notification - definition + Discord + Ntfy + Webhook.
+ * Arr sync notification - definition + Discord + Ntfy + Webhook + Telegram.
  */
 
 import { assertEquals, assertExists } from '@std/assert';
@@ -8,6 +8,7 @@ import { createMockServer, type CapturedRequest } from '../harness/mock-server.t
 import { DiscordNotifier } from '$notifications/notifiers/discord/DiscordNotifier.ts';
 import { NtfyNotifier } from '$notifications/notifiers/ntfy/NtfyNotifier.ts';
 import { WebhookNotifier } from '$notifications/notifiers/webhook/WebhookNotifier.ts';
+import { TelegramNotifier } from '$notifications/notifiers/telegram/TelegramNotifier.ts';
 import { Colors } from '$notifications/notifiers/discord/embed.ts';
 import { arrSync } from '$notifications/definitions/arrSync.ts';
 import type { ArrSyncNotificationParams } from '$notifications/definitions/arrSync.ts';
@@ -20,6 +21,8 @@ let REAL_DISCORD: string | undefined;
 let REAL_NTFY_URL: string | undefined;
 let REAL_NTFY_TOPIC: string | undefined;
 let REAL_WEBHOOK_URL: string | undefined;
+let REAL_TELEGRAM_TOKEN: string | undefined;
+let REAL_TELEGRAM_CHAT_ID: string | undefined;
 try {
 	const envPath = new URL('../.env', import.meta.url).pathname;
 	const content = await Deno.readTextFile(envPath);
@@ -34,6 +37,8 @@ try {
 			if (key === 'TEST_NTFY_URL') REAL_NTFY_URL = value;
 			if (key === 'TEST_NTFY_TOPIC') REAL_NTFY_TOPIC = value;
 			if (key === 'TEST_WEBHOOK_URL') REAL_WEBHOOK_URL = value;
+			if (key === 'TEST_TELEGRAM_BOT_TOKEN') REAL_TELEGRAM_TOKEN = value;
+			if (key === 'TEST_TELEGRAM_CHAT_ID') REAL_TELEGRAM_CHAT_ID = value;
 		}
 	}
 } catch {
@@ -421,6 +426,66 @@ test('webhook: failed sections have no items', async () => {
 });
 
 // =========================================================================
+// Telegram
+// =========================================================================
+
+const MOCK_TOKEN = 'test-token-123';
+
+test('telegram: success has ✅ prefix', async () => {
+	captured.length = 0;
+	const notifier = new TelegramNotifier({
+		bot_token: MOCK_TOKEN,
+		chat_id: '123456',
+		api_base_url: `http://localhost:${MOCK_PORT}`
+	});
+	await notifier.notify(arrSync(makeSuccessParams()));
+
+	const text = (captured[0]?.body as Record<string, unknown>)?.text as string;
+	assertEquals(text.startsWith('\u2705'), true);
+});
+
+test('telegram: failed has ❌ prefix', async () => {
+	captured.length = 0;
+	const notifier = new TelegramNotifier({
+		bot_token: MOCK_TOKEN,
+		chat_id: '123456',
+		api_base_url: `http://localhost:${MOCK_PORT}`
+	});
+	await notifier.notify(arrSync(makeFailedParams()));
+
+	const text = (captured[0]?.body as Record<string, unknown>)?.text as string;
+	assertEquals(text.startsWith('\u274C'), true);
+});
+
+test('telegram: partial has ⚠️ prefix', async () => {
+	captured.length = 0;
+	const notifier = new TelegramNotifier({
+		bot_token: MOCK_TOKEN,
+		chat_id: '123456',
+		api_base_url: `http://localhost:${MOCK_PORT}`
+	});
+	await notifier.notify(arrSync(makePartialParams()));
+
+	const text = (captured[0]?.body as Record<string, unknown>)?.text as string;
+	assertEquals(text.startsWith('\u26A0\uFE0F'), true);
+});
+
+test('telegram: message includes title but omits section item names', async () => {
+	captured.length = 0;
+	const notifier = new TelegramNotifier({
+		bot_token: MOCK_TOKEN,
+		chat_id: '123456',
+		api_base_url: `http://localhost:${MOCK_PORT}`
+	});
+	await notifier.notify(arrSync(makeSuccessParams()));
+
+	const text = (captured[0]?.body as Record<string, unknown>)?.text as string;
+	assertEquals(text.includes('Movies'), true);
+	// Section item names should not appear (summary tier)
+	assertEquals(text.includes('HD Bluray'), false);
+});
+
+// =========================================================================
 // Real sends (skipped without .env)
 // =========================================================================
 
@@ -500,6 +565,16 @@ test('real: sends failed to webhook', async () => {
 		webhook_url: REAL_WEBHOOK_URL
 	});
 	await notifier.notify(arrSync(makeFailedParams()));
+});
+
+test('real: sends success to Telegram', async () => {
+	if (!REAL_TELEGRAM_TOKEN || !REAL_TELEGRAM_CHAT_ID) return;
+	await new Promise((r) => setTimeout(r, 2000));
+	const notifier = new TelegramNotifier({
+		bot_token: REAL_TELEGRAM_TOKEN,
+		chat_id: REAL_TELEGRAM_CHAT_ID
+	});
+	await notifier.notify(arrSync(makeSuccessParams()));
 });
 
 await run();

--- a/tests/integration/notifications/specs/pcdSync.test.ts
+++ b/tests/integration/notifications/specs/pcdSync.test.ts
@@ -1,5 +1,5 @@
 /**
- * PCD sync notification - definition + Discord + Ntfy + Webhook.
+ * PCD sync notification - definition + Discord + Ntfy + Webhook + Telegram.
  */
 
 import { assertEquals, assertExists } from '@std/assert';
@@ -8,6 +8,7 @@ import { createMockServer, type CapturedRequest } from '../harness/mock-server.t
 import { DiscordNotifier } from '$notifications/notifiers/discord/DiscordNotifier.ts';
 import { NtfyNotifier } from '$notifications/notifiers/ntfy/NtfyNotifier.ts';
 import { WebhookNotifier } from '$notifications/notifiers/webhook/WebhookNotifier.ts';
+import { TelegramNotifier } from '$notifications/notifiers/telegram/TelegramNotifier.ts';
 import { Colors } from '$notifications/notifiers/discord/embed.ts';
 import {
 	pcdUpdatesAvailable,
@@ -28,6 +29,8 @@ let REAL_DISCORD: string | undefined;
 let REAL_NTFY_URL: string | undefined;
 let REAL_NTFY_TOPIC: string | undefined;
 let REAL_WEBHOOK_URL: string | undefined;
+let REAL_TELEGRAM_TOKEN: string | undefined;
+let REAL_TELEGRAM_CHAT_ID: string | undefined;
 try {
 	const envPath = new URL('../.env', import.meta.url).pathname;
 	const content = await Deno.readTextFile(envPath);
@@ -42,6 +45,8 @@ try {
 			if (key === 'TEST_NTFY_URL') REAL_NTFY_URL = value;
 			if (key === 'TEST_NTFY_TOPIC') REAL_NTFY_TOPIC = value;
 			if (key === 'TEST_WEBHOOK_URL') REAL_WEBHOOK_URL = value;
+			if (key === 'TEST_TELEGRAM_BOT_TOKEN') REAL_TELEGRAM_TOKEN = value;
+			if (key === 'TEST_TELEGRAM_CHAT_ID') REAL_TELEGRAM_CHAT_ID = value;
 		}
 	}
 } catch {
@@ -394,6 +399,65 @@ test('webhook: sync_failed has empty blocks', async () => {
 });
 
 // =========================================================================
+// Telegram
+// =========================================================================
+
+const MOCK_TOKEN = 'test-token-123';
+
+test('telegram: updates_available has ℹ️ prefix', async () => {
+	captured.length = 0;
+	const notifier = new TelegramNotifier({
+		bot_token: MOCK_TOKEN,
+		chat_id: '123456',
+		api_base_url: `http://localhost:${MOCK_PORT}`
+	});
+	await notifier.notify(pcdUpdatesAvailable(makeUpdatesAvailableParams()));
+
+	const text = (captured[0]?.body as Record<string, unknown>)?.text as string;
+	assertEquals(text.startsWith('\u2139\uFE0F'), true);
+});
+
+test('telegram: sync_success has ✅ prefix', async () => {
+	captured.length = 0;
+	const notifier = new TelegramNotifier({
+		bot_token: MOCK_TOKEN,
+		chat_id: '123456',
+		api_base_url: `http://localhost:${MOCK_PORT}`
+	});
+	await notifier.notify(pcdSyncSuccess(makeSyncSuccessParams()));
+
+	const text = (captured[0]?.body as Record<string, unknown>)?.text as string;
+	assertEquals(text.startsWith('\u2705'), true);
+});
+
+test('telegram: sync_failed has ❌ prefix', async () => {
+	captured.length = 0;
+	const notifier = new TelegramNotifier({
+		bot_token: MOCK_TOKEN,
+		chat_id: '123456',
+		api_base_url: `http://localhost:${MOCK_PORT}`
+	});
+	await notifier.notify(pcdSyncFailed(makeSyncFailedParams()));
+
+	const text = (captured[0]?.body as Record<string, unknown>)?.text as string;
+	assertEquals(text.startsWith('\u274C'), true);
+});
+
+test('telegram: omits section block content', async () => {
+	captured.length = 0;
+	const notifier = new TelegramNotifier({
+		bot_token: MOCK_TOKEN,
+		chat_id: '123456',
+		api_base_url: `http://localhost:${MOCK_PORT}`
+	});
+	await notifier.notify(pcdSyncSuccess(makeSyncSuccessParams()));
+
+	const text = (captured[0]?.body as Record<string, unknown>)?.text as string;
+	// Commit messages are in a section block — should be omitted
+	assertEquals(text.includes('add position to quality groups'), false);
+});
+
+// =========================================================================
 // Real sends (skipped without .env)
 // =========================================================================
 
@@ -486,6 +550,36 @@ test('real: sends sync_failed to webhook', async () => {
 	await new Promise((r) => setTimeout(r, 2000));
 	const notifier = new WebhookNotifier({
 		webhook_url: REAL_WEBHOOK_URL
+	});
+	await notifier.notify(pcdSyncFailed(makeSyncFailedParams()));
+});
+
+test('real: sends updates_available to Telegram', async () => {
+	if (!REAL_TELEGRAM_TOKEN || !REAL_TELEGRAM_CHAT_ID) return;
+	await new Promise((r) => setTimeout(r, 2000));
+	const notifier = new TelegramNotifier({
+		bot_token: REAL_TELEGRAM_TOKEN,
+		chat_id: REAL_TELEGRAM_CHAT_ID
+	});
+	await notifier.notify(pcdUpdatesAvailable(makeUpdatesAvailableParams()));
+});
+
+test('real: sends sync_success to Telegram', async () => {
+	if (!REAL_TELEGRAM_TOKEN || !REAL_TELEGRAM_CHAT_ID) return;
+	await new Promise((r) => setTimeout(r, 2000));
+	const notifier = new TelegramNotifier({
+		bot_token: REAL_TELEGRAM_TOKEN,
+		chat_id: REAL_TELEGRAM_CHAT_ID
+	});
+	await notifier.notify(pcdSyncSuccess(makeSyncSuccessParams()));
+});
+
+test('real: sends sync_failed to Telegram', async () => {
+	if (!REAL_TELEGRAM_TOKEN || !REAL_TELEGRAM_CHAT_ID) return;
+	await new Promise((r) => setTimeout(r, 2000));
+	const notifier = new TelegramNotifier({
+		bot_token: REAL_TELEGRAM_TOKEN,
+		chat_id: REAL_TELEGRAM_CHAT_ID
 	});
 	await notifier.notify(pcdSyncFailed(makeSyncFailedParams()));
 });

--- a/tests/integration/notifications/specs/rename.test.ts
+++ b/tests/integration/notifications/specs/rename.test.ts
@@ -1,5 +1,5 @@
 /**
- * Rename notification - definition + Discord + Ntfy + Webhook.
+ * Rename notification - definition + Discord + Ntfy + Webhook + Telegram.
  */
 
 import { assertEquals, assertExists } from '@std/assert';
@@ -8,6 +8,7 @@ import { createMockServer, type CapturedRequest } from '../harness/mock-server.t
 import { DiscordNotifier } from '$notifications/notifiers/discord/DiscordNotifier.ts';
 import { NtfyNotifier } from '$notifications/notifiers/ntfy/NtfyNotifier.ts';
 import { WebhookNotifier } from '$notifications/notifiers/webhook/WebhookNotifier.ts';
+import { TelegramNotifier } from '$notifications/notifiers/telegram/TelegramNotifier.ts';
 import { Colors } from '$notifications/notifiers/discord/embed.ts';
 import { rename } from '$notifications/definitions/rename.ts';
 import type { RenameJobLog } from '$lib/server/rename/types.ts';
@@ -20,6 +21,8 @@ let REAL_DISCORD: string | undefined;
 let REAL_NTFY_URL: string | undefined;
 let REAL_NTFY_TOPIC: string | undefined;
 let REAL_WEBHOOK_URL: string | undefined;
+let REAL_TELEGRAM_TOKEN: string | undefined;
+let REAL_TELEGRAM_CHAT_ID: string | undefined;
 try {
 	const envPath = new URL('../.env', import.meta.url).pathname;
 	const content = await Deno.readTextFile(envPath);
@@ -34,6 +37,8 @@ try {
 			if (key === 'TEST_NTFY_URL') REAL_NTFY_URL = value;
 			if (key === 'TEST_NTFY_TOPIC') REAL_NTFY_TOPIC = value;
 			if (key === 'TEST_WEBHOOK_URL') REAL_WEBHOOK_URL = value;
+			if (key === 'TEST_TELEGRAM_BOT_TOKEN') REAL_TELEGRAM_TOKEN = value;
+			if (key === 'TEST_TELEGRAM_CHAT_ID') REAL_TELEGRAM_CHAT_ID = value;
 		}
 	}
 } catch {
@@ -395,6 +400,65 @@ test('webhook: includes section blocks with imageUrl', async () => {
 });
 
 // =========================================================================
+// Telegram
+// =========================================================================
+
+const MOCK_TOKEN = 'test-token-123';
+
+test('telegram: success has ✅ prefix', async () => {
+	captured.length = 0;
+	const notifier = new TelegramNotifier({
+		bot_token: MOCK_TOKEN,
+		chat_id: '123456',
+		api_base_url: `http://localhost:${MOCK_PORT}`
+	});
+	await notifier.notify(rename({ log: makeRadarrLog() }));
+
+	const text = (captured[0]?.body as Record<string, unknown>)?.text as string;
+	assertEquals(text.startsWith('\u2705'), true);
+});
+
+test('telegram: failed has ❌ prefix', async () => {
+	captured.length = 0;
+	const notifier = new TelegramNotifier({
+		bot_token: MOCK_TOKEN,
+		chat_id: '123456',
+		api_base_url: `http://localhost:${MOCK_PORT}`
+	});
+	await notifier.notify(rename({ log: makeRadarrLog({ status: 'failed' }) }));
+
+	const text = (captured[0]?.body as Record<string, unknown>)?.text as string;
+	assertEquals(text.startsWith('\u274C'), true);
+});
+
+test('telegram: partial has ⚠️ prefix', async () => {
+	captured.length = 0;
+	const notifier = new TelegramNotifier({
+		bot_token: MOCK_TOKEN,
+		chat_id: '123456',
+		api_base_url: `http://localhost:${MOCK_PORT}`
+	});
+	await notifier.notify(rename({ log: makeRadarrLog({ status: 'partial' }) }));
+
+	const text = (captured[0]?.body as Record<string, unknown>)?.text as string;
+	assertEquals(text.startsWith('\u26A0\uFE0F'), true);
+});
+
+test('telegram: includes field block content but omits section blocks', async () => {
+	captured.length = 0;
+	const notifier = new TelegramNotifier({
+		bot_token: MOCK_TOKEN,
+		chat_id: '123456',
+		api_base_url: `http://localhost:${MOCK_PORT}`
+	});
+	await notifier.notify(rename({ log: makeRadarrLog(), summaryNotifications: false }));
+
+	const text = (captured[0]?.body as Record<string, unknown>)?.text as string;
+	// Should not contain section content (movie titles, file paths)
+	assertEquals(text.includes('Interstellar.2014.2160p'), false);
+});
+
+// =========================================================================
 // Real sends (skipped without .env)
 // =========================================================================
 
@@ -434,6 +498,16 @@ test('real: sends rename to webhook', async () => {
 	await new Promise((r) => setTimeout(r, 2000));
 	const notifier = new WebhookNotifier({
 		webhook_url: REAL_WEBHOOK_URL
+	});
+	await notifier.notify(rename({ log: makeRadarrLog() }));
+});
+
+test('real: sends rename to Telegram', async () => {
+	if (!REAL_TELEGRAM_TOKEN || !REAL_TELEGRAM_CHAT_ID) return;
+	await new Promise((r) => setTimeout(r, 2000));
+	const notifier = new TelegramNotifier({
+		bot_token: REAL_TELEGRAM_TOKEN,
+		chat_id: REAL_TELEGRAM_CHAT_ID
 	});
 	await notifier.notify(rename({ log: makeRadarrLog() }));
 });

--- a/tests/integration/notifications/specs/test.test.ts
+++ b/tests/integration/notifications/specs/test.test.ts
@@ -1,5 +1,5 @@
 /**
- * Test notification - definition + Discord + Ntfy + Webhook.
+ * Test notification - definition + Discord + Ntfy + Webhook + Telegram.
  */
 
 import { assertEquals, assertExists } from '@std/assert';
@@ -8,6 +8,7 @@ import { createMockServer, type CapturedRequest } from '../harness/mock-server.t
 import { DiscordNotifier } from '$notifications/notifiers/discord/DiscordNotifier.ts';
 import { NtfyNotifier } from '$notifications/notifiers/ntfy/NtfyNotifier.ts';
 import { WebhookNotifier } from '$notifications/notifiers/webhook/WebhookNotifier.ts';
+import { TelegramNotifier } from '$notifications/notifiers/telegram/TelegramNotifier.ts';
 import { Colors } from '$notifications/notifiers/discord/embed.ts';
 import { test as testDef } from '$notifications/definitions/test.ts';
 
@@ -19,6 +20,8 @@ let REAL_DISCORD: string | undefined;
 let REAL_NTFY_URL: string | undefined;
 let REAL_NTFY_TOPIC: string | undefined;
 let REAL_WEBHOOK_URL: string | undefined;
+let REAL_TELEGRAM_TOKEN: string | undefined;
+let REAL_TELEGRAM_CHAT_ID: string | undefined;
 try {
 	const envPath = new URL('../.env', import.meta.url).pathname;
 	const content = await Deno.readTextFile(envPath);
@@ -33,6 +36,8 @@ try {
 			if (key === 'TEST_NTFY_URL') REAL_NTFY_URL = value;
 			if (key === 'TEST_NTFY_TOPIC') REAL_NTFY_TOPIC = value;
 			if (key === 'TEST_WEBHOOK_URL') REAL_WEBHOOK_URL = value;
+			if (key === 'TEST_TELEGRAM_BOT_TOKEN') REAL_TELEGRAM_TOKEN = value;
+			if (key === 'TEST_TELEGRAM_CHAT_ID') REAL_TELEGRAM_CHAT_ID = value;
 		}
 	}
 } catch {
@@ -208,6 +213,67 @@ test('webhook: no Authorization header when auth_header absent', async () => {
 });
 
 // =========================================================================
+// Telegram
+// =========================================================================
+
+const MOCK_TOKEN = 'test-token-123';
+
+test('telegram: POSTs to /bot{token}/sendMessage', async () => {
+	captured.length = 0;
+	const notifier = new TelegramNotifier({
+		bot_token: MOCK_TOKEN,
+		chat_id: '123456',
+		api_base_url: `http://localhost:${MOCK_PORT}`
+	});
+	await notifier.notify(testDef());
+
+	assertEquals(captured.length, 1);
+	assertEquals(captured[0]?.method, 'POST');
+	assertEquals(captured[0]?.path, `/bot${MOCK_TOKEN}/sendMessage`);
+});
+
+test('telegram: payload has chat_id, text, and parse_mode HTML', async () => {
+	captured.length = 0;
+	const notifier = new TelegramNotifier({
+		bot_token: MOCK_TOKEN,
+		chat_id: '123456',
+		api_base_url: `http://localhost:${MOCK_PORT}`
+	});
+	await notifier.notify(testDef());
+
+	const payload = captured[0]?.body as Record<string, unknown>;
+	assertEquals(payload?.chat_id, '123456');
+	assertEquals(payload?.parse_mode, 'HTML');
+	assertEquals(typeof payload?.text, 'string');
+});
+
+test('telegram: info severity has emoji prefix', async () => {
+	captured.length = 0;
+	const notifier = new TelegramNotifier({
+		bot_token: MOCK_TOKEN,
+		chat_id: '123456',
+		api_base_url: `http://localhost:${MOCK_PORT}`
+	});
+	await notifier.notify(testDef());
+
+	const text = (captured[0]?.body as Record<string, unknown>)?.text as string;
+	assertEquals(text.startsWith('\u2139\uFE0F'), true);
+});
+
+test('telegram: renders title in bold HTML', async () => {
+	captured.length = 0;
+	const notifier = new TelegramNotifier({
+		bot_token: MOCK_TOKEN,
+		chat_id: '123456',
+		api_base_url: `http://localhost:${MOCK_PORT}`
+	});
+	await notifier.notify(testDef());
+
+	const text = (captured[0]?.body as Record<string, unknown>)?.text as string;
+	assertEquals(text.includes(`<b>${testDef().title}</b>`), true);
+});
+
+// =========================================================================
 // Real sends (skipped without .env)
 // =========================================================================
 
@@ -236,6 +302,16 @@ test('real: sends test notification to webhook', async () => {
 	await new Promise((r) => setTimeout(r, 2000));
 	const notifier = new WebhookNotifier({
 		webhook_url: REAL_WEBHOOK_URL
+	});
+	await notifier.notify(testDef());
+});
+
+test('real: sends test notification to Telegram', async () => {
+	if (!REAL_TELEGRAM_TOKEN || !REAL_TELEGRAM_CHAT_ID) return;
+	await new Promise((r) => setTimeout(r, 2000));
+	const notifier = new TelegramNotifier({
+		bot_token: REAL_TELEGRAM_TOKEN,
+		chat_id: REAL_TELEGRAM_CHAT_ID
 	});
 	await notifier.notify(testDef());
 });

--- a/tests/integration/notifications/specs/upgrade.test.ts
+++ b/tests/integration/notifications/specs/upgrade.test.ts
@@ -1,5 +1,5 @@
 /**
- * Upgrade notification - definition + Discord + Ntfy + Webhook.
+ * Upgrade notification - definition + Discord + Ntfy + Webhook + Telegram.
  */
 
 import { assertEquals, assertExists } from '@std/assert';
@@ -8,6 +8,7 @@ import { createMockServer, type CapturedRequest } from '../harness/mock-server.t
 import { DiscordNotifier } from '$notifications/notifiers/discord/DiscordNotifier.ts';
 import { NtfyNotifier } from '$notifications/notifiers/ntfy/NtfyNotifier.ts';
 import { WebhookNotifier } from '$notifications/notifiers/webhook/WebhookNotifier.ts';
+import { TelegramNotifier } from '$notifications/notifiers/telegram/TelegramNotifier.ts';
 import { Colors } from '$notifications/notifiers/discord/embed.ts';
 import { upgrade } from '$notifications/definitions/upgrade.ts';
 import type { UpgradeJobLog } from '$lib/server/upgrades/types.ts';
@@ -20,6 +21,8 @@ let REAL_DISCORD: string | undefined;
 let REAL_NTFY_URL: string | undefined;
 let REAL_NTFY_TOPIC: string | undefined;
 let REAL_WEBHOOK_URL: string | undefined;
+let REAL_TELEGRAM_TOKEN: string | undefined;
+let REAL_TELEGRAM_CHAT_ID: string | undefined;
 try {
 	const envPath = new URL('../.env', import.meta.url).pathname;
 	const content = await Deno.readTextFile(envPath);
@@ -34,6 +37,8 @@ try {
 			if (key === 'TEST_NTFY_URL') REAL_NTFY_URL = value;
 			if (key === 'TEST_NTFY_TOPIC') REAL_NTFY_TOPIC = value;
 			if (key === 'TEST_WEBHOOK_URL') REAL_WEBHOOK_URL = value;
+			if (key === 'TEST_TELEGRAM_BOT_TOKEN') REAL_TELEGRAM_TOKEN = value;
+			if (key === 'TEST_TELEGRAM_CHAT_ID') REAL_TELEGRAM_CHAT_ID = value;
 		}
 	}
 } catch {
@@ -491,6 +496,53 @@ test('webhook: sends full notification with all blocks', async () => {
 });
 
 // =========================================================================
+// Telegram
+// =========================================================================
+
+const MOCK_TOKEN = 'test-token-123';
+
+test('telegram: success has ✅ prefix', async () => {
+	captured.length = 0;
+	const notifier = new TelegramNotifier({
+		bot_token: MOCK_TOKEN,
+		chat_id: '123456',
+		api_base_url: `http://localhost:${MOCK_PORT}`
+	});
+	await notifier.notify(upgrade({ log: makeLog() }));
+
+	const text = (captured[0]?.body as Record<string, unknown>)?.text as string;
+	assertEquals(text.startsWith('\u2705'), true);
+});
+
+test('telegram: failed has ❌ prefix', async () => {
+	captured.length = 0;
+	const notifier = new TelegramNotifier({
+		bot_token: MOCK_TOKEN,
+		chat_id: '123456',
+		api_base_url: `http://localhost:${MOCK_PORT}`
+	});
+	await notifier.notify(upgrade({ log: makeLog({ status: 'failed' }) }));
+
+	const text = (captured[0]?.body as Record<string, unknown>)?.text as string;
+	assertEquals(text.startsWith('\u274C'), true);
+});
+
+test('telegram: message includes title but omits section blocks', async () => {
+	captured.length = 0;
+	const notifier = new TelegramNotifier({
+		bot_token: MOCK_TOKEN,
+		chat_id: '123456',
+		api_base_url: `http://localhost:${MOCK_PORT}`
+	});
+	await notifier.notify(upgrade({ log: makeLog() }));
+
+	const text = (captured[0]?.body as Record<string, unknown>)?.text as string;
+	assertEquals(text.includes('Movies'), true);
+	// Section content (release filenames) should not appear
+	assertEquals(text.includes('Interstellar.2014.2160p'), false);
+});
+
+// =========================================================================
 // Real sends (skipped without .env)
 // =========================================================================
 
@@ -530,6 +582,16 @@ test('real: sends upgrade to webhook', async () => {
 	await new Promise((r) => setTimeout(r, 2000));
 	const notifier = new WebhookNotifier({
 		webhook_url: REAL_WEBHOOK_URL
+	});
+	await notifier.notify(upgrade({ log: makeLog() }));
+});
+
+test('real: sends upgrade to Telegram', async () => {
+	if (!REAL_TELEGRAM_TOKEN || !REAL_TELEGRAM_CHAT_ID) return;
+	await new Promise((r) => setTimeout(r, 2000));
+	const notifier = new TelegramNotifier({
+		bot_token: REAL_TELEGRAM_TOKEN,
+		chat_id: REAL_TELEGRAM_CHAT_ID
 	});
 	await notifier.notify(upgrade({ log: makeLog() }));
 });


### PR DESCRIPTION
## What does this PR do?

- Adds Telegram as a notification service (summary tier)
- Adds `leadingIcon` prop to Button and icon support to DropdownSelect/DropdownItem
- Unifies notification service icons via simple-icons + lucide
- Replaces DropdownItem check marks with circular IconCheckbox

## Related issues
Part of #334