### PR TITLE
feat: add database CRUD and sync API endpoints

### DIFF
--- a/docs/api/v1/openapi.yaml
+++ b/docs/api/v1/openapi.yaml
@@ -43,6 +43,10 @@ paths:
     $ref: './paths/arr.yaml#/instances'
   /databases:
     $ref: './paths/databases.yaml#/databases'
+  /databases/{id}:
+    $ref: './paths/databases.yaml#/database'
+  /databases/{id}/sync:
+    $ref: './paths/databases.yaml#/database_sync'
   /health:
     $ref: './paths/system.yaml#/health'
   /status:
@@ -206,6 +210,10 @@ components:
       $ref: './schemas/databases.yaml#/DatabaseInstance'
     CreateDatabaseInput:
       $ref: './schemas/databases.yaml#/CreateDatabaseInput'
+    UpdateDatabaseInput:
+      $ref: './schemas/databases.yaml#/UpdateDatabaseInput'
+    SyncTriggerResponse:
+      $ref: './schemas/databases.yaml#/SyncTriggerResponse'
     # Regex
     ValidateRegexRequest:
       $ref: './schemas/regex.yaml#/ValidateRegexRequest'

--- a/docs/api/v1/paths/databases.yaml
+++ b/docs/api/v1/paths/databases.yaml
@@ -80,3 +80,178 @@ databases:
               $ref: '../schemas/common.yaml#/ErrorResponse'
             example:
               error: 'Repository not found or inaccessible'
+
+database:
+  parameters:
+    - name: id
+      in: path
+      required: true
+      description: Database instance ID
+      schema:
+        type: integer
+  get:
+    operationId: getDatabase
+    summary: Get Database
+    description: |
+      Secrets are stripped: `personal_access_token` is replaced by `hasPat` (boolean)
+      and `local_path` is excluded.
+    tags:
+      - Databases
+    responses:
+      '200':
+        description: Database detail
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/databases.yaml#/DatabaseInstance'
+      '401':
+        description: Not authenticated
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/common.yaml#/ErrorResponse'
+            example:
+              error: Unauthorized
+      '404':
+        description: Database not found
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/common.yaml#/ErrorResponse'
+            example:
+              error: Database not found
+  patch:
+    operationId: updateDatabase
+    summary: Update Database
+    description: |
+      Partial update. Only the provided fields are changed. Unknown fields
+      are silently ignored.
+
+      Field dependencies:
+      - `personal_access_token` requires `git_user_name` and `git_user_email`
+      - `local_ops_enabled` requires `personal_access_token`
+      - `conflict_strategy` is only accepted without a PAT, or with PAT + `local_ops_enabled`
+    tags:
+      - Databases
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/databases.yaml#/UpdateDatabaseInput'
+    responses:
+      '200':
+        description: Database updated
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/databases.yaml#/DatabaseInstance'
+      '400':
+        description: Validation error or empty body
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/common.yaml#/ErrorResponse'
+            example:
+              error: No updatable fields provided
+      '401':
+        description: Not authenticated
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/common.yaml#/ErrorResponse'
+            example:
+              error: Unauthorized
+      '404':
+        description: Database not found
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/common.yaml#/ErrorResponse'
+            example:
+              error: Database not found
+      '409':
+        description: A database with this name already exists
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/common.yaml#/ErrorResponse'
+            example:
+              error: A database with this name already exists
+  delete:
+    operationId: deleteDatabase
+    summary: Unlink Database
+    description: |
+      Removes the database row, deletes the cloned repository from disk,
+      and cancels any scheduled sync jobs.
+    tags:
+      - Databases
+    responses:
+      '204':
+        description: Database unlinked
+      '401':
+        description: Not authenticated
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/common.yaml#/ErrorResponse'
+            example:
+              error: Unauthorized
+      '404':
+        description: Database not found
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/common.yaml#/ErrorResponse'
+            example:
+              error: Database not found
+
+database_sync:
+  parameters:
+    - name: id
+      in: path
+      required: true
+      description: Database instance ID
+      schema:
+        type: integer
+  post:
+    operationId: syncDatabase
+    summary: Trigger Sync
+    description: |
+      Async. Enqueues a `pcd.sync` job and returns 202 with the job ID.
+      Poll `GET /api/v1/jobs/{jobId}` for completion.
+    tags:
+      - Databases
+    responses:
+      '202':
+        description: Sync job enqueued
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/databases.yaml#/SyncTriggerResponse'
+            example:
+              jobId: 42
+      '400':
+        description: Database is disabled
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/common.yaml#/ErrorResponse'
+            example:
+              error: Database is disabled
+      '401':
+        description: Not authenticated
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/common.yaml#/ErrorResponse'
+            example:
+              error: Unauthorized
+      '404':
+        description: Database not found
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/common.yaml#/ErrorResponse'
+            example:
+              error: Database not found

--- a/docs/api/v1/schemas/databases.yaml
+++ b/docs/api/v1/schemas/databases.yaml
@@ -116,3 +116,45 @@ CreateDatabaseInput:
         - ask
       default: override
       description: How to handle conflicts (only valid without a PAT, or with PAT + local_ops_enabled)
+
+UpdateDatabaseInput:
+  type: object
+  description: All fields are optional. Unknown fields are silently ignored.
+  properties:
+    name:
+      type: string
+      description: Display name (must be unique)
+    personal_access_token:
+      type: string
+      description: GitHub PAT for private repos and push access
+    git_user_name:
+      type: string
+      description: Required when personal_access_token is set
+    git_user_email:
+      type: string
+      description: Required when personal_access_token is set
+    sync_strategy:
+      type: integer
+      description: Auto-sync interval in minutes (0 = manual only)
+    auto_pull:
+      type: boolean
+      description: Whether to automatically pull updates
+    local_ops_enabled:
+      type: boolean
+      description: Force writes to local user ops even with a PAT (requires personal_access_token)
+    conflict_strategy:
+      type: string
+      enum:
+        - override
+        - align
+        - ask
+      description: How to handle conflicts (only valid without a PAT, or with PAT + local_ops_enabled)
+
+SyncTriggerResponse:
+  type: object
+  required:
+    - jobId
+  properties:
+    jobId:
+      type: integer
+      description: Job queue ID to poll via GET /api/v1/jobs/{jobId}

--- a/src/lib/api/v1.d.ts
+++ b/src/lib/api/v1.d.ts
@@ -64,6 +64,69 @@ export interface paths {
 		patch?: never;
 		trace?: never;
 	};
+	'/databases/{id}': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path: {
+				/** @description Database instance ID */
+				id: number;
+			};
+			cookie?: never;
+		};
+		/**
+		 * Get Database
+		 * @description Secrets are stripped: `personal_access_token` is replaced by `hasPat` (boolean)
+		 *     and `local_path` is excluded.
+		 */
+		get: operations['getDatabase'];
+		put?: never;
+		post?: never;
+		/**
+		 * Unlink Database
+		 * @description Removes the database row, deletes the cloned repository from disk,
+		 *     and cancels any scheduled sync jobs.
+		 */
+		delete: operations['deleteDatabase'];
+		options?: never;
+		head?: never;
+		/**
+		 * Update Database
+		 * @description Partial update. Only the provided fields are changed. Unknown fields
+		 *     are silently ignored.
+		 *
+		 *     Field dependencies:
+		 *     - `personal_access_token` requires `git_user_name` and `git_user_email`
+		 *     - `local_ops_enabled` requires `personal_access_token`
+		 *     - `conflict_strategy` is only accepted without a PAT, or with PAT + `local_ops_enabled`
+		 */
+		patch: operations['updateDatabase'];
+		trace?: never;
+	};
+	'/databases/{id}/sync': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path: {
+				/** @description Database instance ID */
+				id: number;
+			};
+			cookie?: never;
+		};
+		get?: never;
+		put?: never;
+		/**
+		 * Trigger Sync
+		 * @description Async. Enqueues a `pcd.sync` job and returns 202 with the job ID.
+		 *     Poll `GET /api/v1/jobs/{jobId}` for completion.
+		 */
+		post: operations['syncDatabase'];
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
 	'/health': {
 		parameters: {
 			query?: never;
@@ -1211,6 +1274,32 @@ export interface components {
 			 */
 			conflict_strategy: 'override' | 'align' | 'ask';
 		};
+		/** @description All fields are optional. Unknown fields are silently ignored. */
+		UpdateDatabaseInput: {
+			/** @description Display name (must be unique) */
+			name?: string;
+			/** @description GitHub PAT for private repos and push access */
+			personal_access_token?: string;
+			/** @description Required when personal_access_token is set */
+			git_user_name?: string;
+			/** @description Required when personal_access_token is set */
+			git_user_email?: string;
+			/** @description Auto-sync interval in minutes (0 = manual only) */
+			sync_strategy?: number;
+			/** @description Whether to automatically pull updates */
+			auto_pull?: boolean;
+			/** @description Force writes to local user ops even with a PAT (requires personal_access_token) */
+			local_ops_enabled?: boolean;
+			/**
+			 * @description How to handle conflicts (only valid without a PAT, or with PAT + local_ops_enabled)
+			 * @enum {string}
+			 */
+			conflict_strategy?: 'override' | 'align' | 'ask';
+		};
+		SyncTriggerResponse: {
+			/** @description Job queue ID to poll via GET /api/v1/jobs/{jobId} */
+			jobId: number;
+		};
 		ValidateRegexRequest: {
 			/** @description The .NET regex pattern to validate */
 			pattern: string;
@@ -1578,6 +1667,259 @@ export interface operations {
 					/**
 					 * @example {
 					 *       "error": "Repository not found or inaccessible"
+					 *     }
+					 */
+					'application/json': components['schemas']['ErrorResponse'];
+				};
+			};
+		};
+	};
+	getDatabase: {
+		parameters: {
+			query?: never;
+			header?: never;
+			path: {
+				/** @description Database instance ID */
+				id: number;
+			};
+			cookie?: never;
+		};
+		requestBody?: never;
+		responses: {
+			/** @description Database detail */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['DatabaseInstance'];
+				};
+			};
+			/** @description Not authenticated */
+			401: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					/**
+					 * @example {
+					 *       "error": "Unauthorized"
+					 *     }
+					 */
+					'application/json': components['schemas']['ErrorResponse'];
+				};
+			};
+			/** @description Database not found */
+			404: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					/**
+					 * @example {
+					 *       "error": "Database not found"
+					 *     }
+					 */
+					'application/json': components['schemas']['ErrorResponse'];
+				};
+			};
+		};
+	};
+	deleteDatabase: {
+		parameters: {
+			query?: never;
+			header?: never;
+			path: {
+				/** @description Database instance ID */
+				id: number;
+			};
+			cookie?: never;
+		};
+		requestBody?: never;
+		responses: {
+			/** @description Database unlinked */
+			204: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content?: never;
+			};
+			/** @description Not authenticated */
+			401: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					/**
+					 * @example {
+					 *       "error": "Unauthorized"
+					 *     }
+					 */
+					'application/json': components['schemas']['ErrorResponse'];
+				};
+			};
+			/** @description Database not found */
+			404: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					/**
+					 * @example {
+					 *       "error": "Database not found"
+					 *     }
+					 */
+					'application/json': components['schemas']['ErrorResponse'];
+				};
+			};
+		};
+	};
+	updateDatabase: {
+		parameters: {
+			query?: never;
+			header?: never;
+			path: {
+				/** @description Database instance ID */
+				id: number;
+			};
+			cookie?: never;
+		};
+		requestBody: {
+			content: {
+				'application/json': components['schemas']['UpdateDatabaseInput'];
+			};
+		};
+		responses: {
+			/** @description Database updated */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['DatabaseInstance'];
+				};
+			};
+			/** @description Validation error or empty body */
+			400: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					/**
+					 * @example {
+					 *       "error": "No updatable fields provided"
+					 *     }
+					 */
+					'application/json': components['schemas']['ErrorResponse'];
+				};
+			};
+			/** @description Not authenticated */
+			401: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					/**
+					 * @example {
+					 *       "error": "Unauthorized"
+					 *     }
+					 */
+					'application/json': components['schemas']['ErrorResponse'];
+				};
+			};
+			/** @description Database not found */
+			404: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					/**
+					 * @example {
+					 *       "error": "Database not found"
+					 *     }
+					 */
+					'application/json': components['schemas']['ErrorResponse'];
+				};
+			};
+			/** @description A database with this name already exists */
+			409: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					/**
+					 * @example {
+					 *       "error": "A database with this name already exists"
+					 *     }
+					 */
+					'application/json': components['schemas']['ErrorResponse'];
+				};
+			};
+		};
+	};
+	syncDatabase: {
+		parameters: {
+			query?: never;
+			header?: never;
+			path: {
+				/** @description Database instance ID */
+				id: number;
+			};
+			cookie?: never;
+		};
+		requestBody?: never;
+		responses: {
+			/** @description Sync job enqueued */
+			202: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					/**
+					 * @example {
+					 *       "jobId": 42
+					 *     }
+					 */
+					'application/json': components['schemas']['SyncTriggerResponse'];
+				};
+			};
+			/** @description Database is disabled */
+			400: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					/**
+					 * @example {
+					 *       "error": "Database is disabled"
+					 *     }
+					 */
+					'application/json': components['schemas']['ErrorResponse'];
+				};
+			};
+			/** @description Not authenticated */
+			401: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					/**
+					 * @example {
+					 *       "error": "Unauthorized"
+					 *     }
+					 */
+					'application/json': components['schemas']['ErrorResponse'];
+				};
+			};
+			/** @description Database not found */
+			404: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					/**
+					 * @example {
+					 *       "error": "Database not found"
 					 *     }
 					 */
 					'application/json': components['schemas']['ErrorResponse'];

--- a/src/lib/server/jobs/handlers/pcdSync.ts
+++ b/src/lib/server/jobs/handlers/pcdSync.ts
@@ -19,7 +19,7 @@ const dbSyncHandler: JobHandler = async (job) => {
 		return { status: 'cancelled', output: 'Database sync disabled' };
 	}
 
-	if (instance.sync_strategy <= 0) {
+	if (instance.sync_strategy <= 0 && job.source === 'schedule') {
 		return { status: 'cancelled', output: 'Auto-sync disabled' };
 	}
 

--- a/src/lib/server/pcd/core/validate.ts
+++ b/src/lib/server/pcd/core/validate.ts
@@ -1,4 +1,8 @@
 import { databaseInstancesQueries } from '$db/queries/databaseInstances.ts';
+import type {
+	UpdateDatabaseInstanceInput,
+	ConflictStrategy
+} from '$db/queries/databaseInstances.ts';
 import type { LinkOptions } from './types.ts';
 
 type ValidatedLinkInput = Omit<LinkOptions, 'conflictStrategy' | 'syncStrategy'> & {
@@ -7,6 +11,10 @@ type ValidatedLinkInput = Omit<LinkOptions, 'conflictStrategy' | 'syncStrategy'>
 };
 
 type ValidationResult = { ok: true; input: ValidatedLinkInput } | { ok: false; error: string };
+
+type UpdateValidationResult =
+	| { ok: true; input: UpdateDatabaseInstanceInput }
+	| { ok: false; error: string };
 
 const VALID_CONFLICT_STRATEGIES = ['override', 'align', 'ask'] as const;
 
@@ -102,6 +110,91 @@ export function validateLinkInput(body: Record<string, unknown>): ValidationResu
 			conflictStrategy
 		}
 	};
+}
+
+/**
+ * Validate and coerce update input from either API JSON or form data.
+ * All fields are optional. Unknown fields are silently ignored.
+ * Returns camelCase fields matching UpdateDatabaseInstanceInput.
+ */
+export function validateUpdateInput(body: Record<string, unknown>): UpdateValidationResult {
+	const input: UpdateDatabaseInstanceInput = {};
+
+	if (typeof body.name === 'string') {
+		const name = body.name.trim();
+		if (!name) {
+			return { ok: false, error: 'Name cannot be empty' };
+		}
+		input.name = name;
+	}
+
+	if (typeof body.personal_access_token === 'string') {
+		input.personalAccessToken = body.personal_access_token.trim() || undefined;
+	}
+
+	if (typeof body.git_user_name === 'string') {
+		input.gitUserName = body.git_user_name.trim() || null;
+	}
+
+	if (typeof body.git_user_email === 'string') {
+		input.gitUserEmail = body.git_user_email.trim() || null;
+	}
+
+	if (body.sync_strategy !== undefined) {
+		input.syncStrategy =
+			typeof body.sync_strategy === 'number'
+				? Math.floor(body.sync_strategy)
+				: typeof body.sync_strategy === 'string'
+					? parseInt(body.sync_strategy, 10) || 0
+					: 0;
+	}
+
+	if (body.auto_pull !== undefined) {
+		input.autoPull = body.auto_pull === true || body.auto_pull === 1;
+	}
+
+	if (body.local_ops_enabled !== undefined) {
+		input.localOpsEnabled = body.local_ops_enabled === true || body.local_ops_enabled === 1;
+	}
+
+	if (typeof body.conflict_strategy === 'string') {
+		const raw = body.conflict_strategy.trim();
+		if (!VALID_CONFLICT_STRATEGIES.includes(raw as ConflictStrategy)) {
+			return {
+				ok: false,
+				error: `conflict_strategy must be one of: ${VALID_CONFLICT_STRATEGIES.join(', ')}`
+			};
+		}
+		input.conflictStrategy = raw as ConflictStrategy;
+	}
+
+	// Must have at least one updatable field
+	if (Object.keys(input).length === 0) {
+		return { ok: false, error: 'No updatable fields provided' };
+	}
+
+	// PAT requires git identity
+	if (input.personalAccessToken && !input.gitUserName && !input.gitUserEmail) {
+		return {
+			ok: false,
+			error: 'Git author name and email are required when a personal access token is set'
+		};
+	}
+
+	// local_ops_enabled requires PAT
+	if (input.localOpsEnabled && !input.personalAccessToken) {
+		return { ok: false, error: 'local_ops_enabled requires a personal access token' };
+	}
+
+	// conflict_strategy is only valid without PAT, or with PAT + local_ops_enabled
+	if (input.conflictStrategy && input.personalAccessToken && !input.localOpsEnabled) {
+		return {
+			ok: false,
+			error: 'conflict_strategy cannot be set when using a PAT without local_ops_enabled'
+		};
+	}
+
+	return { ok: true, input };
 }
 
 /**

--- a/src/routes/api/v1/databases/[id]/+server.ts
+++ b/src/routes/api/v1/databases/[id]/+server.ts
@@ -1,0 +1,123 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from '@sveltejs/kit';
+import type { components } from '$api/v1';
+import { databaseInstancesQueries } from '$db/queries/databaseInstances.ts';
+import { pcdManager } from '$pcd/core/manager.ts';
+import { validateUpdateInput, checkNameConflict } from '$pcd/core/validate.ts';
+import { schedulePcdSyncForDatabase } from '$lib/server/jobs/init.ts';
+import { logger } from '$logger/logger.ts';
+
+type DatabaseInstance = components['schemas']['DatabaseInstance'];
+type ErrorResponse = components['schemas']['ErrorResponse'];
+
+function parseId(params: Record<string, string>): number | null {
+	const id = parseInt(params.id || '', 10);
+	return Number.isFinite(id) ? id : null;
+}
+
+export const GET: RequestHandler = async ({ params }) => {
+	const id = parseId(params);
+	if (id === null) {
+		return json({ error: 'Invalid database ID' } satisfies ErrorResponse, { status: 400 });
+	}
+
+	const instance = pcdManager.getByIdPublic(id);
+	if (!instance) {
+		return json({ error: 'Database not found' } satisfies ErrorResponse, { status: 404 });
+	}
+
+	const { local_path, ...safe } = instance;
+	return json(safe satisfies DatabaseInstance);
+};
+
+export const PATCH: RequestHandler = async ({ params, request }) => {
+	const id = parseId(params);
+	if (id === null) {
+		return json({ error: 'Invalid database ID' } satisfies ErrorResponse, { status: 400 });
+	}
+
+	const existing = databaseInstancesQueries.getById(id);
+	if (!existing) {
+		return json({ error: 'Database not found' } satisfies ErrorResponse, { status: 404 });
+	}
+
+	let body: Record<string, unknown>;
+	try {
+		body = await request.json();
+	} catch {
+		return json({ error: 'Invalid JSON body' } satisfies ErrorResponse, { status: 400 });
+	}
+
+	const result = validateUpdateInput(body);
+	if (!result.ok) {
+		return json({ error: result.error } satisfies ErrorResponse, { status: 400 });
+	}
+
+	const { input } = result;
+
+	if (input.name && checkNameConflict(input.name, id)) {
+		return json({ error: 'A database with this name already exists' } satisfies ErrorResponse, {
+			status: 409
+		});
+	}
+
+	try {
+		databaseInstancesQueries.update(id, input);
+		schedulePcdSyncForDatabase(id);
+
+		const updated = pcdManager.getByIdPublic(id);
+		if (!updated) {
+			return json({ error: 'Database not found' } satisfies ErrorResponse, { status: 404 });
+		}
+
+		const { local_path, ...safe } = updated;
+		return json(safe satisfies DatabaseInstance);
+	} catch (error) {
+		await logger.error('Failed to update database', {
+			source: 'PATCH /api/v1/databases/{id}',
+			meta: {
+				error: error instanceof Error ? error.message : String(error),
+				id
+			}
+		});
+
+		return json(
+			{
+				error: error instanceof Error ? error.message : 'Failed to update database'
+			} satisfies ErrorResponse,
+			{ status: 422 }
+		);
+	}
+};
+
+export const DELETE: RequestHandler = async ({ params }) => {
+	const id = parseId(params);
+	if (id === null) {
+		return json({ error: 'Invalid database ID' } satisfies ErrorResponse, { status: 400 });
+	}
+
+	const existing = databaseInstancesQueries.getById(id);
+	if (!existing) {
+		return json({ error: 'Database not found' } satisfies ErrorResponse, { status: 404 });
+	}
+
+	try {
+		await pcdManager.unlink(id);
+		return new Response(null, { status: 204 });
+	} catch (error) {
+		await logger.error('Failed to unlink database', {
+			source: 'DELETE /api/v1/databases/{id}',
+			meta: {
+				error: error instanceof Error ? error.message : String(error),
+				id
+			}
+		});
+
+		return json(
+			{
+				error: error instanceof Error ? error.message : 'Failed to unlink database'
+			} satisfies ErrorResponse,
+			{ status: 422 }
+		);
+	}
+};

--- a/src/routes/api/v1/databases/[id]/sync/+server.ts
+++ b/src/routes/api/v1/databases/[id]/sync/+server.ts
@@ -1,0 +1,34 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from '@sveltejs/kit';
+import type { components } from '$api/v1';
+import { databaseInstancesQueries } from '$db/queries/databaseInstances.ts';
+import { enqueueJob } from '$lib/server/jobs/queueService.ts';
+
+type SyncTriggerResponse = components['schemas']['SyncTriggerResponse'];
+type ErrorResponse = components['schemas']['ErrorResponse'];
+
+export const POST: RequestHandler = async ({ params }) => {
+	const id = parseInt(params.id || '', 10);
+	if (!Number.isFinite(id)) {
+		return json({ error: 'Invalid database ID' } satisfies ErrorResponse, { status: 400 });
+	}
+
+	const instance = databaseInstancesQueries.getById(id);
+	if (!instance) {
+		return json({ error: 'Database not found' } satisfies ErrorResponse, { status: 404 });
+	}
+
+	if (instance.enabled === 0) {
+		return json({ error: 'Database is disabled' } satisfies ErrorResponse, { status: 400 });
+	}
+
+	const queued = enqueueJob({
+		jobType: 'pcd.sync',
+		runAt: new Date().toISOString(),
+		payload: { databaseId: id },
+		source: 'manual'
+	});
+
+	const response: SyncTriggerResponse = { jobId: queued.id };
+	return json(response, { status: 202 });
+};

--- a/src/routes/databases/[id]/settings/+page.server.ts
+++ b/src/routes/databases/[id]/settings/+page.server.ts
@@ -1,8 +1,8 @@
 import { redirect, fail } from '@sveltejs/kit';
 import type { Actions } from '@sveltejs/kit';
 import { databaseInstancesQueries } from '$db/queries/databaseInstances.ts';
-import type { ConflictStrategy } from '$db/queries/databaseInstances.ts';
 import { pcdManager } from '$pcd/core/manager.ts';
+import { validateUpdateInput, checkNameConflict } from '$pcd/core/validate.ts';
 import { logger } from '$logger/logger.ts';
 import { schedulePcdSyncForDatabase } from '$lib/server/jobs/init.ts';
 
@@ -10,7 +10,6 @@ export const actions: Actions = {
 	update: async ({ params, request }) => {
 		const id = parseInt(params.id || '', 10);
 
-		// Validate ID
 		if (isNaN(id)) {
 			await logger.warn('Update failed: Invalid database ID', {
 				source: 'databases/[id]/settings',
@@ -19,9 +18,7 @@ export const actions: Actions = {
 			return fail(400, { error: 'Invalid database ID' });
 		}
 
-		// Fetch the instance to verify it exists
 		const instance = databaseInstancesQueries.getById(id);
-
 		if (!instance) {
 			await logger.warn('Update failed: Database not found', {
 				source: 'databases/[id]/settings',
@@ -31,90 +28,47 @@ export const actions: Actions = {
 		}
 
 		const formData = await request.formData();
+		const raw: Record<string, unknown> = {};
+		raw.name = formData.get('name')?.toString();
+		raw.sync_strategy = formData.get('sync_strategy')?.toString();
+		raw.auto_pull = formData.get('auto_pull') === '1';
+		raw.local_ops_enabled = formData.get('local_ops_enabled') === '1';
+		const pat = formData.get('personal_access_token')?.toString().trim();
+		if (pat) raw.personal_access_token = pat;
+		if (formData.has('git_user_name'))
+			raw.git_user_name = formData.get('git_user_name')?.toString();
+		if (formData.has('git_user_email'))
+			raw.git_user_email = formData.get('git_user_email')?.toString();
+		const cs = formData.get('conflict_strategy')?.toString().trim();
+		if (cs) raw.conflict_strategy = cs;
 
-		const name = formData.get('name')?.toString().trim();
-		const syncStrategy = parseInt(formData.get('sync_strategy')?.toString() || '0', 10);
-		const autoPull = formData.get('auto_pull') === '1';
-		const localOpsEnabled = formData.get('local_ops_enabled') === '1';
-		const personalAccessToken =
-			formData.get('personal_access_token')?.toString().trim() || undefined;
-		const gitUserName = formData.has('git_user_name')
-			? formData.get('git_user_name')?.toString().trim() || null
-			: undefined;
-		const gitUserEmail = formData.has('git_user_email')
-			? formData.get('git_user_email')?.toString().trim() || null
-			: undefined;
-		const conflictStrategyRaw = formData.get('conflict_strategy')?.toString().trim() || '';
-		const validConflictStrategies: ConflictStrategy[] = ['override', 'align', 'ask'];
-		const conflictStrategy = validConflictStrategies.includes(
-			conflictStrategyRaw as ConflictStrategy
-		)
-			? (conflictStrategyRaw as ConflictStrategy)
-			: instance.conflict_strategy;
-
-		if (
-			conflictStrategyRaw &&
-			!validConflictStrategies.includes(conflictStrategyRaw as ConflictStrategy)
-		) {
-			await logger.warn('Attempted to update database with invalid conflict strategy', {
-				source: 'databases/[id]/settings',
-				meta: { id, conflictStrategy: conflictStrategyRaw }
-			});
-			return fail(400, { error: 'Invalid conflict strategy' });
+		const result = validateUpdateInput(raw);
+		if (!result.ok) {
+			return fail(400, { error: result.error, values: { name: raw.name } });
 		}
 
-		// Validation
-		if (!name) {
-			await logger.warn('Attempted to update database with missing required fields', {
-				source: 'databases/[id]/settings',
-				meta: { id, name }
-			});
+		const { input } = result;
 
-			return fail(400, {
-				error: 'Name is required',
-				values: { name }
-			});
-		}
-		if (personalAccessToken && (!gitUserName || !gitUserEmail)) {
-			return fail(400, {
-				error: 'Git author name and email are required when a personal access token is set',
-				values: { name }
-			});
-		}
-
-		// Check if name already exists (excluding current instance)
-		if (databaseInstancesQueries.nameExists(name, id)) {
+		if (input.name && checkNameConflict(input.name, id)) {
 			await logger.warn('Attempted to update database with duplicate name', {
 				source: 'databases/[id]/settings',
-				meta: { id, name }
+				meta: { id, name: input.name }
 			});
-
 			return fail(400, {
 				error: 'A database with this name already exists',
-				values: { name }
+				values: { name: input.name }
 			});
 		}
 
 		try {
-			// Update the database
-			const updated = databaseInstancesQueries.update(id, {
-				name,
-				syncStrategy,
-				autoPull,
-				personalAccessToken,
-				localOpsEnabled,
-				gitUserName,
-				gitUserEmail,
-				conflictStrategy
-			});
-
+			const updated = databaseInstancesQueries.update(id, input);
 			if (!updated) {
 				throw new Error('Update returned false');
 			}
 
-			await logger.info(`Updated database: ${name}`, {
+			await logger.info(`Updated database: ${input.name ?? instance.name}`, {
 				source: 'databases/[id]/settings',
-				meta: { id, name }
+				meta: { id, name: input.name ?? instance.name }
 			});
 
 			schedulePcdSyncForDatabase(id);
@@ -128,7 +82,7 @@ export const actions: Actions = {
 
 			return fail(500, {
 				error: 'Failed to update database',
-				values: { name }
+				values: { name: input.name }
 			});
 		}
 	},
@@ -136,7 +90,6 @@ export const actions: Actions = {
 	delete: async ({ params }) => {
 		const id = parseInt(params.id || '', 10);
 
-		// Validate ID
 		if (isNaN(id)) {
 			await logger.warn('Delete failed: Invalid database ID', {
 				source: 'databases/[id]/settings',
@@ -145,9 +98,7 @@ export const actions: Actions = {
 			return fail(400, { error: 'Invalid database ID' });
 		}
 
-		// Fetch the instance to verify it exists
 		const instance = databaseInstancesQueries.getById(id);
-
 		if (!instance) {
 			await logger.warn('Delete failed: Database not found', {
 				source: 'databases/[id]/settings',
@@ -157,7 +108,6 @@ export const actions: Actions = {
 		}
 
 		try {
-			// Unlink the database
 			await pcdManager.unlink(id);
 
 			await logger.info(`Unlinked database: ${instance.name}`, {
@@ -165,10 +115,8 @@ export const actions: Actions = {
 				meta: { id, name: instance.name, repositoryUrl: instance.repository_url }
 			});
 
-			// Redirect to databases list
 			redirect(303, '/databases');
 		} catch (err) {
-			// Re-throw redirect errors (they're not actual errors)
 			if (err && typeof err === 'object' && 'status' in err && 'location' in err) {
 				throw err;
 			}

--- a/tests/integration/api/specs/databases.test.ts
+++ b/tests/integration/api/specs/databases.test.ts
@@ -1,13 +1,13 @@
 /**
  * Integration tests: /api/v1/databases
  *
- * GET:
+ * GET /databases:
  * 1. Returns 401 without auth
  * 2. Returns 200 with empty array when no databases linked
  * 3. Returns populated array after seeding a database instance
  * 4. Response does not contain personal_access_token or local_path
  *
- * POST:
+ * POST /databases:
  * 5. Returns 401 without auth
  * 6. Returns 400 when name is missing
  * 7. Returns 400 when repository_url is missing
@@ -16,6 +16,26 @@
  * 10. Returns 400 when conflict_strategy is set with PAT but without local_ops_enabled
  * 11. Returns 409 when name already exists
  * 12. Returns 201 and links a real database
+ *
+ * GET /databases/{id}:
+ * 13. Returns 404 for non-existent ID
+ * 14. Returns 200 with database detail
+ *
+ * PATCH /databases/{id}:
+ * 15. Returns 404 for non-existent ID
+ * 16. Returns 400 for empty body
+ * 17. Returns 400 when PAT set without git identity
+ * 18. Returns 409 when name conflicts with another database
+ * 19. Returns 200 and updates name
+ *
+ * POST /databases/{id}/sync:
+ * 20. Returns 404 for non-existent ID
+ * 21. Returns 202 with jobId
+ *
+ * DELETE /databases/{id}:
+ * 22. Returns 404 for non-existent ID
+ * 23. Returns 204 and unlinks
+ * 24. GET after delete returns 404
  */
 
 import { assertEquals, assertExists } from '@std/assert';
@@ -30,6 +50,7 @@ const ORIGIN = `http://localhost:${PORT}`;
 const API_KEY = 'databases-test-key-abc123';
 
 let client: TestClient;
+let linkedDbId: number;
 
 function seedDatabase(dbPath: string): void {
 	const db = new Database(dbPath);
@@ -207,6 +228,7 @@ test('POST /api/v1/databases returns 201 and links a real database', async () =>
 
 	// Required fields present
 	assertExists(body.id);
+	linkedDbId = body.id;
 	assertExists(body.uuid);
 	assertEquals(body.name, 'API Linked DB');
 	assertEquals(body.repository_url, TEST_REPO);
@@ -224,6 +246,126 @@ test('POST /api/v1/databases returns 201 and links a real database', async () =>
 	// Secrets stripped
 	assertEquals(body.personal_access_token, undefined);
 	assertEquals(body.local_path, undefined);
+});
+
+// --- GET /api/v1/databases/{id} ---
+
+test('GET /api/v1/databases/{id} returns 404 for non-existent ID', async () => {
+	const res = await client.get('/api/v1/databases/99999', {
+		headers: AUTH_HEADERS
+	});
+	assertEquals(res.status, 404);
+	const body = await res.json();
+	assertExists(body.error);
+});
+
+test('GET /api/v1/databases/{id} returns 200 with database detail', async () => {
+	const res = await client.get(`/api/v1/databases/${linkedDbId}`, {
+		headers: AUTH_HEADERS
+	});
+	assertEquals(res.status, 200);
+	const body = await res.json();
+	assertEquals(body.id, linkedDbId);
+	assertEquals(body.name, 'API Linked DB');
+	assertEquals(body.repository_url, TEST_REPO);
+	assertExists(body.created_at);
+	// Secrets stripped
+	assertEquals(body.personal_access_token, undefined);
+	assertEquals(body.local_path, undefined);
+});
+
+// --- PATCH /api/v1/databases/{id} ---
+
+test('PATCH /api/v1/databases/{id} returns 404 for non-existent ID', async () => {
+	const res = await client.patch(
+		'/api/v1/databases/99999',
+		{ name: 'Nope' },
+		{ headers: AUTH_HEADERS }
+	);
+	assertEquals(res.status, 404);
+});
+
+test('PATCH /api/v1/databases/{id} returns 400 for empty body', async () => {
+	const res = await client.patch(`/api/v1/databases/${linkedDbId}`, {}, { headers: AUTH_HEADERS });
+	assertEquals(res.status, 400);
+	const body = await res.json();
+	assertExists(body.error);
+});
+
+test('PATCH /api/v1/databases/{id} returns 400 when PAT set without git identity', async () => {
+	const res = await client.patch(
+		`/api/v1/databases/${linkedDbId}`,
+		{ personal_access_token: 'ghp_fake' },
+		{ headers: AUTH_HEADERS }
+	);
+	assertEquals(res.status, 400);
+	const body = await res.json();
+	assertExists(body.error);
+});
+
+test('PATCH /api/v1/databases/{id} returns 409 when name conflicts', async () => {
+	// 'Test DB' was seeded earlier
+	const res = await client.patch(
+		`/api/v1/databases/${linkedDbId}`,
+		{ name: 'Test DB' },
+		{ headers: AUTH_HEADERS }
+	);
+	assertEquals(res.status, 409);
+	const body = await res.json();
+	assertExists(body.error);
+});
+
+test('PATCH /api/v1/databases/{id} returns 200 and updates name', async () => {
+	const res = await client.patch(
+		`/api/v1/databases/${linkedDbId}`,
+		{ name: 'Renamed DB' },
+		{ headers: AUTH_HEADERS }
+	);
+	assertEquals(res.status, 200, `Expected 200, got ${res.status}: ${await res.clone().text()}`);
+	const body = await res.json();
+	assertEquals(body.name, 'Renamed DB');
+	assertEquals(body.id, linkedDbId);
+	// Secrets stripped
+	assertEquals(body.personal_access_token, undefined);
+	assertEquals(body.local_path, undefined);
+});
+
+// --- POST /api/v1/databases/{id}/sync ---
+
+test('POST /api/v1/databases/{id}/sync returns 404 for non-existent ID', async () => {
+	const res = await client.post('/api/v1/databases/99999/sync', {}, { headers: AUTH_HEADERS });
+	assertEquals(res.status, 404);
+});
+
+test('POST /api/v1/databases/{id}/sync returns 202 with jobId', async () => {
+	const res = await client.post(
+		`/api/v1/databases/${linkedDbId}/sync`,
+		{},
+		{ headers: AUTH_HEADERS }
+	);
+	assertEquals(res.status, 202, `Expected 202, got ${res.status}: ${await res.clone().text()}`);
+	const body = await res.json();
+	assertExists(body.jobId);
+	assertEquals(typeof body.jobId, 'number');
+});
+
+// --- DELETE /api/v1/databases/{id} ---
+
+test('DELETE /api/v1/databases/{id} returns 404 for non-existent ID', async () => {
+	const res = await client.delete('/api/v1/databases/99999', { headers: AUTH_HEADERS });
+	assertEquals(res.status, 404);
+});
+
+test('DELETE /api/v1/databases/{id} returns 204 and unlinks', async () => {
+	const res = await client.delete(`/api/v1/databases/${linkedDbId}`, { headers: AUTH_HEADERS });
+	assertEquals(res.status, 204);
+});
+
+test('GET /api/v1/databases/{id} returns 404 after delete', async () => {
+	const res = await client.get(`/api/v1/databases/${linkedDbId}`, {
+		headers: AUTH_HEADERS
+	});
+	assertEquals(res.status, 404);
 });
 
 await run();


### PR DESCRIPTION
## Summary
- Add GET, PATCH, DELETE `/api/v1/databases/{id}` and POST `/api/v1/databases/{id}/sync`
- PATCH uses shared `validateUpdateInput()`, refactors settings form action to use it too
- Sync endpoint enqueues async `pcd.sync` job (202 with jobId), fixes handler to allow manual syncs on `sync_strategy=0` databases
- 24 integration tests (12 new)

Part of #401