### PR TITLE
feat: toggle between smart filter and simple search bars

### DIFF
--- a/src/lib/client/stores/filterMode.ts
+++ b/src/lib/client/stores/filterMode.ts
@@ -1,0 +1,31 @@
+/**
+ * Global user preference for which filter bar to render on list pages.
+ * `smart` = SmartFilterBar (typed field/value tags)
+ * `simple` = SearchAction (plain text search)
+ */
+
+import { writable } from 'svelte/store';
+import { browser } from '$app/environment';
+
+export type FilterMode = 'smart' | 'simple';
+
+const STORAGE_KEY = 'filterMode';
+
+function loadFilterMode(): FilterMode {
+	if (!browser) return 'smart';
+	try {
+		const stored = localStorage.getItem(STORAGE_KEY);
+		if (stored === 'smart' || stored === 'simple') return stored;
+	} catch {}
+	return 'smart';
+}
+
+export const filterMode = writable<FilterMode>(loadFilterMode());
+
+if (browser) {
+	filterMode.subscribe((value) => {
+		try {
+			localStorage.setItem(STORAGE_KEY, value);
+		} catch {}
+	});
+}

--- a/src/lib/client/stores/filterMode.ts
+++ b/src/lib/client/stores/filterMode.ts
@@ -16,8 +16,10 @@ function loadFilterMode(): FilterMode {
 	try {
 		const stored = localStorage.getItem(STORAGE_KEY);
 		if (stored === 'smart' || stored === 'simple') return stored;
-	} catch {}
-	return 'smart';
+		return 'smart';
+	} catch {
+		return 'smart';
+	}
 }
 
 export const filterMode = writable<FilterMode>(loadFilterMode());
@@ -26,6 +28,8 @@ if (browser) {
 	filterMode.subscribe((value) => {
 		try {
 			localStorage.setItem(STORAGE_KEY, value);
-		} catch {}
+		} catch {
+			// storage may be unavailable (private mode, quota); non-fatal
+		}
 	});
 }

--- a/src/lib/client/ui/actions/FilterModeToggle.svelte
+++ b/src/lib/client/ui/actions/FilterModeToggle.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+	import ActionButton from './ActionButton.svelte';
+	import Dropdown from '$ui/dropdown/Dropdown.svelte';
+	import DropdownHeader from '$ui/dropdown/DropdownHeader.svelte';
+	import DropdownItem from '$ui/dropdown/DropdownItem.svelte';
+	import { Filter, Search, SlidersHorizontal } from 'lucide-svelte';
+	import type { FilterMode } from '$stores/filterMode';
+
+	export let value: FilterMode = 'smart';
+	export let position: 'left' | 'right' | 'middle' = 'right';
+</script>
+
+<ActionButton icon={SlidersHorizontal} hasDropdown={true} dropdownPosition={position}>
+	<Dropdown slot="dropdown" {position}>
+		<DropdownHeader label="Bar mode" />
+		<DropdownItem
+			icon={Filter}
+			label="Filter"
+			selected={value === 'smart'}
+			on:click={() => (value = 'smart')}
+		/>
+		<DropdownItem
+			icon={Search}
+			label="Search"
+			selected={value === 'simple'}
+			on:click={() => (value = 'simple')}
+		/>
+	</Dropdown>
+</ActionButton>

--- a/src/routes/arr/[id]/library/+page.svelte
+++ b/src/routes/arr/[id]/library/+page.svelte
@@ -33,11 +33,14 @@
 	let filterTags: FilterTag[] = [];
 	let showFilterInfo = false;
 
-	// Mobile simple search
-	$: mobileSearchStore = getPersistentSearchStore(`arrLibrarySearch:${data.instance.id}`, {
+	// Simple search (used on mobile and when filterMode is 'simple')
+	$: simpleSearchStore = getPersistentSearchStore(`arrLibrarySearch:${data.instance.id}`, {
 		debounceMs: 150
 	});
-	$: mobileQuery = $mobileSearchStore.query;
+	$: simpleQuery = $simpleSearchStore.query;
+
+	// useSimpleMode is bound from LibraryActionBar, which derives it from isMobile + filterMode
+	let useSimpleMode = false;
 
 	const radarrFields: FilterFieldDef<RadarrLibraryItem>[] = [
 		{
@@ -539,12 +542,12 @@
 	$: radarrLibrary = library as RadarrLibraryItem[];
 	$: allMoviesWithFiles = isRadarr ? radarrLibrary.filter((m) => m.hasFile) : [];
 	$: moviesWithFiles = (() => {
-		let result = applySmartFilters(allMoviesWithFiles, filterTags, radarrFields);
-		if (mobileQuery) {
-			const q = mobileQuery.toLowerCase();
-			result = result.filter((m) => m.title.toLowerCase().includes(q));
+		if (useSimpleMode) {
+			if (!simpleQuery) return allMoviesWithFiles;
+			const q = simpleQuery.toLowerCase();
+			return allMoviesWithFiles.filter((m) => m.title.toLowerCase().includes(q));
 		}
-		return result;
+		return applySmartFilters(allMoviesWithFiles, filterTags, radarrFields);
 	})();
 
 	// ==========================================================================
@@ -554,12 +557,12 @@
 	$: sonarrLibrary = library as SonarrLibraryItem[];
 	$: filteredSeries = (() => {
 		if (!isSonarr) return [];
-		let result = applySmartFilters(sonarrLibrary, filterTags, sonarrFields);
-		if (mobileQuery) {
-			const q = mobileQuery.toLowerCase();
-			result = result.filter((s) => s.title.toLowerCase().includes(q));
+		if (useSimpleMode) {
+			if (!simpleQuery) return sonarrLibrary;
+			const q = simpleQuery.toLowerCase();
+			return sonarrLibrary.filter((s) => s.title.toLowerCase().includes(q));
 		}
-		return result;
+		return applySmartFilters(sonarrLibrary, filterTags, sonarrFields);
 	})();
 
 	let sonarrTableView: SonarrTableView;
@@ -678,7 +681,8 @@
 			items={isRadarr ? allMoviesWithFiles : sonarrLibrary}
 			bind:tags={filterTags}
 			filterStorageKey={`smartFilter:${data.instance.id}`}
-			searchStore={mobileSearchStore}
+			searchStore={simpleSearchStore}
+			bind:useSimpleMode
 			visibleColumns={activeVisibleColumns}
 			toggleableColumns={activeToggleableColumns}
 			columnLabels={activeColumnLabels}

--- a/src/routes/arr/[id]/library/components/LibraryActionBar.svelte
+++ b/src/routes/arr/[id]/library/components/LibraryActionBar.svelte
@@ -14,6 +14,7 @@
 	import ActionsBar from '$ui/actions/ActionsBar.svelte';
 	import ActionButton from '$ui/actions/ActionButton.svelte';
 	import ViewToggle from '$ui/actions/ViewToggle.svelte';
+	import FilterModeToggle from '$ui/actions/FilterModeToggle.svelte';
 	import Dropdown from '$ui/dropdown/Dropdown.svelte';
 	import DropdownHeader from '$ui/dropdown/DropdownHeader.svelte';
 	import DropdownItem from '$ui/dropdown/DropdownItem.svelte';
@@ -22,6 +23,7 @@
 	import SmartFilterBar from '$ui/filter/SmartFilterBar.svelte';
 	import type { FilterFieldDef, FilterTag } from '$ui/filter/types';
 	import type { SearchStore } from '$stores/search';
+	import { filterMode } from '$stores/filterMode';
 	import type { ViewMode } from '$lib/client/stores/dataPage';
 
 	export let fields: FilterFieldDef[] = [];
@@ -50,6 +52,7 @@
 	export let sortKey: string = 'title';
 	export let sortDirection: 'asc' | 'desc' = 'asc';
 	export let onSort: (key: string, direction: 'asc' | 'desc') => void = () => {};
+	export let useSimpleMode: boolean = false;
 
 	const sortOptions = [
 		{ key: 'title', label: 'Title' },
@@ -93,10 +96,12 @@
 	function handleMediaChange(e: MediaQueryListEvent) {
 		isMobile = e.matches;
 	}
+
+	$: useSimpleMode = isMobile || $filterMode === 'simple';
 </script>
 
 <ActionsBar>
-	{#if isMobile}
+	{#if useSimpleMode}
 		<SearchAction {searchStore} placeholder={filterPlaceholder} responsive />
 	{:else}
 		<SmartFilterBar
@@ -172,6 +177,9 @@
 				</Dropdown>
 			</svelte:fragment>
 		</ActionButton>
+	{/if}
+	{#if !isMobile}
+		<FilterModeToggle bind:value={$filterMode} />
 	{/if}
 	<ViewToggle bind:value={viewMode} />
 </ActionsBar>

--- a/src/routes/custom-formats/[databaseId]/+page.svelte
+++ b/src/routes/custom-formats/[databaseId]/+page.svelte
@@ -6,6 +6,7 @@
 	import ActionButton from '$ui/actions/ActionButton.svelte';
 	import SearchAction from '$ui/actions/SearchAction.svelte';
 	import ViewToggle from '$ui/actions/ViewToggle.svelte';
+	import FilterModeToggle from '$ui/actions/FilterModeToggle.svelte';
 	import SmartFilterBar from '$ui/filter/SmartFilterBar.svelte';
 	import Tooltip from '$ui/tooltip/Tooltip.svelte';
 	import InfoModal from '$ui/modal/InfoModal.svelte';
@@ -13,6 +14,7 @@
 	import TableView from './views/TableView.svelte';
 	import CardView from './views/CardView.svelte';
 	import { getPersistentSearchStore } from '$stores/search';
+	import { filterMode } from '$stores/filterMode';
 	import type { FilterFieldDef, FilterTag } from '$ui/filter/types';
 	import { applySmartFilters } from '$ui/filter/match';
 	import type { ViewMode } from '$lib/client/stores/dataPage';
@@ -105,11 +107,11 @@
 		}
 	];
 
-	// Mobile simple search fallback
-	$: mobileSearchStore = getPersistentSearchStore(`cfSearch:${data.currentDatabase.id}`, {
+	// Simple search fallback (used on mobile and when filterMode is 'simple')
+	$: simpleSearchStore = getPersistentSearchStore(`cfSearch:${data.currentDatabase.id}`, {
 		debounceMs: 150
 	});
-	$: mobileQuery = $mobileSearchStore.query;
+	$: simpleQuery = $simpleSearchStore.query;
 
 	let isMobile = false;
 	let mediaQuery: MediaQueryList | null = null;
@@ -131,6 +133,8 @@
 	function handleMediaChange(e: MediaQueryListEvent) {
 		isMobile = e.matches;
 	}
+
+	$: useSimpleMode = isMobile || $filterMode === 'simple';
 
 	// ======================================================================
 	// View Mode
@@ -158,12 +162,12 @@
 	// ======================================================================
 
 	$: filtered = (() => {
-		let result = applySmartFilters(data.customFormats, filterTags, fields);
-		if (isMobile && mobileQuery) {
-			const q = mobileQuery.toLowerCase();
-			result = result.filter((f) => f.name.toLowerCase().includes(q));
+		if (useSimpleMode) {
+			if (!simpleQuery) return data.customFormats;
+			const q = simpleQuery.toLowerCase();
+			return data.customFormats.filter((f) => f.name.toLowerCase().includes(q));
 		}
-		return result;
+		return applySmartFilters(data.customFormats, filterTags, fields);
 	})();
 
 	// Map databases to tabs
@@ -184,9 +188,9 @@
 
 	<!-- Actions Bar -->
 	<ActionsBar>
-		{#if isMobile}
+		{#if useSimpleMode}
 			<SearchAction
-				searchStore={mobileSearchStore}
+				searchStore={simpleSearchStore}
 				placeholder="Search custom formats..."
 				responsive
 			/>
@@ -205,6 +209,9 @@
 				on:click={() => goto(`/custom-formats/${data.currentDatabase.id}/new`)}
 			/>
 		</Tooltip>
+		{#if !isMobile}
+			<FilterModeToggle bind:value={$filterMode} />
+		{/if}
 		<ViewToggle bind:value={viewMode} />
 		<ActionButton icon={Info} on:click={() => (infoModalOpen = true)} />
 	</ActionsBar>

--- a/src/routes/quality-profiles/[databaseId]/+page.svelte
+++ b/src/routes/quality-profiles/[databaseId]/+page.svelte
@@ -8,12 +8,14 @@
 	import ActionButton from '$ui/actions/ActionButton.svelte';
 	import SearchAction from '$ui/actions/SearchAction.svelte';
 	import ViewToggle from '$ui/actions/ViewToggle.svelte';
+	import FilterModeToggle from '$ui/actions/FilterModeToggle.svelte';
 	import SmartFilterBar from '$ui/filter/SmartFilterBar.svelte';
 	import Tooltip from '$ui/tooltip/Tooltip.svelte';
 	import CloneModal from '$ui/modal/CloneModal.svelte';
 	import TableView from './views/TableView.svelte';
 	import CardView from './views/CardView.svelte';
 	import { getPersistentSearchStore } from '$stores/search';
+	import { filterMode } from '$stores/filterMode';
 	import type { FilterFieldDef, FilterTag } from '$ui/filter/types';
 	import { applySmartFilters } from '$ui/filter/match';
 	import type { ViewMode } from '$lib/client/stores/dataPage';
@@ -110,11 +112,11 @@
 		}
 	];
 
-	// Mobile simple search fallback
-	$: mobileSearchStore = getPersistentSearchStore(`qpSearch:${data.currentDatabase.id}`, {
+	// Simple search fallback (used on mobile and when filterMode is 'simple')
+	$: simpleSearchStore = getPersistentSearchStore(`qpSearch:${data.currentDatabase.id}`, {
 		debounceMs: 150
 	});
-	$: mobileQuery = $mobileSearchStore.query;
+	$: simpleQuery = $simpleSearchStore.query;
 
 	let isMobile = false;
 	let mediaQuery: MediaQueryList | null = null;
@@ -136,6 +138,8 @@
 	function handleMediaChange(e: MediaQueryListEvent) {
 		isMobile = e.matches;
 	}
+
+	$: useSimpleMode = isMobile || $filterMode === 'simple';
 
 	// ======================================================================
 	// View Mode
@@ -163,12 +167,12 @@
 	// ======================================================================
 
 	$: filtered = (() => {
-		let result = applySmartFilters(data.qualityProfiles, filterTags, fields);
-		if (isMobile && mobileQuery) {
-			const q = mobileQuery.toLowerCase();
-			result = result.filter((p) => p.name.toLowerCase().includes(q));
+		if (useSimpleMode) {
+			if (!simpleQuery) return data.qualityProfiles;
+			const q = simpleQuery.toLowerCase();
+			return data.qualityProfiles.filter((p) => p.name.toLowerCase().includes(q));
 		}
-		return result;
+		return applySmartFilters(data.qualityProfiles, filterTags, fields);
 	})();
 
 	// Map databases to tabs
@@ -189,9 +193,9 @@
 
 	<!-- Actions Bar -->
 	<ActionsBar>
-		{#if isMobile}
+		{#if useSimpleMode}
 			<SearchAction
-				searchStore={mobileSearchStore}
+				searchStore={simpleSearchStore}
 				placeholder="Search quality profiles..."
 				responsive
 			/>
@@ -210,6 +214,9 @@
 				on:click={() => goto(`/quality-profiles/${data.currentDatabase.id}/new`)}
 			/>
 		</Tooltip>
+		{#if !isMobile}
+			<FilterModeToggle bind:value={$filterMode} />
+		{/if}
 		<ViewToggle bind:value={viewMode} />
 	</ActionsBar>
 

--- a/src/routes/regular-expressions/[databaseId]/+page.svelte
+++ b/src/routes/regular-expressions/[databaseId]/+page.svelte
@@ -6,6 +6,7 @@
 	import ActionButton from '$ui/actions/ActionButton.svelte';
 	import SearchAction from '$ui/actions/SearchAction.svelte';
 	import ViewToggle from '$ui/actions/ViewToggle.svelte';
+	import FilterModeToggle from '$ui/actions/FilterModeToggle.svelte';
 	import SmartFilterBar from '$ui/filter/SmartFilterBar.svelte';
 	import InfoModal from '$ui/modal/InfoModal.svelte';
 	import CloneModal from '$ui/modal/CloneModal.svelte';
@@ -15,6 +16,7 @@
 	import TableView from './views/TableView.svelte';
 	import CardView from './views/CardView.svelte';
 	import { getPersistentSearchStore } from '$stores/search';
+	import { filterMode } from '$stores/filterMode';
 	import type { FilterFieldDef, FilterTag } from '$ui/filter/types';
 	import { applySmartFilters } from '$ui/filter/match';
 	import type { ViewMode } from '$lib/client/stores/dataPage';
@@ -105,11 +107,11 @@
 		}
 	];
 
-	// Mobile simple search fallback
-	$: mobileSearchStore = getPersistentSearchStore(`reSearch:${data.currentDatabase.id}`, {
+	// Simple search fallback (used on mobile and when filterMode is 'simple')
+	$: simpleSearchStore = getPersistentSearchStore(`reSearch:${data.currentDatabase.id}`, {
 		debounceMs: 150
 	});
-	$: mobileQuery = $mobileSearchStore.query;
+	$: simpleQuery = $simpleSearchStore.query;
 
 	let isMobile = false;
 	let mediaQuery: MediaQueryList | null = null;
@@ -131,6 +133,8 @@
 	function handleMediaChange(e: MediaQueryListEvent) {
 		isMobile = e.matches;
 	}
+
+	$: useSimpleMode = isMobile || $filterMode === 'simple';
 
 	// ======================================================================
 	// View Mode
@@ -158,12 +162,12 @@
 	// ======================================================================
 
 	$: filtered = (() => {
-		let result = applySmartFilters(data.regularExpressions, filterTags, fields);
-		if (isMobile && mobileQuery) {
-			const q = mobileQuery.toLowerCase();
-			result = result.filter((r) => r.name.toLowerCase().includes(q));
+		if (useSimpleMode) {
+			if (!simpleQuery) return data.regularExpressions;
+			const q = simpleQuery.toLowerCase();
+			return data.regularExpressions.filter((r) => r.name.toLowerCase().includes(q));
 		}
-		return result;
+		return applySmartFilters(data.regularExpressions, filterTags, fields);
 	})();
 
 	// Map databases to tabs
@@ -184,9 +188,9 @@
 
 	<!-- Actions Bar -->
 	<ActionsBar>
-		{#if isMobile}
+		{#if useSimpleMode}
 			<SearchAction
-				searchStore={mobileSearchStore}
+				searchStore={simpleSearchStore}
 				placeholder="Search regular expressions..."
 				responsive
 			/>
@@ -217,6 +221,9 @@
 				</Dropdown>
 			</svelte:fragment>
 		</ActionButton>
+		{#if !isMobile}
+			<FilterModeToggle bind:value={$filterMode} />
+		{/if}
 		<ViewToggle bind:value={viewMode} />
 		<ActionButton icon={Info} on:click={() => (infoModalOpen = true)} />
 	</ActionsBar>


### PR DESCRIPTION
Adds a Bar mode toggle to the action bar on the four list pages that use `SmartFilterBar` (regular expressions, quality profiles, custom formats, arr library) so users can opt back into the plain `SearchAction` if they preferred it.

The toggle lives next to `ViewToggle`. Preference is global and persisted to localStorage. Mobile stays forced to simple mode and hides the toggle. Each mode owns its own state so switching back restores the previous tags or query.