### PR TITLE
feat: smart entity search

### DIFF
--- a/docs/frontend/ui.md
+++ b/docs/frontend/ui.md
@@ -388,8 +388,10 @@ Sub-components for building custom menu UIs:
 
 - **`Dropdown.svelte`**: positioning container with fixed-positioning and
   hover-bridge support.
-- **`DropdownHeader.svelte`**, **`DropdownItem.svelte`**: styled section
-  header and menu item.
+- **`DropdownHeader.svelte`**, **`DropdownFooter.svelte`**,
+  **`DropdownItem.svelte`**: styled section header, footer, and menu item.
+  `DropdownFooter` mirrors `DropdownHeader` but uses `border-top` instead
+  of `border-bottom` and sits at the end of a menu (e.g. "and 12 more").
 - **`DropdownSelect.svelte`**: the `<select>` replacement (covered under
   [Inputs](#searchdropdown-and-dropdownselect)).
 - **`CustomGroupManager.svelte`**: specialized dropdown used by the custom

--- a/src/lib/client/ui/dropdown/DropdownFooter.svelte
+++ b/src/lib/client/ui/dropdown/DropdownFooter.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+	export let label: string;
+	export let compact: boolean = false;
+
+	$: sizeClasses = compact
+		? 'px-2 py-1 text-xs last:rounded-b-lg'
+		: 'px-3 py-1.5 text-xs last:rounded-b-xl';
+</script>
+
+<div
+	class="flex w-full items-center border-t border-neutral-200/50 dark:border-neutral-700/40 {sizeClasses}"
+>
+	<span class="text-neutral-400 dark:text-neutral-500">{label}</span>
+</div>

--- a/src/lib/client/ui/filter/SmartFilterBar.svelte
+++ b/src/lib/client/ui/filter/SmartFilterBar.svelte
@@ -340,18 +340,10 @@
 </div>
 
 <style>
+	/* Re-apply rounding stripped by ActionsBar's global border-radius reset.
+	   The Dropdown component's own overflow-hidden + rounded-xl handles
+	   internal clipping, so we only need to restore the container radius. */
 	.smart-filter-bar > :global(:nth-child(n + 2)) {
 		border-radius: 0.75rem !important;
-	}
-	.smart-filter-bar > :global(:nth-child(n + 2)) :global(*) {
-		border-radius: 0 !important;
-	}
-	.smart-filter-bar > :global(:nth-child(n + 2)) :global(:first-child) {
-		border-top-left-radius: 0.75rem !important;
-		border-top-right-radius: 0.75rem !important;
-	}
-	.smart-filter-bar > :global(:nth-child(n + 2)) :global(:last-child) {
-		border-bottom-left-radius: 0.75rem !important;
-		border-bottom-right-radius: 0.75rem !important;
 	}
 </style>

--- a/src/lib/client/ui/filter/SmartFilterBar.svelte
+++ b/src/lib/client/ui/filter/SmartFilterBar.svelte
@@ -7,6 +7,7 @@
 	import Dropdown from '$ui/dropdown/Dropdown.svelte';
 	import DropdownHeader from '$ui/dropdown/DropdownHeader.svelte';
 	import DropdownItem from '$ui/dropdown/DropdownItem.svelte';
+	import DropdownFooter from '$ui/dropdown/DropdownFooter.svelte';
 	import type { FilterFieldDef, FilterTag, SerializedFilterTag } from './types';
 
 	export let fields: FilterFieldDef[] = [];
@@ -91,13 +92,23 @@
 			.map((f) => ({ key: f.key, label: f.label, type: f.type }));
 	})();
 
+	let remainingValueCount = 0;
+
 	$: valueSuggestions = (() => {
-		if (phase !== 'value' || !activeFieldDef) return [];
-		if (activeFieldDef.type === 'number') return [];
+		if (phase !== 'value' || !activeFieldDef) {
+			remainingValueCount = 0;
+			return [];
+		}
+		if (activeFieldDef.type === 'number') {
+			remainingValueCount = 0;
+			return [];
+		}
 		const allSuggestions = activeFieldDef.suggestions?.(items) ?? [];
-		if (!valueInputValue) return allSuggestions.slice(0, 5);
-		const q = valueInputValue.toLowerCase();
-		return allSuggestions.filter((s) => s.toLowerCase().includes(q)).slice(0, 5);
+		const matched = valueInputValue
+			? allSuggestions.filter((s) => s.toLowerCase().includes(valueInputValue.toLowerCase()))
+			: allSuggestions;
+		remainingValueCount = Math.max(0, matched.length - 5);
+		return matched.slice(0, 5);
 	})();
 
 	$: suggestions =
@@ -335,6 +346,9 @@
 					on:click={() => handleSuggestionClick(i)}
 				/>
 			{/each}
+			{#if phase === 'value' && remainingValueCount > 0}
+				<DropdownFooter label="and {remainingValueCount} more" />
+			{/if}
 		</Dropdown>
 	{/if}
 </div>

--- a/src/routes/custom-formats/[databaseId]/+page.svelte
+++ b/src/routes/custom-formats/[databaseId]/+page.svelte
@@ -7,6 +7,7 @@
 	import SearchAction from '$ui/actions/SearchAction.svelte';
 	import ViewToggle from '$ui/actions/ViewToggle.svelte';
 	import SmartFilterBar from '$ui/filter/SmartFilterBar.svelte';
+	import Tooltip from '$ui/tooltip/Tooltip.svelte';
 	import InfoModal from '$ui/modal/InfoModal.svelte';
 	import CloneModal from '$ui/modal/CloneModal.svelte';
 	import TableView from './views/TableView.svelte';
@@ -198,10 +199,12 @@
 				placeholder="Filter custom formats..."
 			/>
 		{/if}
-		<ActionButton
-			icon={Plus}
-			on:click={() => goto(`/custom-formats/${data.currentDatabase.id}/new`)}
-		/>
+		<Tooltip text="New">
+			<ActionButton
+				icon={Plus}
+				on:click={() => goto(`/custom-formats/${data.currentDatabase.id}/new`)}
+			/>
+		</Tooltip>
 		<ViewToggle bind:value={viewMode} />
 		<ActionButton icon={Info} on:click={() => (infoModalOpen = true)} />
 	</ActionsBar>

--- a/src/routes/custom-formats/[databaseId]/+page.svelte
+++ b/src/routes/custom-formats/[databaseId]/+page.svelte
@@ -76,6 +76,13 @@
 			suggestions: (items) => [...new Set(items.flatMap((i) => i.tags.map((t) => t.name)))].sort()
 		},
 		{
+			key: 'tagged',
+			label: 'Tagged',
+			type: 'text',
+			accessor: (item) => (item.tags.length > 0 ? 'yes' : 'no'),
+			suggestions: () => ['yes', 'no']
+		},
+		{
 			key: 'description',
 			label: 'Description',
 			type: 'text',

--- a/src/routes/custom-formats/[databaseId]/+page.svelte
+++ b/src/routes/custom-formats/[databaseId]/+page.svelte
@@ -1,18 +1,21 @@
 <script lang="ts">
+	import { onMount, onDestroy } from 'svelte';
+	import { browser } from '$app/environment';
 	import Tabs from '$ui/navigation/tabs/Tabs.svelte';
 	import ActionsBar from '$ui/actions/ActionsBar.svelte';
 	import ActionButton from '$ui/actions/ActionButton.svelte';
 	import SearchAction from '$ui/actions/SearchAction.svelte';
-	import SearchModeToggle from '$ui/actions/SearchModeToggle.svelte';
-	import TagInput from '$ui/form/TagInput.svelte';
 	import ViewToggle from '$ui/actions/ViewToggle.svelte';
+	import SmartFilterBar from '$ui/filter/SmartFilterBar.svelte';
 	import InfoModal from '$ui/modal/InfoModal.svelte';
 	import CloneModal from '$ui/modal/CloneModal.svelte';
 	import TableView from './views/TableView.svelte';
 	import CardView from './views/CardView.svelte';
-	import { createDataPageStore } from '$lib/client/stores/dataPage';
-	import { filterByText, filterByTags, createSearchFieldState } from '$lib/client/utils/search';
-	import { Info, Plus, Type, Tag, AlignLeft, ListChecks } from 'lucide-svelte';
+	import { getPersistentSearchStore } from '$stores/search';
+	import type { FilterFieldDef, FilterTag } from '$ui/filter/types';
+	import { applySmartFilters } from '$ui/filter/match';
+	import type { ViewMode } from '$lib/client/stores/dataPage';
+	import { Info, Plus } from 'lucide-svelte';
 	import { goto } from '$app/navigation';
 	import { alertStore } from '$alerts/store';
 	import type { CustomFormatTableRow } from '$shared/pcd/display.ts';
@@ -50,82 +53,109 @@
 		}
 	}
 
-	// Search field options
-	const searchFields = [
-		{ value: 'name', label: 'Name' },
-		{ value: 'tags', label: 'Tags' },
-		{ value: 'description', label: 'Description' },
-		{ value: 'conditions', label: 'Conditions' }
+	// ======================================================================
+	// Smart Filter
+	// ======================================================================
+
+	let filterTags: FilterTag[] = [];
+
+	const fields: FilterFieldDef<CustomFormatTableRow>[] = [
+		{
+			key: 'name',
+			label: 'Name',
+			type: 'text',
+			isDefault: true,
+			accessor: (item) => item.name,
+			suggestions: (items) => items.map((i) => i.name).sort()
+		},
+		{
+			key: 'tag',
+			label: 'Tag',
+			type: 'text',
+			accessor: (item) => item.tags.map((t) => t.name),
+			suggestions: (items) => [...new Set(items.flatMap((i) => i.tags.map((t) => t.name)))].sort()
+		},
+		{
+			key: 'description',
+			label: 'Description',
+			type: 'text',
+			accessor: (item) => item.description ?? null
+		},
+		{
+			key: 'condition',
+			label: 'Condition',
+			type: 'text',
+			accessor: (item) => item.conditions.map((c) => c.name),
+			suggestions: (items) =>
+				[...new Set(items.flatMap((i) => i.conditions.map((c) => c.name)))].sort()
+		},
+		{
+			key: 'tests',
+			label: 'Tests',
+			type: 'number',
+			accessor: (item) => item.testCount
+		}
 	];
 
-	const searchFieldIcons: Record<string, typeof Type> = {
-		name: Type,
-		tags: Tag,
-		description: AlignLeft,
-		conditions: ListChecks
-	};
+	// Mobile simple search fallback
+	$: mobileSearchStore = getPersistentSearchStore(`cfSearch:${data.currentDatabase.id}`, {
+		debounceMs: 150
+	});
+	$: mobileQuery = $mobileSearchStore.query;
 
-	const searchState = createSearchFieldState('customFormatsSearch', searchFields);
+	let isMobile = false;
+	let mediaQuery: MediaQueryList | null = null;
 
-	let activeSearchField = searchState.initialField;
-	let searchTags: string[] = searchState.initialTags;
-
-	$: isTagMode = activeSearchField === 'tags' || activeSearchField === 'conditions';
-	$: searchFieldIcon = searchFieldIcons[activeSearchField] || Type;
-
-	function handleFieldChange(field: string) {
-		if (field === activeSearchField) return;
-		const wasTagMode = activeSearchField === 'tags' || activeSearchField === 'conditions';
-		const willBeTagMode = field === 'tags' || field === 'conditions';
-		if (willBeTagMode && !wasTagMode) {
-			search.clear();
-		} else if (!willBeTagMode && wasTagMode) {
-			searchTags = [];
-			searchState.clearTags();
-		} else if (willBeTagMode && wasTagMode) {
-			// Switching between tag modes — clear tags
-			searchTags = [];
-			searchState.clearTags();
+	onMount(() => {
+		if (typeof window !== 'undefined') {
+			mediaQuery = window.matchMedia('(max-width: 767px)');
+			isMobile = mediaQuery.matches;
+			mediaQuery.addEventListener('change', handleMediaChange);
 		}
-		activeSearchField = field;
-		searchState.saveField(field);
-	}
-
-	function handleTagsChange(tags: string[]) {
-		searchTags = tags;
-		searchState.saveTags(tags);
-	}
-
-	// Field accessors for text search
-	const fieldAccessors: Record<string, (item: CustomFormatTableRow) => string | string[] | null> = {
-		name: (item) => item.name,
-		tags: (item) => item.tags.map((t) => t.name),
-		description: (item) => item.description ?? null,
-		conditions: (item) => item.conditions.map((c) => c.name)
-	};
-
-	// Initialize data page store (we use search and view, but do our own filtering)
-	const { search, view, setItems } = createDataPageStore(data.customFormats, {
-		storageKey: 'customFormatsView',
-		searchKeys: ['name'], // Placeholder, we do our own filtering
-		searchKey: `customFormatsSearch:${data.currentDatabase.id}`
 	});
 
-	const debouncedQuery = search.debouncedQuery;
-
-	// Update items when data changes (e.g., switching databases)
-	$: setItems(data.customFormats);
-
-	// Filtering based on active search field
-	$: filtered = (() => {
-		if (isTagMode) {
-			const getItemTags =
-				activeSearchField === 'conditions'
-					? (item: CustomFormatTableRow) => item.conditions.map((c) => c.name)
-					: (item: CustomFormatTableRow) => item.tags.map((t) => t.name);
-			return filterByTags(data.customFormats, searchTags, getItemTags);
+	onDestroy(() => {
+		if (mediaQuery) {
+			mediaQuery.removeEventListener('change', handleMediaChange);
 		}
-		return filterByText(data.customFormats, $debouncedQuery, fieldAccessors, [activeSearchField]);
+	});
+
+	function handleMediaChange(e: MediaQueryListEvent) {
+		isMobile = e.matches;
+	}
+
+	// ======================================================================
+	// View Mode
+	// ======================================================================
+
+	const VIEW_STORAGE_KEY = 'customFormatsView';
+
+	function loadViewMode(): ViewMode {
+		if (!browser) return 'table';
+		try {
+			const stored = localStorage.getItem(VIEW_STORAGE_KEY);
+			if (stored === 'cards' || stored === 'table') return stored;
+		} catch {}
+		return window.innerWidth < 768 ? 'cards' : 'table';
+	}
+
+	let viewMode: ViewMode = loadViewMode();
+
+	$: if (browser) {
+		localStorage.setItem(VIEW_STORAGE_KEY, viewMode);
+	}
+
+	// ======================================================================
+	// Filtering
+	// ======================================================================
+
+	$: filtered = (() => {
+		let result = applySmartFilters(data.customFormats, filterTags, fields);
+		if (isMobile && mobileQuery) {
+			const q = mobileQuery.toLowerCase();
+			result = result.filter((f) => f.name.toLowerCase().includes(q));
+		}
+		return result;
 	})();
 
 	// Map databases to tabs
@@ -146,36 +176,26 @@
 
 	<!-- Actions Bar -->
 	<ActionsBar>
-		<SearchModeToggle
-			options={searchFields}
-			value={activeSearchField}
-			icon={searchFieldIcon}
-			onchange={handleFieldChange}
-		/>
-		{#if isTagMode}
-			<div class="flex-1">
-				<TagInput
-					tags={searchTags}
-					placeholder="Type a {activeSearchField === 'conditions'
-						? 'condition'
-						: 'tag'} name and press Enter... (prefix NOT: to exclude)"
-					onchange={handleTagsChange}
-				/>
-			</div>
-		{:else}
+		{#if isMobile}
 			<SearchAction
-				searchStore={search}
-				placeholder="Search {searchFields
-					.find((f) => f.value === activeSearchField)
-					?.label.toLowerCase() ?? ''}..."
+				searchStore={mobileSearchStore}
+				placeholder="Search custom formats..."
 				responsive
+			/>
+		{:else}
+			<SmartFilterBar
+				{fields}
+				items={data.customFormats}
+				bind:tags={filterTags}
+				storageKey={`smartFilter:customFormats:${data.currentDatabase.id}`}
+				placeholder="Filter custom formats..."
 			/>
 		{/if}
 		<ActionButton
 			icon={Plus}
 			on:click={() => goto(`/custom-formats/${data.currentDatabase.id}/new`)}
 		/>
-		<ViewToggle bind:value={$view} />
+		<ViewToggle bind:value={viewMode} />
 		<ActionButton icon={Info} on:click={() => (infoModalOpen = true)} />
 	</ActionsBar>
 
@@ -193,9 +213,11 @@
 			<div
 				class="rounded-lg border border-neutral-200 bg-white p-8 text-center dark:border-neutral-800 dark:bg-neutral-900"
 			>
-				<p class="text-neutral-600 dark:text-neutral-400">No custom formats match your search</p>
+				<p class="text-neutral-600 dark:text-neutral-400">
+					No custom formats match the current filters
+				</p>
 			</div>
-		{:else if $view === 'table'}
+		{:else if viewMode === 'table'}
 			<TableView formats={filtered} on:clone={handleClone} on:export={handleExport} />
 		{:else}
 			<CardView formats={filtered} on:clone={handleClone} on:export={handleExport} />

--- a/src/routes/quality-profiles/[databaseId]/+page.svelte
+++ b/src/routes/quality-profiles/[databaseId]/+page.svelte
@@ -1,18 +1,22 @@
 <script lang="ts">
+	import { onMount, onDestroy } from 'svelte';
+	import { browser } from '$app/environment';
 	import { goto } from '$app/navigation';
-	import { Plus, Type, Tag, AlignLeft } from 'lucide-svelte';
+	import { Plus } from 'lucide-svelte';
 	import Tabs from '$ui/navigation/tabs/Tabs.svelte';
 	import ActionsBar from '$ui/actions/ActionsBar.svelte';
 	import ActionButton from '$ui/actions/ActionButton.svelte';
 	import SearchAction from '$ui/actions/SearchAction.svelte';
-	import SearchModeToggle from '$ui/actions/SearchModeToggle.svelte';
-	import TagInput from '$ui/form/TagInput.svelte';
 	import ViewToggle from '$ui/actions/ViewToggle.svelte';
+	import SmartFilterBar from '$ui/filter/SmartFilterBar.svelte';
+	import Tooltip from '$ui/tooltip/Tooltip.svelte';
 	import CloneModal from '$ui/modal/CloneModal.svelte';
 	import TableView from './views/TableView.svelte';
 	import CardView from './views/CardView.svelte';
-	import { createDataPageStore } from '$lib/client/stores/dataPage';
-	import { filterByText, filterByTags, createSearchFieldState } from '$lib/client/utils/search';
+	import { getPersistentSearchStore } from '$stores/search';
+	import type { FilterFieldDef, FilterTag } from '$ui/filter/types';
+	import { applySmartFilters } from '$ui/filter/match';
+	import type { ViewMode } from '$lib/client/stores/dataPage';
 	import { alertStore } from '$alerts/store';
 	import type { QualityProfileTableRow } from '$shared/pcd/display';
 	import type { PageData } from './$types';
@@ -48,70 +52,123 @@
 		}
 	}
 
-	// Search field options
-	const searchFields = [
-		{ value: 'name', label: 'Name' },
-		{ value: 'tags', label: 'Tags' },
-		{ value: 'description', label: 'Description' }
+	// ======================================================================
+	// Smart Filter
+	// ======================================================================
+
+	let filterTags: FilterTag[] = [];
+
+	const fields: FilterFieldDef<QualityProfileTableRow>[] = [
+		{
+			key: 'name',
+			label: 'Name',
+			type: 'text',
+			isDefault: true,
+			accessor: (item) => item.name,
+			suggestions: (items) => items.map((i) => i.name).sort()
+		},
+		{
+			key: 'tag',
+			label: 'Tag',
+			type: 'text',
+			accessor: (item) => item.tags.map((t) => t.name),
+			suggestions: (items) => [...new Set(items.flatMap((i) => i.tags.map((t) => t.name)))].sort()
+		},
+		{
+			key: 'tagged',
+			label: 'Tagged',
+			type: 'text',
+			accessor: (item) => (item.tags.length > 0 ? 'yes' : 'no'),
+			suggestions: () => ['yes', 'no']
+		},
+		{
+			key: 'description',
+			label: 'Description',
+			type: 'text',
+			accessor: (item) => item.description ?? null
+		},
+		{
+			key: 'language',
+			label: 'Language',
+			type: 'text',
+			accessor: (item) => item.language?.name ?? null,
+			suggestions: (items) =>
+				[...new Set(items.map((i) => i.language?.name).filter(Boolean) as string[])].sort()
+		},
+		{
+			key: 'upgrades',
+			label: 'Upgrades',
+			type: 'text',
+			accessor: (item) => (item.upgrades_allowed ? 'yes' : 'no'),
+			suggestions: () => ['yes', 'no']
+		},
+		{
+			key: 'formats',
+			label: 'Formats',
+			type: 'number',
+			accessor: (item) => item.custom_formats.total
+		}
 	];
 
-	const searchFieldIcons: Record<string, typeof Type> = {
-		name: Type,
-		tags: Tag,
-		description: AlignLeft
-	};
+	// Mobile simple search fallback
+	$: mobileSearchStore = getPersistentSearchStore(`qpSearch:${data.currentDatabase.id}`, {
+		debounceMs: 150
+	});
+	$: mobileQuery = $mobileSearchStore.query;
 
-	const searchState = createSearchFieldState('qualityProfilesSearch', searchFields);
+	let isMobile = false;
+	let mediaQuery: MediaQueryList | null = null;
 
-	let activeSearchField = searchState.initialField;
-	let searchTags: string[] = searchState.initialTags;
-
-	$: isTagMode = activeSearchField === 'tags';
-	$: searchFieldIcon = searchFieldIcons[activeSearchField] || Type;
-
-	function handleFieldChange(field: string) {
-		if (field === activeSearchField) return;
-		if (field === 'tags') {
-			search.clear();
-		} else {
-			searchTags = [];
-			searchState.clearTags();
+	onMount(() => {
+		if (typeof window !== 'undefined') {
+			mediaQuery = window.matchMedia('(max-width: 767px)');
+			isMobile = mediaQuery.matches;
+			mediaQuery.addEventListener('change', handleMediaChange);
 		}
-		activeSearchField = field;
-		searchState.saveField(field);
-	}
-
-	function handleTagsChange(tags: string[]) {
-		searchTags = tags;
-		searchState.saveTags(tags);
-	}
-
-	// Field accessors for text search
-	const fieldAccessors: Record<string, (item: QualityProfileTableRow) => string | string[] | null> =
-		{
-			name: (item) => item.name,
-			tags: (item) => item.tags.map((t) => t.name),
-			description: (item) => item.description ?? null
-		};
-
-	// Initialize data page store (we use search and view, but do our own filtering)
-	const { search, view, setItems } = createDataPageStore(data.qualityProfiles, {
-		storageKey: 'qualityProfilesView',
-		searchKeys: ['name'], // Placeholder, we do our own filtering
-		searchKey: `qualityProfilesSearch:${data.currentDatabase.id}`
 	});
 
-	const debouncedQuery = search.debouncedQuery;
-
-	// Update items when data changes (e.g., switching databases)
-	$: setItems(data.qualityProfiles);
-
-	// Filtering based on active search field
-	$: filtered = (() => {
-		if (isTagMode) {
-			return filterByTags(data.qualityProfiles, searchTags, (item) => item.tags.map((t) => t.name));
+	onDestroy(() => {
+		if (mediaQuery) {
+			mediaQuery.removeEventListener('change', handleMediaChange);
 		}
-		return filterByText(data.qualityProfiles, $debouncedQuery, fieldAccessors, [activeSearchField]);
+	});
+
+	function handleMediaChange(e: MediaQueryListEvent) {
+		isMobile = e.matches;
+	}
+
+	// ======================================================================
+	// View Mode
+	// ======================================================================
+
+	const VIEW_STORAGE_KEY = 'qualityProfilesView';
+
+	function loadViewMode(): ViewMode {
+		if (!browser) return 'table';
+		try {
+			const stored = localStorage.getItem(VIEW_STORAGE_KEY);
+			if (stored === 'cards' || stored === 'table') return stored;
+		} catch {}
+		return window.innerWidth < 768 ? 'cards' : 'table';
+	}
+
+	let viewMode: ViewMode = loadViewMode();
+
+	$: if (browser) {
+		localStorage.setItem(VIEW_STORAGE_KEY, viewMode);
+	}
+
+	// ======================================================================
+	// Filtering
+	// ======================================================================
+
+	$: filtered = (() => {
+		let result = applySmartFilters(data.qualityProfiles, filterTags, fields);
+		if (isMobile && mobileQuery) {
+			const q = mobileQuery.toLowerCase();
+			result = result.filter((p) => p.name.toLowerCase().includes(q));
+		}
+		return result;
 	})();
 
 	// Map databases to tabs
@@ -132,34 +189,28 @@
 
 	<!-- Actions Bar -->
 	<ActionsBar>
-		<SearchModeToggle
-			options={searchFields}
-			value={activeSearchField}
-			icon={searchFieldIcon}
-			onchange={handleFieldChange}
-		/>
-		{#if isTagMode}
-			<div class="flex-1">
-				<TagInput
-					tags={searchTags}
-					placeholder="Type a tag name and press Enter... (prefix NOT: to exclude)"
-					onchange={handleTagsChange}
-				/>
-			</div>
-		{:else}
+		{#if isMobile}
 			<SearchAction
-				searchStore={search}
-				placeholder="Search {searchFields
-					.find((f) => f.value === activeSearchField)
-					?.label.toLowerCase() ?? ''}..."
+				searchStore={mobileSearchStore}
+				placeholder="Search quality profiles..."
 				responsive
 			/>
+		{:else}
+			<SmartFilterBar
+				{fields}
+				items={data.qualityProfiles}
+				bind:tags={filterTags}
+				storageKey={`smartFilter:qualityProfiles:${data.currentDatabase.id}`}
+				placeholder="Filter quality profiles..."
+			/>
 		{/if}
-		<ActionButton
-			icon={Plus}
-			on:click={() => goto(`/quality-profiles/${data.currentDatabase.id}/new`)}
-		/>
-		<ViewToggle bind:value={$view} />
+		<Tooltip text="New">
+			<ActionButton
+				icon={Plus}
+				on:click={() => goto(`/quality-profiles/${data.currentDatabase.id}/new`)}
+			/>
+		</Tooltip>
+		<ViewToggle bind:value={viewMode} />
 	</ActionsBar>
 
 	<!-- Quality Profiles Content -->
@@ -176,9 +227,11 @@
 			<div
 				class="rounded-lg border border-neutral-200 bg-white p-8 text-center dark:border-neutral-800 dark:bg-neutral-900"
 			>
-				<p class="text-neutral-600 dark:text-neutral-400">No quality profiles match your search</p>
+				<p class="text-neutral-600 dark:text-neutral-400">
+					No quality profiles match the current filters
+				</p>
 			</div>
-		{:else if $view === 'table'}
+		{:else if viewMode === 'table'}
 			<TableView
 				profiles={filtered}
 				databaseId={data.currentDatabase.id}

--- a/src/routes/regular-expressions/[databaseId]/+page.svelte
+++ b/src/routes/regular-expressions/[databaseId]/+page.svelte
@@ -1,20 +1,24 @@
 <script lang="ts">
+	import { onMount, onDestroy } from 'svelte';
+	import { browser } from '$app/environment';
 	import Tabs from '$ui/navigation/tabs/Tabs.svelte';
 	import ActionsBar from '$ui/actions/ActionsBar.svelte';
 	import ActionButton from '$ui/actions/ActionButton.svelte';
 	import SearchAction from '$ui/actions/SearchAction.svelte';
 	import ViewToggle from '$ui/actions/ViewToggle.svelte';
+	import SmartFilterBar from '$ui/filter/SmartFilterBar.svelte';
 	import InfoModal from '$ui/modal/InfoModal.svelte';
 	import CloneModal from '$ui/modal/CloneModal.svelte';
 	import Dropdown from '$ui/dropdown/Dropdown.svelte';
+	import DropdownHeader from '$ui/dropdown/DropdownHeader.svelte';
 	import DropdownItem from '$ui/dropdown/DropdownItem.svelte';
 	import TableView from './views/TableView.svelte';
 	import CardView from './views/CardView.svelte';
-	import SearchModeToggle from '$ui/actions/SearchModeToggle.svelte';
-	import TagInput from '$ui/form/TagInput.svelte';
-	import { createDataPageStore } from '$lib/client/stores/dataPage';
-	import { filterByText, filterByTags, createSearchFieldState } from '$lib/client/utils/search';
-	import { Info, Plus, FileText, Users, Type, Tag, Code, AlignLeft, Link } from 'lucide-svelte';
+	import { getPersistentSearchStore } from '$stores/search';
+	import type { FilterFieldDef, FilterTag } from '$ui/filter/types';
+	import { applySmartFilters } from '$ui/filter/match';
+	import type { ViewMode } from '$lib/client/stores/dataPage';
+	import { Info, Plus, FileText, Users } from 'lucide-svelte';
 	import { goto } from '$app/navigation';
 	import { alertStore } from '$alerts/store';
 	import type { RegularExpressionWithTags } from '$shared/pcd/display';
@@ -52,83 +56,114 @@
 		}
 	}
 
-	// Search field options
-	const searchFields = [
-		{ value: 'name', label: 'Name' },
-		{ value: 'tags', label: 'Tags' },
-		{ value: 'pattern', label: 'Pattern' },
-		{ value: 'description', label: 'Description' },
-		{ value: 'regex101_id', label: 'Regex101 ID' }
+	// ======================================================================
+	// Smart Filter
+	// ======================================================================
+
+	let filterTags: FilterTag[] = [];
+
+	const fields: FilterFieldDef<RegularExpressionWithTags>[] = [
+		{
+			key: 'name',
+			label: 'Name',
+			type: 'text',
+			isDefault: true,
+			accessor: (item) => item.name,
+			suggestions: (items) => items.map((i) => i.name).sort()
+		},
+		{
+			key: 'tag',
+			label: 'Tag',
+			type: 'text',
+			accessor: (item) => item.tags.map((t) => t.name),
+			suggestions: (items) => [...new Set(items.flatMap((i) => i.tags.map((t) => t.name)))].sort()
+		},
+		{
+			key: 'tagged',
+			label: 'Tagged',
+			type: 'text',
+			accessor: (item) => (item.tags.length > 0 ? 'yes' : 'no'),
+			suggestions: () => ['yes', 'no']
+		},
+		{
+			key: 'pattern',
+			label: 'Pattern',
+			type: 'text',
+			accessor: (item) => item.pattern
+		},
+		{
+			key: 'description',
+			label: 'Description',
+			type: 'text',
+			accessor: (item) => item.description ?? null
+		},
+		{
+			key: 'regex101_id',
+			label: 'Regex101 ID',
+			type: 'text',
+			accessor: (item) => item.regex101_id ?? null
+		}
 	];
 
-	const searchFieldIcons: Record<string, typeof Type> = {
-		name: Type,
-		tags: Tag,
-		pattern: Code,
-		description: AlignLeft,
-		regex101_id: Link
-	};
+	// Mobile simple search fallback
+	$: mobileSearchStore = getPersistentSearchStore(`reSearch:${data.currentDatabase.id}`, {
+		debounceMs: 150
+	});
+	$: mobileQuery = $mobileSearchStore.query;
 
-	const searchState = createSearchFieldState('regularExpressionsSearch', searchFields);
+	let isMobile = false;
+	let mediaQuery: MediaQueryList | null = null;
 
-	let activeSearchField = searchState.initialField;
-	let searchTags: string[] = searchState.initialTags;
-
-	$: isTagMode = activeSearchField === 'tags';
-	$: searchFieldIcon = searchFieldIcons[activeSearchField] || Type;
-
-	function handleFieldChange(field: string) {
-		if (field === activeSearchField) return;
-		if (field === 'tags') {
-			search.clear();
-		} else {
-			searchTags = [];
-			searchState.clearTags();
+	onMount(() => {
+		if (typeof window !== 'undefined') {
+			mediaQuery = window.matchMedia('(max-width: 767px)');
+			isMobile = mediaQuery.matches;
+			mediaQuery.addEventListener('change', handleMediaChange);
 		}
-		activeSearchField = field;
-		searchState.saveField(field);
-	}
-
-	function handleTagsChange(tags: string[]) {
-		searchTags = tags;
-		searchState.saveTags(tags);
-	}
-
-	// Field accessors for text search
-	const fieldAccessors: Record<
-		string,
-		(item: RegularExpressionWithTags) => string | string[] | null
-	> = {
-		name: (item) => item.name,
-		tags: (item) => item.tags.map((t) => t.name),
-		pattern: (item) => item.pattern,
-		description: (item) => item.description ?? null,
-		regex101_id: (item) => item.regex101_id ?? null
-	};
-
-	// Initialize data page store (we'll use search and view, but do our own filtering)
-	const { search, view, setItems } = createDataPageStore(data.regularExpressions, {
-		storageKey: 'regularExpressionsView',
-		searchKeys: ['name'], // Placeholder, we do our own filtering
-		searchKey: `regularExpressionsSearch:${data.currentDatabase.id}`
 	});
 
-	// Extract the debounced query store for reactive access
-	const debouncedQuery = search.debouncedQuery;
-
-	// Update items when data changes (e.g., switching databases)
-	$: setItems(data.regularExpressions);
-
-	// Filtering based on active search field
-	$: filtered = (() => {
-		if (isTagMode) {
-			return filterByTags(data.regularExpressions, searchTags, (item) =>
-				item.tags.map((t) => t.name)
-			);
+	onDestroy(() => {
+		if (mediaQuery) {
+			mediaQuery.removeEventListener('change', handleMediaChange);
 		}
-		return filterByText(data.regularExpressions, $debouncedQuery, fieldAccessors, [
-			activeSearchField
-		]);
+	});
+
+	function handleMediaChange(e: MediaQueryListEvent) {
+		isMobile = e.matches;
+	}
+
+	// ======================================================================
+	// View Mode
+	// ======================================================================
+
+	const VIEW_STORAGE_KEY = 'regularExpressionsView';
+
+	function loadViewMode(): ViewMode {
+		if (!browser) return 'table';
+		try {
+			const stored = localStorage.getItem(VIEW_STORAGE_KEY);
+			if (stored === 'cards' || stored === 'table') return stored;
+		} catch {}
+		return window.innerWidth < 768 ? 'cards' : 'table';
+	}
+
+	let viewMode: ViewMode = loadViewMode();
+
+	$: if (browser) {
+		localStorage.setItem(VIEW_STORAGE_KEY, viewMode);
+	}
+
+	// ======================================================================
+	// Filtering
+	// ======================================================================
+
+	$: filtered = (() => {
+		let result = applySmartFilters(data.regularExpressions, filterTags, fields);
+		if (isMobile && mobileQuery) {
+			const q = mobileQuery.toLowerCase();
+			result = result.filter((r) => r.name.toLowerCase().includes(q));
+		}
+		return result;
 	})();
 
 	// Map databases to tabs
@@ -149,32 +184,25 @@
 
 	<!-- Actions Bar -->
 	<ActionsBar>
-		<SearchModeToggle
-			options={searchFields}
-			value={activeSearchField}
-			icon={searchFieldIcon}
-			onchange={handleFieldChange}
-		/>
-		{#if isTagMode}
-			<div class="flex-1">
-				<TagInput
-					tags={searchTags}
-					placeholder="Type a tag name and press Enter... (prefix NOT: to exclude)"
-					onchange={handleTagsChange}
-				/>
-			</div>
-		{:else}
+		{#if isMobile}
 			<SearchAction
-				searchStore={search}
-				placeholder="Search {searchFields
-					.find((f) => f.value === activeSearchField)
-					?.label.toLowerCase() ?? ''}..."
+				searchStore={mobileSearchStore}
+				placeholder="Search regular expressions..."
 				responsive
+			/>
+		{:else}
+			<SmartFilterBar
+				{fields}
+				items={data.regularExpressions}
+				bind:tags={filterTags}
+				storageKey={`smartFilter:regularExpressions:${data.currentDatabase.id}`}
+				placeholder="Filter regular expressions..."
 			/>
 		{/if}
 		<ActionButton icon={Plus} hasDropdown={true} dropdownPosition="right">
 			<svelte:fragment slot="dropdown">
-				<Dropdown position="right">
+				<Dropdown position="right" minWidth="14rem">
+					<DropdownHeader label="New expression" />
 					<DropdownItem
 						icon={FileText}
 						label="Blank"
@@ -189,7 +217,7 @@
 				</Dropdown>
 			</svelte:fragment>
 		</ActionButton>
-		<ViewToggle bind:value={$view} />
+		<ViewToggle bind:value={viewMode} />
 		<ActionButton icon={Info} on:click={() => (infoModalOpen = true)} />
 	</ActionsBar>
 
@@ -208,10 +236,10 @@
 				class="rounded-lg border border-neutral-200 bg-white p-8 text-center dark:border-neutral-800 dark:bg-neutral-900"
 			>
 				<p class="text-neutral-600 dark:text-neutral-400">
-					No regular expressions match your search
+					No regular expressions match the current filters
 				</p>
 			</div>
-		{:else if $view === 'table'}
+		{:else if viewMode === 'table'}
 			<TableView expressions={filtered} on:clone={handleClone} on:export={handleExport} />
 		{:else}
 			<CardView expressions={filtered} on:clone={handleClone} on:export={handleExport} />


### PR DESCRIPTION
## Summary

Replaces the SearchModeToggle + SearchAction + TagInput search pattern on all three PCD entity list pages (custom formats, quality profiles, regular expressions) with SmartFilterBar. Users get a unified filter input with multi-field autocomplete, simultaneous filters (AND logic), click-to-negate, and number range operators.

Also includes:
- Fix for rounded hover backgrounds in SmartFilterBar dropdown items
- New DropdownFooter component for "and X more" indicator on truncated suggestions
- Tagged yes/no filter on all entity pages for finding untagged items
- Tooltip on new entity buttons (custom formats, quality profiles)
- Dropdown header and wider menu on regex new button

**Filter fields by page:**
- Custom Formats: name, tag, tagged, description, condition, tests
- Quality Profiles: name, tag, tagged, description, language, upgrades, formats
- Regular Expressions: name, tag, tagged, pattern, description, regex101 id