### PR TITLE
feat: add custom formats onboarding cutscene group

### DIFF
--- a/docs/frontend/cutscene.md
+++ b/docs/frontend/cutscene.md
@@ -134,19 +134,22 @@ like Help where a "you're done" modal would be redundant.
 
 ### Current Stages
 
-| ID                | Name        | Steps | Prerequisites    | Description                                     |
-| ----------------- | ----------- | ----- | ---------------- | ----------------------------------------------- |
-| `welcome`         | Welcome     | 3     |                  | What Profilarr is and how it works              |
-| `navigation`      | Navigation  | 5     |                  | The main sections of the app                    |
-| `personalize`     | Personalize | 2     |                  | Theme toggle and accent color picker            |
-| `help`            | Help        | 1     |                  | Introduces the help button (silent)             |
-| `database-link`   | Link        | 7     |                  | Connect a configuration database                |
-| `database-manage` | Overview    | 6     | `hasDatabase`    | Tabs and features of a connected database       |
-| `arr-link`        | Link        | 5     |                  | Connect a Radarr or Sonarr instance             |
-| `arr-manage`      | Overview    | 7     | `hasArrInstance` | Tabs and features of a connected Arr instance   |
-| `arr-sync`        | Sync        | 7     | `hasArrInstance` | Configure what gets synced and when             |
-| `arr-upgrades`    | Upgrades    | 11    | `hasArrInstance` | Automated searching for better quality releases |
-| `arr-renames`     | Rename      | 7     | `hasArrInstance` | Automated file and folder renaming              |
+| ID                | Name        | Steps | Prerequisites                     | Description                                     |
+| ----------------- | ----------- | ----- | --------------------------------- | ----------------------------------------------- |
+| `welcome`         | Welcome     | 3     |                                   | What Profilarr is and how it works              |
+| `navigation`      | Navigation  | 5     |                                   | The main sections of the app                    |
+| `personalize`     | Personalize | 2     |                                   | Theme toggle and accent color picker            |
+| `help`            | Help        | 1     |                                   | Introduces the help button (silent)             |
+| `database-link`   | Link        | 7     |                                   | Connect a configuration database                |
+| `database-manage` | Overview    | 6     | `hasDatabase`                     | Tabs and features of a connected database       |
+| `arr-link`        | Link        | 5     |                                   | Connect a Radarr or Sonarr instance             |
+| `arr-manage`      | Overview    | 7     | `hasArrInstance`                  | Tabs and features of a connected Arr instance   |
+| `arr-sync`        | Sync        | 7     | `hasArrInstance`                  | Configure what gets synced and when             |
+| `arr-upgrades`    | Upgrades    | 11    | `hasArrInstance`                  | Automated searching for better quality releases |
+| `arr-renames`     | Rename      | 7     | `hasArrInstance`                  | Automated file and folder renaming              |
+| `cf-general`      | General     | 6     | `hasDatabase`                     | Identity, rename behavior, and references       |
+| `cf-conditions`   | Conditions  | 8     | `hasDatabase`                     | Define what a custom format matches             |
+| `cf-testing`      | Testing     | 7     | `hasDevDatabase`, `parserHealthy` | Verify a format against real release titles     |
 
 ## Prerequisites
 
@@ -233,6 +236,7 @@ export const GROUPS: StageGroup[] = [
 | Getting Started | Welcome, Navigation, Personalize, Help            |
 | Databases       | Connect a Database, Managing a Database           |
 | Arr Instances   | Connect an Arr Instance, Managing an Arr Instance |
+| Custom Formats  | General, Conditions, Testing                      |
 
 ## Adding Content
 

--- a/src/lib/client/cutscene/definitions/index.ts
+++ b/src/lib/client/cutscene/definitions/index.ts
@@ -10,6 +10,9 @@ import { arrOverviewStage } from './stages/arrs/overview.ts';
 import { arrSyncStage } from './stages/arrs/sync.ts';
 import { arrUpgradesStage } from './stages/arrs/upgrades.ts';
 import { arrRenameStage } from './stages/arrs/renames.ts';
+import { cfGeneralStage } from './stages/custom-formats/general.ts';
+import { cfConditionsStage } from './stages/custom-formats/conditions.ts';
+import { cfTestingStage } from './stages/custom-formats/testing.ts';
 
 export const STAGES: Record<string, Stage> = {
 	welcome: welcomeStage,
@@ -22,6 +25,9 @@ export const STAGES: Record<string, Stage> = {
 	'arr-sync': arrSyncStage,
 	'arr-upgrades': arrUpgradesStage,
 	'arr-renames': arrRenameStage,
+	'cf-general': cfGeneralStage,
+	'cf-conditions': cfConditionsStage,
+	'cf-testing': cfTestingStage,
 	help: helpStage
 };
 
@@ -40,5 +46,10 @@ export const GROUPS: StageGroup[] = [
 		name: 'Arr Instances',
 		description: 'Connect and manage Radarr/Sonarr instances',
 		stages: ['arr-link', 'arr-manage', 'arr-sync', 'arr-upgrades', 'arr-renames']
+	},
+	{
+		name: 'Custom Formats',
+		description: 'Build and test custom formats',
+		stages: ['cf-general', 'cf-conditions', 'cf-testing']
 	}
 ];

--- a/src/lib/client/cutscene/definitions/stages/custom-formats/conditions.ts
+++ b/src/lib/client/cutscene/definitions/stages/custom-formats/conditions.ts
@@ -1,0 +1,82 @@
+import type { Stage } from '$cutscene/types.ts';
+
+export const cfConditionsStage: Stage = {
+	id: 'cf-conditions',
+	name: 'Conditions',
+	description: 'Define what a custom format matches on a release',
+	prerequisites: [
+		{
+			check: 'hasDatabase',
+			message:
+				'You need at least one connected database to start this stage. Follow the "Link" stage under Databases from the onboarding page to connect one.'
+		}
+	],
+	steps: [
+		{
+			id: 'cf-conditions-intro',
+			route: { resolve: 'firstCustomFormatConditions' },
+			title: 'Conditions',
+			body: 'Conditions are the rules that decide whether a release matches a custom format. Each one targets a specific piece of parsed metadata (release title, release group, source, resolution, language, year, size, and so on) and checks it against a value or regex pattern. Conditions of the same type are combined with OR by default, and conditions across types are combined with AND. Two modifiers, Required and Negate, let you flip that logic where needed. This stage walks through adding one condition from scratch.',
+			completion: { type: 'manual' }
+		},
+		{
+			id: 'cf-conditions-add',
+			target: 'cf-conditions-add',
+			title: 'Add a Condition',
+			body: 'Click Add Condition to spawn a draft card. Drafts sit at the top of the list until you confirm them, which keeps you from accidentally saving a half-configured rule.',
+			position: 'below-left',
+			completion: { type: 'click' }
+		},
+		{
+			id: 'cf-conditions-name',
+			target: 'cf-cond-name',
+			title: 'Name',
+			body: "Names label conditions within a format and must be unique. A good name describes the match in plain language (for example, '1080p' or 'FraMeSToR release group') so the purpose is obvious when you revisit the format later.",
+			position: 'below',
+			freeInteract: true,
+			completion: { type: 'manual' }
+		},
+		{
+			id: 'cf-conditions-type',
+			target: 'cf-cond-type',
+			title: 'Type',
+			body: 'Type chooses which piece of parsed metadata this condition looks at. Release Title, Release Group, and Edition take regex patterns. Resolution, Source, Quality Modifier, Language, Release Type, and Indexer Flag pick from a fixed list. Size and Year take a numeric range. The value field adapts to the type you pick.',
+			position: 'below',
+			freeInteract: true,
+			completion: { type: 'manual' }
+		},
+		{
+			id: 'cf-conditions-value',
+			target: 'cf-cond-value',
+			title: 'Value',
+			body: 'Value is what the condition actually matches against. For Release Title, Release Group, and Edition you pick a reusable regex pattern managed on the Regular Expressions page, which means one pattern can power many custom formats. For the other types you pick from a dropdown or enter a numeric range.',
+			position: 'below',
+			freeInteract: true,
+			completion: { type: 'manual' }
+		},
+		{
+			id: 'cf-conditions-modifiers',
+			target: 'cf-cond-flags-modifiers',
+			title: 'Required & Negate',
+			body: "Required switches the logic within a type from OR to AND, so every Required condition of that type must match. Negate inverts a single condition so it matches when the pattern is absent rather than present. Together they cover the 'must have all of these' and 'must not have this' cases.",
+			position: 'below',
+			freeInteract: true,
+			completion: { type: 'manual' }
+		},
+		{
+			id: 'cf-conditions-arr',
+			target: 'cf-cond-flags-arr',
+			title: 'Radarr & Sonarr',
+			body: 'Radarr and Sonarr toggle which apps this condition applies to. Some metadata (Edition, Quality Modifier) only exists in Radarr; Release Type only exists in Sonarr. For everything else you can keep both on to share one condition across movies and series, or split it if the two apps need different rules.',
+			position: 'below',
+			freeInteract: true,
+			completion: { type: 'manual' }
+		},
+		{
+			id: 'cf-conditions-summary',
+			title: 'Summary',
+			body: 'Each condition pairs a type with a value. Required and Negate flip the matching logic, and the Radarr/Sonarr toggles scope it per app. Stack conditions to narrow a format down to exactly the releases you want, then head to Testing to verify it.',
+			completion: { type: 'manual' }
+		}
+	]
+};

--- a/src/lib/client/cutscene/definitions/stages/custom-formats/general.ts
+++ b/src/lib/client/cutscene/definitions/stages/custom-formats/general.ts
@@ -1,0 +1,64 @@
+import type { Stage } from '$cutscene/types.ts';
+
+export const cfGeneralStage: Stage = {
+	id: 'cf-general',
+	name: 'General',
+	description: 'Identity, rename behavior, and references for a custom format',
+	prerequisites: [
+		{
+			check: 'hasDatabase',
+			message:
+				'You need at least one connected database to start this stage. Follow the "Link" stage under Databases from the onboarding page to connect one.'
+		}
+	],
+	steps: [
+		{
+			id: 'cf-general-intro',
+			route: { resolve: 'firstCustomFormatGeneral' },
+			title: 'Custom Formats',
+			body: "A custom format is a name attached to a set of conditions. When a release matches those conditions, the format applies, identifying something about the release: a codec, a release group, a source, a resolution. Quality profiles then score matched formats to rank competing releases. This stage walks through the General tab, where you set a format's identity and rename behavior.",
+			completion: { type: 'manual' }
+		},
+		{
+			id: 'cf-general-name',
+			target: 'cf-general-name',
+			title: 'Name',
+			body: 'The name identifies this format in quality profiles and filenames. Keep it short and descriptive.',
+			position: 'below',
+			freeInteract: true,
+			completion: { type: 'manual' }
+		},
+		{
+			id: 'cf-general-include-in-rename',
+			target: 'cf-general-include-in-rename',
+			title: 'Include In Rename',
+			body: "When enabled, this format's name is appended to renamed filenames whenever a release matches. Use it to surface important tags like REMUX or HDR in the file itself. Leave it off for formats that shouldn't show up in filenames.",
+			position: 'below-left',
+			freeInteract: true,
+			completion: { type: 'manual' }
+		},
+		{
+			id: 'cf-general-description-tags',
+			target: 'cf-general-description-tags',
+			title: 'Description & Tags',
+			body: 'Description is a markdown field for notes about what this format matches and why. Tags group formats for filtering on the custom formats list: codec, audio, HDR, language, and so on. Neither affects matching or scoring, but both pay off when you are looking through a large library of formats later.',
+			position: 'below',
+			freeInteract: true,
+			completion: { type: 'manual' }
+		},
+		{
+			id: 'cf-general-references',
+			target: 'cf-general-references',
+			title: 'References',
+			body: 'References lists every quality profile this format appears in, along with the score it receives in Radarr and Sonarr. Scoring is a profile-level setting, so the same format can be weighted differently in different profiles. This view is a quick check for where a change to the format might ripple before you make it.',
+			position: 'above',
+			completion: { type: 'manual' }
+		},
+		{
+			id: 'cf-general-summary',
+			title: 'Summary',
+			body: 'Name, include in rename, description, and tags all live on the General tab, and the References section shows where this format is scored. Next you will define what the format actually matches by adding conditions.',
+			completion: { type: 'manual' }
+		}
+	]
+};

--- a/src/lib/client/cutscene/definitions/stages/custom-formats/testing.ts
+++ b/src/lib/client/cutscene/definitions/stages/custom-formats/testing.ts
@@ -1,0 +1,78 @@
+import type { Stage } from '$cutscene/types.ts';
+
+export const cfTestingStage: Stage = {
+	id: 'cf-testing',
+	name: 'Testing',
+	description: 'Verify a custom format against real release titles',
+	prerequisites: [
+		{
+			check: 'hasDevDatabase',
+			message:
+				'You need at least one development database (a database with a personal access token and local ops disabled) to start this stage. Testing is only editable on databases you own.'
+		},
+		{
+			check: 'parserHealthy',
+			message:
+				'The parser service is not running. Start the Profilarr parser microservice so test results can be evaluated before running this stage.'
+		}
+	],
+	steps: [
+		{
+			id: 'cf-testing-intro',
+			route: { resolve: 'firstDevCustomFormatTesting' },
+			title: 'Testing',
+			body: 'Tests let you feed a release title into a custom format and see whether it matches, along with the parsed metadata and per-condition breakdown. Regex is easy to get subtly wrong, so tests are the safety net that proves a format does what you intended before it ends up in a quality profile. This tab is editable on development databases; other databases show tests read-only.',
+			completion: { type: 'manual' }
+		},
+		{
+			id: 'cf-testing-add',
+			target: 'cf-testing-add',
+			title: 'Add a Test',
+			body: 'Click Add Test to open a blank test form. Each test pins a release title to an expected outcome, which is how you lock in regressions as the format evolves.',
+			position: 'below-left',
+			completion: { type: 'click' }
+		},
+		{
+			id: 'cf-testing-title',
+			target: 'cf-test-title',
+			title: 'Release Title',
+			body: 'The release title is what gets parsed and matched against the format. Paste a real release name (for example, Movie.Name.2024.1080p.BluRay.x264-GROUP) rather than a paraphrased one, since small differences in the string can change how the parser extracts source, resolution, and group.',
+			position: 'below',
+			freeInteract: true,
+			completion: { type: 'manual' }
+		},
+		{
+			id: 'cf-testing-type',
+			target: 'cf-test-type',
+			title: 'Media Type',
+			body: 'Movie and Series tell the parser which naming conventions to apply. Series releases expose season and episode metadata and release types that movies do not, so picking the wrong type can change what the format sees. Match the type to where the release would actually come from.',
+			position: 'below',
+			freeInteract: true,
+			completion: { type: 'manual' }
+		},
+		{
+			id: 'cf-testing-expected',
+			target: 'cf-test-expected',
+			title: 'Expected Result',
+			body: "Expected Result is your assertion: should this title match the format or not? Pass means the parsed metadata matches and the actual outcome equals the expected one. Include both positive cases (titles that should match) and negative ones (titles that look close but shouldn't) to catch regex drift in both directions.",
+			position: 'above',
+			freeInteract: true,
+			completion: { type: 'manual' }
+		},
+		{
+			id: 'cf-testing-description',
+			target: 'cf-test-description',
+			title: 'Description',
+			body: 'Description is optional context for a test case: what edge case it covers, which bug it guards against, or which real-world release it came from. It is never used for matching, only for you and anyone else reading the test list later.',
+			position: 'above',
+			freeInteract: true,
+			completion: { type: 'manual' }
+		},
+		{
+			id: 'cf-testing-summary',
+			title: 'Summary',
+			body: 'Tests turn a custom format from something that looks right into something you can prove is right. Build up a small set of tests covering the matches you expect and the near-misses you want to avoid, and rerun them whenever the format or its patterns change.',
+			completion: { type: 'manual' }
+		}
+	]
+};

--- a/src/lib/client/cutscene/routeResolvers.ts
+++ b/src/lib/client/cutscene/routeResolvers.ts
@@ -58,5 +58,26 @@ export const routeResolvers: Record<string, () => Promise<string>> = {
 		const res = await fetch('/api/v1/arr');
 		const arr = await res.json();
 		return `/arr/${arr[0].id}/settings`;
+	},
+	firstCustomFormatGeneral: async () => {
+		const dbs = await (await fetch('/api/v1/databases')).json();
+		if (!dbs.length) return '/custom-formats';
+		const { path } = await (await fetch(`/custom-formats/${dbs[0].id}/first/general`)).json();
+		return path;
+	},
+	firstCustomFormatConditions: async () => {
+		const dbs = await (await fetch('/api/v1/databases')).json();
+		if (!dbs.length) return '/custom-formats';
+		const { path } = await (await fetch(`/custom-formats/${dbs[0].id}/first/conditions`)).json();
+		return path;
+	},
+	firstDevCustomFormatTesting: async () => {
+		const dbs: Array<{ id: number; hasPat: boolean; local_ops_enabled: number }> = await (
+			await fetch('/api/v1/databases')
+		).json();
+		const dev = dbs.find((d) => d.hasPat && !d.local_ops_enabled);
+		if (!dev) return '/custom-formats';
+		const { path } = await (await fetch(`/custom-formats/${dev.id}/first/testing`)).json();
+		return path;
 	}
 };

--- a/src/lib/client/cutscene/stateChecks.ts
+++ b/src/lib/client/cutscene/stateChecks.ts
@@ -3,6 +3,9 @@
  * Each function returns true when the condition is satisfied.
  * Add new checks here as stages require them.
  */
+import { get } from 'svelte/store';
+import { page } from '$app/stores';
+
 export const stateChecks: Record<string, () => Promise<boolean>> = {
 	hasDatabase: async () => {
 		const res = await fetch('/api/v1/databases');
@@ -15,5 +18,14 @@ export const stateChecks: Record<string, () => Promise<boolean>> = {
 		if (!res.ok) return false;
 		const data = await res.json();
 		return data.length > 0;
+	},
+	hasDevDatabase: async () => {
+		const res = await fetch('/api/v1/databases');
+		if (!res.ok) return false;
+		const data: Array<{ hasPat: boolean; local_ops_enabled: number }> = await res.json();
+		return data.some((d) => d.hasPat && !d.local_ops_enabled);
+	},
+	parserHealthy: async () => {
+		return get(page).data?.parserAvailable === true;
 	}
 };

--- a/src/lib/client/ui/button/Button.svelte
+++ b/src/lib/client/ui/button/Button.svelte
@@ -30,6 +30,8 @@
 	export let tooltip: string = '';
 	export let tooltipPosition: 'top' | 'bottom' = 'bottom';
 	export let loading: boolean = false;
+	// Optional data-onboarding attribute for cutscene targeting
+	export let onboarding: string | undefined = undefined;
 
 	let isSmallScreen = false;
 	let mediaQuery: MediaQueryList | null = null;
@@ -102,6 +104,7 @@
 			title={!tooltip && title ? title : undefined}
 			aria-label={ariaLabel || tooltip || undefined}
 			class={classes}
+			data-onboarding={onboarding}
 			on:click
 		>
 			{#if effectiveIcon && iconPosition === 'left'}
@@ -141,6 +144,7 @@
 			title={!tooltip && title ? title : undefined}
 			aria-label={ariaLabel || tooltip || undefined}
 			class={classes}
+			data-onboarding={onboarding}
 			on:click
 		>
 			{#if effectiveIcon && iconPosition === 'left'}

--- a/src/routes/custom-formats/[databaseId]/[id]/conditions/+page.svelte
+++ b/src/routes/custom-formats/[databaseId]/[id]/conditions/+page.svelte
@@ -289,6 +289,7 @@
 					icon={Plus}
 					iconColor="text-blue-600 dark:text-blue-400"
 					variant="secondary"
+					onboarding="cf-conditions-add"
 					on:click={addDraftCondition}
 				/>
 				<Button

--- a/src/routes/custom-formats/[databaseId]/[id]/conditions/components/ConditionCard.svelte
+++ b/src/routes/custom-formats/[databaseId]/[id]/conditions/components/ConditionCard.svelte
@@ -262,6 +262,7 @@
 			<div
 				class="w-full min-w-0 shrink-0 wide:w-48"
 				title={nameConflict ? 'Duplicate condition name' : ''}
+				data-onboarding="cf-cond-name"
 			>
 				<FormInput
 					label="Name"
@@ -273,7 +274,7 @@
 					on:input={(e) => emitChange({ name: e.detail })}
 				/>
 			</div>
-			<div class="w-full min-w-0 shrink-0 wide:w-52">
+			<div class="w-full min-w-0 shrink-0 wide:w-52" data-onboarding="cf-cond-type">
 				<SearchDropdown
 					options={typeOptions}
 					value={condition.type}
@@ -294,7 +295,7 @@
 		>
 			Value
 		</div>
-		<div class="min-w-0 wide:flex-1">
+		<div class="min-w-0 wide:flex-1" data-onboarding="cf-cond-value">
 			{#if isPatternType}
 				<SearchDropdown
 					options={patternOptions}
@@ -415,36 +416,46 @@
 			Flags
 		</div>
 		<div
-			class="grid grid-cols-2 gap-2 wide:ml-auto wide:flex wide:shrink-0 wide:flex-wrap wide:items-center wide:gap-2 md:grid-cols-4"
+			class="grid grid-cols-1 gap-2 wide:ml-auto wide:flex wide:shrink-0 wide:flex-wrap wide:items-center wide:gap-2 md:grid-cols-2"
 		>
-			<Toggle
-				checked={condition.negate}
-				ariaLabel="Negate"
-				label="Negate"
-				color="red"
-				on:change={(e) => emitChange({ negate: e.detail })}
-			/>
-			<Toggle
-				checked={condition.required}
-				ariaLabel="Required"
-				label="Required"
-				color="green"
-				on:change={(e) => emitChange({ required: e.detail })}
-			/>
-			<Toggle
-				checked={radarrEnabled}
-				ariaLabel="Radarr"
-				label="Radarr"
-				checkboxColor="var(--arr-radarr-color)"
-				on:change={(e) => handleArrTypeToggle('radarr', e.detail)}
-			/>
-			<Toggle
-				checked={sonarrEnabled}
-				ariaLabel="Sonarr"
-				label="Sonarr"
-				checkboxColor="var(--arr-sonarr-color)"
-				on:change={(e) => handleArrTypeToggle('sonarr', e.detail)}
-			/>
+			<div
+				class="grid grid-cols-2 gap-2 wide:flex wide:flex-wrap wide:items-center wide:gap-2"
+				data-onboarding="cf-cond-flags-modifiers"
+			>
+				<Toggle
+					checked={condition.negate}
+					ariaLabel="Negate"
+					label="Negate"
+					color="red"
+					on:change={(e) => emitChange({ negate: e.detail })}
+				/>
+				<Toggle
+					checked={condition.required}
+					ariaLabel="Required"
+					label="Required"
+					color="green"
+					on:change={(e) => emitChange({ required: e.detail })}
+				/>
+			</div>
+			<div
+				class="grid grid-cols-2 gap-2 wide:flex wide:flex-wrap wide:items-center wide:gap-2"
+				data-onboarding="cf-cond-flags-arr"
+			>
+				<Toggle
+					checked={radarrEnabled}
+					ariaLabel="Radarr"
+					label="Radarr"
+					checkboxColor="var(--arr-radarr-color)"
+					on:change={(e) => handleArrTypeToggle('radarr', e.detail)}
+				/>
+				<Toggle
+					checked={sonarrEnabled}
+					ariaLabel="Sonarr"
+					label="Sonarr"
+					checkboxColor="var(--arr-sonarr-color)"
+					on:change={(e) => handleArrTypeToggle('sonarr', e.detail)}
+				/>
+			</div>
 		</div>
 	</div>
 

--- a/src/routes/custom-formats/[databaseId]/[id]/general/+page.svelte
+++ b/src/routes/custom-formats/[databaseId]/[id]/general/+page.svelte
@@ -31,7 +31,7 @@
 
 <GeneralForm mode="edit" canWriteToBase={data.canWriteToBase} actionUrl="?/update" {initialData} />
 
-<div class="space-y-3 md:px-4">
+<div class="space-y-3 md:px-4" data-onboarding="cf-general-references">
 	<div class="text-sm font-medium text-neutral-900 dark:text-neutral-100">
 		References ({data.profileRefs.length})
 	</div>

--- a/src/routes/custom-formats/[databaseId]/[id]/testing/+page.svelte
+++ b/src/routes/custom-formats/[databaseId]/[id]/testing/+page.svelte
@@ -119,6 +119,7 @@
 				icon={Plus}
 				iconColor="text-blue-600 dark:text-blue-400"
 				variant="secondary"
+				onboarding="cf-testing-add"
 				on:click={handleAddTest}
 			/>
 		</svelte:fragment>

--- a/src/routes/custom-formats/[databaseId]/[id]/testing/components/TestForm.svelte
+++ b/src/routes/custom-formats/[databaseId]/[id]/testing/components/TestForm.svelte
@@ -169,17 +169,19 @@
 		>
 			<div class="space-y-6 p-4">
 				<!-- Title -->
-				<FormInput
-					label="Release Title"
-					name="title"
-					bind:value={title}
-					required
-					mono
-					placeholder="e.g., Movie.Name.2024.1080p.BluRay.x264-GROUP"
-				/>
+				<div data-onboarding="cf-test-title">
+					<FormInput
+						label="Release Title"
+						name="title"
+						bind:value={title}
+						required
+						mono
+						placeholder="e.g., Movie.Name.2024.1080p.BluRay.x264-GROUP"
+					/>
+				</div>
 
 				<!-- Media Type -->
-				<div>
+				<div data-onboarding="cf-test-type">
 					<div class="mb-3 block text-sm font-medium text-neutral-700 dark:text-neutral-300">
 						Media Type
 					</div>
@@ -202,7 +204,7 @@
 				</div>
 
 				<!-- Expected Result -->
-				<div>
+				<div data-onboarding="cf-test-expected">
 					<div class="mb-3 block text-sm font-medium text-neutral-700 dark:text-neutral-300">
 						Expected Result
 					</div>
@@ -226,13 +228,15 @@
 				</div>
 
 				<!-- Description -->
-				<MarkdownInput
-					label="Description"
-					placeholder="Why this test exists or what edge case it covers"
-					value={description}
-					onchange={(v) => (description = v)}
-					rows={2}
-				/>
+				<div data-onboarding="cf-test-description">
+					<MarkdownInput
+						label="Description"
+						placeholder="Why this test exists or what edge case it covers"
+						value={description}
+						onchange={(v) => (description = v)}
+						rows={2}
+					/>
+				</div>
 			</div>
 		</div>
 	</form>

--- a/src/routes/custom-formats/[databaseId]/components/GeneralForm.svelte
+++ b/src/routes/custom-formats/[databaseId]/components/GeneralForm.svelte
@@ -201,7 +201,7 @@
 					</p>
 				</div>
 				<div class="flex items-end gap-4">
-					<div class="min-w-0 flex-[19]">
+					<div class="min-w-0 flex-[19]" data-onboarding="cf-general-name">
 						<FormInput
 							label="Name"
 							name="name"
@@ -212,7 +212,7 @@
 							on:input={(e) => update('name', e.detail)}
 						/>
 					</div>
-					<div class="flex-1">
+					<div class="flex-1" data-onboarding="cf-general-include-in-rename">
 						<Toggle
 							checked={includeInRename}
 							ariaLabel="Include in rename"
@@ -225,23 +225,25 @@
 				</div>
 			</div>
 
-			<!-- Description -->
-			<MarkdownInput
-				id="description"
-				name="description"
-				label="Description"
-				description="Add any notes or details about this custom format's purpose and configuration."
-				value={description}
-				onchange={(v) => update('description', v)}
-			/>
+			<div data-onboarding="cf-general-description-tags" class="space-y-6">
+				<!-- Description -->
+				<MarkdownInput
+					id="description"
+					name="description"
+					label="Description"
+					description="Add any notes or details about this custom format's purpose and configuration."
+					value={description}
+					onchange={(v) => update('description', v)}
+				/>
 
-			<!-- Tags -->
-			<div class="space-y-2">
-				<div class="block text-sm font-medium text-neutral-900 dark:text-neutral-100">Tags</div>
-				<p class="text-xs text-neutral-600 dark:text-neutral-400">
-					Add tags to organize and categorize this custom format.
-				</p>
-				<TagInput {tags} onchange={(newTags) => update('tags', newTags)} />
+				<!-- Tags -->
+				<div class="space-y-2">
+					<div class="block text-sm font-medium text-neutral-900 dark:text-neutral-100">Tags</div>
+					<p class="text-xs text-neutral-600 dark:text-neutral-400">
+						Add tags to organize and categorize this custom format.
+					</p>
+					<TagInput {tags} onchange={(newTags) => update('tags', newTags)} />
+				</div>
 			</div>
 		</div>
 	</form>

--- a/src/routes/custom-formats/[databaseId]/first/[tab]/+server.ts
+++ b/src/routes/custom-formats/[databaseId]/first/[tab]/+server.ts
@@ -1,0 +1,21 @@
+import { error, json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { pcdManager } from '$pcd/core/manager.ts';
+import * as customFormatQueries from '$pcd/entities/customFormats/index.ts';
+
+const TABS = new Set(['general', 'conditions', 'testing']);
+
+export const GET: RequestHandler = async ({ params }) => {
+	const dbId = parseInt(params.databaseId, 10);
+	if (isNaN(dbId)) error(400, 'Invalid database ID');
+	if (!TABS.has(params.tab)) error(400, 'Invalid tab');
+
+	const cache = pcdManager.getCache(dbId);
+	if (!cache) error(404, 'Database cache not available');
+
+	const cfs = await customFormatQueries.list(cache);
+	const path = cfs.length
+		? `/custom-formats/${dbId}/${cfs[0].id}/${params.tab}`
+		: `/custom-formats/${dbId}`;
+	return json({ path });
+};


### PR DESCRIPTION
Adds the Custom Formats cutscene group: General, Conditions, and Testing stages.

Introduces `hasDevDatabase` and `parserHealthy` state checks, three new route resolvers that land on the first custom format per database, and a page-local redirect endpoint at `/custom-formats/[databaseId]/first/[tab]` returning the final path as JSON.

Refs #375.