### PR TITLE
feat: add non-root fast path for K8s and hardened Docker deployments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,6 +91,13 @@ COPY --from=builder /build/dist/build/static /app/static
 COPY scripts/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
+# Create a fixed profilarr user/group (UID/GID 1000).
+# - Root/PUID mode: entrypoint may reassign UID/GID at runtime via usermod.
+# - Non-root mode: set runAsUser: 1000 (K8s) or --user 1000 (Docker) to skip
+#   all privilege operations and run directly as this user.
+RUN groupadd -g 1000 profilarr && \
+    useradd -u 1000 -g profilarr -d /config -s /sbin/nologin profilarr
+
 # Create config directory
 RUN mkdir -p /config
 

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,10 +1,39 @@
 #!/bin/bash
+
+set -e
+
 # =============================================================================
 # Profilarr Container Entrypoint
 # =============================================================================
-# Handles PUID/PGID/UMASK setup for proper file permissions
-set -e
+# Two operational modes:
+#
+# 1. Root mode (default Docker):
+#    Container starts as root. PUID/PGID/UMASK env vars control which user
+#    the app ultimately runs as. Useful for NAS/home server deployments where
+#    bind-mount ownership must match a specific host UID/GID.
+#
+# 2. Non-root mode (Kubernetes / hardened Docker):
+#    Set runAsUser/runAsNonRoot in your pod securityContext (or --user in
+#    docker run). The entrypoint detects it is not root, skips all privilege
+#    operations, and execs the app directly. Volume ownership should be
+#    handled externally (K8s fsGroup, init containers, or pre-provisioned
+#    storage permissions).
+# -----------------------------------------------------------------------------
+# Set architecture-dependent SQLite path
+# -----------------------------------------------------------------------------
+ARCH=$(uname -m)
+export DENO_SQLITE_PATH="/usr/lib/${ARCH}-linux-gnu/libsqlite3.so.0"
 
+# -----------------------------------------------------------------------------
+# Non-root fast path — skip all privilege operations
+# -----------------------------------------------------------------------------
+if [ "$(id -u)" != "0" ]; then
+    umask "${UMASK:-022}"
+    mkdir -p /config/data /config/logs /config/backups /config/databases
+    exec /app/profilarr
+fi
+
+# Handles PUID/PGID/UMASK setup for proper file permissions
 PUID=${PUID:-1000}
 PGID=${PGID:-1000}
 UMASK=${UMASK:-022}
@@ -56,12 +85,6 @@ mkdir -p /config/data /config/logs /config/backups /config/databases
 # Fix ownership of config directory
 # -----------------------------------------------------------------------------
 chown -R "${PUID}:${PGID}" /config
-
-# -----------------------------------------------------------------------------
-# Set architecture-dependent SQLite path
-# -----------------------------------------------------------------------------
-ARCH=$(uname -m)
-export DENO_SQLITE_PATH="/usr/lib/${ARCH}-linux-gnu/libsqlite3.so.0"
 
 # -----------------------------------------------------------------------------
 # Drop privileges and run


### PR DESCRIPTION
The container previously required starting as root to handle PUID/PGID/UMASK and chown the config volume. This made it incompatible with Kubernetes Pod Security Standards (runAsNonRoot, capability dropping) and hardened Docker setups.

The entrypoint now detects if it is already running as a non-root user and skips all privilege operations, execing the app directly. Volume ownership is expected to be handled externally (K8s fsGroup, pre-provisioned storage).

A build-time profilarr user (UID/GID 1000) is added to the image so tooling that requires a named passwd entry is satisfied. Existing root/PUID/PGID behaviour is unchanged.