### PR TITLE
feat: add GET /api/v1/arr endpoint

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -43,7 +43,7 @@
 		"check:server": "deno check --quiet src/lib/server/**/*.ts",
 		"check:client": "NODE_ENV=development npx svelte-check --tsconfig ./tsconfig.json",
 		"test": "deno run -A tests/runner.ts",
-		"generate:api-types": "npx openapi-typescript docs/api/v1/openapi.yaml -o src/lib/api/v1.d.ts",
+		"generate:api-types": "npx openapi-typescript docs/api/v1/openapi.yaml -o src/lib/api/v1.d.ts && prettier --write src/lib/api/v1.d.ts",
 		"generate:pcd-types": "deno run -A scripts/generate-pcd-types.ts",
 		"stats": "bash scripts/stats.sh",
 		"webhook": "deno run --allow-net scripts/webhook-listener.ts"

--- a/deno.json
+++ b/deno.json
@@ -26,7 +26,8 @@
 		"marked": "npm:marked@^15.0.6",
 		"simple-icons": "npm:simple-icons@^15.17.0",
 		"croner": "npm:croner@^9.1.0",
-		"@felix/bcrypt": "jsr:@felix/bcrypt@^1.0.8"
+		"@felix/bcrypt": "jsr:@felix/bcrypt@^1.0.8",
+		"@db/sqlite": "jsr:@db/sqlite@0.12"
 	},
 	"tasks": {
 		"dev": "deno run -A scripts/dev.ts",

--- a/deno.lock
+++ b/deno.lock
@@ -1634,6 +1634,7 @@
   },
   "workspace": {
     "dependencies": [
+      "jsr:@db/sqlite@0.12",
       "jsr:@felix/bcrypt@^1.0.8",
       "jsr:@soapbox/kysely-deno-sqlite@^2.2.0",
       "jsr:@std/assert@1",

--- a/docs/api/v1/openapi.yaml
+++ b/docs/api/v1/openapi.yaml
@@ -17,7 +17,7 @@ tags:
   - name: Entity Testing
     description: Release parsing and custom format evaluation
   - name: Arr
-    description: Arr instance library and release endpoints
+    description: Arr instance management, library, and sync endpoints
   - name: PCD
     description: PCD entity export and portable format endpoints
   - name: Databases
@@ -26,6 +26,8 @@ tags:
     description: Regex pattern validation
 
 paths:
+  /arr:
+    $ref: './paths/arr.yaml#/instances'
   /databases:
     $ref: './paths/databases.yaml#/databases'
   /health:
@@ -144,6 +146,9 @@ components:
       $ref: './schemas/pcd.yaml#/ImportRequest'
     ImportResponse:
       $ref: './schemas/pcd.yaml#/ImportResponse'
+    # Arr
+    ArrInstance:
+      $ref: './schemas/arr.yaml#/ArrInstance'
     # Databases
     DatabaseInstance:
       $ref: './schemas/databases.yaml#/DatabaseInstance'

--- a/docs/api/v1/paths/arr.yaml
+++ b/docs/api/v1/paths/arr.yaml
@@ -1,3 +1,32 @@
+instances:
+  get:
+    operationId: listArrInstances
+    summary: List Arr Instances
+    description: |
+      Returns all Arr instances (Radarr/Sonarr) with secrets stripped.
+
+      **Use cases:**
+      - Dashboard widgets showing connected instances
+      - Automation scripts checking instance state
+      - Prerequisite checks (e.g. onboarding)
+
+      **Behavior:**
+      - Returns an empty array if no instances are connected
+      - The `api_key` field is never included
+    tags:
+      - Arr
+    responses:
+      '200':
+        description: List of Arr instances
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '../schemas/arr.yaml#/ArrInstance'
+      '401':
+        description: Not authenticated
+
 library:
   get:
     operationId: getLibrary

--- a/docs/api/v1/schemas/arr.yaml
+++ b/docs/api/v1/schemas/arr.yaml
@@ -1,3 +1,47 @@
+ArrInstance:
+  type: object
+  required:
+    - id
+    - name
+    - type
+    - url
+    - enabled
+    - library_refresh_interval
+    - created_at
+    - updated_at
+  properties:
+    id:
+      type: integer
+      description: Instance ID
+    name:
+      type: string
+      description: Display name
+    type:
+      $ref: '#/ArrType'
+    url:
+      type: string
+      description: Instance URL
+    tags:
+      type: string
+      nullable: true
+      description: JSON array of tags
+    enabled:
+      type: integer
+      description: Whether the instance is active (0 or 1)
+    library_refresh_interval:
+      type: integer
+      description: Library cache refresh interval in minutes (0 = manual)
+    library_last_refreshed_at:
+      type: string
+      nullable: true
+      description: Last library refresh timestamp
+    created_at:
+      type: string
+      description: Creation timestamp
+    updated_at:
+      type: string
+      description: Last update timestamp
+
 ArrType:
   type: string
   enum:

--- a/src/lib/api/v1.d.ts
+++ b/src/lib/api/v1.d.ts
@@ -4,1723 +4,1761 @@
  */
 
 export interface paths {
-	'/databases': {
-		parameters: {
-			query?: never;
-			header?: never;
-			path?: never;
-			cookie?: never;
-		};
-		/**
-		 * List Databases
-		 * @description Returns all linked database instances with secrets stripped.
-		 *
-		 *     **Use cases:**
-		 *     - Dashboard widgets showing connected databases
-		 *     - Automation scripts checking database state
-		 *     - Prerequisite checks (e.g. cutscene onboarding)
-		 *
-		 *     **Behavior:**
-		 *     - Returns an empty array if no databases are linked
-		 *     - The `personal_access_token` field is never included; `hasPat` indicates
-		 *       whether one is configured
-		 *     - The `local_path` field is excluded (internal detail)
-		 */
-		get: operations['listDatabases'];
-		put?: never;
-		post?: never;
-		delete?: never;
-		options?: never;
-		head?: never;
-		patch?: never;
-		trace?: never;
-	};
-	'/health': {
-		parameters: {
-			query?: never;
-			header?: never;
-			path?: never;
-			cookie?: never;
-		};
-		/**
-		 * Health check (public)
-		 * @description Public endpoint for uptime monitors. Returns only the overall status and
-		 *     timestamp — no version, uptime, or component details.
-		 *
-		 *     Status values:
-		 *     - `healthy`: All components functioning normally
-		 *     - `degraded`: Core functionality works but some components have issues
-		 *     - `unhealthy`: Core functionality is broken
-		 */
-		get: operations['getHealth'];
-		put?: never;
-		post?: never;
-		delete?: never;
-		options?: never;
-		head?: never;
-		patch?: never;
-		trace?: never;
-	};
-	'/health/diagnostics': {
-		parameters: {
-			query?: never;
-			header?: never;
-			path?: never;
-			cookie?: never;
-		};
-		/**
-		 * Health diagnostics (authenticated)
-		 * @description Detailed health diagnostics including version, uptime, and per-component
-		 *     status. Requires authentication (session or API key).
-		 *
-		 *     Use `?verbose=true` for additional counts, sizes, and timestamps.
-		 */
-		get: operations['getHealthDiagnostics'];
-		put?: never;
-		post?: never;
-		delete?: never;
-		options?: never;
-		head?: never;
-		patch?: never;
-		trace?: never;
-	};
-	'/openapi.json': {
-		parameters: {
-			query?: never;
-			header?: never;
-			path?: never;
-			cookie?: never;
-		};
-		/**
-		 * OpenAPI specification
-		 * @description Returns the OpenAPI specification for this API
-		 */
-		get: operations['getOpenApiSpec'];
-		put?: never;
-		post?: never;
-		delete?: never;
-		options?: never;
-		head?: never;
-		patch?: never;
-		trace?: never;
-	};
-	'/entity-testing/evaluate': {
-		parameters: {
-			query?: never;
-			header?: never;
-			path?: never;
-			cookie?: never;
-		};
-		get?: never;
-		put?: never;
-		/**
-		 * Evaluate releases against custom formats
-		 * @description Parses release titles and evaluates them against all custom formats in the specified database.
-		 *
-		 *     This endpoint:
-		 *     - Parses each release title to extract metadata (resolution, source, languages, etc.)
-		 *     - Matches regex patterns using .NET-compatible regex via the parser service
-		 *     - Evaluates each release against all custom formats in the database
-		 *     - Returns which custom formats match each release
-		 *
-		 *     Results are cached for performance - repeated requests with the same titles will be faster.
-		 */
-		post: operations['evaluateReleases'];
-		delete?: never;
-		options?: never;
-		head?: never;
-		patch?: never;
-		trace?: never;
-	};
-	'/arr/library': {
-		parameters: {
-			query?: never;
-			header?: never;
-			path?: never;
-			cookie?: never;
-		};
-		/**
-		 * Get Arr instance library
-		 * @description Fetches the full movie or series library from an Arr instance with quality profile,
-		 *     score, and progress information.
-		 *
-		 *     - For Radarr: Returns movies with file quality, custom format scores, and cutoff progress
-		 *     - For Sonarr: Returns series with season summaries and episode statistics
-		 *
-		 *     Results include Profilarr profile matching to indicate which items use managed profiles.
-		 *     Responses are cached server-side for 5 minutes.
-		 */
-		get: operations['getLibrary'];
-		put?: never;
-		post?: never;
-		/**
-		 * Invalidate library cache
-		 * @description Clears the server-side cache for an Arr instance's library data.
-		 *     The next GET request will fetch fresh data from the Arr instance.
-		 */
-		delete: operations['invalidateLibraryCache'];
-		options?: never;
-		head?: never;
-		patch?: never;
-		trace?: never;
-	};
-	'/arr/library/episodes': {
-		parameters: {
-			query?: never;
-			header?: never;
-			path?: never;
-			cookie?: never;
-		};
-		/**
-		 * Get episode details for a Sonarr series
-		 * @description Lazy-loads episode-level data for a specific series in a Sonarr instance.
-		 *     Returns episodes with quality, custom format scores, and cutoff progress.
-		 *
-		 *     This endpoint is designed for on-demand loading when a series row is expanded
-		 *     in the library view. Sonarr instances only.
-		 *
-		 *     Results are cached server-side for 5 minutes per series.
-		 */
-		get: operations['getLibraryEpisodes'];
-		put?: never;
-		post?: never;
-		delete?: never;
-		options?: never;
-		head?: never;
-		patch?: never;
-		trace?: never;
-	};
-	'/arr/releases': {
-		parameters: {
-			query?: never;
-			header?: never;
-			path?: never;
-			cookie?: never;
-		};
-		/**
-		 * Search for releases
-		 * @description Triggers an interactive search on an Arr instance and returns grouped/deduplicated results.
-		 *
-		 *     For Radarr: Searches for releases for the specified movie.
-		 *     For Sonarr: Searches for season pack releases for the specified series and season.
-		 *
-		 *     Results are grouped by title, combining information from multiple indexers.
-		 */
-		get: operations['getReleases'];
-		put?: never;
-		post?: never;
-		delete?: never;
-		options?: never;
-		head?: never;
-		patch?: never;
-		trace?: never;
-	};
-	'/arr/cleanup': {
-		parameters: {
-			query?: never;
-			header?: never;
-			path?: never;
-			cookie?: never;
-		};
-		get?: never;
-		put?: never;
-		/**
-		 * Scan or execute cleanup of stale configs
-		 * @description Detects and deletes stale namespace-suffixed custom formats and quality profiles
-		 *     from an Arr instance that are no longer in the current sync selections.
-		 *
-		 *     Two actions are supported via the `action` field in the request body:
-		 *     - `scan`: Scans for stale items and returns what would be deleted.
-		 *     - `execute`: Deletes the stale items from a previous scan result.
-		 *
-		 *     Quality profiles assigned to media will be skipped with a warning (Arr returns HTTP 500 "in use").
-		 */
-		post: operations['arrCleanup'];
-		delete?: never;
-		options?: never;
-		head?: never;
-		patch?: never;
-		trace?: never;
-	};
-	'/arr/sync-entity': {
-		parameters: {
-			query?: never;
-			header?: never;
-			path?: never;
-			cookie?: never;
-		};
-		get?: never;
-		put?: never;
-		/**
-		 * Sync a single entity to an Arr instance
-		 * @description Pushes a single entity to an Arr instance. Runs inline and returns when complete.
-		 *
-		 *     Entity types are grouped into sync sections that share cooldown and status tracking:
-		 *       - **qualityProfiles**: qualityProfile, customFormat, regularExpression
-		 *       - **delayProfiles**: delayProfile
-		 *       - **mediaManagement**: naming, qualityDefinitions, mediaSettings
-		 *
-		 *     The section is derived automatically from the entity type. A 5-second cooldown
-		 *     is enforced per section per instance — entity types within the same section share
-		 *     the cooldown. Returns 409 if a sync is already in progress or the cooldown is active.
-		 */
-		post: operations['syncEntity'];
-		delete?: never;
-		options?: never;
-		head?: never;
-		patch?: never;
-		trace?: never;
-	};
-	'/pcd/export': {
-		parameters: {
-			query?: never;
-			header?: never;
-			path?: never;
-			cookie?: never;
-		};
-		/**
-		 * Export a portable entity
-		 * @description Serializes a PCD entity into its portable JSON representation.
-		 *
-		 *     The portable format strips database IDs and timestamps, producing a
-		 *     self-contained snapshot suitable for clipboard copy, file export, or
-		 *     cross-database import.
-		 */
-		get: operations['exportEntity'];
-		put?: never;
-		post?: never;
-		delete?: never;
-		options?: never;
-		head?: never;
-		patch?: never;
-		trace?: never;
-	};
-	'/pcd/import': {
-		parameters: {
-			query?: never;
-			header?: never;
-			path?: never;
-			cookie?: never;
-		};
-		get?: never;
-		put?: never;
-		/**
-		 * Import a portable entity
-		 * @description Deserializes a portable entity into PCD operations, creating the entity
-		 *     in the target database and layer.
-		 *
-		 *     The request body matches the export response format (`entityType` + `data`),
-		 *     plus `databaseId` and `layer` to specify the target.
-		 *
-		 *     Name uniqueness is validated — importing an entity with a name that already
-		 *     exists will return a 400 error.
-		 */
-		post: operations['importEntity'];
-		delete?: never;
-		options?: never;
-		head?: never;
-		patch?: never;
-		trace?: never;
-	};
-	'/regex/validate': {
-		parameters: {
-			query?: never;
-			header?: never;
-			path?: never;
-			cookie?: never;
-		};
-		get?: never;
-		put?: never;
-		/**
-		 * Validate a .NET regex pattern
-		 * @description Validates a regex pattern using the .NET regex engine (via the parser service).
-		 *     This matches the exact validation Radarr and Sonarr perform when importing custom formats.
-		 *     If the parser service is offline, returns { valid: true } to avoid blocking saves.
-		 */
-		post: operations['validateRegex'];
-		delete?: never;
-		options?: never;
-		head?: never;
-		patch?: never;
-		trace?: never;
-	};
+    "/arr": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Arr Instances
+         * @description Returns all Arr instances (Radarr/Sonarr) with secrets stripped.
+         *
+         *     **Use cases:**
+         *     - Dashboard widgets showing connected instances
+         *     - Automation scripts checking instance state
+         *     - Prerequisite checks (e.g. onboarding)
+         *
+         *     **Behavior:**
+         *     - Returns an empty array if no instances are connected
+         *     - The `api_key` field is never included
+         */
+        get: operations["listArrInstances"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/databases": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Databases
+         * @description Returns all linked database instances with secrets stripped.
+         *
+         *     **Use cases:**
+         *     - Dashboard widgets showing connected databases
+         *     - Automation scripts checking database state
+         *     - Prerequisite checks (e.g. cutscene onboarding)
+         *
+         *     **Behavior:**
+         *     - Returns an empty array if no databases are linked
+         *     - The `personal_access_token` field is never included; `hasPat` indicates
+         *       whether one is configured
+         *     - The `local_path` field is excluded (internal detail)
+         */
+        get: operations["listDatabases"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/health": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Health check (public)
+         * @description Public endpoint for uptime monitors. Returns only the overall status and
+         *     timestamp — no version, uptime, or component details.
+         *
+         *     Status values:
+         *     - `healthy`: All components functioning normally
+         *     - `degraded`: Core functionality works but some components have issues
+         *     - `unhealthy`: Core functionality is broken
+         */
+        get: operations["getHealth"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/health/diagnostics": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Health diagnostics (authenticated)
+         * @description Detailed health diagnostics including version, uptime, and per-component
+         *     status. Requires authentication (session or API key).
+         *
+         *     Use `?verbose=true` for additional counts, sizes, and timestamps.
+         */
+        get: operations["getHealthDiagnostics"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/openapi.json": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * OpenAPI specification
+         * @description Returns the OpenAPI specification for this API
+         */
+        get: operations["getOpenApiSpec"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/entity-testing/evaluate": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Evaluate releases against custom formats
+         * @description Parses release titles and evaluates them against all custom formats in the specified database.
+         *
+         *     This endpoint:
+         *     - Parses each release title to extract metadata (resolution, source, languages, etc.)
+         *     - Matches regex patterns using .NET-compatible regex via the parser service
+         *     - Evaluates each release against all custom formats in the database
+         *     - Returns which custom formats match each release
+         *
+         *     Results are cached for performance - repeated requests with the same titles will be faster.
+         */
+        post: operations["evaluateReleases"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/arr/library": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Arr instance library
+         * @description Fetches the full movie or series library from an Arr instance with quality profile,
+         *     score, and progress information.
+         *
+         *     - For Radarr: Returns movies with file quality, custom format scores, and cutoff progress
+         *     - For Sonarr: Returns series with season summaries and episode statistics
+         *
+         *     Results include Profilarr profile matching to indicate which items use managed profiles.
+         *     Responses are cached server-side for 5 minutes.
+         */
+        get: operations["getLibrary"];
+        put?: never;
+        post?: never;
+        /**
+         * Invalidate library cache
+         * @description Clears the server-side cache for an Arr instance's library data.
+         *     The next GET request will fetch fresh data from the Arr instance.
+         */
+        delete: operations["invalidateLibraryCache"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/arr/library/episodes": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get episode details for a Sonarr series
+         * @description Lazy-loads episode-level data for a specific series in a Sonarr instance.
+         *     Returns episodes with quality, custom format scores, and cutoff progress.
+         *
+         *     This endpoint is designed for on-demand loading when a series row is expanded
+         *     in the library view. Sonarr instances only.
+         *
+         *     Results are cached server-side for 5 minutes per series.
+         */
+        get: operations["getLibraryEpisodes"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/arr/releases": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Search for releases
+         * @description Triggers an interactive search on an Arr instance and returns grouped/deduplicated results.
+         *
+         *     For Radarr: Searches for releases for the specified movie.
+         *     For Sonarr: Searches for season pack releases for the specified series and season.
+         *
+         *     Results are grouped by title, combining information from multiple indexers.
+         */
+        get: operations["getReleases"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/arr/cleanup": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Scan or execute cleanup of stale configs
+         * @description Detects and deletes stale namespace-suffixed custom formats and quality profiles
+         *     from an Arr instance that are no longer in the current sync selections.
+         *
+         *     Two actions are supported via the `action` field in the request body:
+         *     - `scan`: Scans for stale items and returns what would be deleted.
+         *     - `execute`: Deletes the stale items from a previous scan result.
+         *
+         *     Quality profiles assigned to media will be skipped with a warning (Arr returns HTTP 500 "in use").
+         */
+        post: operations["arrCleanup"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/arr/sync-entity": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Sync a single entity to an Arr instance
+         * @description Pushes a single entity to an Arr instance. Runs inline and returns when complete.
+         *
+         *     Entity types are grouped into sync sections that share cooldown and status tracking:
+         *       - **qualityProfiles**: qualityProfile, customFormat, regularExpression
+         *       - **delayProfiles**: delayProfile
+         *       - **mediaManagement**: naming, qualityDefinitions, mediaSettings
+         *
+         *     The section is derived automatically from the entity type. A 5-second cooldown
+         *     is enforced per section per instance — entity types within the same section share
+         *     the cooldown. Returns 409 if a sync is already in progress or the cooldown is active.
+         */
+        post: operations["syncEntity"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/pcd/export": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Export a portable entity
+         * @description Serializes a PCD entity into its portable JSON representation.
+         *
+         *     The portable format strips database IDs and timestamps, producing a
+         *     self-contained snapshot suitable for clipboard copy, file export, or
+         *     cross-database import.
+         */
+        get: operations["exportEntity"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/pcd/import": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Import a portable entity
+         * @description Deserializes a portable entity into PCD operations, creating the entity
+         *     in the target database and layer.
+         *
+         *     The request body matches the export response format (`entityType` + `data`),
+         *     plus `databaseId` and `layer` to specify the target.
+         *
+         *     Name uniqueness is validated — importing an entity with a name that already
+         *     exists will return a 400 error.
+         */
+        post: operations["importEntity"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/regex/validate": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Validate a .NET regex pattern
+         * @description Validates a regex pattern using the .NET regex engine (via the parser service).
+         *     This matches the exact validation Radarr and Sonarr perform when importing custom formats.
+         *     If the parser service is offline, returns { valid: true } to avoid blocking saves.
+         */
+        post: operations["validateRegex"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
-	schemas: {
-		/**
-		 * @description Individual component health status
-		 * @enum {string}
-		 */
-		ComponentStatus: 'healthy' | 'degraded' | 'unhealthy';
-		/**
-		 * @description Overall health status
-		 * @enum {string}
-		 */
-		HealthStatus: 'healthy' | 'degraded' | 'unhealthy';
-		HealthCheckResponse: {
-			status: components['schemas']['HealthStatus'];
-			/**
-			 * Format: date-time
-			 * @description Current server time
-			 */
-			timestamp: string;
-		};
-		HealthDiagnosticsResponse: {
-			status: components['schemas']['HealthStatus'];
-			/**
-			 * Format: date-time
-			 * @description Current server time
-			 */
-			timestamp: string;
-			/** @description Application version */
-			version: string;
-			/** @description Server uptime in seconds */
-			uptime: number;
-			components: {
-				sqlite: components['schemas']['SqliteHealth'];
-				repos: components['schemas']['ReposHealth'];
-				jobs: components['schemas']['JobsHealth'];
-				backups: components['schemas']['BackupsHealth'];
-				logs: components['schemas']['LogsHealth'];
-			};
-		};
-		/**
-		 * @description Type of media
-		 * @enum {string}
-		 */
-		MediaType: 'movie' | 'series';
-		ParsedInfo: {
-			/** @description Detected source (e.g., bluray, webdl, webrip) */
-			source: string;
-			/** @description Detected resolution (e.g., 1080p, 2160p) */
-			resolution: string;
-			/** @description Quality modifier (e.g., remux, none) */
-			modifier: string;
-			/** @description Detected languages */
-			languages: string[];
-			/**
-			 * @description Where the language information came from (Indexer = indexer-provided, Title = parsed from release title)
-			 * @enum {string}
-			 */
-			languageSource: 'Indexer' | 'Title';
-			/** @description Detected release group */
-			releaseGroup?: string | null;
-			/** @description Detected year */
-			year: number;
-			/** @description Detected edition (e.g., Director's Cut) */
-			edition?: string | null;
-			/** @description Release type for series (single_episode, season_pack, etc.) */
-			releaseType?: string | null;
-		};
-		ReleaseInput: {
-			/** @description Release ID */
-			id: number;
-			/** @description Release title to parse and evaluate */
-			title: string;
-			type: components['schemas']['MediaType'];
-			/** @description Indexer-provided languages. When present and non-empty, these override languages parsed from the title. */
-			languages?: string[];
-		};
-		ReleaseEvaluation: {
-			/** @description Release ID */
-			releaseId: number;
-			/** @description Release title */
-			title: string;
-			/** @description Parsed release info (null if parsing failed) */
-			parsed?: components['schemas']['ParsedInfo'];
-			/** @description Map of custom format ID to whether it matches */
-			cfMatches: {
-				[key: string]: boolean;
-			};
-		};
-		EvaluateRequest: {
-			/** @description Database ID to use for custom format evaluation. If omitted, only parsing is performed (no CF matching). */
-			databaseId?: number;
-			/** @description Releases to evaluate */
-			releases: components['schemas']['ReleaseInput'][];
-		};
-		EvaluateResponse: {
-			/** @description Whether the parser service is available */
-			parserAvailable: boolean;
-			/** @description Evaluation results for each release */
-			evaluations: components['schemas']['ReleaseEvaluation'][];
-		};
-		/**
-		 * @description Type of Arr instance
-		 * @enum {string}
-		 */
-		ArrType: 'radarr' | 'sonarr';
-		CustomFormatRef: {
-			/** @description Custom format ID */
-			id: number;
-			/** @description Custom format name */
-			name: string;
-		};
-		ScoreBreakdownItem: {
-			/** @description Custom format name */
-			name: string;
-			/** @description Score assigned by the quality profile */
-			score: number;
-		};
-		ProfileByDatabase: {
-			/** @description Profilarr database ID */
-			databaseId: number;
-			/** @description Profilarr database name */
-			databaseName: string;
-			/** @description Quality profile names in this database */
-			profiles: string[];
-		};
-		ErrorResponse: {
-			/** @description Error message */
-			error: string;
-		};
-		RadarrLibraryItem: {
-			/** @description Radarr movie ID */
-			id: number;
-			/** @description TMDB ID */
-			tmdbId?: number;
-			/** @description IMDB ID */
-			imdbId?: string;
-			/** @description Movie title */
-			title: string;
-			/** @description Release year */
-			year?: number;
-			/** @description Assigned quality profile ID */
-			qualityProfileId: number;
-			/** @description Assigned quality profile name */
-			qualityProfileName: string;
-			/** @description Whether the movie has a downloaded file */
-			hasFile: boolean;
-			/** @description Whether the movie is monitored */
-			monitored: boolean;
-			/** @description Movie status (released, announced, inCinemas) */
-			status?: string;
-			/**
-			 * Format: date-time
-			 * @description When the movie was added
-			 */
-			dateAdded?: string;
-			/** @description TMDB popularity score */
-			popularity?: number;
-			/** @description File size in bytes */
-			sizeOnDisk?: number;
-			/** @description Runtime in minutes */
-			runtime?: number;
-			/** @description Content rating (e.g. R, PG-13) */
-			certification?: string;
-			/** @description Genre list */
-			genres?: string[];
-			/** @description Production studio */
-			studio?: string;
-			/** @description Ratings from various sources */
-			ratings?: {
-				imdb?: components['schemas']['RatingSource'];
-				tmdb?: components['schemas']['RatingSource'];
-				metacritic?: components['schemas']['RatingSource'];
-				rottenTomatoes?: components['schemas']['RatingSource'];
-				trakt?: components['schemas']['RatingSource'];
-			};
-			/** @description Poster and fanart images */
-			images?: components['schemas']['ArrImage'][];
-			collection?: {
-				title?: string;
-				tmdbId?: number;
-			};
-			originalLanguage?: {
-				id?: number;
-				name?: string;
-			};
-			/** @description Quality of the downloaded file (null if no file) */
-			qualityName?: string | null;
-			/** @description File name of the downloaded file (null if no file) */
-			fileName?: string | null;
-			/** @description Release group name from the file */
-			releaseGroup?: string;
-			/** @description Edition name (e.g. Final Cut, Director's Cut) */
-			edition?: string;
-			/** @description Languages in the file */
-			languages?: {
-				id?: number;
-				name?: string;
-			}[];
-			mediaInfo?: components['schemas']['ArrMediaInfo'];
-			/** @description Custom formats matched on the file */
-			customFormats: components['schemas']['CustomFormatRef'][];
-			/** @description Total custom format score */
-			customFormatScore: number;
-			/** @description Per-custom-format score breakdown */
-			scoreBreakdown: components['schemas']['ScoreBreakdownItem'][];
-			/** @description Profile cutoff score threshold */
-			cutoffScore: number;
-			/** @description Profile minimum score threshold */
-			minScore: number;
-			/** @description Score progress toward cutoff (0-1+) */
-			progress: number;
-			/** @description Whether the cutoff score has been met */
-			cutoffMet: boolean;
-			/** @description Whether the profile is managed by Profilarr */
-			isProfilarrProfile: boolean;
-		};
-		SonarrSeasonItem: {
-			/** @description Season number (0 = specials) */
-			seasonNumber: number;
-			/** @description Whether this season is monitored */
-			monitored: boolean;
-			/** @description Number of aired episodes */
-			episodeCount: number;
-			/** @description Number of episodes with files */
-			episodeFileCount: number;
-			/** @description Total episodes including unaired */
-			totalEpisodeCount: number;
-			/** @description Total size of episode files in bytes */
-			sizeOnDisk: number;
-			/** @description Percentage of episodes with files (0-100) */
-			percentOfEpisodes: number;
-		};
-		SonarrLibraryItem: {
-			/** @description Sonarr series ID */
-			id: number;
-			/** @description TVDB ID */
-			tvdbId?: number;
-			/** @description Series title */
-			title: string;
-			/** @description URL-friendly slug from Sonarr (used for series page links) */
-			titleSlug?: string;
-			/** @description First air year */
-			year?: number;
-			/** @description Assigned quality profile ID */
-			qualityProfileId: number;
-			/** @description Assigned quality profile name */
-			qualityProfileName: string;
-			/** @description Series status (continuing, ended, etc.) */
-			status?: string;
-			/** @description Whether the series is monitored */
-			monitored: boolean;
-			/** @description Number of seasons */
-			seasonCount: number;
-			/** @description Number of aired episodes */
-			episodeCount: number;
-			/** @description Number of episodes with files */
-			episodeFileCount: number;
-			/** @description Total episodes including unaired */
-			totalEpisodeCount: number;
-			/** @description Total size of all episode files in bytes */
-			sizeOnDisk: number;
-			/** @description Percentage of episodes with files (0-100) */
-			percentOfEpisodes: number;
-			/**
-			 * Format: date-time
-			 * @description When the series was added
-			 */
-			dateAdded?: string;
-			/** @description Season-level statistics */
-			seasons: components['schemas']['SonarrSeasonItem'][];
-			/** @description Whether the profile is managed by Profilarr */
-			isProfilarrProfile: boolean;
-			/** @description TV network (e.g. HBO, CBS) */
-			network?: string;
-			/** @description Series type (standard, daily, anime) */
-			seriesType?: string;
-			/** @description Content rating (e.g. TV-MA, TV-PG) */
-			certification?: string;
-			/** @description Genre list */
-			genres?: string[];
-			/** @description Episode runtime in minutes */
-			runtime?: number;
-			ratings?: {
-				votes?: number;
-				value?: number;
-			};
-			/** @description Poster, banner, fanart images */
-			images?: components['schemas']['ArrImage'][];
-			originalLanguage?: {
-				id?: number;
-				name?: string;
-			};
-			/**
-			 * Format: date-time
-			 * @description First air date
-			 */
-			firstAired?: string;
-			/**
-			 * Format: date-time
-			 * @description Last air date
-			 */
-			lastAired?: string;
-			/** @description IMDB ID */
-			imdbId?: string;
-		};
-		SonarrEpisodeItem: {
-			/** @description Sonarr episode ID */
-			id: number;
-			/** @description Episode number within the season */
-			episodeNumber: number;
-			/** @description Season number */
-			seasonNumber: number;
-			/** @description Episode title */
-			title: string;
-			/** @description Whether the episode has a downloaded file */
-			hasFile: boolean;
-			/** @description Whether the episode is monitored */
-			monitored: boolean;
-			/** @description Quality of the downloaded file */
-			qualityName?: string;
-			/** @description File name of the downloaded file */
-			fileName?: string;
-			/** @description File size in bytes */
-			size?: number;
-			/** @description Custom formats matched on the file */
-			customFormats: components['schemas']['CustomFormatRef'][];
-			/** @description Total custom format score */
-			customFormatScore: number;
-			/** @description Per-custom-format score breakdown */
-			scoreBreakdown: components['schemas']['ScoreBreakdownItem'][];
-			/** @description Profile cutoff score threshold */
-			cutoffScore: number;
-			/** @description Score progress toward cutoff (0-1+) */
-			progress: number;
-			/** @description Whether the cutoff score has been met */
-			cutoffMet: boolean;
-			/** @description Release group name from the file */
-			releaseGroup?: string;
-			/** @description Languages in the file */
-			languages?: {
-				id?: number;
-				name?: string;
-			}[];
-			mediaInfo?: components['schemas']['ArrMediaInfo'];
-		};
-		/** @description Library response varies by instance type */
-		LibraryResponse:
-			| components['schemas']['LibraryRadarrResponse']
-			| components['schemas']['LibrarySonarrResponse'];
-		EpisodesResponse: {
-			/** @description Episode details with quality and score data */
-			episodes: components['schemas']['SonarrEpisodeItem'][];
-		};
-		CacheInvalidatedResponse: {
-			/** @description Whether the cache was invalidated */
-			success: boolean;
-		};
-		GroupedRelease: {
-			/** @description Release title */
-			title: string;
-			/** @description Release size in bytes */
-			size: number;
-			/** @description Languages detected in the release */
-			languages: string[];
-			/** @description Indexers where this release was found */
-			indexers: string[];
-			/** @description Release flags (e.g., freeleech, internal) */
-			flags: string[];
-		};
-		ReleasesResponse: {
-			type: components['schemas']['ArrType'];
-			/** @description Total number of raw releases before grouping */
-			rawCount: number;
-			/** @description Grouped and deduplicated releases */
-			releases: components['schemas']['GroupedRelease'][];
-		};
-		StaleItem: {
-			/** @description Arr entity ID */
-			id: number;
-			/** @description Full name including namespace suffix */
-			name: string;
-			/** @description Name with namespace suffix removed */
-			strippedName: string;
-		};
-		CleanupScanRequest: {
-			/** @description Arr instance ID */
-			instanceId: number;
-			/** @enum {string} */
-			action: 'scan';
-		};
-		CleanupExecuteRequest: {
-			/** @description Arr instance ID */
-			instanceId: number;
-			/** @enum {string} */
-			action: 'execute';
-			scanResult: components['schemas']['CleanupScanResult'];
-		};
-		CleanupScanResult: {
-			/** @description Custom formats that are no longer in sync selections */
-			staleCustomFormats: components['schemas']['StaleItem'][];
-			/** @description Quality profiles that are no longer in sync selections */
-			staleQualityProfiles: components['schemas']['StaleItem'][];
-		};
-		CleanupDeleteResult: {
-			/** @description Custom formats that were successfully deleted */
-			deletedCustomFormats: components['schemas']['StaleItem'][];
-			/** @description Quality profiles that were successfully deleted */
-			deletedQualityProfiles: components['schemas']['StaleItem'][];
-			/** @description Quality profiles that were skipped (assigned to media) */
-			skippedQualityProfiles: components['schemas']['SkippedItem'][];
-		};
-		SyncEntityRequest: {
-			/** @description Arr instance ID */
-			instanceId: number;
-			/** @description PCD database ID */
-			databaseId: number;
-			/** @description Name of the entity to sync */
-			entityName: string;
-			/**
-			 * @description Type of entity being synced. Determines which sync function runs and which cooldown group applies (qualityProfiles, delayProfiles, or mediaManagement).
-			 * @enum {string}
-			 */
-			entityType:
-				| 'qualityProfile'
-				| 'customFormat'
-				| 'regularExpression'
-				| 'delayProfile'
-				| 'naming'
-				| 'qualityDefinitions'
-				| 'mediaSettings';
-		};
-		SyncEntitySuccessResponse: {
-			/** @enum {boolean} */
-			success: true;
-		};
-		SyncEntityCooldownResponse: {
-			/** @description Cooldown or in-progress message */
-			error: string;
-			/** @description Seconds until cooldown expires */
-			retryAfter?: number;
-		};
-		/** @enum {string} */
-		EntityType:
-			| 'delay_profile'
-			| 'regular_expression'
-			| 'custom_format'
-			| 'quality_profile'
-			| 'radarr_naming'
-			| 'sonarr_naming'
-			| 'radarr_media_settings'
-			| 'sonarr_media_settings'
-			| 'radarr_quality_definitions'
-			| 'sonarr_quality_definitions';
-		ExportResponse: {
-			entityType: components['schemas']['EntityType'];
-			/**
-			 * @description The portable entity payload. Shape varies by entityType:
-			 *     - `delay_profile` → PortableDelayProfile
-			 *     - `regular_expression` → PortableRegularExpression
-			 *     - `custom_format` → PortableCustomFormat
-			 *     - `quality_profile` → PortableQualityProfile
-			 *     - `radarr_naming` → PortableRadarrNaming
-			 *     - `sonarr_naming` → PortableSonarrNaming
-			 *     - `radarr_media_settings` → PortableMediaSettings
-			 *     - `sonarr_media_settings` → PortableMediaSettings
-			 *     - `radarr_quality_definitions` → PortableQualityDefinitions
-			 *     - `sonarr_quality_definitions` → PortableQualityDefinitions
-			 */
-			data:
-				| components['schemas']['PortableDelayProfile']
-				| components['schemas']['PortableRegularExpression']
-				| components['schemas']['PortableCustomFormat']
-				| components['schemas']['PortableQualityProfile']
-				| components['schemas']['PortableRadarrNaming']
-				| components['schemas']['PortableSonarrNaming']
-				| components['schemas']['PortableMediaSettings']
-				| components['schemas']['PortableQualityDefinitions'];
-		};
-		PcdErrorResponse: {
-			error: string;
-		};
-		BundledDependency: {
-			/** @description The entity type of the dependency */
-			entityType: string;
-			/** @description The portable entity payload for the dependency */
-			data: {
-				name: string;
-			} & {
-				[key: string]: unknown;
-			};
-		};
-		ImportConflict: {
-			/** @description The entity type that conflicts */
-			entityType: string;
-			/** @description The name of the conflicting entity */
-			name: string;
-		};
-		ConflictResolution: {
-			/** @description The entity type being resolved */
-			entityType: string;
-			/** @description The original name of the conflicting entity */
-			originalName: string;
-			/**
-			 * @description How to resolve the conflict
-			 * @enum {string}
-			 */
-			action: 'skip' | 'rename';
-			/** @description The new name when action is rename */
-			newName?: string;
-		};
-		ImportRequest: {
-			/** @description The PCD database ID to import into */
-			databaseId: number;
-			/**
-			 * @description The operation layer to write to
-			 * @enum {string}
-			 */
-			layer: 'user' | 'base';
-			entityType: components['schemas']['EntityType'];
-			/** @description The portable entity payload (same shape as ExportResponse.data) */
-			data:
-				| components['schemas']['PortableDelayProfile']
-				| components['schemas']['PortableRegularExpression']
-				| components['schemas']['PortableCustomFormat']
-				| components['schemas']['PortableQualityProfile']
-				| components['schemas']['PortableRadarrNaming']
-				| components['schemas']['PortableSonarrNaming']
-				| components['schemas']['PortableMediaSettings']
-				| components['schemas']['PortableQualityDefinitions'];
-		};
-		ImportResponse: {
-			success: boolean;
-		};
-		DatabaseInstance: {
-			/** @description Database instance ID */
-			id: number;
-			/**
-			 * Format: uuid
-			 * @description Unique identifier
-			 */
-			uuid: string;
-			/** @description Display name */
-			name: string;
-			/** @description GitHub repository URL */
-			repository_url: string;
-			/** @description Auto-sync interval in minutes (0 = manual only) */
-			sync_strategy: number;
-			/** @description Whether to automatically pull updates (0 or 1) */
-			auto_pull: number;
-			/** @description Whether the database is active (0 or 1) */
-			enabled: number;
-			/** @description Whether the repository is private (0 or 1) */
-			is_private: number;
-			/** @description Whether local ops editing is enabled (0 or 1) */
-			local_ops_enabled: number;
-			/** @description Git user name for commits */
-			git_user_name?: string | null;
-			/** @description Git user email for commits */
-			git_user_email?: string | null;
-			/**
-			 * @description How to handle conflicts between local tweaks and upstream updates
-			 * @enum {string}
-			 */
-			conflict_strategy: 'override' | 'align' | 'ask';
-			/** @description Last successful sync timestamp */
-			last_synced_at?: string | null;
-			/** @description Creation timestamp */
-			created_at: string;
-			/** @description Last update timestamp */
-			updated_at: string;
-			/** @description Whether a personal access token is configured */
-			hasPat: boolean;
-		};
-		ValidateRegexRequest: {
-			/** @description The .NET regex pattern to validate */
-			pattern: string;
-		};
-		ValidateRegexResponse: {
-			/** @description Whether the pattern is a valid .NET regex */
-			valid: boolean;
-			/** @description The .NET ArgumentException message if invalid */
-			error?: string | null;
-			/** @description Whether the parser service was reachable. False means validation was skipped. */
-			available?: boolean | null;
-		};
-		SqliteHealth: {
-			status: components['schemas']['ComponentStatus'];
-			/** @description Database query response time in milliseconds */
-			responseTimeMs: number;
-			/** @description Current migration version */
-			migration: number;
-			/** @description Error message if unhealthy */
-			message?: string;
-		};
-		ReposHealth: {
-			status: components['schemas']['ComponentStatus'];
-			/** @description Additional status information */
-			message?: string;
-			/** @description Total number of PCD repos configured (verbose only) */
-			total?: number;
-			/** @description Number of enabled repos (verbose only) */
-			enabled?: number;
-			/** @description Number of repos with compiled cache (verbose only) */
-			cached?: number;
-			/** @description Number of disabled repos (verbose only) */
-			disabled?: number;
-		};
-		JobsHealth: {
-			status: components['schemas']['ComponentStatus'];
-			/** @description Additional status information */
-			message?: string;
-			/**
-			 * Format: date-time
-			 * @description Oldest queued job run_at timestamp (verbose only)
-			 */
-			oldestQueued?: string | null;
-		};
-		BackupsHealth: {
-			status: components['schemas']['ComponentStatus'];
-			/** @description Whether backups are enabled */
-			enabled: boolean;
-			/** @description Additional status information */
-			message?: string;
-			/**
-			 * Format: date-time
-			 * @description Timestamp of last backup (verbose only)
-			 */
-			lastBackup?: string | null;
-			/** @description Number of backup files (verbose only) */
-			count?: number;
-			/** @description Human-readable total size of all backups (verbose only) */
-			totalSize?: string;
-			/** @description Configured retention period in days (verbose only) */
-			retentionDays?: number;
-		};
-		LogsHealth: {
-			status: components['schemas']['ComponentStatus'];
-			/** @description Additional status information */
-			message?: string;
-			/** @description Human-readable total size of log files (verbose only) */
-			totalSize?: string;
-			/** @description Number of log files (verbose only) */
-			fileCount?: number;
-			/**
-			 * Format: date
-			 * @description Date of oldest log file (verbose only)
-			 */
-			oldestLog?: string | null;
-			/**
-			 * Format: date
-			 * @description Date of newest log file (verbose only)
-			 */
-			newestLog?: string | null;
-		};
-		RatingSource: {
-			votes?: number;
-			value?: number;
-		};
-		ArrImage: {
-			/** @description Image type (poster, fanart, banner, clearlogo) */
-			coverType?: string;
-			/** @description Local image URL (relative to Arr instance) */
-			url?: string;
-			/** @description Remote CDN URL (TMDB/TVDB) */
-			remoteUrl?: string;
-		};
-		ArrMediaInfo: {
-			audioCodec?: string;
-			audioChannels?: number;
-			videoCodec?: string;
-			videoBitDepth?: number;
-			videoDynamicRange?: string;
-			videoDynamicRangeType?: string;
-			resolution?: string;
-			subtitles?: string;
-		};
-		LibraryRadarrResponse: {
-			/** @enum {string} */
-			type: 'radarr';
-			items: components['schemas']['RadarrLibraryItem'][];
-			profilesByDatabase: components['schemas']['ProfileByDatabase'][];
-		};
-		LibrarySonarrResponse: {
-			/** @enum {string} */
-			type: 'sonarr';
-			items: components['schemas']['SonarrLibraryItem'][];
-			profilesByDatabase: components['schemas']['ProfileByDatabase'][];
-		};
-		SkippedItem: {
-			item: components['schemas']['StaleItem'];
-			/** @description Why the item was skipped (e.g. "Profile is assigned to media") */
-			reason: string;
-		};
-		PortableDelayProfile: {
-			name: string;
-			/** @enum {string} */
-			preferredProtocol: 'prefer_usenet' | 'prefer_torrent' | 'only_usenet' | 'only_torrent';
-			usenetDelay: number;
-			torrentDelay: number;
-			bypassIfHighestQuality: boolean;
-			bypassIfAboveCfScore: boolean;
-			minimumCfScore: number;
-		};
-		PortableRegularExpression: {
-			name: string;
-			pattern: string;
-			tags: string[];
-			description: string | null;
-			regex101Id: string | null;
-		};
-		PortableCustomFormatTest: {
-			title: string;
-			/** @enum {string} */
-			type: 'movie' | 'series';
-			shouldMatch: boolean;
-			description: string | null;
-		};
-		PortableCustomFormat: {
-			name: string;
-			description: string | null;
-			includeInRename: boolean;
-			tags: string[];
-			conditions: Record<string, never>[];
-			tests: components['schemas']['PortableCustomFormatTest'][];
-		};
-		PortableCustomFormatScore: {
-			customFormatName: string;
-			arrType: string;
-			score: number;
-		};
-		PortableQualityProfile: {
-			name: string;
-			description: string | null;
-			tags: string[];
-			language: string | null;
-			orderedItems: Record<string, never>[];
-			minimumScore: number;
-			upgradeUntilScore: number;
-			upgradeScoreIncrement: number;
-			customFormatScores: components['schemas']['PortableCustomFormatScore'][];
-		};
-		PortableRadarrNaming: {
-			name: string;
-			rename: boolean;
-			movieFormat: string;
-			movieFolderFormat: string;
-			replaceIllegalCharacters: boolean;
-			colonReplacementFormat: string;
-		};
-		PortableSonarrNaming: {
-			name: string;
-			rename: boolean;
-			standardEpisodeFormat: string;
-			dailyEpisodeFormat: string;
-			animeEpisodeFormat: string;
-			seriesFolderFormat: string;
-			seasonFolderFormat: string;
-			replaceIllegalCharacters: boolean;
-			colonReplacementFormat: string;
-			customColonReplacementFormat: string | null;
-			multiEpisodeStyle: string;
-		};
-		PortableMediaSettings: {
-			name: string;
-			propersRepacks: string;
-			enableMediaInfo: boolean;
-		};
-		PortableQualityDefinitions: {
-			name: string;
-			entries: Record<string, never>[];
-		};
-	};
-	responses: never;
-	parameters: never;
-	requestBodies: never;
-	headers: never;
-	pathItems: never;
+    schemas: {
+        /**
+         * @description Individual component health status
+         * @enum {string}
+         */
+        ComponentStatus: "healthy" | "degraded" | "unhealthy";
+        /**
+         * @description Overall health status
+         * @enum {string}
+         */
+        HealthStatus: "healthy" | "degraded" | "unhealthy";
+        HealthCheckResponse: {
+            status: components["schemas"]["HealthStatus"];
+            /**
+             * Format: date-time
+             * @description Current server time
+             */
+            timestamp: string;
+        };
+        HealthDiagnosticsResponse: {
+            status: components["schemas"]["HealthStatus"];
+            /**
+             * Format: date-time
+             * @description Current server time
+             */
+            timestamp: string;
+            /** @description Application version */
+            version: string;
+            /** @description Server uptime in seconds */
+            uptime: number;
+            components: {
+                sqlite: components["schemas"]["SqliteHealth"];
+                repos: components["schemas"]["ReposHealth"];
+                jobs: components["schemas"]["JobsHealth"];
+                backups: components["schemas"]["BackupsHealth"];
+                logs: components["schemas"]["LogsHealth"];
+            };
+        };
+        /**
+         * @description Type of media
+         * @enum {string}
+         */
+        MediaType: "movie" | "series";
+        ParsedInfo: {
+            /** @description Detected source (e.g., bluray, webdl, webrip) */
+            source: string;
+            /** @description Detected resolution (e.g., 1080p, 2160p) */
+            resolution: string;
+            /** @description Quality modifier (e.g., remux, none) */
+            modifier: string;
+            /** @description Detected languages */
+            languages: string[];
+            /**
+             * @description Where the language information came from (Indexer = indexer-provided, Title = parsed from release title)
+             * @enum {string}
+             */
+            languageSource: "Indexer" | "Title";
+            /** @description Detected release group */
+            releaseGroup?: string | null;
+            /** @description Detected year */
+            year: number;
+            /** @description Detected edition (e.g., Director's Cut) */
+            edition?: string | null;
+            /** @description Release type for series (single_episode, season_pack, etc.) */
+            releaseType?: string | null;
+        };
+        ReleaseInput: {
+            /** @description Release ID */
+            id: number;
+            /** @description Release title to parse and evaluate */
+            title: string;
+            type: components["schemas"]["MediaType"];
+            /** @description Indexer-provided languages. When present and non-empty, these override languages parsed from the title. */
+            languages?: string[];
+        };
+        ReleaseEvaluation: {
+            /** @description Release ID */
+            releaseId: number;
+            /** @description Release title */
+            title: string;
+            /** @description Parsed release info (null if parsing failed) */
+            parsed?: components["schemas"]["ParsedInfo"];
+            /** @description Map of custom format ID to whether it matches */
+            cfMatches: {
+                [key: string]: boolean;
+            };
+        };
+        EvaluateRequest: {
+            /** @description Database ID to use for custom format evaluation. If omitted, only parsing is performed (no CF matching). */
+            databaseId?: number;
+            /** @description Releases to evaluate */
+            releases: components["schemas"]["ReleaseInput"][];
+        };
+        EvaluateResponse: {
+            /** @description Whether the parser service is available */
+            parserAvailable: boolean;
+            /** @description Evaluation results for each release */
+            evaluations: components["schemas"]["ReleaseEvaluation"][];
+        };
+        /**
+         * @description Type of Arr instance
+         * @enum {string}
+         */
+        ArrType: "radarr" | "sonarr";
+        CustomFormatRef: {
+            /** @description Custom format ID */
+            id: number;
+            /** @description Custom format name */
+            name: string;
+        };
+        ScoreBreakdownItem: {
+            /** @description Custom format name */
+            name: string;
+            /** @description Score assigned by the quality profile */
+            score: number;
+        };
+        ProfileByDatabase: {
+            /** @description Profilarr database ID */
+            databaseId: number;
+            /** @description Profilarr database name */
+            databaseName: string;
+            /** @description Quality profile names in this database */
+            profiles: string[];
+        };
+        ErrorResponse: {
+            /** @description Error message */
+            error: string;
+        };
+        RadarrLibraryItem: {
+            /** @description Radarr movie ID */
+            id: number;
+            /** @description TMDB ID */
+            tmdbId?: number;
+            /** @description IMDB ID */
+            imdbId?: string;
+            /** @description Movie title */
+            title: string;
+            /** @description Release year */
+            year?: number;
+            /** @description Assigned quality profile ID */
+            qualityProfileId: number;
+            /** @description Assigned quality profile name */
+            qualityProfileName: string;
+            /** @description Whether the movie has a downloaded file */
+            hasFile: boolean;
+            /** @description Whether the movie is monitored */
+            monitored: boolean;
+            /** @description Movie status (released, announced, inCinemas) */
+            status?: string;
+            /**
+             * Format: date-time
+             * @description When the movie was added
+             */
+            dateAdded?: string;
+            /** @description TMDB popularity score */
+            popularity?: number;
+            /** @description File size in bytes */
+            sizeOnDisk?: number;
+            /** @description Runtime in minutes */
+            runtime?: number;
+            /** @description Content rating (e.g. R, PG-13) */
+            certification?: string;
+            /** @description Genre list */
+            genres?: string[];
+            /** @description Production studio */
+            studio?: string;
+            /** @description Ratings from various sources */
+            ratings?: {
+                imdb?: components["schemas"]["RatingSource"];
+                tmdb?: components["schemas"]["RatingSource"];
+                metacritic?: components["schemas"]["RatingSource"];
+                rottenTomatoes?: components["schemas"]["RatingSource"];
+                trakt?: components["schemas"]["RatingSource"];
+            };
+            /** @description Poster and fanart images */
+            images?: components["schemas"]["ArrImage"][];
+            collection?: {
+                title?: string;
+                tmdbId?: number;
+            };
+            originalLanguage?: {
+                id?: number;
+                name?: string;
+            };
+            /** @description Quality of the downloaded file (null if no file) */
+            qualityName?: string | null;
+            /** @description File name of the downloaded file (null if no file) */
+            fileName?: string | null;
+            /** @description Release group name from the file */
+            releaseGroup?: string;
+            /** @description Edition name (e.g. Final Cut, Director's Cut) */
+            edition?: string;
+            /** @description Languages in the file */
+            languages?: {
+                id?: number;
+                name?: string;
+            }[];
+            mediaInfo?: components["schemas"]["ArrMediaInfo"];
+            /** @description Custom formats matched on the file */
+            customFormats: components["schemas"]["CustomFormatRef"][];
+            /** @description Total custom format score */
+            customFormatScore: number;
+            /** @description Per-custom-format score breakdown */
+            scoreBreakdown: components["schemas"]["ScoreBreakdownItem"][];
+            /** @description Profile cutoff score threshold */
+            cutoffScore: number;
+            /** @description Profile minimum score threshold */
+            minScore: number;
+            /** @description Score progress toward cutoff (0-1+) */
+            progress: number;
+            /** @description Whether the cutoff score has been met */
+            cutoffMet: boolean;
+            /** @description Whether the profile is managed by Profilarr */
+            isProfilarrProfile: boolean;
+        };
+        SonarrSeasonItem: {
+            /** @description Season number (0 = specials) */
+            seasonNumber: number;
+            /** @description Whether this season is monitored */
+            monitored: boolean;
+            /** @description Number of aired episodes */
+            episodeCount: number;
+            /** @description Number of episodes with files */
+            episodeFileCount: number;
+            /** @description Total episodes including unaired */
+            totalEpisodeCount: number;
+            /** @description Total size of episode files in bytes */
+            sizeOnDisk: number;
+            /** @description Percentage of episodes with files (0-100) */
+            percentOfEpisodes: number;
+        };
+        SonarrLibraryItem: {
+            /** @description Sonarr series ID */
+            id: number;
+            /** @description TVDB ID */
+            tvdbId?: number;
+            /** @description Series title */
+            title: string;
+            /** @description URL-friendly slug from Sonarr (used for series page links) */
+            titleSlug?: string;
+            /** @description First air year */
+            year?: number;
+            /** @description Assigned quality profile ID */
+            qualityProfileId: number;
+            /** @description Assigned quality profile name */
+            qualityProfileName: string;
+            /** @description Series status (continuing, ended, etc.) */
+            status?: string;
+            /** @description Whether the series is monitored */
+            monitored: boolean;
+            /** @description Number of seasons */
+            seasonCount: number;
+            /** @description Number of aired episodes */
+            episodeCount: number;
+            /** @description Number of episodes with files */
+            episodeFileCount: number;
+            /** @description Total episodes including unaired */
+            totalEpisodeCount: number;
+            /** @description Total size of all episode files in bytes */
+            sizeOnDisk: number;
+            /** @description Percentage of episodes with files (0-100) */
+            percentOfEpisodes: number;
+            /**
+             * Format: date-time
+             * @description When the series was added
+             */
+            dateAdded?: string;
+            /** @description Season-level statistics */
+            seasons: components["schemas"]["SonarrSeasonItem"][];
+            /** @description Whether the profile is managed by Profilarr */
+            isProfilarrProfile: boolean;
+            /** @description TV network (e.g. HBO, CBS) */
+            network?: string;
+            /** @description Series type (standard, daily, anime) */
+            seriesType?: string;
+            /** @description Content rating (e.g. TV-MA, TV-PG) */
+            certification?: string;
+            /** @description Genre list */
+            genres?: string[];
+            /** @description Episode runtime in minutes */
+            runtime?: number;
+            ratings?: {
+                votes?: number;
+                value?: number;
+            };
+            /** @description Poster, banner, fanart images */
+            images?: components["schemas"]["ArrImage"][];
+            originalLanguage?: {
+                id?: number;
+                name?: string;
+            };
+            /**
+             * Format: date-time
+             * @description First air date
+             */
+            firstAired?: string;
+            /**
+             * Format: date-time
+             * @description Last air date
+             */
+            lastAired?: string;
+            /** @description IMDB ID */
+            imdbId?: string;
+        };
+        SonarrEpisodeItem: {
+            /** @description Sonarr episode ID */
+            id: number;
+            /** @description Episode number within the season */
+            episodeNumber: number;
+            /** @description Season number */
+            seasonNumber: number;
+            /** @description Episode title */
+            title: string;
+            /** @description Whether the episode has a downloaded file */
+            hasFile: boolean;
+            /** @description Whether the episode is monitored */
+            monitored: boolean;
+            /** @description Quality of the downloaded file */
+            qualityName?: string;
+            /** @description File name of the downloaded file */
+            fileName?: string;
+            /** @description File size in bytes */
+            size?: number;
+            /** @description Custom formats matched on the file */
+            customFormats: components["schemas"]["CustomFormatRef"][];
+            /** @description Total custom format score */
+            customFormatScore: number;
+            /** @description Per-custom-format score breakdown */
+            scoreBreakdown: components["schemas"]["ScoreBreakdownItem"][];
+            /** @description Profile cutoff score threshold */
+            cutoffScore: number;
+            /** @description Score progress toward cutoff (0-1+) */
+            progress: number;
+            /** @description Whether the cutoff score has been met */
+            cutoffMet: boolean;
+            /** @description Release group name from the file */
+            releaseGroup?: string;
+            /** @description Languages in the file */
+            languages?: {
+                id?: number;
+                name?: string;
+            }[];
+            mediaInfo?: components["schemas"]["ArrMediaInfo"];
+        };
+        /** @description Library response varies by instance type */
+        LibraryResponse: components["schemas"]["LibraryRadarrResponse"] | components["schemas"]["LibrarySonarrResponse"];
+        EpisodesResponse: {
+            /** @description Episode details with quality and score data */
+            episodes: components["schemas"]["SonarrEpisodeItem"][];
+        };
+        CacheInvalidatedResponse: {
+            /** @description Whether the cache was invalidated */
+            success: boolean;
+        };
+        GroupedRelease: {
+            /** @description Release title */
+            title: string;
+            /** @description Release size in bytes */
+            size: number;
+            /** @description Languages detected in the release */
+            languages: string[];
+            /** @description Indexers where this release was found */
+            indexers: string[];
+            /** @description Release flags (e.g., freeleech, internal) */
+            flags: string[];
+        };
+        ReleasesResponse: {
+            type: components["schemas"]["ArrType"];
+            /** @description Total number of raw releases before grouping */
+            rawCount: number;
+            /** @description Grouped and deduplicated releases */
+            releases: components["schemas"]["GroupedRelease"][];
+        };
+        StaleItem: {
+            /** @description Arr entity ID */
+            id: number;
+            /** @description Full name including namespace suffix */
+            name: string;
+            /** @description Name with namespace suffix removed */
+            strippedName: string;
+        };
+        CleanupScanRequest: {
+            /** @description Arr instance ID */
+            instanceId: number;
+            /** @enum {string} */
+            action: "scan";
+        };
+        CleanupExecuteRequest: {
+            /** @description Arr instance ID */
+            instanceId: number;
+            /** @enum {string} */
+            action: "execute";
+            scanResult: components["schemas"]["CleanupScanResult"];
+        };
+        CleanupScanResult: {
+            /** @description Custom formats that are no longer in sync selections */
+            staleCustomFormats: components["schemas"]["StaleItem"][];
+            /** @description Quality profiles that are no longer in sync selections */
+            staleQualityProfiles: components["schemas"]["StaleItem"][];
+        };
+        CleanupDeleteResult: {
+            /** @description Custom formats that were successfully deleted */
+            deletedCustomFormats: components["schemas"]["StaleItem"][];
+            /** @description Quality profiles that were successfully deleted */
+            deletedQualityProfiles: components["schemas"]["StaleItem"][];
+            /** @description Quality profiles that were skipped (assigned to media) */
+            skippedQualityProfiles: components["schemas"]["SkippedItem"][];
+        };
+        SyncEntityRequest: {
+            /** @description Arr instance ID */
+            instanceId: number;
+            /** @description PCD database ID */
+            databaseId: number;
+            /** @description Name of the entity to sync */
+            entityName: string;
+            /**
+             * @description Type of entity being synced. Determines which sync function runs and which cooldown group applies (qualityProfiles, delayProfiles, or mediaManagement).
+             * @enum {string}
+             */
+            entityType: "qualityProfile" | "customFormat" | "regularExpression" | "delayProfile" | "naming" | "qualityDefinitions" | "mediaSettings";
+        };
+        SyncEntitySuccessResponse: {
+            /** @enum {boolean} */
+            success: true;
+        };
+        SyncEntityCooldownResponse: {
+            /** @description Cooldown or in-progress message */
+            error: string;
+            /** @description Seconds until cooldown expires */
+            retryAfter?: number;
+        };
+        /** @enum {string} */
+        EntityType: "delay_profile" | "regular_expression" | "custom_format" | "quality_profile" | "radarr_naming" | "sonarr_naming" | "radarr_media_settings" | "sonarr_media_settings" | "radarr_quality_definitions" | "sonarr_quality_definitions";
+        ExportResponse: {
+            entityType: components["schemas"]["EntityType"];
+            /**
+             * @description The portable entity payload. Shape varies by entityType:
+             *     - `delay_profile` → PortableDelayProfile
+             *     - `regular_expression` → PortableRegularExpression
+             *     - `custom_format` → PortableCustomFormat
+             *     - `quality_profile` → PortableQualityProfile
+             *     - `radarr_naming` → PortableRadarrNaming
+             *     - `sonarr_naming` → PortableSonarrNaming
+             *     - `radarr_media_settings` → PortableMediaSettings
+             *     - `sonarr_media_settings` → PortableMediaSettings
+             *     - `radarr_quality_definitions` → PortableQualityDefinitions
+             *     - `sonarr_quality_definitions` → PortableQualityDefinitions
+             */
+            data: components["schemas"]["PortableDelayProfile"] | components["schemas"]["PortableRegularExpression"] | components["schemas"]["PortableCustomFormat"] | components["schemas"]["PortableQualityProfile"] | components["schemas"]["PortableRadarrNaming"] | components["schemas"]["PortableSonarrNaming"] | components["schemas"]["PortableMediaSettings"] | components["schemas"]["PortableQualityDefinitions"];
+        };
+        PcdErrorResponse: {
+            error: string;
+        };
+        BundledDependency: {
+            /** @description The entity type of the dependency */
+            entityType: string;
+            /** @description The portable entity payload for the dependency */
+            data: {
+                name: string;
+            } & {
+                [key: string]: unknown;
+            };
+        };
+        ImportConflict: {
+            /** @description The entity type that conflicts */
+            entityType: string;
+            /** @description The name of the conflicting entity */
+            name: string;
+        };
+        ConflictResolution: {
+            /** @description The entity type being resolved */
+            entityType: string;
+            /** @description The original name of the conflicting entity */
+            originalName: string;
+            /**
+             * @description How to resolve the conflict
+             * @enum {string}
+             */
+            action: "skip" | "rename";
+            /** @description The new name when action is rename */
+            newName?: string;
+        };
+        ImportRequest: {
+            /** @description The PCD database ID to import into */
+            databaseId: number;
+            /**
+             * @description The operation layer to write to
+             * @enum {string}
+             */
+            layer: "user" | "base";
+            entityType: components["schemas"]["EntityType"];
+            /** @description The portable entity payload (same shape as ExportResponse.data) */
+            data: components["schemas"]["PortableDelayProfile"] | components["schemas"]["PortableRegularExpression"] | components["schemas"]["PortableCustomFormat"] | components["schemas"]["PortableQualityProfile"] | components["schemas"]["PortableRadarrNaming"] | components["schemas"]["PortableSonarrNaming"] | components["schemas"]["PortableMediaSettings"] | components["schemas"]["PortableQualityDefinitions"];
+        };
+        ImportResponse: {
+            success: boolean;
+        };
+        ArrInstance: {
+            /** @description Instance ID */
+            id: number;
+            /** @description Display name */
+            name: string;
+            type: components["schemas"]["ArrType"];
+            /** @description Instance URL */
+            url: string;
+            /** @description JSON array of tags */
+            tags?: string | null;
+            /** @description Whether the instance is active (0 or 1) */
+            enabled: number;
+            /** @description Library cache refresh interval in minutes (0 = manual) */
+            library_refresh_interval: number;
+            /** @description Last library refresh timestamp */
+            library_last_refreshed_at?: string | null;
+            /** @description Creation timestamp */
+            created_at: string;
+            /** @description Last update timestamp */
+            updated_at: string;
+        };
+        DatabaseInstance: {
+            /** @description Database instance ID */
+            id: number;
+            /**
+             * Format: uuid
+             * @description Unique identifier
+             */
+            uuid: string;
+            /** @description Display name */
+            name: string;
+            /** @description GitHub repository URL */
+            repository_url: string;
+            /** @description Auto-sync interval in minutes (0 = manual only) */
+            sync_strategy: number;
+            /** @description Whether to automatically pull updates (0 or 1) */
+            auto_pull: number;
+            /** @description Whether the database is active (0 or 1) */
+            enabled: number;
+            /** @description Whether the repository is private (0 or 1) */
+            is_private: number;
+            /** @description Whether local ops editing is enabled (0 or 1) */
+            local_ops_enabled: number;
+            /** @description Git user name for commits */
+            git_user_name?: string | null;
+            /** @description Git user email for commits */
+            git_user_email?: string | null;
+            /**
+             * @description How to handle conflicts between local tweaks and upstream updates
+             * @enum {string}
+             */
+            conflict_strategy: "override" | "align" | "ask";
+            /** @description Last successful sync timestamp */
+            last_synced_at?: string | null;
+            /** @description Creation timestamp */
+            created_at: string;
+            /** @description Last update timestamp */
+            updated_at: string;
+            /** @description Whether a personal access token is configured */
+            hasPat: boolean;
+        };
+        ValidateRegexRequest: {
+            /** @description The .NET regex pattern to validate */
+            pattern: string;
+        };
+        ValidateRegexResponse: {
+            /** @description Whether the pattern is a valid .NET regex */
+            valid: boolean;
+            /** @description The .NET ArgumentException message if invalid */
+            error?: string | null;
+            /** @description Whether the parser service was reachable. False means validation was skipped. */
+            available?: boolean | null;
+        };
+        SqliteHealth: {
+            status: components["schemas"]["ComponentStatus"];
+            /** @description Database query response time in milliseconds */
+            responseTimeMs: number;
+            /** @description Current migration version */
+            migration: number;
+            /** @description Error message if unhealthy */
+            message?: string;
+        };
+        ReposHealth: {
+            status: components["schemas"]["ComponentStatus"];
+            /** @description Additional status information */
+            message?: string;
+            /** @description Total number of PCD repos configured (verbose only) */
+            total?: number;
+            /** @description Number of enabled repos (verbose only) */
+            enabled?: number;
+            /** @description Number of repos with compiled cache (verbose only) */
+            cached?: number;
+            /** @description Number of disabled repos (verbose only) */
+            disabled?: number;
+        };
+        JobsHealth: {
+            status: components["schemas"]["ComponentStatus"];
+            /** @description Additional status information */
+            message?: string;
+            /**
+             * Format: date-time
+             * @description Oldest queued job run_at timestamp (verbose only)
+             */
+            oldestQueued?: string | null;
+        };
+        BackupsHealth: {
+            status: components["schemas"]["ComponentStatus"];
+            /** @description Whether backups are enabled */
+            enabled: boolean;
+            /** @description Additional status information */
+            message?: string;
+            /**
+             * Format: date-time
+             * @description Timestamp of last backup (verbose only)
+             */
+            lastBackup?: string | null;
+            /** @description Number of backup files (verbose only) */
+            count?: number;
+            /** @description Human-readable total size of all backups (verbose only) */
+            totalSize?: string;
+            /** @description Configured retention period in days (verbose only) */
+            retentionDays?: number;
+        };
+        LogsHealth: {
+            status: components["schemas"]["ComponentStatus"];
+            /** @description Additional status information */
+            message?: string;
+            /** @description Human-readable total size of log files (verbose only) */
+            totalSize?: string;
+            /** @description Number of log files (verbose only) */
+            fileCount?: number;
+            /**
+             * Format: date
+             * @description Date of oldest log file (verbose only)
+             */
+            oldestLog?: string | null;
+            /**
+             * Format: date
+             * @description Date of newest log file (verbose only)
+             */
+            newestLog?: string | null;
+        };
+        RatingSource: {
+            votes?: number;
+            value?: number;
+        };
+        ArrImage: {
+            /** @description Image type (poster, fanart, banner, clearlogo) */
+            coverType?: string;
+            /** @description Local image URL (relative to Arr instance) */
+            url?: string;
+            /** @description Remote CDN URL (TMDB/TVDB) */
+            remoteUrl?: string;
+        };
+        ArrMediaInfo: {
+            audioCodec?: string;
+            audioChannels?: number;
+            videoCodec?: string;
+            videoBitDepth?: number;
+            videoDynamicRange?: string;
+            videoDynamicRangeType?: string;
+            resolution?: string;
+            subtitles?: string;
+        };
+        LibraryRadarrResponse: {
+            /** @enum {string} */
+            type: "radarr";
+            items: components["schemas"]["RadarrLibraryItem"][];
+            profilesByDatabase: components["schemas"]["ProfileByDatabase"][];
+        };
+        LibrarySonarrResponse: {
+            /** @enum {string} */
+            type: "sonarr";
+            items: components["schemas"]["SonarrLibraryItem"][];
+            profilesByDatabase: components["schemas"]["ProfileByDatabase"][];
+        };
+        SkippedItem: {
+            item: components["schemas"]["StaleItem"];
+            /** @description Why the item was skipped (e.g. "Profile is assigned to media") */
+            reason: string;
+        };
+        PortableDelayProfile: {
+            name: string;
+            /** @enum {string} */
+            preferredProtocol: "prefer_usenet" | "prefer_torrent" | "only_usenet" | "only_torrent";
+            usenetDelay: number;
+            torrentDelay: number;
+            bypassIfHighestQuality: boolean;
+            bypassIfAboveCfScore: boolean;
+            minimumCfScore: number;
+        };
+        PortableRegularExpression: {
+            name: string;
+            pattern: string;
+            tags: string[];
+            description: string | null;
+            regex101Id: string | null;
+        };
+        PortableCustomFormatTest: {
+            title: string;
+            /** @enum {string} */
+            type: "movie" | "series";
+            shouldMatch: boolean;
+            description: string | null;
+        };
+        PortableCustomFormat: {
+            name: string;
+            description: string | null;
+            includeInRename: boolean;
+            tags: string[];
+            conditions: Record<string, never>[];
+            tests: components["schemas"]["PortableCustomFormatTest"][];
+        };
+        PortableCustomFormatScore: {
+            customFormatName: string;
+            arrType: string;
+            score: number;
+        };
+        PortableQualityProfile: {
+            name: string;
+            description: string | null;
+            tags: string[];
+            language: string | null;
+            orderedItems: Record<string, never>[];
+            minimumScore: number;
+            upgradeUntilScore: number;
+            upgradeScoreIncrement: number;
+            customFormatScores: components["schemas"]["PortableCustomFormatScore"][];
+        };
+        PortableRadarrNaming: {
+            name: string;
+            rename: boolean;
+            movieFormat: string;
+            movieFolderFormat: string;
+            replaceIllegalCharacters: boolean;
+            colonReplacementFormat: string;
+        };
+        PortableSonarrNaming: {
+            name: string;
+            rename: boolean;
+            standardEpisodeFormat: string;
+            dailyEpisodeFormat: string;
+            animeEpisodeFormat: string;
+            seriesFolderFormat: string;
+            seasonFolderFormat: string;
+            replaceIllegalCharacters: boolean;
+            colonReplacementFormat: string;
+            customColonReplacementFormat: string | null;
+            multiEpisodeStyle: string;
+        };
+        PortableMediaSettings: {
+            name: string;
+            propersRepacks: string;
+            enableMediaInfo: boolean;
+        };
+        PortableQualityDefinitions: {
+            name: string;
+            entries: Record<string, never>[];
+        };
+    };
+    responses: never;
+    parameters: never;
+    requestBodies: never;
+    headers: never;
+    pathItems: never;
 }
 export type $defs = Record<string, never>;
 export interface operations {
-	listDatabases: {
-		parameters: {
-			query?: never;
-			header?: never;
-			path?: never;
-			cookie?: never;
-		};
-		requestBody?: never;
-		responses: {
-			/** @description List of linked databases */
-			200: {
-				headers: {
-					[name: string]: unknown;
-				};
-				content: {
-					'application/json': components['schemas']['DatabaseInstance'][];
-				};
-			};
-			/** @description Not authenticated */
-			401: {
-				headers: {
-					[name: string]: unknown;
-				};
-				content?: never;
-			};
-		};
-	};
-	getHealth: {
-		parameters: {
-			query?: never;
-			header?: never;
-			path?: never;
-			cookie?: never;
-		};
-		requestBody?: never;
-		responses: {
-			/** @description Service is healthy or degraded */
-			200: {
-				headers: {
-					[name: string]: unknown;
-				};
-				content: {
-					'application/json': components['schemas']['HealthCheckResponse'];
-				};
-			};
-			/** @description Service is unhealthy */
-			503: {
-				headers: {
-					[name: string]: unknown;
-				};
-				content: {
-					'application/json': components['schemas']['HealthCheckResponse'];
-				};
-			};
-		};
-	};
-	getHealthDiagnostics: {
-		parameters: {
-			query?: {
-				/** @description Include extra detail per component (counts, sizes, timestamps) */
-				verbose?: boolean;
-			};
-			header?: never;
-			path?: never;
-			cookie?: never;
-		};
-		requestBody?: never;
-		responses: {
-			/** @description Diagnostics response (healthy or degraded) */
-			200: {
-				headers: {
-					[name: string]: unknown;
-				};
-				content: {
-					'application/json': components['schemas']['HealthDiagnosticsResponse'];
-				};
-			};
-			/** @description Not authenticated */
-			401: {
-				headers: {
-					[name: string]: unknown;
-				};
-				content: {
-					'application/json': {
-						/** @example Unauthorized */
-						error: string;
-					};
-				};
-			};
-			/** @description Service is unhealthy */
-			503: {
-				headers: {
-					[name: string]: unknown;
-				};
-				content: {
-					'application/json': components['schemas']['HealthDiagnosticsResponse'];
-				};
-			};
-		};
-	};
-	getOpenApiSpec: {
-		parameters: {
-			query?: never;
-			header?: never;
-			path?: never;
-			cookie?: never;
-		};
-		requestBody?: never;
-		responses: {
-			/** @description OpenAPI specification */
-			200: {
-				headers: {
-					[name: string]: unknown;
-				};
-				content: {
-					'application/json': Record<string, never>;
-				};
-			};
-		};
-	};
-	evaluateReleases: {
-		parameters: {
-			query?: never;
-			header?: never;
-			path?: never;
-			cookie?: never;
-		};
-		requestBody: {
-			content: {
-				'application/json': components['schemas']['EvaluateRequest'];
-			};
-		};
-		responses: {
-			/** @description Evaluation results */
-			200: {
-				headers: {
-					[name: string]: unknown;
-				};
-				content: {
-					'application/json': components['schemas']['EvaluateResponse'];
-				};
-			};
-			/** @description Invalid request (missing databaseId or releases) */
-			400: {
-				headers: {
-					[name: string]: unknown;
-				};
-				content?: never;
-			};
-			/** @description Database cache not available */
-			500: {
-				headers: {
-					[name: string]: unknown;
-				};
-				content?: never;
-			};
-		};
-	};
-	getLibrary: {
-		parameters: {
-			query: {
-				/** @description Arr instance ID */
-				instanceId: number;
-			};
-			header?: never;
-			path?: never;
-			cookie?: never;
-		};
-		requestBody?: never;
-		responses: {
-			/** @description Library items with quality and score data */
-			200: {
-				headers: {
-					[name: string]: unknown;
-				};
-				content: {
-					'application/json': components['schemas']['LibraryResponse'];
-				};
-			};
-			/** @description Invalid or missing instanceId */
-			400: {
-				headers: {
-					[name: string]: unknown;
-				};
-				content: {
-					'application/json': components['schemas']['ErrorResponse'];
-				};
-			};
-			/** @description Instance not found */
-			404: {
-				headers: {
-					[name: string]: unknown;
-				};
-				content: {
-					'application/json': components['schemas']['ErrorResponse'];
-				};
-			};
-			/** @description Failed to fetch library */
-			500: {
-				headers: {
-					[name: string]: unknown;
-				};
-				content: {
-					'application/json': components['schemas']['ErrorResponse'];
-				};
-			};
-		};
-	};
-	invalidateLibraryCache: {
-		parameters: {
-			query: {
-				/** @description Arr instance ID */
-				instanceId: number;
-			};
-			header?: never;
-			path?: never;
-			cookie?: never;
-		};
-		requestBody?: never;
-		responses: {
-			/** @description Cache invalidated */
-			200: {
-				headers: {
-					[name: string]: unknown;
-				};
-				content: {
-					'application/json': components['schemas']['CacheInvalidatedResponse'];
-				};
-			};
-			/** @description Invalid or missing instanceId */
-			400: {
-				headers: {
-					[name: string]: unknown;
-				};
-				content: {
-					'application/json': components['schemas']['ErrorResponse'];
-				};
-			};
-		};
-	};
-	getLibraryEpisodes: {
-		parameters: {
-			query: {
-				/** @description Arr instance ID (must be a Sonarr instance) */
-				instanceId: number;
-				/** @description Sonarr series ID */
-				seriesId: number;
-			};
-			header?: never;
-			path?: never;
-			cookie?: never;
-		};
-		requestBody?: never;
-		responses: {
-			/** @description Episode details with quality and score data */
-			200: {
-				headers: {
-					[name: string]: unknown;
-				};
-				content: {
-					'application/json': components['schemas']['EpisodesResponse'];
-				};
-			};
-			/** @description Invalid parameters or not a Sonarr instance */
-			400: {
-				headers: {
-					[name: string]: unknown;
-				};
-				content: {
-					'application/json': components['schemas']['ErrorResponse'];
-				};
-			};
-			/** @description Instance not found */
-			404: {
-				headers: {
-					[name: string]: unknown;
-				};
-				content: {
-					'application/json': components['schemas']['ErrorResponse'];
-				};
-			};
-			/** @description Failed to fetch episode details */
-			500: {
-				headers: {
-					[name: string]: unknown;
-				};
-				content: {
-					'application/json': components['schemas']['ErrorResponse'];
-				};
-			};
-		};
-	};
-	getReleases: {
-		parameters: {
-			query: {
-				/** @description Arr instance ID */
-				instanceId: number;
-				/** @description Movie ID (Radarr) or Series ID (Sonarr) */
-				itemId: number;
-				/** @description Season number for Sonarr searches (defaults to 1) */
-				season?: number;
-			};
-			header?: never;
-			path?: never;
-			cookie?: never;
-		};
-		requestBody?: never;
-		responses: {
-			/** @description Release search results */
-			200: {
-				headers: {
-					[name: string]: unknown;
-				};
-				content: {
-					'application/json': components['schemas']['ReleasesResponse'];
-				};
-			};
-			/** @description Invalid or missing parameters */
-			400: {
-				headers: {
-					[name: string]: unknown;
-				};
-				content: {
-					'application/json': components['schemas']['ErrorResponse'];
-				};
-			};
-			/** @description Instance not found */
-			404: {
-				headers: {
-					[name: string]: unknown;
-				};
-				content: {
-					'application/json': components['schemas']['ErrorResponse'];
-				};
-			};
-			/** @description Failed to fetch releases */
-			500: {
-				headers: {
-					[name: string]: unknown;
-				};
-				content: {
-					'application/json': components['schemas']['ErrorResponse'];
-				};
-			};
-		};
-	};
-	arrCleanup: {
-		parameters: {
-			query?: never;
-			header?: never;
-			path?: never;
-			cookie?: never;
-		};
-		requestBody: {
-			content: {
-				'application/json':
-					| components['schemas']['CleanupScanRequest']
-					| components['schemas']['CleanupExecuteRequest'];
-			};
-		};
-		responses: {
-			/** @description Scan or delete result */
-			200: {
-				headers: {
-					[name: string]: unknown;
-				};
-				content: {
-					'application/json':
-						| components['schemas']['CleanupScanResult']
-						| components['schemas']['CleanupDeleteResult'];
-				};
-			};
-			/** @description Invalid request (missing instanceId, invalid action) */
-			400: {
-				headers: {
-					[name: string]: unknown;
-				};
-				content: {
-					'application/json': components['schemas']['ErrorResponse'];
-				};
-			};
-			/** @description Instance not found */
-			404: {
-				headers: {
-					[name: string]: unknown;
-				};
-				content: {
-					'application/json': components['schemas']['ErrorResponse'];
-				};
-			};
-			/** @description Failed to perform cleanup */
-			500: {
-				headers: {
-					[name: string]: unknown;
-				};
-				content: {
-					'application/json': components['schemas']['ErrorResponse'];
-				};
-			};
-		};
-	};
-	syncEntity: {
-		parameters: {
-			query?: never;
-			header?: never;
-			path?: never;
-			cookie?: never;
-		};
-		requestBody: {
-			content: {
-				'application/json': components['schemas']['SyncEntityRequest'];
-			};
-		};
-		responses: {
-			/** @description Entity synced successfully */
-			200: {
-				headers: {
-					[name: string]: unknown;
-				};
-				content: {
-					'application/json': components['schemas']['SyncEntitySuccessResponse'];
-				};
-			};
-			/** @description Invalid request parameters */
-			400: {
-				headers: {
-					[name: string]: unknown;
-				};
-				content: {
-					'application/json': components['schemas']['ErrorResponse'];
-				};
-			};
-			/** @description Instance not found */
-			404: {
-				headers: {
-					[name: string]: unknown;
-				};
-				content: {
-					'application/json': components['schemas']['ErrorResponse'];
-				};
-			};
-			/** @description Cooldown active or sync in progress */
-			409: {
-				headers: {
-					[name: string]: unknown;
-				};
-				content: {
-					'application/json': components['schemas']['SyncEntityCooldownResponse'];
-				};
-			};
-			/** @description Sync failed */
-			500: {
-				headers: {
-					[name: string]: unknown;
-				};
-				content: {
-					'application/json': components['schemas']['ErrorResponse'];
-				};
-			};
-		};
-	};
-	exportEntity: {
-		parameters: {
-			query: {
-				/** @description The PCD database ID to export from */
-				databaseId: number;
-				/** @description The entity type to export */
-				entityType: components['schemas']['EntityType'];
-				/** @description The entity name to export */
-				name: string;
-			};
-			header?: never;
-			path?: never;
-			cookie?: never;
-		};
-		requestBody?: never;
-		responses: {
-			/** @description Portable entity JSON */
-			200: {
-				headers: {
-					[name: string]: unknown;
-				};
-				content: {
-					'application/json': components['schemas']['ExportResponse'];
-				};
-			};
-			/** @description Missing or invalid parameters */
-			400: {
-				headers: {
-					[name: string]: unknown;
-				};
-				content: {
-					'application/json': components['schemas']['PcdErrorResponse'];
-				};
-			};
-			/** @description Entity not found */
-			404: {
-				headers: {
-					[name: string]: unknown;
-				};
-				content: {
-					'application/json': components['schemas']['PcdErrorResponse'];
-				};
-			};
-			/** @description Database cache not available */
-			500: {
-				headers: {
-					[name: string]: unknown;
-				};
-				content: {
-					'application/json': components['schemas']['PcdErrorResponse'];
-				};
-			};
-		};
-	};
-	importEntity: {
-		parameters: {
-			query?: never;
-			header?: never;
-			path?: never;
-			cookie?: never;
-		};
-		requestBody: {
-			content: {
-				'application/json': components['schemas']['ImportRequest'];
-			};
-		};
-		responses: {
-			/** @description Entity created successfully */
-			200: {
-				headers: {
-					[name: string]: unknown;
-				};
-				content: {
-					'application/json': components['schemas']['ImportResponse'];
-				};
-			};
-			/** @description Validation error (missing fields, duplicate name, invalid data) */
-			400: {
-				headers: {
-					[name: string]: unknown;
-				};
-				content: {
-					'application/json': components['schemas']['PcdErrorResponse'];
-				};
-			};
-			/** @description Cannot write to base layer */
-			403: {
-				headers: {
-					[name: string]: unknown;
-				};
-				content: {
-					'application/json': components['schemas']['PcdErrorResponse'];
-				};
-			};
-			/** @description Database cache not available */
-			500: {
-				headers: {
-					[name: string]: unknown;
-				};
-				content: {
-					'application/json': components['schemas']['PcdErrorResponse'];
-				};
-			};
-		};
-	};
-	validateRegex: {
-		parameters: {
-			query?: never;
-			header?: never;
-			path?: never;
-			cookie?: never;
-		};
-		requestBody: {
-			content: {
-				'application/json': components['schemas']['ValidateRegexRequest'];
-			};
-		};
-		responses: {
-			/** @description Validation result */
-			200: {
-				headers: {
-					[name: string]: unknown;
-				};
-				content: {
-					'application/json': components['schemas']['ValidateRegexResponse'];
-				};
-			};
-			/** @description Missing pattern */
-			400: {
-				headers: {
-					[name: string]: unknown;
-				};
-				content?: never;
-			};
-		};
-	};
+    listArrInstances: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description List of Arr instances */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ArrInstance"][];
+                };
+            };
+            /** @description Not authenticated */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    listDatabases: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description List of linked databases */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DatabaseInstance"][];
+                };
+            };
+            /** @description Not authenticated */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    getHealth: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Service is healthy or degraded */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HealthCheckResponse"];
+                };
+            };
+            /** @description Service is unhealthy */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HealthCheckResponse"];
+                };
+            };
+        };
+    };
+    getHealthDiagnostics: {
+        parameters: {
+            query?: {
+                /** @description Include extra detail per component (counts, sizes, timestamps) */
+                verbose?: boolean;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Diagnostics response (healthy or degraded) */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HealthDiagnosticsResponse"];
+                };
+            };
+            /** @description Not authenticated */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example Unauthorized */
+                        error: string;
+                    };
+                };
+            };
+            /** @description Service is unhealthy */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HealthDiagnosticsResponse"];
+                };
+            };
+        };
+    };
+    getOpenApiSpec: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OpenAPI specification */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": Record<string, never>;
+                };
+            };
+        };
+    };
+    evaluateReleases: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["EvaluateRequest"];
+            };
+        };
+        responses: {
+            /** @description Evaluation results */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EvaluateResponse"];
+                };
+            };
+            /** @description Invalid request (missing databaseId or releases) */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Database cache not available */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    getLibrary: {
+        parameters: {
+            query: {
+                /** @description Arr instance ID */
+                instanceId: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Library items with quality and score data */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["LibraryResponse"];
+                };
+            };
+            /** @description Invalid or missing instanceId */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Instance not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Failed to fetch library */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    invalidateLibraryCache: {
+        parameters: {
+            query: {
+                /** @description Arr instance ID */
+                instanceId: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Cache invalidated */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CacheInvalidatedResponse"];
+                };
+            };
+            /** @description Invalid or missing instanceId */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    getLibraryEpisodes: {
+        parameters: {
+            query: {
+                /** @description Arr instance ID (must be a Sonarr instance) */
+                instanceId: number;
+                /** @description Sonarr series ID */
+                seriesId: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Episode details with quality and score data */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EpisodesResponse"];
+                };
+            };
+            /** @description Invalid parameters or not a Sonarr instance */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Instance not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Failed to fetch episode details */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    getReleases: {
+        parameters: {
+            query: {
+                /** @description Arr instance ID */
+                instanceId: number;
+                /** @description Movie ID (Radarr) or Series ID (Sonarr) */
+                itemId: number;
+                /** @description Season number for Sonarr searches (defaults to 1) */
+                season?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Release search results */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ReleasesResponse"];
+                };
+            };
+            /** @description Invalid or missing parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Instance not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Failed to fetch releases */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    arrCleanup: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CleanupScanRequest"] | components["schemas"]["CleanupExecuteRequest"];
+            };
+        };
+        responses: {
+            /** @description Scan or delete result */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CleanupScanResult"] | components["schemas"]["CleanupDeleteResult"];
+                };
+            };
+            /** @description Invalid request (missing instanceId, invalid action) */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Instance not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Failed to perform cleanup */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    syncEntity: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SyncEntityRequest"];
+            };
+        };
+        responses: {
+            /** @description Entity synced successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SyncEntitySuccessResponse"];
+                };
+            };
+            /** @description Invalid request parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Instance not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Cooldown active or sync in progress */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SyncEntityCooldownResponse"];
+                };
+            };
+            /** @description Sync failed */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    exportEntity: {
+        parameters: {
+            query: {
+                /** @description The PCD database ID to export from */
+                databaseId: number;
+                /** @description The entity type to export */
+                entityType: components["schemas"]["EntityType"];
+                /** @description The entity name to export */
+                name: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Portable entity JSON */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ExportResponse"];
+                };
+            };
+            /** @description Missing or invalid parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PcdErrorResponse"];
+                };
+            };
+            /** @description Entity not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PcdErrorResponse"];
+                };
+            };
+            /** @description Database cache not available */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PcdErrorResponse"];
+                };
+            };
+        };
+    };
+    importEntity: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ImportRequest"];
+            };
+        };
+        responses: {
+            /** @description Entity created successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ImportResponse"];
+                };
+            };
+            /** @description Validation error (missing fields, duplicate name, invalid data) */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PcdErrorResponse"];
+                };
+            };
+            /** @description Cannot write to base layer */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PcdErrorResponse"];
+                };
+            };
+            /** @description Database cache not available */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PcdErrorResponse"];
+                };
+            };
+        };
+    };
+    validateRegex: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ValidateRegexRequest"];
+            };
+        };
+        responses: {
+            /** @description Validation result */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ValidateRegexResponse"];
+                };
+            };
+            /** @description Missing pattern */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
 }

--- a/src/lib/api/v1.d.ts
+++ b/src/lib/api/v1.d.ts
@@ -4,1761 +4,1800 @@
  */
 
 export interface paths {
-    "/arr": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * List Arr Instances
-         * @description Returns all Arr instances (Radarr/Sonarr) with secrets stripped.
-         *
-         *     **Use cases:**
-         *     - Dashboard widgets showing connected instances
-         *     - Automation scripts checking instance state
-         *     - Prerequisite checks (e.g. onboarding)
-         *
-         *     **Behavior:**
-         *     - Returns an empty array if no instances are connected
-         *     - The `api_key` field is never included
-         */
-        get: operations["listArrInstances"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/databases": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * List Databases
-         * @description Returns all linked database instances with secrets stripped.
-         *
-         *     **Use cases:**
-         *     - Dashboard widgets showing connected databases
-         *     - Automation scripts checking database state
-         *     - Prerequisite checks (e.g. cutscene onboarding)
-         *
-         *     **Behavior:**
-         *     - Returns an empty array if no databases are linked
-         *     - The `personal_access_token` field is never included; `hasPat` indicates
-         *       whether one is configured
-         *     - The `local_path` field is excluded (internal detail)
-         */
-        get: operations["listDatabases"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/health": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Health check (public)
-         * @description Public endpoint for uptime monitors. Returns only the overall status and
-         *     timestamp — no version, uptime, or component details.
-         *
-         *     Status values:
-         *     - `healthy`: All components functioning normally
-         *     - `degraded`: Core functionality works but some components have issues
-         *     - `unhealthy`: Core functionality is broken
-         */
-        get: operations["getHealth"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/health/diagnostics": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Health diagnostics (authenticated)
-         * @description Detailed health diagnostics including version, uptime, and per-component
-         *     status. Requires authentication (session or API key).
-         *
-         *     Use `?verbose=true` for additional counts, sizes, and timestamps.
-         */
-        get: operations["getHealthDiagnostics"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/openapi.json": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * OpenAPI specification
-         * @description Returns the OpenAPI specification for this API
-         */
-        get: operations["getOpenApiSpec"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/entity-testing/evaluate": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Evaluate releases against custom formats
-         * @description Parses release titles and evaluates them against all custom formats in the specified database.
-         *
-         *     This endpoint:
-         *     - Parses each release title to extract metadata (resolution, source, languages, etc.)
-         *     - Matches regex patterns using .NET-compatible regex via the parser service
-         *     - Evaluates each release against all custom formats in the database
-         *     - Returns which custom formats match each release
-         *
-         *     Results are cached for performance - repeated requests with the same titles will be faster.
-         */
-        post: operations["evaluateReleases"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/arr/library": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Arr instance library
-         * @description Fetches the full movie or series library from an Arr instance with quality profile,
-         *     score, and progress information.
-         *
-         *     - For Radarr: Returns movies with file quality, custom format scores, and cutoff progress
-         *     - For Sonarr: Returns series with season summaries and episode statistics
-         *
-         *     Results include Profilarr profile matching to indicate which items use managed profiles.
-         *     Responses are cached server-side for 5 minutes.
-         */
-        get: operations["getLibrary"];
-        put?: never;
-        post?: never;
-        /**
-         * Invalidate library cache
-         * @description Clears the server-side cache for an Arr instance's library data.
-         *     The next GET request will fetch fresh data from the Arr instance.
-         */
-        delete: operations["invalidateLibraryCache"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/arr/library/episodes": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get episode details for a Sonarr series
-         * @description Lazy-loads episode-level data for a specific series in a Sonarr instance.
-         *     Returns episodes with quality, custom format scores, and cutoff progress.
-         *
-         *     This endpoint is designed for on-demand loading when a series row is expanded
-         *     in the library view. Sonarr instances only.
-         *
-         *     Results are cached server-side for 5 minutes per series.
-         */
-        get: operations["getLibraryEpisodes"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/arr/releases": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Search for releases
-         * @description Triggers an interactive search on an Arr instance and returns grouped/deduplicated results.
-         *
-         *     For Radarr: Searches for releases for the specified movie.
-         *     For Sonarr: Searches for season pack releases for the specified series and season.
-         *
-         *     Results are grouped by title, combining information from multiple indexers.
-         */
-        get: operations["getReleases"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/arr/cleanup": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Scan or execute cleanup of stale configs
-         * @description Detects and deletes stale namespace-suffixed custom formats and quality profiles
-         *     from an Arr instance that are no longer in the current sync selections.
-         *
-         *     Two actions are supported via the `action` field in the request body:
-         *     - `scan`: Scans for stale items and returns what would be deleted.
-         *     - `execute`: Deletes the stale items from a previous scan result.
-         *
-         *     Quality profiles assigned to media will be skipped with a warning (Arr returns HTTP 500 "in use").
-         */
-        post: operations["arrCleanup"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/arr/sync-entity": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Sync a single entity to an Arr instance
-         * @description Pushes a single entity to an Arr instance. Runs inline and returns when complete.
-         *
-         *     Entity types are grouped into sync sections that share cooldown and status tracking:
-         *       - **qualityProfiles**: qualityProfile, customFormat, regularExpression
-         *       - **delayProfiles**: delayProfile
-         *       - **mediaManagement**: naming, qualityDefinitions, mediaSettings
-         *
-         *     The section is derived automatically from the entity type. A 5-second cooldown
-         *     is enforced per section per instance — entity types within the same section share
-         *     the cooldown. Returns 409 if a sync is already in progress or the cooldown is active.
-         */
-        post: operations["syncEntity"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/pcd/export": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Export a portable entity
-         * @description Serializes a PCD entity into its portable JSON representation.
-         *
-         *     The portable format strips database IDs and timestamps, producing a
-         *     self-contained snapshot suitable for clipboard copy, file export, or
-         *     cross-database import.
-         */
-        get: operations["exportEntity"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/pcd/import": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Import a portable entity
-         * @description Deserializes a portable entity into PCD operations, creating the entity
-         *     in the target database and layer.
-         *
-         *     The request body matches the export response format (`entityType` + `data`),
-         *     plus `databaseId` and `layer` to specify the target.
-         *
-         *     Name uniqueness is validated — importing an entity with a name that already
-         *     exists will return a 400 error.
-         */
-        post: operations["importEntity"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/regex/validate": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Validate a .NET regex pattern
-         * @description Validates a regex pattern using the .NET regex engine (via the parser service).
-         *     This matches the exact validation Radarr and Sonarr perform when importing custom formats.
-         *     If the parser service is offline, returns { valid: true } to avoid blocking saves.
-         */
-        post: operations["validateRegex"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
+	'/arr': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		/**
+		 * List Arr Instances
+		 * @description Returns all Arr instances (Radarr/Sonarr) with secrets stripped.
+		 *
+		 *     **Use cases:**
+		 *     - Dashboard widgets showing connected instances
+		 *     - Automation scripts checking instance state
+		 *     - Prerequisite checks (e.g. onboarding)
+		 *
+		 *     **Behavior:**
+		 *     - Returns an empty array if no instances are connected
+		 *     - The `api_key` field is never included
+		 */
+		get: operations['listArrInstances'];
+		put?: never;
+		post?: never;
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
+	'/databases': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		/**
+		 * List Databases
+		 * @description Returns all linked database instances with secrets stripped.
+		 *
+		 *     **Use cases:**
+		 *     - Dashboard widgets showing connected databases
+		 *     - Automation scripts checking database state
+		 *     - Prerequisite checks (e.g. cutscene onboarding)
+		 *
+		 *     **Behavior:**
+		 *     - Returns an empty array if no databases are linked
+		 *     - The `personal_access_token` field is never included; `hasPat` indicates
+		 *       whether one is configured
+		 *     - The `local_path` field is excluded (internal detail)
+		 */
+		get: operations['listDatabases'];
+		put?: never;
+		post?: never;
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
+	'/health': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		/**
+		 * Health check (public)
+		 * @description Public endpoint for uptime monitors. Returns only the overall status and
+		 *     timestamp — no version, uptime, or component details.
+		 *
+		 *     Status values:
+		 *     - `healthy`: All components functioning normally
+		 *     - `degraded`: Core functionality works but some components have issues
+		 *     - `unhealthy`: Core functionality is broken
+		 */
+		get: operations['getHealth'];
+		put?: never;
+		post?: never;
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
+	'/health/diagnostics': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		/**
+		 * Health diagnostics (authenticated)
+		 * @description Detailed health diagnostics including version, uptime, and per-component
+		 *     status. Requires authentication (session or API key).
+		 *
+		 *     Use `?verbose=true` for additional counts, sizes, and timestamps.
+		 */
+		get: operations['getHealthDiagnostics'];
+		put?: never;
+		post?: never;
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
+	'/openapi.json': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		/**
+		 * OpenAPI specification
+		 * @description Returns the OpenAPI specification for this API
+		 */
+		get: operations['getOpenApiSpec'];
+		put?: never;
+		post?: never;
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
+	'/entity-testing/evaluate': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		get?: never;
+		put?: never;
+		/**
+		 * Evaluate releases against custom formats
+		 * @description Parses release titles and evaluates them against all custom formats in the specified database.
+		 *
+		 *     This endpoint:
+		 *     - Parses each release title to extract metadata (resolution, source, languages, etc.)
+		 *     - Matches regex patterns using .NET-compatible regex via the parser service
+		 *     - Evaluates each release against all custom formats in the database
+		 *     - Returns which custom formats match each release
+		 *
+		 *     Results are cached for performance - repeated requests with the same titles will be faster.
+		 */
+		post: operations['evaluateReleases'];
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
+	'/arr/library': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		/**
+		 * Get Arr instance library
+		 * @description Fetches the full movie or series library from an Arr instance with quality profile,
+		 *     score, and progress information.
+		 *
+		 *     - For Radarr: Returns movies with file quality, custom format scores, and cutoff progress
+		 *     - For Sonarr: Returns series with season summaries and episode statistics
+		 *
+		 *     Results include Profilarr profile matching to indicate which items use managed profiles.
+		 *     Responses are cached server-side for 5 minutes.
+		 */
+		get: operations['getLibrary'];
+		put?: never;
+		post?: never;
+		/**
+		 * Invalidate library cache
+		 * @description Clears the server-side cache for an Arr instance's library data.
+		 *     The next GET request will fetch fresh data from the Arr instance.
+		 */
+		delete: operations['invalidateLibraryCache'];
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
+	'/arr/library/episodes': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		/**
+		 * Get episode details for a Sonarr series
+		 * @description Lazy-loads episode-level data for a specific series in a Sonarr instance.
+		 *     Returns episodes with quality, custom format scores, and cutoff progress.
+		 *
+		 *     This endpoint is designed for on-demand loading when a series row is expanded
+		 *     in the library view. Sonarr instances only.
+		 *
+		 *     Results are cached server-side for 5 minutes per series.
+		 */
+		get: operations['getLibraryEpisodes'];
+		put?: never;
+		post?: never;
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
+	'/arr/releases': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		/**
+		 * Search for releases
+		 * @description Triggers an interactive search on an Arr instance and returns grouped/deduplicated results.
+		 *
+		 *     For Radarr: Searches for releases for the specified movie.
+		 *     For Sonarr: Searches for season pack releases for the specified series and season.
+		 *
+		 *     Results are grouped by title, combining information from multiple indexers.
+		 */
+		get: operations['getReleases'];
+		put?: never;
+		post?: never;
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
+	'/arr/cleanup': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		get?: never;
+		put?: never;
+		/**
+		 * Scan or execute cleanup of stale configs
+		 * @description Detects and deletes stale namespace-suffixed custom formats and quality profiles
+		 *     from an Arr instance that are no longer in the current sync selections.
+		 *
+		 *     Two actions are supported via the `action` field in the request body:
+		 *     - `scan`: Scans for stale items and returns what would be deleted.
+		 *     - `execute`: Deletes the stale items from a previous scan result.
+		 *
+		 *     Quality profiles assigned to media will be skipped with a warning (Arr returns HTTP 500 "in use").
+		 */
+		post: operations['arrCleanup'];
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
+	'/arr/sync-entity': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		get?: never;
+		put?: never;
+		/**
+		 * Sync a single entity to an Arr instance
+		 * @description Pushes a single entity to an Arr instance. Runs inline and returns when complete.
+		 *
+		 *     Entity types are grouped into sync sections that share cooldown and status tracking:
+		 *       - **qualityProfiles**: qualityProfile, customFormat, regularExpression
+		 *       - **delayProfiles**: delayProfile
+		 *       - **mediaManagement**: naming, qualityDefinitions, mediaSettings
+		 *
+		 *     The section is derived automatically from the entity type. A 5-second cooldown
+		 *     is enforced per section per instance — entity types within the same section share
+		 *     the cooldown. Returns 409 if a sync is already in progress or the cooldown is active.
+		 */
+		post: operations['syncEntity'];
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
+	'/pcd/export': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		/**
+		 * Export a portable entity
+		 * @description Serializes a PCD entity into its portable JSON representation.
+		 *
+		 *     The portable format strips database IDs and timestamps, producing a
+		 *     self-contained snapshot suitable for clipboard copy, file export, or
+		 *     cross-database import.
+		 */
+		get: operations['exportEntity'];
+		put?: never;
+		post?: never;
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
+	'/pcd/import': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		get?: never;
+		put?: never;
+		/**
+		 * Import a portable entity
+		 * @description Deserializes a portable entity into PCD operations, creating the entity
+		 *     in the target database and layer.
+		 *
+		 *     The request body matches the export response format (`entityType` + `data`),
+		 *     plus `databaseId` and `layer` to specify the target.
+		 *
+		 *     Name uniqueness is validated — importing an entity with a name that already
+		 *     exists will return a 400 error.
+		 */
+		post: operations['importEntity'];
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
+	'/regex/validate': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		get?: never;
+		put?: never;
+		/**
+		 * Validate a .NET regex pattern
+		 * @description Validates a regex pattern using the .NET regex engine (via the parser service).
+		 *     This matches the exact validation Radarr and Sonarr perform when importing custom formats.
+		 *     If the parser service is offline, returns { valid: true } to avoid blocking saves.
+		 */
+		post: operations['validateRegex'];
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
 }
 export type webhooks = Record<string, never>;
 export interface components {
-    schemas: {
-        /**
-         * @description Individual component health status
-         * @enum {string}
-         */
-        ComponentStatus: "healthy" | "degraded" | "unhealthy";
-        /**
-         * @description Overall health status
-         * @enum {string}
-         */
-        HealthStatus: "healthy" | "degraded" | "unhealthy";
-        HealthCheckResponse: {
-            status: components["schemas"]["HealthStatus"];
-            /**
-             * Format: date-time
-             * @description Current server time
-             */
-            timestamp: string;
-        };
-        HealthDiagnosticsResponse: {
-            status: components["schemas"]["HealthStatus"];
-            /**
-             * Format: date-time
-             * @description Current server time
-             */
-            timestamp: string;
-            /** @description Application version */
-            version: string;
-            /** @description Server uptime in seconds */
-            uptime: number;
-            components: {
-                sqlite: components["schemas"]["SqliteHealth"];
-                repos: components["schemas"]["ReposHealth"];
-                jobs: components["schemas"]["JobsHealth"];
-                backups: components["schemas"]["BackupsHealth"];
-                logs: components["schemas"]["LogsHealth"];
-            };
-        };
-        /**
-         * @description Type of media
-         * @enum {string}
-         */
-        MediaType: "movie" | "series";
-        ParsedInfo: {
-            /** @description Detected source (e.g., bluray, webdl, webrip) */
-            source: string;
-            /** @description Detected resolution (e.g., 1080p, 2160p) */
-            resolution: string;
-            /** @description Quality modifier (e.g., remux, none) */
-            modifier: string;
-            /** @description Detected languages */
-            languages: string[];
-            /**
-             * @description Where the language information came from (Indexer = indexer-provided, Title = parsed from release title)
-             * @enum {string}
-             */
-            languageSource: "Indexer" | "Title";
-            /** @description Detected release group */
-            releaseGroup?: string | null;
-            /** @description Detected year */
-            year: number;
-            /** @description Detected edition (e.g., Director's Cut) */
-            edition?: string | null;
-            /** @description Release type for series (single_episode, season_pack, etc.) */
-            releaseType?: string | null;
-        };
-        ReleaseInput: {
-            /** @description Release ID */
-            id: number;
-            /** @description Release title to parse and evaluate */
-            title: string;
-            type: components["schemas"]["MediaType"];
-            /** @description Indexer-provided languages. When present and non-empty, these override languages parsed from the title. */
-            languages?: string[];
-        };
-        ReleaseEvaluation: {
-            /** @description Release ID */
-            releaseId: number;
-            /** @description Release title */
-            title: string;
-            /** @description Parsed release info (null if parsing failed) */
-            parsed?: components["schemas"]["ParsedInfo"];
-            /** @description Map of custom format ID to whether it matches */
-            cfMatches: {
-                [key: string]: boolean;
-            };
-        };
-        EvaluateRequest: {
-            /** @description Database ID to use for custom format evaluation. If omitted, only parsing is performed (no CF matching). */
-            databaseId?: number;
-            /** @description Releases to evaluate */
-            releases: components["schemas"]["ReleaseInput"][];
-        };
-        EvaluateResponse: {
-            /** @description Whether the parser service is available */
-            parserAvailable: boolean;
-            /** @description Evaluation results for each release */
-            evaluations: components["schemas"]["ReleaseEvaluation"][];
-        };
-        /**
-         * @description Type of Arr instance
-         * @enum {string}
-         */
-        ArrType: "radarr" | "sonarr";
-        CustomFormatRef: {
-            /** @description Custom format ID */
-            id: number;
-            /** @description Custom format name */
-            name: string;
-        };
-        ScoreBreakdownItem: {
-            /** @description Custom format name */
-            name: string;
-            /** @description Score assigned by the quality profile */
-            score: number;
-        };
-        ProfileByDatabase: {
-            /** @description Profilarr database ID */
-            databaseId: number;
-            /** @description Profilarr database name */
-            databaseName: string;
-            /** @description Quality profile names in this database */
-            profiles: string[];
-        };
-        ErrorResponse: {
-            /** @description Error message */
-            error: string;
-        };
-        RadarrLibraryItem: {
-            /** @description Radarr movie ID */
-            id: number;
-            /** @description TMDB ID */
-            tmdbId?: number;
-            /** @description IMDB ID */
-            imdbId?: string;
-            /** @description Movie title */
-            title: string;
-            /** @description Release year */
-            year?: number;
-            /** @description Assigned quality profile ID */
-            qualityProfileId: number;
-            /** @description Assigned quality profile name */
-            qualityProfileName: string;
-            /** @description Whether the movie has a downloaded file */
-            hasFile: boolean;
-            /** @description Whether the movie is monitored */
-            monitored: boolean;
-            /** @description Movie status (released, announced, inCinemas) */
-            status?: string;
-            /**
-             * Format: date-time
-             * @description When the movie was added
-             */
-            dateAdded?: string;
-            /** @description TMDB popularity score */
-            popularity?: number;
-            /** @description File size in bytes */
-            sizeOnDisk?: number;
-            /** @description Runtime in minutes */
-            runtime?: number;
-            /** @description Content rating (e.g. R, PG-13) */
-            certification?: string;
-            /** @description Genre list */
-            genres?: string[];
-            /** @description Production studio */
-            studio?: string;
-            /** @description Ratings from various sources */
-            ratings?: {
-                imdb?: components["schemas"]["RatingSource"];
-                tmdb?: components["schemas"]["RatingSource"];
-                metacritic?: components["schemas"]["RatingSource"];
-                rottenTomatoes?: components["schemas"]["RatingSource"];
-                trakt?: components["schemas"]["RatingSource"];
-            };
-            /** @description Poster and fanart images */
-            images?: components["schemas"]["ArrImage"][];
-            collection?: {
-                title?: string;
-                tmdbId?: number;
-            };
-            originalLanguage?: {
-                id?: number;
-                name?: string;
-            };
-            /** @description Quality of the downloaded file (null if no file) */
-            qualityName?: string | null;
-            /** @description File name of the downloaded file (null if no file) */
-            fileName?: string | null;
-            /** @description Release group name from the file */
-            releaseGroup?: string;
-            /** @description Edition name (e.g. Final Cut, Director's Cut) */
-            edition?: string;
-            /** @description Languages in the file */
-            languages?: {
-                id?: number;
-                name?: string;
-            }[];
-            mediaInfo?: components["schemas"]["ArrMediaInfo"];
-            /** @description Custom formats matched on the file */
-            customFormats: components["schemas"]["CustomFormatRef"][];
-            /** @description Total custom format score */
-            customFormatScore: number;
-            /** @description Per-custom-format score breakdown */
-            scoreBreakdown: components["schemas"]["ScoreBreakdownItem"][];
-            /** @description Profile cutoff score threshold */
-            cutoffScore: number;
-            /** @description Profile minimum score threshold */
-            minScore: number;
-            /** @description Score progress toward cutoff (0-1+) */
-            progress: number;
-            /** @description Whether the cutoff score has been met */
-            cutoffMet: boolean;
-            /** @description Whether the profile is managed by Profilarr */
-            isProfilarrProfile: boolean;
-        };
-        SonarrSeasonItem: {
-            /** @description Season number (0 = specials) */
-            seasonNumber: number;
-            /** @description Whether this season is monitored */
-            monitored: boolean;
-            /** @description Number of aired episodes */
-            episodeCount: number;
-            /** @description Number of episodes with files */
-            episodeFileCount: number;
-            /** @description Total episodes including unaired */
-            totalEpisodeCount: number;
-            /** @description Total size of episode files in bytes */
-            sizeOnDisk: number;
-            /** @description Percentage of episodes with files (0-100) */
-            percentOfEpisodes: number;
-        };
-        SonarrLibraryItem: {
-            /** @description Sonarr series ID */
-            id: number;
-            /** @description TVDB ID */
-            tvdbId?: number;
-            /** @description Series title */
-            title: string;
-            /** @description URL-friendly slug from Sonarr (used for series page links) */
-            titleSlug?: string;
-            /** @description First air year */
-            year?: number;
-            /** @description Assigned quality profile ID */
-            qualityProfileId: number;
-            /** @description Assigned quality profile name */
-            qualityProfileName: string;
-            /** @description Series status (continuing, ended, etc.) */
-            status?: string;
-            /** @description Whether the series is monitored */
-            monitored: boolean;
-            /** @description Number of seasons */
-            seasonCount: number;
-            /** @description Number of aired episodes */
-            episodeCount: number;
-            /** @description Number of episodes with files */
-            episodeFileCount: number;
-            /** @description Total episodes including unaired */
-            totalEpisodeCount: number;
-            /** @description Total size of all episode files in bytes */
-            sizeOnDisk: number;
-            /** @description Percentage of episodes with files (0-100) */
-            percentOfEpisodes: number;
-            /**
-             * Format: date-time
-             * @description When the series was added
-             */
-            dateAdded?: string;
-            /** @description Season-level statistics */
-            seasons: components["schemas"]["SonarrSeasonItem"][];
-            /** @description Whether the profile is managed by Profilarr */
-            isProfilarrProfile: boolean;
-            /** @description TV network (e.g. HBO, CBS) */
-            network?: string;
-            /** @description Series type (standard, daily, anime) */
-            seriesType?: string;
-            /** @description Content rating (e.g. TV-MA, TV-PG) */
-            certification?: string;
-            /** @description Genre list */
-            genres?: string[];
-            /** @description Episode runtime in minutes */
-            runtime?: number;
-            ratings?: {
-                votes?: number;
-                value?: number;
-            };
-            /** @description Poster, banner, fanart images */
-            images?: components["schemas"]["ArrImage"][];
-            originalLanguage?: {
-                id?: number;
-                name?: string;
-            };
-            /**
-             * Format: date-time
-             * @description First air date
-             */
-            firstAired?: string;
-            /**
-             * Format: date-time
-             * @description Last air date
-             */
-            lastAired?: string;
-            /** @description IMDB ID */
-            imdbId?: string;
-        };
-        SonarrEpisodeItem: {
-            /** @description Sonarr episode ID */
-            id: number;
-            /** @description Episode number within the season */
-            episodeNumber: number;
-            /** @description Season number */
-            seasonNumber: number;
-            /** @description Episode title */
-            title: string;
-            /** @description Whether the episode has a downloaded file */
-            hasFile: boolean;
-            /** @description Whether the episode is monitored */
-            monitored: boolean;
-            /** @description Quality of the downloaded file */
-            qualityName?: string;
-            /** @description File name of the downloaded file */
-            fileName?: string;
-            /** @description File size in bytes */
-            size?: number;
-            /** @description Custom formats matched on the file */
-            customFormats: components["schemas"]["CustomFormatRef"][];
-            /** @description Total custom format score */
-            customFormatScore: number;
-            /** @description Per-custom-format score breakdown */
-            scoreBreakdown: components["schemas"]["ScoreBreakdownItem"][];
-            /** @description Profile cutoff score threshold */
-            cutoffScore: number;
-            /** @description Score progress toward cutoff (0-1+) */
-            progress: number;
-            /** @description Whether the cutoff score has been met */
-            cutoffMet: boolean;
-            /** @description Release group name from the file */
-            releaseGroup?: string;
-            /** @description Languages in the file */
-            languages?: {
-                id?: number;
-                name?: string;
-            }[];
-            mediaInfo?: components["schemas"]["ArrMediaInfo"];
-        };
-        /** @description Library response varies by instance type */
-        LibraryResponse: components["schemas"]["LibraryRadarrResponse"] | components["schemas"]["LibrarySonarrResponse"];
-        EpisodesResponse: {
-            /** @description Episode details with quality and score data */
-            episodes: components["schemas"]["SonarrEpisodeItem"][];
-        };
-        CacheInvalidatedResponse: {
-            /** @description Whether the cache was invalidated */
-            success: boolean;
-        };
-        GroupedRelease: {
-            /** @description Release title */
-            title: string;
-            /** @description Release size in bytes */
-            size: number;
-            /** @description Languages detected in the release */
-            languages: string[];
-            /** @description Indexers where this release was found */
-            indexers: string[];
-            /** @description Release flags (e.g., freeleech, internal) */
-            flags: string[];
-        };
-        ReleasesResponse: {
-            type: components["schemas"]["ArrType"];
-            /** @description Total number of raw releases before grouping */
-            rawCount: number;
-            /** @description Grouped and deduplicated releases */
-            releases: components["schemas"]["GroupedRelease"][];
-        };
-        StaleItem: {
-            /** @description Arr entity ID */
-            id: number;
-            /** @description Full name including namespace suffix */
-            name: string;
-            /** @description Name with namespace suffix removed */
-            strippedName: string;
-        };
-        CleanupScanRequest: {
-            /** @description Arr instance ID */
-            instanceId: number;
-            /** @enum {string} */
-            action: "scan";
-        };
-        CleanupExecuteRequest: {
-            /** @description Arr instance ID */
-            instanceId: number;
-            /** @enum {string} */
-            action: "execute";
-            scanResult: components["schemas"]["CleanupScanResult"];
-        };
-        CleanupScanResult: {
-            /** @description Custom formats that are no longer in sync selections */
-            staleCustomFormats: components["schemas"]["StaleItem"][];
-            /** @description Quality profiles that are no longer in sync selections */
-            staleQualityProfiles: components["schemas"]["StaleItem"][];
-        };
-        CleanupDeleteResult: {
-            /** @description Custom formats that were successfully deleted */
-            deletedCustomFormats: components["schemas"]["StaleItem"][];
-            /** @description Quality profiles that were successfully deleted */
-            deletedQualityProfiles: components["schemas"]["StaleItem"][];
-            /** @description Quality profiles that were skipped (assigned to media) */
-            skippedQualityProfiles: components["schemas"]["SkippedItem"][];
-        };
-        SyncEntityRequest: {
-            /** @description Arr instance ID */
-            instanceId: number;
-            /** @description PCD database ID */
-            databaseId: number;
-            /** @description Name of the entity to sync */
-            entityName: string;
-            /**
-             * @description Type of entity being synced. Determines which sync function runs and which cooldown group applies (qualityProfiles, delayProfiles, or mediaManagement).
-             * @enum {string}
-             */
-            entityType: "qualityProfile" | "customFormat" | "regularExpression" | "delayProfile" | "naming" | "qualityDefinitions" | "mediaSettings";
-        };
-        SyncEntitySuccessResponse: {
-            /** @enum {boolean} */
-            success: true;
-        };
-        SyncEntityCooldownResponse: {
-            /** @description Cooldown or in-progress message */
-            error: string;
-            /** @description Seconds until cooldown expires */
-            retryAfter?: number;
-        };
-        /** @enum {string} */
-        EntityType: "delay_profile" | "regular_expression" | "custom_format" | "quality_profile" | "radarr_naming" | "sonarr_naming" | "radarr_media_settings" | "sonarr_media_settings" | "radarr_quality_definitions" | "sonarr_quality_definitions";
-        ExportResponse: {
-            entityType: components["schemas"]["EntityType"];
-            /**
-             * @description The portable entity payload. Shape varies by entityType:
-             *     - `delay_profile` → PortableDelayProfile
-             *     - `regular_expression` → PortableRegularExpression
-             *     - `custom_format` → PortableCustomFormat
-             *     - `quality_profile` → PortableQualityProfile
-             *     - `radarr_naming` → PortableRadarrNaming
-             *     - `sonarr_naming` → PortableSonarrNaming
-             *     - `radarr_media_settings` → PortableMediaSettings
-             *     - `sonarr_media_settings` → PortableMediaSettings
-             *     - `radarr_quality_definitions` → PortableQualityDefinitions
-             *     - `sonarr_quality_definitions` → PortableQualityDefinitions
-             */
-            data: components["schemas"]["PortableDelayProfile"] | components["schemas"]["PortableRegularExpression"] | components["schemas"]["PortableCustomFormat"] | components["schemas"]["PortableQualityProfile"] | components["schemas"]["PortableRadarrNaming"] | components["schemas"]["PortableSonarrNaming"] | components["schemas"]["PortableMediaSettings"] | components["schemas"]["PortableQualityDefinitions"];
-        };
-        PcdErrorResponse: {
-            error: string;
-        };
-        BundledDependency: {
-            /** @description The entity type of the dependency */
-            entityType: string;
-            /** @description The portable entity payload for the dependency */
-            data: {
-                name: string;
-            } & {
-                [key: string]: unknown;
-            };
-        };
-        ImportConflict: {
-            /** @description The entity type that conflicts */
-            entityType: string;
-            /** @description The name of the conflicting entity */
-            name: string;
-        };
-        ConflictResolution: {
-            /** @description The entity type being resolved */
-            entityType: string;
-            /** @description The original name of the conflicting entity */
-            originalName: string;
-            /**
-             * @description How to resolve the conflict
-             * @enum {string}
-             */
-            action: "skip" | "rename";
-            /** @description The new name when action is rename */
-            newName?: string;
-        };
-        ImportRequest: {
-            /** @description The PCD database ID to import into */
-            databaseId: number;
-            /**
-             * @description The operation layer to write to
-             * @enum {string}
-             */
-            layer: "user" | "base";
-            entityType: components["schemas"]["EntityType"];
-            /** @description The portable entity payload (same shape as ExportResponse.data) */
-            data: components["schemas"]["PortableDelayProfile"] | components["schemas"]["PortableRegularExpression"] | components["schemas"]["PortableCustomFormat"] | components["schemas"]["PortableQualityProfile"] | components["schemas"]["PortableRadarrNaming"] | components["schemas"]["PortableSonarrNaming"] | components["schemas"]["PortableMediaSettings"] | components["schemas"]["PortableQualityDefinitions"];
-        };
-        ImportResponse: {
-            success: boolean;
-        };
-        ArrInstance: {
-            /** @description Instance ID */
-            id: number;
-            /** @description Display name */
-            name: string;
-            type: components["schemas"]["ArrType"];
-            /** @description Instance URL */
-            url: string;
-            /** @description JSON array of tags */
-            tags?: string | null;
-            /** @description Whether the instance is active (0 or 1) */
-            enabled: number;
-            /** @description Library cache refresh interval in minutes (0 = manual) */
-            library_refresh_interval: number;
-            /** @description Last library refresh timestamp */
-            library_last_refreshed_at?: string | null;
-            /** @description Creation timestamp */
-            created_at: string;
-            /** @description Last update timestamp */
-            updated_at: string;
-        };
-        DatabaseInstance: {
-            /** @description Database instance ID */
-            id: number;
-            /**
-             * Format: uuid
-             * @description Unique identifier
-             */
-            uuid: string;
-            /** @description Display name */
-            name: string;
-            /** @description GitHub repository URL */
-            repository_url: string;
-            /** @description Auto-sync interval in minutes (0 = manual only) */
-            sync_strategy: number;
-            /** @description Whether to automatically pull updates (0 or 1) */
-            auto_pull: number;
-            /** @description Whether the database is active (0 or 1) */
-            enabled: number;
-            /** @description Whether the repository is private (0 or 1) */
-            is_private: number;
-            /** @description Whether local ops editing is enabled (0 or 1) */
-            local_ops_enabled: number;
-            /** @description Git user name for commits */
-            git_user_name?: string | null;
-            /** @description Git user email for commits */
-            git_user_email?: string | null;
-            /**
-             * @description How to handle conflicts between local tweaks and upstream updates
-             * @enum {string}
-             */
-            conflict_strategy: "override" | "align" | "ask";
-            /** @description Last successful sync timestamp */
-            last_synced_at?: string | null;
-            /** @description Creation timestamp */
-            created_at: string;
-            /** @description Last update timestamp */
-            updated_at: string;
-            /** @description Whether a personal access token is configured */
-            hasPat: boolean;
-        };
-        ValidateRegexRequest: {
-            /** @description The .NET regex pattern to validate */
-            pattern: string;
-        };
-        ValidateRegexResponse: {
-            /** @description Whether the pattern is a valid .NET regex */
-            valid: boolean;
-            /** @description The .NET ArgumentException message if invalid */
-            error?: string | null;
-            /** @description Whether the parser service was reachable. False means validation was skipped. */
-            available?: boolean | null;
-        };
-        SqliteHealth: {
-            status: components["schemas"]["ComponentStatus"];
-            /** @description Database query response time in milliseconds */
-            responseTimeMs: number;
-            /** @description Current migration version */
-            migration: number;
-            /** @description Error message if unhealthy */
-            message?: string;
-        };
-        ReposHealth: {
-            status: components["schemas"]["ComponentStatus"];
-            /** @description Additional status information */
-            message?: string;
-            /** @description Total number of PCD repos configured (verbose only) */
-            total?: number;
-            /** @description Number of enabled repos (verbose only) */
-            enabled?: number;
-            /** @description Number of repos with compiled cache (verbose only) */
-            cached?: number;
-            /** @description Number of disabled repos (verbose only) */
-            disabled?: number;
-        };
-        JobsHealth: {
-            status: components["schemas"]["ComponentStatus"];
-            /** @description Additional status information */
-            message?: string;
-            /**
-             * Format: date-time
-             * @description Oldest queued job run_at timestamp (verbose only)
-             */
-            oldestQueued?: string | null;
-        };
-        BackupsHealth: {
-            status: components["schemas"]["ComponentStatus"];
-            /** @description Whether backups are enabled */
-            enabled: boolean;
-            /** @description Additional status information */
-            message?: string;
-            /**
-             * Format: date-time
-             * @description Timestamp of last backup (verbose only)
-             */
-            lastBackup?: string | null;
-            /** @description Number of backup files (verbose only) */
-            count?: number;
-            /** @description Human-readable total size of all backups (verbose only) */
-            totalSize?: string;
-            /** @description Configured retention period in days (verbose only) */
-            retentionDays?: number;
-        };
-        LogsHealth: {
-            status: components["schemas"]["ComponentStatus"];
-            /** @description Additional status information */
-            message?: string;
-            /** @description Human-readable total size of log files (verbose only) */
-            totalSize?: string;
-            /** @description Number of log files (verbose only) */
-            fileCount?: number;
-            /**
-             * Format: date
-             * @description Date of oldest log file (verbose only)
-             */
-            oldestLog?: string | null;
-            /**
-             * Format: date
-             * @description Date of newest log file (verbose only)
-             */
-            newestLog?: string | null;
-        };
-        RatingSource: {
-            votes?: number;
-            value?: number;
-        };
-        ArrImage: {
-            /** @description Image type (poster, fanart, banner, clearlogo) */
-            coverType?: string;
-            /** @description Local image URL (relative to Arr instance) */
-            url?: string;
-            /** @description Remote CDN URL (TMDB/TVDB) */
-            remoteUrl?: string;
-        };
-        ArrMediaInfo: {
-            audioCodec?: string;
-            audioChannels?: number;
-            videoCodec?: string;
-            videoBitDepth?: number;
-            videoDynamicRange?: string;
-            videoDynamicRangeType?: string;
-            resolution?: string;
-            subtitles?: string;
-        };
-        LibraryRadarrResponse: {
-            /** @enum {string} */
-            type: "radarr";
-            items: components["schemas"]["RadarrLibraryItem"][];
-            profilesByDatabase: components["schemas"]["ProfileByDatabase"][];
-        };
-        LibrarySonarrResponse: {
-            /** @enum {string} */
-            type: "sonarr";
-            items: components["schemas"]["SonarrLibraryItem"][];
-            profilesByDatabase: components["schemas"]["ProfileByDatabase"][];
-        };
-        SkippedItem: {
-            item: components["schemas"]["StaleItem"];
-            /** @description Why the item was skipped (e.g. "Profile is assigned to media") */
-            reason: string;
-        };
-        PortableDelayProfile: {
-            name: string;
-            /** @enum {string} */
-            preferredProtocol: "prefer_usenet" | "prefer_torrent" | "only_usenet" | "only_torrent";
-            usenetDelay: number;
-            torrentDelay: number;
-            bypassIfHighestQuality: boolean;
-            bypassIfAboveCfScore: boolean;
-            minimumCfScore: number;
-        };
-        PortableRegularExpression: {
-            name: string;
-            pattern: string;
-            tags: string[];
-            description: string | null;
-            regex101Id: string | null;
-        };
-        PortableCustomFormatTest: {
-            title: string;
-            /** @enum {string} */
-            type: "movie" | "series";
-            shouldMatch: boolean;
-            description: string | null;
-        };
-        PortableCustomFormat: {
-            name: string;
-            description: string | null;
-            includeInRename: boolean;
-            tags: string[];
-            conditions: Record<string, never>[];
-            tests: components["schemas"]["PortableCustomFormatTest"][];
-        };
-        PortableCustomFormatScore: {
-            customFormatName: string;
-            arrType: string;
-            score: number;
-        };
-        PortableQualityProfile: {
-            name: string;
-            description: string | null;
-            tags: string[];
-            language: string | null;
-            orderedItems: Record<string, never>[];
-            minimumScore: number;
-            upgradeUntilScore: number;
-            upgradeScoreIncrement: number;
-            customFormatScores: components["schemas"]["PortableCustomFormatScore"][];
-        };
-        PortableRadarrNaming: {
-            name: string;
-            rename: boolean;
-            movieFormat: string;
-            movieFolderFormat: string;
-            replaceIllegalCharacters: boolean;
-            colonReplacementFormat: string;
-        };
-        PortableSonarrNaming: {
-            name: string;
-            rename: boolean;
-            standardEpisodeFormat: string;
-            dailyEpisodeFormat: string;
-            animeEpisodeFormat: string;
-            seriesFolderFormat: string;
-            seasonFolderFormat: string;
-            replaceIllegalCharacters: boolean;
-            colonReplacementFormat: string;
-            customColonReplacementFormat: string | null;
-            multiEpisodeStyle: string;
-        };
-        PortableMediaSettings: {
-            name: string;
-            propersRepacks: string;
-            enableMediaInfo: boolean;
-        };
-        PortableQualityDefinitions: {
-            name: string;
-            entries: Record<string, never>[];
-        };
-    };
-    responses: never;
-    parameters: never;
-    requestBodies: never;
-    headers: never;
-    pathItems: never;
+	schemas: {
+		/**
+		 * @description Individual component health status
+		 * @enum {string}
+		 */
+		ComponentStatus: 'healthy' | 'degraded' | 'unhealthy';
+		/**
+		 * @description Overall health status
+		 * @enum {string}
+		 */
+		HealthStatus: 'healthy' | 'degraded' | 'unhealthy';
+		HealthCheckResponse: {
+			status: components['schemas']['HealthStatus'];
+			/**
+			 * Format: date-time
+			 * @description Current server time
+			 */
+			timestamp: string;
+		};
+		HealthDiagnosticsResponse: {
+			status: components['schemas']['HealthStatus'];
+			/**
+			 * Format: date-time
+			 * @description Current server time
+			 */
+			timestamp: string;
+			/** @description Application version */
+			version: string;
+			/** @description Server uptime in seconds */
+			uptime: number;
+			components: {
+				sqlite: components['schemas']['SqliteHealth'];
+				repos: components['schemas']['ReposHealth'];
+				jobs: components['schemas']['JobsHealth'];
+				backups: components['schemas']['BackupsHealth'];
+				logs: components['schemas']['LogsHealth'];
+			};
+		};
+		/**
+		 * @description Type of media
+		 * @enum {string}
+		 */
+		MediaType: 'movie' | 'series';
+		ParsedInfo: {
+			/** @description Detected source (e.g., bluray, webdl, webrip) */
+			source: string;
+			/** @description Detected resolution (e.g., 1080p, 2160p) */
+			resolution: string;
+			/** @description Quality modifier (e.g., remux, none) */
+			modifier: string;
+			/** @description Detected languages */
+			languages: string[];
+			/**
+			 * @description Where the language information came from (Indexer = indexer-provided, Title = parsed from release title)
+			 * @enum {string}
+			 */
+			languageSource: 'Indexer' | 'Title';
+			/** @description Detected release group */
+			releaseGroup?: string | null;
+			/** @description Detected year */
+			year: number;
+			/** @description Detected edition (e.g., Director's Cut) */
+			edition?: string | null;
+			/** @description Release type for series (single_episode, season_pack, etc.) */
+			releaseType?: string | null;
+		};
+		ReleaseInput: {
+			/** @description Release ID */
+			id: number;
+			/** @description Release title to parse and evaluate */
+			title: string;
+			type: components['schemas']['MediaType'];
+			/** @description Indexer-provided languages. When present and non-empty, these override languages parsed from the title. */
+			languages?: string[];
+		};
+		ReleaseEvaluation: {
+			/** @description Release ID */
+			releaseId: number;
+			/** @description Release title */
+			title: string;
+			/** @description Parsed release info (null if parsing failed) */
+			parsed?: components['schemas']['ParsedInfo'];
+			/** @description Map of custom format ID to whether it matches */
+			cfMatches: {
+				[key: string]: boolean;
+			};
+		};
+		EvaluateRequest: {
+			/** @description Database ID to use for custom format evaluation. If omitted, only parsing is performed (no CF matching). */
+			databaseId?: number;
+			/** @description Releases to evaluate */
+			releases: components['schemas']['ReleaseInput'][];
+		};
+		EvaluateResponse: {
+			/** @description Whether the parser service is available */
+			parserAvailable: boolean;
+			/** @description Evaluation results for each release */
+			evaluations: components['schemas']['ReleaseEvaluation'][];
+		};
+		/**
+		 * @description Type of Arr instance
+		 * @enum {string}
+		 */
+		ArrType: 'radarr' | 'sonarr';
+		CustomFormatRef: {
+			/** @description Custom format ID */
+			id: number;
+			/** @description Custom format name */
+			name: string;
+		};
+		ScoreBreakdownItem: {
+			/** @description Custom format name */
+			name: string;
+			/** @description Score assigned by the quality profile */
+			score: number;
+		};
+		ProfileByDatabase: {
+			/** @description Profilarr database ID */
+			databaseId: number;
+			/** @description Profilarr database name */
+			databaseName: string;
+			/** @description Quality profile names in this database */
+			profiles: string[];
+		};
+		ErrorResponse: {
+			/** @description Error message */
+			error: string;
+		};
+		RadarrLibraryItem: {
+			/** @description Radarr movie ID */
+			id: number;
+			/** @description TMDB ID */
+			tmdbId?: number;
+			/** @description IMDB ID */
+			imdbId?: string;
+			/** @description Movie title */
+			title: string;
+			/** @description Release year */
+			year?: number;
+			/** @description Assigned quality profile ID */
+			qualityProfileId: number;
+			/** @description Assigned quality profile name */
+			qualityProfileName: string;
+			/** @description Whether the movie has a downloaded file */
+			hasFile: boolean;
+			/** @description Whether the movie is monitored */
+			monitored: boolean;
+			/** @description Movie status (released, announced, inCinemas) */
+			status?: string;
+			/**
+			 * Format: date-time
+			 * @description When the movie was added
+			 */
+			dateAdded?: string;
+			/** @description TMDB popularity score */
+			popularity?: number;
+			/** @description File size in bytes */
+			sizeOnDisk?: number;
+			/** @description Runtime in minutes */
+			runtime?: number;
+			/** @description Content rating (e.g. R, PG-13) */
+			certification?: string;
+			/** @description Genre list */
+			genres?: string[];
+			/** @description Production studio */
+			studio?: string;
+			/** @description Ratings from various sources */
+			ratings?: {
+				imdb?: components['schemas']['RatingSource'];
+				tmdb?: components['schemas']['RatingSource'];
+				metacritic?: components['schemas']['RatingSource'];
+				rottenTomatoes?: components['schemas']['RatingSource'];
+				trakt?: components['schemas']['RatingSource'];
+			};
+			/** @description Poster and fanart images */
+			images?: components['schemas']['ArrImage'][];
+			collection?: {
+				title?: string;
+				tmdbId?: number;
+			};
+			originalLanguage?: {
+				id?: number;
+				name?: string;
+			};
+			/** @description Quality of the downloaded file (null if no file) */
+			qualityName?: string | null;
+			/** @description File name of the downloaded file (null if no file) */
+			fileName?: string | null;
+			/** @description Release group name from the file */
+			releaseGroup?: string;
+			/** @description Edition name (e.g. Final Cut, Director's Cut) */
+			edition?: string;
+			/** @description Languages in the file */
+			languages?: {
+				id?: number;
+				name?: string;
+			}[];
+			mediaInfo?: components['schemas']['ArrMediaInfo'];
+			/** @description Custom formats matched on the file */
+			customFormats: components['schemas']['CustomFormatRef'][];
+			/** @description Total custom format score */
+			customFormatScore: number;
+			/** @description Per-custom-format score breakdown */
+			scoreBreakdown: components['schemas']['ScoreBreakdownItem'][];
+			/** @description Profile cutoff score threshold */
+			cutoffScore: number;
+			/** @description Profile minimum score threshold */
+			minScore: number;
+			/** @description Score progress toward cutoff (0-1+) */
+			progress: number;
+			/** @description Whether the cutoff score has been met */
+			cutoffMet: boolean;
+			/** @description Whether the profile is managed by Profilarr */
+			isProfilarrProfile: boolean;
+		};
+		SonarrSeasonItem: {
+			/** @description Season number (0 = specials) */
+			seasonNumber: number;
+			/** @description Whether this season is monitored */
+			monitored: boolean;
+			/** @description Number of aired episodes */
+			episodeCount: number;
+			/** @description Number of episodes with files */
+			episodeFileCount: number;
+			/** @description Total episodes including unaired */
+			totalEpisodeCount: number;
+			/** @description Total size of episode files in bytes */
+			sizeOnDisk: number;
+			/** @description Percentage of episodes with files (0-100) */
+			percentOfEpisodes: number;
+		};
+		SonarrLibraryItem: {
+			/** @description Sonarr series ID */
+			id: number;
+			/** @description TVDB ID */
+			tvdbId?: number;
+			/** @description Series title */
+			title: string;
+			/** @description URL-friendly slug from Sonarr (used for series page links) */
+			titleSlug?: string;
+			/** @description First air year */
+			year?: number;
+			/** @description Assigned quality profile ID */
+			qualityProfileId: number;
+			/** @description Assigned quality profile name */
+			qualityProfileName: string;
+			/** @description Series status (continuing, ended, etc.) */
+			status?: string;
+			/** @description Whether the series is monitored */
+			monitored: boolean;
+			/** @description Number of seasons */
+			seasonCount: number;
+			/** @description Number of aired episodes */
+			episodeCount: number;
+			/** @description Number of episodes with files */
+			episodeFileCount: number;
+			/** @description Total episodes including unaired */
+			totalEpisodeCount: number;
+			/** @description Total size of all episode files in bytes */
+			sizeOnDisk: number;
+			/** @description Percentage of episodes with files (0-100) */
+			percentOfEpisodes: number;
+			/**
+			 * Format: date-time
+			 * @description When the series was added
+			 */
+			dateAdded?: string;
+			/** @description Season-level statistics */
+			seasons: components['schemas']['SonarrSeasonItem'][];
+			/** @description Whether the profile is managed by Profilarr */
+			isProfilarrProfile: boolean;
+			/** @description TV network (e.g. HBO, CBS) */
+			network?: string;
+			/** @description Series type (standard, daily, anime) */
+			seriesType?: string;
+			/** @description Content rating (e.g. TV-MA, TV-PG) */
+			certification?: string;
+			/** @description Genre list */
+			genres?: string[];
+			/** @description Episode runtime in minutes */
+			runtime?: number;
+			ratings?: {
+				votes?: number;
+				value?: number;
+			};
+			/** @description Poster, banner, fanart images */
+			images?: components['schemas']['ArrImage'][];
+			originalLanguage?: {
+				id?: number;
+				name?: string;
+			};
+			/**
+			 * Format: date-time
+			 * @description First air date
+			 */
+			firstAired?: string;
+			/**
+			 * Format: date-time
+			 * @description Last air date
+			 */
+			lastAired?: string;
+			/** @description IMDB ID */
+			imdbId?: string;
+		};
+		SonarrEpisodeItem: {
+			/** @description Sonarr episode ID */
+			id: number;
+			/** @description Episode number within the season */
+			episodeNumber: number;
+			/** @description Season number */
+			seasonNumber: number;
+			/** @description Episode title */
+			title: string;
+			/** @description Whether the episode has a downloaded file */
+			hasFile: boolean;
+			/** @description Whether the episode is monitored */
+			monitored: boolean;
+			/** @description Quality of the downloaded file */
+			qualityName?: string;
+			/** @description File name of the downloaded file */
+			fileName?: string;
+			/** @description File size in bytes */
+			size?: number;
+			/** @description Custom formats matched on the file */
+			customFormats: components['schemas']['CustomFormatRef'][];
+			/** @description Total custom format score */
+			customFormatScore: number;
+			/** @description Per-custom-format score breakdown */
+			scoreBreakdown: components['schemas']['ScoreBreakdownItem'][];
+			/** @description Profile cutoff score threshold */
+			cutoffScore: number;
+			/** @description Score progress toward cutoff (0-1+) */
+			progress: number;
+			/** @description Whether the cutoff score has been met */
+			cutoffMet: boolean;
+			/** @description Release group name from the file */
+			releaseGroup?: string;
+			/** @description Languages in the file */
+			languages?: {
+				id?: number;
+				name?: string;
+			}[];
+			mediaInfo?: components['schemas']['ArrMediaInfo'];
+		};
+		/** @description Library response varies by instance type */
+		LibraryResponse:
+			| components['schemas']['LibraryRadarrResponse']
+			| components['schemas']['LibrarySonarrResponse'];
+		EpisodesResponse: {
+			/** @description Episode details with quality and score data */
+			episodes: components['schemas']['SonarrEpisodeItem'][];
+		};
+		CacheInvalidatedResponse: {
+			/** @description Whether the cache was invalidated */
+			success: boolean;
+		};
+		GroupedRelease: {
+			/** @description Release title */
+			title: string;
+			/** @description Release size in bytes */
+			size: number;
+			/** @description Languages detected in the release */
+			languages: string[];
+			/** @description Indexers where this release was found */
+			indexers: string[];
+			/** @description Release flags (e.g., freeleech, internal) */
+			flags: string[];
+		};
+		ReleasesResponse: {
+			type: components['schemas']['ArrType'];
+			/** @description Total number of raw releases before grouping */
+			rawCount: number;
+			/** @description Grouped and deduplicated releases */
+			releases: components['schemas']['GroupedRelease'][];
+		};
+		StaleItem: {
+			/** @description Arr entity ID */
+			id: number;
+			/** @description Full name including namespace suffix */
+			name: string;
+			/** @description Name with namespace suffix removed */
+			strippedName: string;
+		};
+		CleanupScanRequest: {
+			/** @description Arr instance ID */
+			instanceId: number;
+			/** @enum {string} */
+			action: 'scan';
+		};
+		CleanupExecuteRequest: {
+			/** @description Arr instance ID */
+			instanceId: number;
+			/** @enum {string} */
+			action: 'execute';
+			scanResult: components['schemas']['CleanupScanResult'];
+		};
+		CleanupScanResult: {
+			/** @description Custom formats that are no longer in sync selections */
+			staleCustomFormats: components['schemas']['StaleItem'][];
+			/** @description Quality profiles that are no longer in sync selections */
+			staleQualityProfiles: components['schemas']['StaleItem'][];
+		};
+		CleanupDeleteResult: {
+			/** @description Custom formats that were successfully deleted */
+			deletedCustomFormats: components['schemas']['StaleItem'][];
+			/** @description Quality profiles that were successfully deleted */
+			deletedQualityProfiles: components['schemas']['StaleItem'][];
+			/** @description Quality profiles that were skipped (assigned to media) */
+			skippedQualityProfiles: components['schemas']['SkippedItem'][];
+		};
+		SyncEntityRequest: {
+			/** @description Arr instance ID */
+			instanceId: number;
+			/** @description PCD database ID */
+			databaseId: number;
+			/** @description Name of the entity to sync */
+			entityName: string;
+			/**
+			 * @description Type of entity being synced. Determines which sync function runs and which cooldown group applies (qualityProfiles, delayProfiles, or mediaManagement).
+			 * @enum {string}
+			 */
+			entityType:
+				| 'qualityProfile'
+				| 'customFormat'
+				| 'regularExpression'
+				| 'delayProfile'
+				| 'naming'
+				| 'qualityDefinitions'
+				| 'mediaSettings';
+		};
+		SyncEntitySuccessResponse: {
+			/** @enum {boolean} */
+			success: true;
+		};
+		SyncEntityCooldownResponse: {
+			/** @description Cooldown or in-progress message */
+			error: string;
+			/** @description Seconds until cooldown expires */
+			retryAfter?: number;
+		};
+		/** @enum {string} */
+		EntityType:
+			| 'delay_profile'
+			| 'regular_expression'
+			| 'custom_format'
+			| 'quality_profile'
+			| 'radarr_naming'
+			| 'sonarr_naming'
+			| 'radarr_media_settings'
+			| 'sonarr_media_settings'
+			| 'radarr_quality_definitions'
+			| 'sonarr_quality_definitions';
+		ExportResponse: {
+			entityType: components['schemas']['EntityType'];
+			/**
+			 * @description The portable entity payload. Shape varies by entityType:
+			 *     - `delay_profile` → PortableDelayProfile
+			 *     - `regular_expression` → PortableRegularExpression
+			 *     - `custom_format` → PortableCustomFormat
+			 *     - `quality_profile` → PortableQualityProfile
+			 *     - `radarr_naming` → PortableRadarrNaming
+			 *     - `sonarr_naming` → PortableSonarrNaming
+			 *     - `radarr_media_settings` → PortableMediaSettings
+			 *     - `sonarr_media_settings` → PortableMediaSettings
+			 *     - `radarr_quality_definitions` → PortableQualityDefinitions
+			 *     - `sonarr_quality_definitions` → PortableQualityDefinitions
+			 */
+			data:
+				| components['schemas']['PortableDelayProfile']
+				| components['schemas']['PortableRegularExpression']
+				| components['schemas']['PortableCustomFormat']
+				| components['schemas']['PortableQualityProfile']
+				| components['schemas']['PortableRadarrNaming']
+				| components['schemas']['PortableSonarrNaming']
+				| components['schemas']['PortableMediaSettings']
+				| components['schemas']['PortableQualityDefinitions'];
+		};
+		PcdErrorResponse: {
+			error: string;
+		};
+		BundledDependency: {
+			/** @description The entity type of the dependency */
+			entityType: string;
+			/** @description The portable entity payload for the dependency */
+			data: {
+				name: string;
+			} & {
+				[key: string]: unknown;
+			};
+		};
+		ImportConflict: {
+			/** @description The entity type that conflicts */
+			entityType: string;
+			/** @description The name of the conflicting entity */
+			name: string;
+		};
+		ConflictResolution: {
+			/** @description The entity type being resolved */
+			entityType: string;
+			/** @description The original name of the conflicting entity */
+			originalName: string;
+			/**
+			 * @description How to resolve the conflict
+			 * @enum {string}
+			 */
+			action: 'skip' | 'rename';
+			/** @description The new name when action is rename */
+			newName?: string;
+		};
+		ImportRequest: {
+			/** @description The PCD database ID to import into */
+			databaseId: number;
+			/**
+			 * @description The operation layer to write to
+			 * @enum {string}
+			 */
+			layer: 'user' | 'base';
+			entityType: components['schemas']['EntityType'];
+			/** @description The portable entity payload (same shape as ExportResponse.data) */
+			data:
+				| components['schemas']['PortableDelayProfile']
+				| components['schemas']['PortableRegularExpression']
+				| components['schemas']['PortableCustomFormat']
+				| components['schemas']['PortableQualityProfile']
+				| components['schemas']['PortableRadarrNaming']
+				| components['schemas']['PortableSonarrNaming']
+				| components['schemas']['PortableMediaSettings']
+				| components['schemas']['PortableQualityDefinitions'];
+		};
+		ImportResponse: {
+			success: boolean;
+		};
+		ArrInstance: {
+			/** @description Instance ID */
+			id: number;
+			/** @description Display name */
+			name: string;
+			type: components['schemas']['ArrType'];
+			/** @description Instance URL */
+			url: string;
+			/** @description JSON array of tags */
+			tags?: string | null;
+			/** @description Whether the instance is active (0 or 1) */
+			enabled: number;
+			/** @description Library cache refresh interval in minutes (0 = manual) */
+			library_refresh_interval: number;
+			/** @description Last library refresh timestamp */
+			library_last_refreshed_at?: string | null;
+			/** @description Creation timestamp */
+			created_at: string;
+			/** @description Last update timestamp */
+			updated_at: string;
+		};
+		DatabaseInstance: {
+			/** @description Database instance ID */
+			id: number;
+			/**
+			 * Format: uuid
+			 * @description Unique identifier
+			 */
+			uuid: string;
+			/** @description Display name */
+			name: string;
+			/** @description GitHub repository URL */
+			repository_url: string;
+			/** @description Auto-sync interval in minutes (0 = manual only) */
+			sync_strategy: number;
+			/** @description Whether to automatically pull updates (0 or 1) */
+			auto_pull: number;
+			/** @description Whether the database is active (0 or 1) */
+			enabled: number;
+			/** @description Whether the repository is private (0 or 1) */
+			is_private: number;
+			/** @description Whether local ops editing is enabled (0 or 1) */
+			local_ops_enabled: number;
+			/** @description Git user name for commits */
+			git_user_name?: string | null;
+			/** @description Git user email for commits */
+			git_user_email?: string | null;
+			/**
+			 * @description How to handle conflicts between local tweaks and upstream updates
+			 * @enum {string}
+			 */
+			conflict_strategy: 'override' | 'align' | 'ask';
+			/** @description Last successful sync timestamp */
+			last_synced_at?: string | null;
+			/** @description Creation timestamp */
+			created_at: string;
+			/** @description Last update timestamp */
+			updated_at: string;
+			/** @description Whether a personal access token is configured */
+			hasPat: boolean;
+		};
+		ValidateRegexRequest: {
+			/** @description The .NET regex pattern to validate */
+			pattern: string;
+		};
+		ValidateRegexResponse: {
+			/** @description Whether the pattern is a valid .NET regex */
+			valid: boolean;
+			/** @description The .NET ArgumentException message if invalid */
+			error?: string | null;
+			/** @description Whether the parser service was reachable. False means validation was skipped. */
+			available?: boolean | null;
+		};
+		SqliteHealth: {
+			status: components['schemas']['ComponentStatus'];
+			/** @description Database query response time in milliseconds */
+			responseTimeMs: number;
+			/** @description Current migration version */
+			migration: number;
+			/** @description Error message if unhealthy */
+			message?: string;
+		};
+		ReposHealth: {
+			status: components['schemas']['ComponentStatus'];
+			/** @description Additional status information */
+			message?: string;
+			/** @description Total number of PCD repos configured (verbose only) */
+			total?: number;
+			/** @description Number of enabled repos (verbose only) */
+			enabled?: number;
+			/** @description Number of repos with compiled cache (verbose only) */
+			cached?: number;
+			/** @description Number of disabled repos (verbose only) */
+			disabled?: number;
+		};
+		JobsHealth: {
+			status: components['schemas']['ComponentStatus'];
+			/** @description Additional status information */
+			message?: string;
+			/**
+			 * Format: date-time
+			 * @description Oldest queued job run_at timestamp (verbose only)
+			 */
+			oldestQueued?: string | null;
+		};
+		BackupsHealth: {
+			status: components['schemas']['ComponentStatus'];
+			/** @description Whether backups are enabled */
+			enabled: boolean;
+			/** @description Additional status information */
+			message?: string;
+			/**
+			 * Format: date-time
+			 * @description Timestamp of last backup (verbose only)
+			 */
+			lastBackup?: string | null;
+			/** @description Number of backup files (verbose only) */
+			count?: number;
+			/** @description Human-readable total size of all backups (verbose only) */
+			totalSize?: string;
+			/** @description Configured retention period in days (verbose only) */
+			retentionDays?: number;
+		};
+		LogsHealth: {
+			status: components['schemas']['ComponentStatus'];
+			/** @description Additional status information */
+			message?: string;
+			/** @description Human-readable total size of log files (verbose only) */
+			totalSize?: string;
+			/** @description Number of log files (verbose only) */
+			fileCount?: number;
+			/**
+			 * Format: date
+			 * @description Date of oldest log file (verbose only)
+			 */
+			oldestLog?: string | null;
+			/**
+			 * Format: date
+			 * @description Date of newest log file (verbose only)
+			 */
+			newestLog?: string | null;
+		};
+		RatingSource: {
+			votes?: number;
+			value?: number;
+		};
+		ArrImage: {
+			/** @description Image type (poster, fanart, banner, clearlogo) */
+			coverType?: string;
+			/** @description Local image URL (relative to Arr instance) */
+			url?: string;
+			/** @description Remote CDN URL (TMDB/TVDB) */
+			remoteUrl?: string;
+		};
+		ArrMediaInfo: {
+			audioCodec?: string;
+			audioChannels?: number;
+			videoCodec?: string;
+			videoBitDepth?: number;
+			videoDynamicRange?: string;
+			videoDynamicRangeType?: string;
+			resolution?: string;
+			subtitles?: string;
+		};
+		LibraryRadarrResponse: {
+			/** @enum {string} */
+			type: 'radarr';
+			items: components['schemas']['RadarrLibraryItem'][];
+			profilesByDatabase: components['schemas']['ProfileByDatabase'][];
+		};
+		LibrarySonarrResponse: {
+			/** @enum {string} */
+			type: 'sonarr';
+			items: components['schemas']['SonarrLibraryItem'][];
+			profilesByDatabase: components['schemas']['ProfileByDatabase'][];
+		};
+		SkippedItem: {
+			item: components['schemas']['StaleItem'];
+			/** @description Why the item was skipped (e.g. "Profile is assigned to media") */
+			reason: string;
+		};
+		PortableDelayProfile: {
+			name: string;
+			/** @enum {string} */
+			preferredProtocol: 'prefer_usenet' | 'prefer_torrent' | 'only_usenet' | 'only_torrent';
+			usenetDelay: number;
+			torrentDelay: number;
+			bypassIfHighestQuality: boolean;
+			bypassIfAboveCfScore: boolean;
+			minimumCfScore: number;
+		};
+		PortableRegularExpression: {
+			name: string;
+			pattern: string;
+			tags: string[];
+			description: string | null;
+			regex101Id: string | null;
+		};
+		PortableCustomFormatTest: {
+			title: string;
+			/** @enum {string} */
+			type: 'movie' | 'series';
+			shouldMatch: boolean;
+			description: string | null;
+		};
+		PortableCustomFormat: {
+			name: string;
+			description: string | null;
+			includeInRename: boolean;
+			tags: string[];
+			conditions: Record<string, never>[];
+			tests: components['schemas']['PortableCustomFormatTest'][];
+		};
+		PortableCustomFormatScore: {
+			customFormatName: string;
+			arrType: string;
+			score: number;
+		};
+		PortableQualityProfile: {
+			name: string;
+			description: string | null;
+			tags: string[];
+			language: string | null;
+			orderedItems: Record<string, never>[];
+			minimumScore: number;
+			upgradeUntilScore: number;
+			upgradeScoreIncrement: number;
+			customFormatScores: components['schemas']['PortableCustomFormatScore'][];
+		};
+		PortableRadarrNaming: {
+			name: string;
+			rename: boolean;
+			movieFormat: string;
+			movieFolderFormat: string;
+			replaceIllegalCharacters: boolean;
+			colonReplacementFormat: string;
+		};
+		PortableSonarrNaming: {
+			name: string;
+			rename: boolean;
+			standardEpisodeFormat: string;
+			dailyEpisodeFormat: string;
+			animeEpisodeFormat: string;
+			seriesFolderFormat: string;
+			seasonFolderFormat: string;
+			replaceIllegalCharacters: boolean;
+			colonReplacementFormat: string;
+			customColonReplacementFormat: string | null;
+			multiEpisodeStyle: string;
+		};
+		PortableMediaSettings: {
+			name: string;
+			propersRepacks: string;
+			enableMediaInfo: boolean;
+		};
+		PortableQualityDefinitions: {
+			name: string;
+			entries: Record<string, never>[];
+		};
+	};
+	responses: never;
+	parameters: never;
+	requestBodies: never;
+	headers: never;
+	pathItems: never;
 }
 export type $defs = Record<string, never>;
 export interface operations {
-    listArrInstances: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description List of Arr instances */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ArrInstance"][];
-                };
-            };
-            /** @description Not authenticated */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    listDatabases: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description List of linked databases */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["DatabaseInstance"][];
-                };
-            };
-            /** @description Not authenticated */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    getHealth: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Service is healthy or degraded */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HealthCheckResponse"];
-                };
-            };
-            /** @description Service is unhealthy */
-            503: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HealthCheckResponse"];
-                };
-            };
-        };
-    };
-    getHealthDiagnostics: {
-        parameters: {
-            query?: {
-                /** @description Include extra detail per component (counts, sizes, timestamps) */
-                verbose?: boolean;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Diagnostics response (healthy or degraded) */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HealthDiagnosticsResponse"];
-                };
-            };
-            /** @description Not authenticated */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @example Unauthorized */
-                        error: string;
-                    };
-                };
-            };
-            /** @description Service is unhealthy */
-            503: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HealthDiagnosticsResponse"];
-                };
-            };
-        };
-    };
-    getOpenApiSpec: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OpenAPI specification */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": Record<string, never>;
-                };
-            };
-        };
-    };
-    evaluateReleases: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["EvaluateRequest"];
-            };
-        };
-        responses: {
-            /** @description Evaluation results */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["EvaluateResponse"];
-                };
-            };
-            /** @description Invalid request (missing databaseId or releases) */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Database cache not available */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    getLibrary: {
-        parameters: {
-            query: {
-                /** @description Arr instance ID */
-                instanceId: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Library items with quality and score data */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["LibraryResponse"];
-                };
-            };
-            /** @description Invalid or missing instanceId */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description Instance not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description Failed to fetch library */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
-    };
-    invalidateLibraryCache: {
-        parameters: {
-            query: {
-                /** @description Arr instance ID */
-                instanceId: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Cache invalidated */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["CacheInvalidatedResponse"];
-                };
-            };
-            /** @description Invalid or missing instanceId */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
-    };
-    getLibraryEpisodes: {
-        parameters: {
-            query: {
-                /** @description Arr instance ID (must be a Sonarr instance) */
-                instanceId: number;
-                /** @description Sonarr series ID */
-                seriesId: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Episode details with quality and score data */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["EpisodesResponse"];
-                };
-            };
-            /** @description Invalid parameters or not a Sonarr instance */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description Instance not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description Failed to fetch episode details */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
-    };
-    getReleases: {
-        parameters: {
-            query: {
-                /** @description Arr instance ID */
-                instanceId: number;
-                /** @description Movie ID (Radarr) or Series ID (Sonarr) */
-                itemId: number;
-                /** @description Season number for Sonarr searches (defaults to 1) */
-                season?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Release search results */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ReleasesResponse"];
-                };
-            };
-            /** @description Invalid or missing parameters */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description Instance not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description Failed to fetch releases */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
-    };
-    arrCleanup: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["CleanupScanRequest"] | components["schemas"]["CleanupExecuteRequest"];
-            };
-        };
-        responses: {
-            /** @description Scan or delete result */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["CleanupScanResult"] | components["schemas"]["CleanupDeleteResult"];
-                };
-            };
-            /** @description Invalid request (missing instanceId, invalid action) */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description Instance not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description Failed to perform cleanup */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
-    };
-    syncEntity: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["SyncEntityRequest"];
-            };
-        };
-        responses: {
-            /** @description Entity synced successfully */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SyncEntitySuccessResponse"];
-                };
-            };
-            /** @description Invalid request parameters */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description Instance not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description Cooldown active or sync in progress */
-            409: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SyncEntityCooldownResponse"];
-                };
-            };
-            /** @description Sync failed */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
-    };
-    exportEntity: {
-        parameters: {
-            query: {
-                /** @description The PCD database ID to export from */
-                databaseId: number;
-                /** @description The entity type to export */
-                entityType: components["schemas"]["EntityType"];
-                /** @description The entity name to export */
-                name: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Portable entity JSON */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ExportResponse"];
-                };
-            };
-            /** @description Missing or invalid parameters */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["PcdErrorResponse"];
-                };
-            };
-            /** @description Entity not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["PcdErrorResponse"];
-                };
-            };
-            /** @description Database cache not available */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["PcdErrorResponse"];
-                };
-            };
-        };
-    };
-    importEntity: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ImportRequest"];
-            };
-        };
-        responses: {
-            /** @description Entity created successfully */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ImportResponse"];
-                };
-            };
-            /** @description Validation error (missing fields, duplicate name, invalid data) */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["PcdErrorResponse"];
-                };
-            };
-            /** @description Cannot write to base layer */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["PcdErrorResponse"];
-                };
-            };
-            /** @description Database cache not available */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["PcdErrorResponse"];
-                };
-            };
-        };
-    };
-    validateRegex: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ValidateRegexRequest"];
-            };
-        };
-        responses: {
-            /** @description Validation result */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ValidateRegexResponse"];
-                };
-            };
-            /** @description Missing pattern */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
+	listArrInstances: {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		requestBody?: never;
+		responses: {
+			/** @description List of Arr instances */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['ArrInstance'][];
+				};
+			};
+			/** @description Not authenticated */
+			401: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content?: never;
+			};
+		};
+	};
+	listDatabases: {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		requestBody?: never;
+		responses: {
+			/** @description List of linked databases */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['DatabaseInstance'][];
+				};
+			};
+			/** @description Not authenticated */
+			401: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content?: never;
+			};
+		};
+	};
+	getHealth: {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		requestBody?: never;
+		responses: {
+			/** @description Service is healthy or degraded */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['HealthCheckResponse'];
+				};
+			};
+			/** @description Service is unhealthy */
+			503: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['HealthCheckResponse'];
+				};
+			};
+		};
+	};
+	getHealthDiagnostics: {
+		parameters: {
+			query?: {
+				/** @description Include extra detail per component (counts, sizes, timestamps) */
+				verbose?: boolean;
+			};
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		requestBody?: never;
+		responses: {
+			/** @description Diagnostics response (healthy or degraded) */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['HealthDiagnosticsResponse'];
+				};
+			};
+			/** @description Not authenticated */
+			401: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': {
+						/** @example Unauthorized */
+						error: string;
+					};
+				};
+			};
+			/** @description Service is unhealthy */
+			503: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['HealthDiagnosticsResponse'];
+				};
+			};
+		};
+	};
+	getOpenApiSpec: {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		requestBody?: never;
+		responses: {
+			/** @description OpenAPI specification */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': Record<string, never>;
+				};
+			};
+		};
+	};
+	evaluateReleases: {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		requestBody: {
+			content: {
+				'application/json': components['schemas']['EvaluateRequest'];
+			};
+		};
+		responses: {
+			/** @description Evaluation results */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['EvaluateResponse'];
+				};
+			};
+			/** @description Invalid request (missing databaseId or releases) */
+			400: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content?: never;
+			};
+			/** @description Database cache not available */
+			500: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content?: never;
+			};
+		};
+	};
+	getLibrary: {
+		parameters: {
+			query: {
+				/** @description Arr instance ID */
+				instanceId: number;
+			};
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		requestBody?: never;
+		responses: {
+			/** @description Library items with quality and score data */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['LibraryResponse'];
+				};
+			};
+			/** @description Invalid or missing instanceId */
+			400: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['ErrorResponse'];
+				};
+			};
+			/** @description Instance not found */
+			404: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['ErrorResponse'];
+				};
+			};
+			/** @description Failed to fetch library */
+			500: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['ErrorResponse'];
+				};
+			};
+		};
+	};
+	invalidateLibraryCache: {
+		parameters: {
+			query: {
+				/** @description Arr instance ID */
+				instanceId: number;
+			};
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		requestBody?: never;
+		responses: {
+			/** @description Cache invalidated */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['CacheInvalidatedResponse'];
+				};
+			};
+			/** @description Invalid or missing instanceId */
+			400: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['ErrorResponse'];
+				};
+			};
+		};
+	};
+	getLibraryEpisodes: {
+		parameters: {
+			query: {
+				/** @description Arr instance ID (must be a Sonarr instance) */
+				instanceId: number;
+				/** @description Sonarr series ID */
+				seriesId: number;
+			};
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		requestBody?: never;
+		responses: {
+			/** @description Episode details with quality and score data */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['EpisodesResponse'];
+				};
+			};
+			/** @description Invalid parameters or not a Sonarr instance */
+			400: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['ErrorResponse'];
+				};
+			};
+			/** @description Instance not found */
+			404: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['ErrorResponse'];
+				};
+			};
+			/** @description Failed to fetch episode details */
+			500: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['ErrorResponse'];
+				};
+			};
+		};
+	};
+	getReleases: {
+		parameters: {
+			query: {
+				/** @description Arr instance ID */
+				instanceId: number;
+				/** @description Movie ID (Radarr) or Series ID (Sonarr) */
+				itemId: number;
+				/** @description Season number for Sonarr searches (defaults to 1) */
+				season?: number;
+			};
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		requestBody?: never;
+		responses: {
+			/** @description Release search results */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['ReleasesResponse'];
+				};
+			};
+			/** @description Invalid or missing parameters */
+			400: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['ErrorResponse'];
+				};
+			};
+			/** @description Instance not found */
+			404: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['ErrorResponse'];
+				};
+			};
+			/** @description Failed to fetch releases */
+			500: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['ErrorResponse'];
+				};
+			};
+		};
+	};
+	arrCleanup: {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		requestBody: {
+			content: {
+				'application/json':
+					| components['schemas']['CleanupScanRequest']
+					| components['schemas']['CleanupExecuteRequest'];
+			};
+		};
+		responses: {
+			/** @description Scan or delete result */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json':
+						| components['schemas']['CleanupScanResult']
+						| components['schemas']['CleanupDeleteResult'];
+				};
+			};
+			/** @description Invalid request (missing instanceId, invalid action) */
+			400: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['ErrorResponse'];
+				};
+			};
+			/** @description Instance not found */
+			404: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['ErrorResponse'];
+				};
+			};
+			/** @description Failed to perform cleanup */
+			500: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['ErrorResponse'];
+				};
+			};
+		};
+	};
+	syncEntity: {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		requestBody: {
+			content: {
+				'application/json': components['schemas']['SyncEntityRequest'];
+			};
+		};
+		responses: {
+			/** @description Entity synced successfully */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['SyncEntitySuccessResponse'];
+				};
+			};
+			/** @description Invalid request parameters */
+			400: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['ErrorResponse'];
+				};
+			};
+			/** @description Instance not found */
+			404: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['ErrorResponse'];
+				};
+			};
+			/** @description Cooldown active or sync in progress */
+			409: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['SyncEntityCooldownResponse'];
+				};
+			};
+			/** @description Sync failed */
+			500: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['ErrorResponse'];
+				};
+			};
+		};
+	};
+	exportEntity: {
+		parameters: {
+			query: {
+				/** @description The PCD database ID to export from */
+				databaseId: number;
+				/** @description The entity type to export */
+				entityType: components['schemas']['EntityType'];
+				/** @description The entity name to export */
+				name: string;
+			};
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		requestBody?: never;
+		responses: {
+			/** @description Portable entity JSON */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['ExportResponse'];
+				};
+			};
+			/** @description Missing or invalid parameters */
+			400: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['PcdErrorResponse'];
+				};
+			};
+			/** @description Entity not found */
+			404: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['PcdErrorResponse'];
+				};
+			};
+			/** @description Database cache not available */
+			500: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['PcdErrorResponse'];
+				};
+			};
+		};
+	};
+	importEntity: {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		requestBody: {
+			content: {
+				'application/json': components['schemas']['ImportRequest'];
+			};
+		};
+		responses: {
+			/** @description Entity created successfully */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['ImportResponse'];
+				};
+			};
+			/** @description Validation error (missing fields, duplicate name, invalid data) */
+			400: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['PcdErrorResponse'];
+				};
+			};
+			/** @description Cannot write to base layer */
+			403: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['PcdErrorResponse'];
+				};
+			};
+			/** @description Database cache not available */
+			500: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['PcdErrorResponse'];
+				};
+			};
+		};
+	};
+	validateRegex: {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		requestBody: {
+			content: {
+				'application/json': components['schemas']['ValidateRegexRequest'];
+			};
+		};
+		responses: {
+			/** @description Validation result */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['ValidateRegexResponse'];
+				};
+			};
+			/** @description Missing pattern */
+			400: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content?: never;
+			};
+		};
+	};
 }

--- a/src/routes/api/v1/arr/+server.ts
+++ b/src/routes/api/v1/arr/+server.ts
@@ -1,0 +1,8 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from '@sveltejs/kit';
+import { arrInstancesQueries } from '$db/queries/arrInstances.ts';
+
+export const GET: RequestHandler = async () => {
+	const instances = arrInstancesQueries.getAll().map(({ api_key, ...safe }) => safe);
+	return json(instances);
+};

--- a/src/routes/api/v1/arr/+server.ts
+++ b/src/routes/api/v1/arr/+server.ts
@@ -1,8 +1,13 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from '@sveltejs/kit';
+import type { components } from '$api/v1';
 import { arrInstancesQueries } from '$db/queries/arrInstances.ts';
 
+type ArrInstance = components['schemas']['ArrInstance'];
+
 export const GET: RequestHandler = async () => {
-	const instances = arrInstancesQueries.getAll().map(({ api_key, ...safe }) => safe);
+	const instances = arrInstancesQueries
+		.getAll()
+		.map(({ api_key, ...safe }) => safe) as ArrInstance[];
 	return json(instances);
 };

--- a/src/routes/api/v1/databases/+server.ts
+++ b/src/routes/api/v1/databases/+server.ts
@@ -1,8 +1,13 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from '@sveltejs/kit';
+import type { components } from '$api/v1';
 import { pcdManager } from '$pcd/core/manager.ts';
 
+type DatabaseInstance = components['schemas']['DatabaseInstance'];
+
 export const GET: RequestHandler = async () => {
-	const databases = pcdManager.getAllPublic().map(({ local_path, ...rest }) => rest);
+	const databases: DatabaseInstance[] = pcdManager
+		.getAllPublic()
+		.map(({ local_path, ...rest }) => rest);
 	return json(databases);
 };

--- a/tests/integration/api/specs/arr.test.ts
+++ b/tests/integration/api/specs/arr.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Integration tests: GET /api/v1/arr
+ *
+ * Tests:
+ * 1. Returns 401 without auth
+ * 2. Returns 200 with empty array when no instances exist
+ * 3. Returns populated array after seeding an instance
+ * 4. Response does not contain api_key
+ */
+
+import { assertEquals, assertExists } from '@std/assert';
+import { TestClient } from '$test-harness/client.ts';
+import { startServer, stopServer, getDbPath } from '$test-harness/server.ts';
+import { createUserDirect, setApiKey } from '$test-harness/setup.ts';
+import { setup, teardown, test, run } from '$test-harness/runner.ts';
+import { Database } from 'jsr:@db/sqlite@0.12';
+
+const PORT = 7021;
+const ORIGIN = `http://localhost:${PORT}`;
+const API_KEY = 'arr-test-key-abc123';
+
+let client: TestClient;
+
+function seedArrInstance(dbPath: string): void {
+	const db = new Database(dbPath);
+	try {
+		db.exec(
+			`INSERT INTO arr_instances (name, type, url, api_key, enabled)
+			 VALUES ('Test Radarr', 'radarr', 'http://localhost:7878', 'secret-arr-api-key', 1)`
+		);
+	} finally {
+		db.close();
+	}
+}
+
+setup(async () => {
+	await startServer(PORT, { AUTH: 'on', ORIGIN }, 'preview');
+	const dbPath = getDbPath(PORT);
+	await createUserDirect(dbPath, 'admin', 'password123');
+	await setApiKey(dbPath, API_KEY);
+	client = new TestClient(ORIGIN);
+});
+
+teardown(async () => {
+	await stopServer(PORT);
+});
+
+test('GET /api/v1/arr returns 401 without auth', async () => {
+	const unauthClient = new TestClient(ORIGIN);
+	const res = await unauthClient.get('/api/v1/arr');
+	assertEquals(res.status, 401);
+});
+
+test('GET /api/v1/arr returns 200 with empty array', async () => {
+	const res = await client.get('/api/v1/arr', {
+		headers: { 'X-Api-Key': API_KEY }
+	});
+	assertEquals(res.status, 200);
+	const body = await res.json();
+	assertEquals(Array.isArray(body), true);
+	assertEquals(body.length, 0);
+});
+
+test('GET /api/v1/arr returns seeded instance', async () => {
+	seedArrInstance(getDbPath(PORT));
+	const res = await client.get('/api/v1/arr', {
+		headers: { 'X-Api-Key': API_KEY }
+	});
+	assertEquals(res.status, 200);
+	const body = await res.json();
+	assertEquals(body.length, 1);
+	assertEquals(body[0].name, 'Test Radarr');
+	assertEquals(body[0].type, 'radarr');
+	assertEquals(body[0].url, 'http://localhost:7878');
+	assertExists(body[0].enabled);
+});
+
+test('response does not contain api_key', async () => {
+	const res = await client.get('/api/v1/arr', {
+		headers: { 'X-Api-Key': API_KEY }
+	});
+	const body = await res.json();
+	assertEquals(body.length, 1);
+	assertEquals(body[0].api_key, undefined);
+});
+
+await run();

--- a/tests/integration/api/specs/arr.test.ts
+++ b/tests/integration/api/specs/arr.test.ts
@@ -13,7 +13,7 @@ import { TestClient } from '$test-harness/client.ts';
 import { startServer, stopServer, getDbPath } from '$test-harness/server.ts';
 import { createUserDirect, setApiKey } from '$test-harness/setup.ts';
 import { setup, teardown, test, run } from '$test-harness/runner.ts';
-import { Database } from 'jsr:@db/sqlite@0.12';
+import { Database } from '@db/sqlite';
 
 const PORT = 7021;
 const ORIGIN = `http://localhost:${PORT}`;

--- a/tests/integration/api/specs/databases.test.ts
+++ b/tests/integration/api/specs/databases.test.ts
@@ -13,7 +13,7 @@ import { TestClient } from '$test-harness/client.ts';
 import { startServer, stopServer, getDbPath } from '$test-harness/server.ts';
 import { createUserDirect, setApiKey } from '$test-harness/setup.ts';
 import { setup, teardown, test, run } from '$test-harness/runner.ts';
-import { Database } from 'jsr:@db/sqlite@0.12';
+import { Database } from '@db/sqlite';
 
 const PORT = 7020;
 const ORIGIN = `http://localhost:${PORT}`;

--- a/tests/integration/auth/specs/backupSecrets.test.ts
+++ b/tests/integration/auth/specs/backupSecrets.test.ts
@@ -36,7 +36,7 @@ import { TestClient } from '$test-harness/client.ts';
 import { startServer, stopServer, getDbPath } from '$test-harness/server.ts';
 import { createUserDirect, login } from '$test-harness/setup.ts';
 import { setup, teardown, test, run } from '$test-harness/runner.ts';
-import { Database } from 'jsr:@db/sqlite@0.12';
+import { Database } from '@db/sqlite';
 import { hash } from '@felix/bcrypt';
 
 const PORT = 7017;

--- a/tests/integration/auth/specs/pathTraversal.test.ts
+++ b/tests/integration/auth/specs/pathTraversal.test.ts
@@ -21,7 +21,7 @@ import { TestClient } from '$test-harness/client.ts';
 import { startServer, stopServer, getDbPath } from '$test-harness/server.ts';
 import { createUserDirect, login } from '$test-harness/setup.ts';
 import { setup, teardown, test, run } from '$test-harness/runner.ts';
-import { Database } from 'jsr:@db/sqlite@0.12';
+import { Database } from '@db/sqlite';
 
 const PORT = 7018;
 const ORIGIN = `http://localhost:${PORT}`;

--- a/tests/integration/auth/specs/secretExposure.test.ts
+++ b/tests/integration/auth/specs/secretExposure.test.ts
@@ -48,7 +48,7 @@ import { TestClient } from '$test-harness/client.ts';
 import { startServer, stopServer, getDbPath } from '$test-harness/server.ts';
 import { createUserDirect, login } from '$test-harness/setup.ts';
 import { setup, teardown, test, run } from '$test-harness/runner.ts';
-import { Database } from 'jsr:@db/sqlite@0.12';
+import { Database } from '@db/sqlite';
 import { hash } from '@felix/bcrypt';
 
 const PORT = 7016;

--- a/tests/integration/auth/specs/xForwardedFor.test.ts
+++ b/tests/integration/auth/specs/xForwardedFor.test.ts
@@ -24,7 +24,7 @@ import { TestClient } from '$test-harness/client.ts';
 import { startServer, stopServer, getDbPath } from '$test-harness/server.ts';
 import { createUserDirect, clearLoginAttempts, queryDb } from '$test-harness/setup.ts';
 import { setup, teardown, test, run } from '$test-harness/runner.ts';
-import { Database } from 'jsr:@db/sqlite@0.12';
+import { Database } from '@db/sqlite';
 
 const PORT = 7015;
 const ORIGIN = `http://localhost:${PORT}`;

--- a/tests/integration/conflicts/harness/setup.ts
+++ b/tests/integration/conflicts/harness/setup.ts
@@ -2,7 +2,7 @@
  * PCD conflict test helpers — create database instances, insert ops, query state.
  */
 
-import { Database } from 'jsr:@db/sqlite@0.12';
+import { Database } from '@db/sqlite';
 import { log } from '$test-harness/log.ts';
 
 // ─── Database Instance ─────────────────────────────────────────────────────────

--- a/tests/integration/conflicts/specs/group-member-position.test.ts
+++ b/tests/integration/conflicts/specs/group-member-position.test.ts
@@ -18,7 +18,7 @@ import {
 	queryLatestConflicts,
 	queryLatestHistory
 } from '../harness/setup.ts';
-import { Database } from 'jsr:@db/sqlite@0.12';
+import { Database } from '@db/sqlite';
 
 const PORT = 7026;
 const ORIGIN = `http://localhost:${PORT}`;

--- a/tests/integration/harness/setup.ts
+++ b/tests/integration/harness/setup.ts
@@ -3,7 +3,7 @@
  */
 
 import { TestClient } from '$test-harness/client.ts';
-import { Database } from 'jsr:@db/sqlite@0.12';
+import { Database } from '@db/sqlite';
 import { hash } from '@felix/bcrypt';
 import { log } from '$test-harness/log.ts';
 


### PR DESCRIPTION
Add list endpoint for Arr instances to the public API, returning all instances with api_key stripped. Also uses generated API types in both arr and databases endpoints, auto-formats generated types with prettier, and adds @db/sqlite to the import map so test dependencies are cached in CI.

Part of #401