### PR TITLE
fix: cron input layout on weekly/monthly and mobile

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -9,11 +9,13 @@
   - [Starting Your Branch](#starting-your-branch)
   - [Staying Up to Date](#staying-up-to-date)
   - [Submitting a Pull Request](#submitting-a-pull-request)
+  - [PR Scope](#pr-scope)
 - [Guidelines](#guidelines)
   - [Naming](#naming)
   - [Code Conventions](#code-conventions)
   - [Off-Limits](#off-limits)
   - [Reporting Issues](#reporting-issues)
+  - [Closing Issues](#closing-issues)
 - [Examples](#examples)
   - [Adding a settings page](#adding-a-settings-page)
   - [Bug found during testing](#bug-found-during-testing)
@@ -243,6 +245,18 @@ the queue until `develop` is free, then get included in the next batch for
 testing. Community contributions are prioritised for testing over internal work
 where possible.
 
+### PR Scope
+
+One feature or fix per PR. If you spot something small while working (a typo,
+a missing null check, a wrong label) and it's in code you're already touching,
+it's fine to include it. If you'd describe the PR as doing two things, split it.
+
+The reason is squash merging: everything collapses into one commit. If a bundled
+change causes a regression, you can't revert just that part; you revert the
+whole PR. Keeping unrelated changes separate preserves that option.
+
+Doc-only changes (comments, wording, formatting) are always fine to bundle.
+
 ## Guidelines
 
 ### Naming
@@ -299,6 +313,17 @@ includes the op replay system, the compile pipeline, and the export flow. See
 Use the
 [GitHub issue templates](https://github.com/Dictionarry-Hub/profilarr/issues/new/choose).
 There are templates for bugs, feature requests, and general feedback.
+
+### Closing Issues
+
+Close an issue when the fixing PR merges into `develop`. There's no need to
+wait for a stable release. The work is done and in the pipeline. Leave a short
+comment so the reporter knows what to expect:
+
+> Fixed in `develop`, will ship with the next release.
+
+Duplicates, out-of-scope requests, and won't-fix decisions should be closed
+immediately with a brief explanation.
 
 ## Examples
 

--- a/src/lib/client/ui/cron/CronInput.svelte
+++ b/src/lib/client/ui/cron/CronInput.svelte
@@ -7,6 +7,7 @@
 
 	export let value: string = '0 * * * *';
 	export let disabled: boolean = false;
+	export let fixed: boolean = false;
 	export let minIntervalMinutes: number = 0;
 	export let onWarning: ((message: string) => void) | undefined = undefined;
 
@@ -244,13 +245,14 @@
 </script>
 
 <div
-	class="flex items-center gap-1.5"
+	class="flex items-center gap-1.5 md:flex-nowrap"
 	class:flex-wrap={scheduleType === 'weekly' || scheduleType === 'monthly'}
 >
 	<DropdownSelect
 		value={scheduleType}
 		options={scheduleOptions}
 		{disabled}
+		{fixed}
 		buttonSize="sm"
 		width="w-24"
 		justify="center"
@@ -312,11 +314,12 @@
 			}}
 		/>
 	{:else if scheduleType === 'weekly'}
-		<div class="basis-full"></div>
+		<div class="basis-full md:hidden"></div>
 		<DropdownSelect
 			value={String(weeklyDay)}
 			options={weekdayOptions}
 			{disabled}
+			{fixed}
 			buttonSize="sm"
 			width="w-20"
 			justify="center"
@@ -338,7 +341,7 @@
 			}}
 		/>
 	{:else if scheduleType === 'monthly'}
-		<div class="basis-full"></div>
+		<div class="basis-full md:hidden"></div>
 		<span class="text-sm text-neutral-500 dark:text-neutral-400">day</span>
 		<div class="w-24">
 			<NumberInput

--- a/src/routes/arr/components/InstanceForm.svelte
+++ b/src/routes/arr/components/InstanceForm.svelte
@@ -437,13 +437,16 @@
 
 					{#if cleanupEnabled}
 						<!-- Schedule -->
-						<span class="text-sm text-neutral-500 md:hidden dark:text-neutral-400">Schedule</span>
-						<div class="md:flex md:items-center md:gap-2">
+						<div class="col-span-2 md:col-span-1 md:flex md:items-center md:gap-2">
+							<span class="mb-1 block text-sm text-neutral-500 md:hidden dark:text-neutral-400"
+								>Schedule</span
+							>
 							<span class="hidden text-sm text-neutral-500 md:inline dark:text-neutral-400"
 								>Schedule:</span
 							>
 							<CronInput
 								bind:value={cronInputValue}
+								fixed={true}
 								minIntervalMinutes={60}
 								onWarning={(msg) => alertStore.add('warning', msg)}
 							/>


### PR DESCRIPTION
- Fixes weekly/monthly schedule type wrapping onto a new line on desktop wide view
- Corrects mobile layout in the cleanup section of instance settings
- Adds PR scope and issue closing guidelines to CONTRIBUTING.md