### PR TITLE
fix: use on-demand SSE for job status

### DIFF
--- a/docs/backend/jobs.md
+++ b/docs/backend/jobs.md
@@ -297,10 +297,30 @@ auth. API keys cannot access it.
 
 ### Client Side
 
-**Store** (`src/lib/client/stores/jobStatus.ts`): A Svelte writable store that
-manages an `EventSource` connection and a three-state machine:
+**On-demand connections**: The SSE connection is not always open. Browsers
+limit HTTP/1.1 connections to ~6 per origin, and a persistent EventSource
+would consume one of those slots permanently. Instead, the store connects
+just-in-time when a job is triggered and auto-disconnects after completion.
+This means zero baseline connection usage.
 
-- `idle` - no job activity, version block shows normally
+The flow:
+
+1. The triggering component calls `jobStatus.connect()` before firing the
+   action that enqueues the job.
+2. The store opens an `EventSource` to `/jobs/events` (no-op if already open).
+3. SSE delivers `job.started` and `job.finished` events as the job runs.
+4. After `job.finished`, the completion message displays for 6 seconds, then
+   the store transitions to `idle` and closes the EventSource.
+
+If multiple jobs are triggered in quick succession, the second `connect()` is
+a no-op since the connection is already open. Jobs run serially, so the SSE
+sees all started/finished events in order. The connection stays open until the
+final job's 6-second display expires.
+
+**Store** (`src/lib/client/stores/jobStatus.ts`): A Svelte writable store with
+a three-state machine:
+
+- `idle` - no job activity, EventSource closed
 - `running` - job in progress, shows spinner and label
 - `completed` - job finished, shows result for 6 seconds then returns to idle
 
@@ -308,16 +328,6 @@ The store includes holdoff logic: if a new `job.started` arrives within 5
 seconds of entering `completed`, the completion message is held for the
 remaining time before transitioning. This prevents flickering during
 back-to-back jobs.
-
-**Multi-tab coordination**: Browsers limit HTTP/1.1 connections to 6 per
-origin. Since each SSE connection is long-lived, opening 6+ tabs would exhaust
-all connection slots and freeze the app. To prevent this, the store uses the
-Web Locks API for leader election: only one tab holds the `EventSource`
-connection. The leader relays events to all other tabs via `BroadcastChannel`.
-When the leader tab closes, the browser auto-releases the lock and the next
-queued tab takes over as leader. In browsers without Web Locks or
-BroadcastChannel support, each tab falls back to its own direct `EventSource`
-connection (original behavior).
 
 **Desktop UI** (`src/lib/client/ui/navigation/pageNav/jobStatus.svelte`): A
 card component that appears above the version block in the sidebar when a job

--- a/src/lib/client/stores/jobStatus.ts
+++ b/src/lib/client/stores/jobStatus.ts
@@ -1,15 +1,15 @@
 /**
- * Job status store with SSE connection and multi-tab leader election.
+ * Job status store with on-demand SSE connection.
  *
- * Uses Web Locks API so only one tab holds the EventSource connection.
- * The leader tab relays events to followers via BroadcastChannel.
- * Falls back to direct EventSource if Web Locks/BroadcastChannel
- * are unavailable.
+ * Opens an EventSource to /jobs/events only when a sync is triggered
+ * (via connect()), and auto-disconnects after the job completes and
+ * the 6-second completion display expires. No persistent connections,
+ * no cross-tab coordination needed.
  *
  * States: idle -> running -> completed -> idle
  *
  * Timer rules:
- * - completed -> idle after 6 seconds
+ * - completed -> idle after 6 seconds (then auto-disconnect)
  * - If job.started arrives during completed and < 5s elapsed, hold
  *   the completion message until 5s pass, then transition to running
  */
@@ -40,14 +40,8 @@ interface FinishedPayload {
 	durationMs: number;
 }
 
-type ChannelMessage =
-	| { type: 'job.started'; data: StartedPayload }
-	| { type: 'job.finished'; data: FinishedPayload };
-
 const COMPLETED_DISPLAY_MS = 6_000;
 const COMPLETED_HOLDOFF_MS = 5_000;
-const LOCK_NAME = 'profilarr-sse-leader';
-const CHANNEL_NAME = 'profilarr-jobs';
 
 function createJobStatusStore() {
 	const { subscribe, set } = writable<JobStatusState>({ state: 'idle' });
@@ -57,13 +51,7 @@ function createJobStatusStore() {
 	let completedAt = 0;
 	let pendingStartEvent: StartedPayload | null = null;
 
-	// Cross-tab coordination
-	let connected = false;
 	let eventSource: EventSource | null = null;
-	let channel: BroadcastChannel | null = null;
-	let lockHeld = false;
-	let disconnectController: AbortController | null = null;
-	let disconnectResolve: (() => void) | null = null;
 
 	function clearTimers() {
 		if (resetTimer) {
@@ -126,36 +114,19 @@ function createJobStatusStore() {
 			set({ state: 'idle' });
 			completedAt = 0;
 			resetTimer = null;
+			// Auto-disconnect: no more events expected
+			closeSSE();
 		}, COMPLETED_DISPLAY_MS);
 	}
 
-	/** Open SSE and relay events to followers via BroadcastChannel (leader only). */
-	function openLeaderSSE() {
-		eventSource = new EventSource('/jobs/events');
-
-		eventSource.addEventListener('job.started', (e) => {
-			try {
-				const data: StartedPayload = JSON.parse(e.data);
-				handleStarted(data);
-				channel?.postMessage({ type: 'job.started', data } satisfies ChannelMessage);
-			} catch {
-				// Invalid event data
-			}
-		});
-
-		eventSource.addEventListener('job.finished', (e) => {
-			try {
-				const data: FinishedPayload = JSON.parse(e.data);
-				handleFinished(data);
-				channel?.postMessage({ type: 'job.finished', data } satisfies ChannelMessage);
-			} catch {
-				// Invalid event data
-			}
-		});
+	function closeSSE() {
+		eventSource?.close();
+		eventSource = null;
 	}
 
-	/** Open SSE directly without cross-tab coordination (fallback). */
-	function openDirectSSE() {
+	function connect() {
+		if (!browser || eventSource) return;
+
 		eventSource = new EventSource('/jobs/events');
 
 		eventSource.addEventListener('job.started', (e) => {
@@ -175,66 +146,8 @@ function createJobStatusStore() {
 		});
 	}
 
-	function connect() {
-		if (!browser || connected) return;
-		connected = true;
-
-		if (
-			typeof BroadcastChannel !== 'undefined' &&
-			typeof navigator !== 'undefined' &&
-			'locks' in navigator
-		) {
-			// All tabs listen for relayed events
-			channel = new BroadcastChannel(CHANNEL_NAME);
-			channel.onmessage = (e: MessageEvent<ChannelMessage>) => {
-				if (lockHeld) return; // Leader already handled locally
-				const msg = e.data;
-				if (msg.type === 'job.started') handleStarted(msg.data);
-				else if (msg.type === 'job.finished') handleFinished(msg.data);
-			};
-
-			// Compete for SSE leadership
-			disconnectController = new AbortController();
-			navigator.locks
-				.request(LOCK_NAME, { signal: disconnectController.signal }, () => {
-					lockHeld = true;
-					openLeaderSSE();
-					// Hold the lock until disconnect() resolves this promise
-					return new Promise<void>((resolve) => {
-						disconnectResolve = resolve;
-					});
-				})
-				.catch((err: unknown) => {
-					// AbortError is expected when a follower disconnects
-					if (err instanceof DOMException && err.name === 'AbortError') return;
-					// Unexpected error: fall back to direct SSE
-					if (connected && !eventSource) openDirectSSE();
-				});
-		} else {
-			// No Web Locks / BroadcastChannel support: old behavior
-			openDirectSSE();
-		}
-	}
-
 	function disconnect() {
-		if (!connected) return;
-		connected = false;
-
-		eventSource?.close();
-		eventSource = null;
-
-		channel?.close();
-		channel = null;
-
-		if (lockHeld) {
-			lockHeld = false;
-			disconnectResolve?.();
-			disconnectResolve = null;
-		} else {
-			disconnectController?.abort();
-		}
-		disconnectController = null;
-
+		closeSSE();
 		clearTimers();
 		completedAt = 0;
 		set({ state: 'idle' });

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -14,8 +14,7 @@
 	import { FEATURES } from '$lib/shared/features';
 	import { dev } from '$app/environment';
 	import { page } from '$app/stores';
-	import { onMount, onDestroy } from 'svelte';
-	import { jobStatus } from '$stores/jobStatus';
+	import { onMount } from 'svelte';
 
 	export let data;
 
@@ -28,12 +27,7 @@
 	$: isDesktop = innerWidth >= 768;
 
 	onMount(() => {
-		if (!isAuthPage) jobStatus.connect();
 		if (!isAuthPage && cutsceneEnabled) cutscene.init(data.onboardingShown);
-	});
-
-	onDestroy(() => {
-		jobStatus.disconnect();
 	});
 </script>
 

--- a/src/routes/arr/[id]/sync/components/DelayProfiles.svelte
+++ b/src/routes/arr/[id]/sync/components/DelayProfiles.svelte
@@ -4,6 +4,7 @@
 	import SyncFooter from './SyncFooter.svelte';
 	import { alertStore } from '$lib/client/alerts/store.ts';
 	import { deserialize } from '$app/forms';
+	import { jobStatus } from '$stores/jobStatus';
 
 	interface DatabaseWithProfiles {
 		id: number;
@@ -82,6 +83,7 @@
 	}
 
 	async function handleSync() {
+		jobStatus.connect();
 		syncing = true;
 		try {
 			const response = await fetch('?/syncDelayProfiles', {

--- a/src/routes/arr/[id]/sync/components/MediaManagement.svelte
+++ b/src/routes/arr/[id]/sync/components/MediaManagement.svelte
@@ -3,6 +3,7 @@
 	import SyncFooter from './SyncFooter.svelte';
 	import { alertStore } from '$lib/client/alerts/store.ts';
 	import { deserialize } from '$app/forms';
+	import { jobStatus } from '$stores/jobStatus';
 
 	interface ConfigOption {
 		name: string;
@@ -189,6 +190,7 @@
 	}
 
 	async function handleSync() {
+		jobStatus.connect();
 		syncing = true;
 		try {
 			const response = await fetch('?/syncMediaManagement', {

--- a/src/routes/arr/[id]/sync/components/QualityProfiles.svelte
+++ b/src/routes/arr/[id]/sync/components/QualityProfiles.svelte
@@ -4,6 +4,7 @@
 	import SyncFooter from './SyncFooter.svelte';
 	import { alertStore } from '$lib/client/alerts/store.ts';
 	import { deserialize } from '$app/forms';
+	import { jobStatus } from '$stores/jobStatus';
 
 	interface DatabaseWithProfiles {
 		id: number;
@@ -123,6 +124,7 @@
 	}
 
 	async function handleSync() {
+		jobStatus.connect();
 		syncing = true;
 		try {
 			const response = await fetch('?/syncQualityProfiles', {


### PR DESCRIPTION
## Summary

- Replace always-on EventSource with just-in-time connections that open when a sync is triggered and auto-close after the 6s completion display
- Remove leader election, BroadcastChannel, and Web Locks (no persistent connection to coordinate)
- Zero baseline connection usage; SSE only lives for the duration of a job