### PR TITLE
fix: instance form submits stale conflict_strategy with PAT

### DIFF
--- a/src/routes/databases/components/InstanceForm.svelte
+++ b/src/routes/databases/components/InstanceForm.svelte
@@ -469,7 +469,9 @@
 	<input type="hidden" name="git_user_name" value={gitUserName} />
 	<input type="hidden" name="git_user_email" value={gitUserEmail} />
 	<input type="hidden" name="local_ops_enabled" value={localOpsEnabled === 'true' ? '1' : '0'} />
-	<input type="hidden" name="conflict_strategy" value={conflictStrategy} />
+	{#if !showGitIdentity || localOpsEnabled === 'true'}
+		<input type="hidden" name="conflict_strategy" value={conflictStrategy} />
+	{/if}
 	<input type="hidden" name="sync_strategy" value={syncStrategy} />
 	<input type="hidden" name="auto_pull" value={autoPull === 'true' ? '1' : '0'} />
 </form>

--- a/src/routes/databases/new/+page.server.ts
+++ b/src/routes/databases/new/+page.server.ts
@@ -48,9 +48,10 @@ export const actions = {
 			git_user_email: getFirstNonEmptyFormValue(formData, 'git_user_email'),
 			sync_strategy: formData.get('sync_strategy')?.toString() || '0',
 			auto_pull: formData.get('auto_pull') === '1',
-			local_ops_enabled: formData.get('local_ops_enabled') === '1',
-			conflict_strategy: formData.get('conflict_strategy')?.toString().trim() || 'override'
+			local_ops_enabled: formData.get('local_ops_enabled') === '1'
 		};
+		const cs = formData.get('conflict_strategy')?.toString().trim();
+		if (cs) raw.conflict_strategy = cs;
 
 		const result = validateLinkInput(raw);
 		if (!result.ok) {


### PR DESCRIPTION
Hidden `conflict_strategy` input was still submitting when the dropdown was hidden (PAT set, local ops off), causing validation to reject the save.