### PR TITLE
fix: use leader election for SSE to prevent multi-tab connection exhaustion

### DIFF
--- a/docs/backend/jobs.md
+++ b/docs/backend/jobs.md
@@ -309,8 +309,15 @@ seconds of entering `completed`, the completion message is held for the
 remaining time before transitioning. This prevents flickering during
 back-to-back jobs.
 
-The `EventSource` connects on app load (from `+layout.svelte`) and stays open
-for the session. It auto-reconnects on network drops.
+**Multi-tab coordination**: Browsers limit HTTP/1.1 connections to 6 per
+origin. Since each SSE connection is long-lived, opening 6+ tabs would exhaust
+all connection slots and freeze the app. To prevent this, the store uses the
+Web Locks API for leader election: only one tab holds the `EventSource`
+connection. The leader relays events to all other tabs via `BroadcastChannel`.
+When the leader tab closes, the browser auto-releases the lock and the next
+queued tab takes over as leader. In browsers without Web Locks or
+BroadcastChannel support, each tab falls back to its own direct `EventSource`
+connection (original behavior).
 
 **Desktop UI** (`src/lib/client/ui/navigation/pageNav/jobStatus.svelte`): A
 card component that appears above the version block in the sidebar when a job

--- a/src/lib/client/stores/jobStatus.ts
+++ b/src/lib/client/stores/jobStatus.ts
@@ -1,13 +1,15 @@
 /**
- * Job status store with SSE connection.
+ * Job status store with SSE connection and multi-tab leader election.
  *
- * Manages the state machine for the sidebar job status indicator.
- * Connects to /jobs/events via EventSource on app load.
+ * Uses Web Locks API so only one tab holds the EventSource connection.
+ * The leader tab relays events to followers via BroadcastChannel.
+ * Falls back to direct EventSource if Web Locks/BroadcastChannel
+ * are unavailable.
  *
- * States: idle → running → completed → idle
+ * States: idle -> running -> completed -> idle
  *
  * Timer rules:
- * - completed → idle after 10 seconds
+ * - completed -> idle after 6 seconds
  * - If job.started arrives during completed and < 5s elapsed, hold
  *   the completion message until 5s pass, then transition to running
  */
@@ -26,17 +28,42 @@ export type JobStatusState =
 			durationMs: number;
 	  };
 
+interface StartedPayload {
+	jobType: string;
+	displayLabel: string;
+}
+
+interface FinishedPayload {
+	jobType: string;
+	displayLabel: string;
+	status: string;
+	durationMs: number;
+}
+
+type ChannelMessage =
+	| { type: 'job.started'; data: StartedPayload }
+	| { type: 'job.finished'; data: FinishedPayload };
+
 const COMPLETED_DISPLAY_MS = 6_000;
 const COMPLETED_HOLDOFF_MS = 5_000;
+const LOCK_NAME = 'profilarr-sse-leader';
+const CHANNEL_NAME = 'profilarr-jobs';
 
 function createJobStatusStore() {
 	const { subscribe, set } = writable<JobStatusState>({ state: 'idle' });
 
-	let eventSource: EventSource | null = null;
 	let resetTimer: ReturnType<typeof setTimeout> | null = null;
 	let holdoffTimer: ReturnType<typeof setTimeout> | null = null;
 	let completedAt = 0;
-	let pendingStartEvent: { jobType: string; displayLabel: string } | null = null;
+	let pendingStartEvent: StartedPayload | null = null;
+
+	// Cross-tab coordination
+	let connected = false;
+	let eventSource: EventSource | null = null;
+	let channel: BroadcastChannel | null = null;
+	let lockHeld = false;
+	let disconnectController: AbortController | null = null;
+	let disconnectResolve: (() => void) | null = null;
 
 	function clearTimers() {
 		if (resetTimer) {
@@ -50,8 +77,7 @@ function createJobStatusStore() {
 		pendingStartEvent = null;
 	}
 
-	function handleStarted(data: { jobType: string; displayLabel: string }) {
-		// Clear the idle reset timer if running
+	function handleStarted(data: StartedPayload) {
 		if (resetTimer) {
 			clearTimeout(resetTimer);
 			resetTimer = null;
@@ -59,7 +85,6 @@ function createJobStatusStore() {
 
 		const elapsed = Date.now() - completedAt;
 
-		// If in completed state within holdoff window, delay the transition
 		if (completedAt > 0 && elapsed < COMPLETED_HOLDOFF_MS) {
 			pendingStartEvent = data;
 			if (holdoffTimer) clearTimeout(holdoffTimer);
@@ -78,7 +103,6 @@ function createJobStatusStore() {
 			return;
 		}
 
-		// Transition immediately
 		completedAt = 0;
 		pendingStartEvent = null;
 		if (holdoffTimer) {
@@ -88,12 +112,7 @@ function createJobStatusStore() {
 		set({ state: 'running', jobType: data.jobType, displayLabel: data.displayLabel });
 	}
 
-	function handleFinished(data: {
-		jobType: string;
-		displayLabel: string;
-		status: string;
-		durationMs: number;
-	}) {
+	function handleFinished(data: FinishedPayload) {
 		clearTimers();
 		completedAt = Date.now();
 		set({
@@ -110,9 +129,33 @@ function createJobStatusStore() {
 		}, COMPLETED_DISPLAY_MS);
 	}
 
-	function connect() {
-		if (!browser || eventSource) return;
+	/** Open SSE and relay events to followers via BroadcastChannel (leader only). */
+	function openLeaderSSE() {
+		eventSource = new EventSource('/jobs/events');
 
+		eventSource.addEventListener('job.started', (e) => {
+			try {
+				const data: StartedPayload = JSON.parse(e.data);
+				handleStarted(data);
+				channel?.postMessage({ type: 'job.started', data } satisfies ChannelMessage);
+			} catch {
+				// Invalid event data
+			}
+		});
+
+		eventSource.addEventListener('job.finished', (e) => {
+			try {
+				const data: FinishedPayload = JSON.parse(e.data);
+				handleFinished(data);
+				channel?.postMessage({ type: 'job.finished', data } satisfies ChannelMessage);
+			} catch {
+				// Invalid event data
+			}
+		});
+	}
+
+	/** Open SSE directly without cross-tab coordination (fallback). */
+	function openDirectSSE() {
 		eventSource = new EventSource('/jobs/events');
 
 		eventSource.addEventListener('job.started', (e) => {
@@ -132,9 +175,66 @@ function createJobStatusStore() {
 		});
 	}
 
+	function connect() {
+		if (!browser || connected) return;
+		connected = true;
+
+		if (
+			typeof BroadcastChannel !== 'undefined' &&
+			typeof navigator !== 'undefined' &&
+			'locks' in navigator
+		) {
+			// All tabs listen for relayed events
+			channel = new BroadcastChannel(CHANNEL_NAME);
+			channel.onmessage = (e: MessageEvent<ChannelMessage>) => {
+				if (lockHeld) return; // Leader already handled locally
+				const msg = e.data;
+				if (msg.type === 'job.started') handleStarted(msg.data);
+				else if (msg.type === 'job.finished') handleFinished(msg.data);
+			};
+
+			// Compete for SSE leadership
+			disconnectController = new AbortController();
+			navigator.locks
+				.request(LOCK_NAME, { signal: disconnectController.signal }, () => {
+					lockHeld = true;
+					openLeaderSSE();
+					// Hold the lock until disconnect() resolves this promise
+					return new Promise<void>((resolve) => {
+						disconnectResolve = resolve;
+					});
+				})
+				.catch((err: unknown) => {
+					// AbortError is expected when a follower disconnects
+					if (err instanceof DOMException && err.name === 'AbortError') return;
+					// Unexpected error: fall back to direct SSE
+					if (connected && !eventSource) openDirectSSE();
+				});
+		} else {
+			// No Web Locks / BroadcastChannel support: old behavior
+			openDirectSSE();
+		}
+	}
+
 	function disconnect() {
+		if (!connected) return;
+		connected = false;
+
 		eventSource?.close();
 		eventSource = null;
+
+		channel?.close();
+		channel = null;
+
+		if (lockHeld) {
+			lockHeld = false;
+			disconnectResolve?.();
+			disconnectResolve = null;
+		} else {
+			disconnectController?.abort();
+		}
+		disconnectController = null;
+
 		clearTimers();
 		completedAt = 0;
 		set({ state: 'idle' });


### PR DESCRIPTION
Closes #434

Each tab opened a persistent EventSource to `/jobs/events`. Browsers cap
HTTP/1.1 connections at 6 per origin, so 6+ tabs exhausted all slots and
froze the app entirely.

Uses Web Locks API to elect a single leader tab that holds the SSE
connection. The leader relays events to all other tabs via
BroadcastChannel. When the leader closes, the next queued tab takes
over automatically. Falls back to direct per-tab SSE in older browsers.