### PR TITLE
feat: add settings onboarding cutscene group

### DIFF
--- a/docs/frontend/cutscene.md
+++ b/docs/frontend/cutscene.md
@@ -158,6 +158,12 @@ like Help where a "you're done" modal would be redundant.
 | `media-naming`              | Naming              | 4     | `hasDatabase`                     | Naming formats and character replacement for files and folders |
 | `media-quality-definitions` | Quality Definitions | 1     | `hasDatabase`                     | File size gates per quality tier                               |
 | `media-settings`            | Media Settings      | 5     | `hasDatabase`                     | Propers/repacks handling and file analysis                     |
+| `settings-general`          | General             | 7     |                                   | App-wide preferences bucket                                    |
+| `settings-jobs`             | Jobs                | 4     |                                   | The event-driven job queue                                     |
+| `settings-logs`             | Logs                | 4     |                                   | Read, filter, and download log files                           |
+| `settings-backups`          | Backups             | 4     |                                   | Archive viewer and manual operations                           |
+| `settings-notifications`    | Notifications       | 5     |                                   | Push alerts to Discord, Telegram, Ntfy, or webhooks            |
+| `settings-security`         | Security            | 6     |                                   | Password, API key, local bypass, sessions                      |
 
 ## Prerequisites
 
@@ -239,16 +245,17 @@ export const GROUPS: StageGroup[] = [
 
 ### Current Groups
 
-| Name                | Stages                                            |
-| ------------------- | ------------------------------------------------- |
-| Getting Started     | Welcome, Navigation, Personalize, Help            |
-| Databases           | Connect a Database, Managing a Database           |
-| Arr Instances       | Connect an Arr Instance, Managing an Arr Instance |
-| Media Management    | Naming, Quality Definitions, Media Settings       |
-| Custom Formats      | General, Conditions, Testing                      |
-| Quality Profiles    | General, Scoring, Qualities                       |
-| Regular Expressions | General                                           |
-| Delay Profiles      | General                                           |
+| Name                | Stages                                                |
+| ------------------- | ----------------------------------------------------- |
+| Getting Started     | Welcome, Navigation, Personalize, Help                |
+| Databases           | Connect a Database, Managing a Database               |
+| Arr Instances       | Connect an Arr Instance, Managing an Arr Instance     |
+| Media Management    | Naming, Quality Definitions, Media Settings           |
+| Custom Formats      | General, Conditions, Testing                          |
+| Quality Profiles    | General, Scoring, Qualities                           |
+| Regular Expressions | General                                               |
+| Delay Profiles      | General                                               |
+| Settings            | General, Jobs, Logs, Backups, Notifications, Security |
 
 ## Adding Content
 

--- a/src/lib/client/cutscene/CutsceneCard.svelte
+++ b/src/lib/client/cutscene/CutsceneCard.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { X } from 'lucide-svelte';
 	import Button from '$ui/button/Button.svelte';
+	import InlineCode from '$ui/code/InlineCode.svelte';
 	import CutsceneProgress from './CutsceneProgress.svelte';
 
 	export let title: string;
@@ -21,6 +22,17 @@
 	];
 
 	$: cancelTooltip = cancelQuips[Math.floor(Math.random() * cancelQuips.length)];
+
+	// Split body into segments: even indices are plain text, odd indices are inline code.
+	// Backticks without a closing pair stay as literal text.
+	$: bodySegments = (() => {
+		const parts = body.split('`');
+		if (parts.length % 2 === 0) {
+			// Unclosed backtick — render the whole body as text.
+			return [{ code: false, text: body }];
+		}
+		return parts.map((text, i) => ({ code: i % 2 === 1, text }));
+	})();
 </script>
 
 <div
@@ -36,7 +48,13 @@
 			{/if}
 		</div>
 		<p class="mt-1 text-sm text-neutral-600 dark:text-neutral-400">
-			{body}
+			{#each bodySegments as segment}
+				{#if segment.code}
+					<InlineCode text={segment.text} rounded="sm" />
+				{:else}
+					{segment.text}
+				{/if}
+			{/each}
 		</p>
 	</div>
 	<CutsceneProgress {currentStep} {totalSteps} {onBack} {onForward} {showBack} />

--- a/src/lib/client/cutscene/CutsceneOverlay.svelte
+++ b/src/lib/client/cutscene/CutsceneOverlay.svelte
@@ -222,7 +222,7 @@
 	$: cardStyle = computeCardPosition(step?.position, targetRect);
 
 	function computeCardPosition(position: string | undefined, rect: DOMRect | null): string {
-		if (!rect) {
+		if (!rect || position === 'center') {
 			return 'position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%);';
 		}
 

--- a/src/lib/client/cutscene/definitions/index.ts
+++ b/src/lib/client/cutscene/definitions/index.ts
@@ -21,6 +21,12 @@ import { delayGeneralStage } from './stages/delay-profiles/general.ts';
 import { mediaNamingStage } from './stages/media-management/naming.ts';
 import { mediaQualityDefinitionsStage } from './stages/media-management/quality-definitions.ts';
 import { mediaSettingsStage } from './stages/media-management/media-settings.ts';
+import { settingsGeneralStage } from './stages/settings/general.ts';
+import { settingsJobsStage } from './stages/settings/jobs.ts';
+import { settingsLogsStage } from './stages/settings/logs.ts';
+import { settingsBackupsStage } from './stages/settings/backups.ts';
+import { settingsNotificationsStage } from './stages/settings/notifications.ts';
+import { settingsSecurityStage } from './stages/settings/security.ts';
 
 export const STAGES: Record<string, Stage> = {
 	welcome: welcomeStage,
@@ -44,6 +50,12 @@ export const STAGES: Record<string, Stage> = {
 	'media-naming': mediaNamingStage,
 	'media-quality-definitions': mediaQualityDefinitionsStage,
 	'media-settings': mediaSettingsStage,
+	'settings-general': settingsGeneralStage,
+	'settings-jobs': settingsJobsStage,
+	'settings-logs': settingsLogsStage,
+	'settings-backups': settingsBackupsStage,
+	'settings-notifications': settingsNotificationsStage,
+	'settings-security': settingsSecurityStage,
 	help: helpStage
 };
 
@@ -87,5 +99,18 @@ export const GROUPS: StageGroup[] = [
 		name: 'Delay Profiles',
 		description: 'Wait for better releases before committing to a grab',
 		stages: ['delay-general']
+	},
+	{
+		name: 'Settings',
+		description:
+			'App-wide preferences, background jobs, logs, backups, notifications, and security',
+		stages: [
+			'settings-general',
+			'settings-jobs',
+			'settings-logs',
+			'settings-backups',
+			'settings-notifications',
+			'settings-security'
+		]
 	}
 ];

--- a/src/lib/client/cutscene/definitions/stages/settings/backups.ts
+++ b/src/lib/client/cutscene/definitions/stages/settings/backups.ts
@@ -1,0 +1,40 @@
+import type { Stage } from '$cutscene/types.ts';
+
+export const settingsBackupsStage: Stage = {
+	id: 'settings-backups',
+	name: 'Backups',
+	description: "Manage archived snapshots of Profilarr's data directory",
+	steps: [
+		{
+			id: 'settings-backups-intro',
+			route: '/settings/backups',
+			title: 'Backups',
+			body: "Backups are compressed `.tar.gz` archives of Profilarr's data directory. Secrets (API keys, tokens, webhook URLs, and session records) are stripped from the database copy before it is archived, so an archive is safe to move between hosts. The automatic schedule and retention are configured under General > Backups; this page covers manual operations and restoring from an archive.",
+			completion: { type: 'manual' }
+		},
+		{
+			id: 'settings-backups-actions',
+			target: 'backups-actions',
+			title: 'Actions Bar',
+			body: 'The actions bar covers the three manual operations. Search narrows the archive list by filename. Upload lets you drop a `.tar.gz` from another Profilarr instance, which is the main path for migrating between hosts. Create Backup enqueues a `backup.create` job that runs on the normal job queue and appears in the table below once it finishes. Cleanup fires the `backup.cleanup` job immediately instead of waiting for its next scheduled run.',
+			position: 'below',
+			freeInteract: true,
+			completion: { type: 'manual' }
+		},
+		{
+			id: 'settings-backups-table',
+			target: 'backups-table',
+			title: 'Backup Row',
+			body: 'Each row is one archive: when it was created, its filename, and its size. Per-row actions are Download (saves the archive to your machine), Restore (replaces current state with the contents of the archive, asks for confirmation, and requires an app restart afterward), and Delete (removes the archive from disk).',
+			position: 'center',
+			freeInteract: true,
+			completion: { type: 'manual' }
+		},
+		{
+			id: 'settings-backups-summary',
+			title: 'Summary',
+			body: 'Automatic backups on the job schedule are the default protection; this page is for manual snapshots before risky operations, migrating between hosts via upload, and restoring when something has gone wrong.',
+			completion: { type: 'manual' }
+		}
+	]
+};

--- a/src/lib/client/cutscene/definitions/stages/settings/general.ts
+++ b/src/lib/client/cutscene/definitions/stages/settings/general.ts
@@ -1,0 +1,67 @@
+import type { Stage } from '$cutscene/types.ts';
+
+export const settingsGeneralStage: Stage = {
+	id: 'settings-general',
+	name: 'General',
+	description: 'App-wide preferences: interface, Arr defaults, backups, logging, and TMDB',
+	steps: [
+		{
+			id: 'settings-general-intro',
+			route: '/settings/general',
+			title: 'General Settings',
+			body: 'General is the app-wide preferences bucket: look-and-feel choices, defaults applied when you add a new Arr, plus quick toggles for the backup and logging jobs. Everything on this page sits on a single form with one Save button at the top, so changes do not apply until you save.',
+			completion: { type: 'manual' }
+		},
+		{
+			id: 'settings-general-interface',
+			target: 'general-interface',
+			title: 'Interface',
+			body: 'Interface covers cosmetic preferences: whether the app uses emoji or lucide icons, where alerts appear and how long they stay on screen, and the sans and mono font families. The demo alert buttons on this card fire a sample notification so you can preview your choices without leaving the page.',
+			position: 'below',
+			freeInteract: true,
+			completion: { type: 'manual' }
+		},
+		{
+			id: 'settings-general-arr-defaults',
+			target: 'general-arr-defaults',
+			title: 'Arr Instance Defaults',
+			body: 'Defaults applied when a new Arr instance is added. "Apply Default Delay Profile" toggles whether Profilarr sets a default delay profile on the first sync to a new Arr. On by default, so linking a fresh Arr picks up a sensible wait window without extra setup; turn it off if you would rather leave new Arrs with whatever delay profile they already have (or none) and set one yourself.',
+			position: 'below',
+			freeInteract: true,
+			completion: { type: 'manual' }
+		},
+		{
+			id: 'settings-general-backups',
+			target: 'general-backups',
+			title: 'Backups',
+			body: 'Controls the automatic `backup.create` and `backup.cleanup` jobs: whether they run, when, and how long archives are kept. The archives themselves, plus manual create, upload, restore, and delete, all live on the Backups page. The Backups stage covers that side in detail.',
+			position: 'below',
+			freeInteract: true,
+			completion: { type: 'manual' }
+		},
+		{
+			id: 'settings-general-logging',
+			target: 'general-logging',
+			title: 'Logging',
+			body: 'Controls what Profilarr captures and for how long: file and console logging on/off, minimum level, and retention days for the daily-rotated files. The Logs page is where you read what was captured. The Logs stage covers that viewer.',
+			position: 'above',
+			freeInteract: true,
+			completion: { type: 'manual' }
+		},
+		{
+			id: 'settings-general-tmdb',
+			target: 'general-tmdb',
+			title: 'TMDB Configuration',
+			body: 'A TMDB API Read Access Token is only needed for the entity-testing feature inside quality profiles, which resolves titles and metadata against TMDB so you can test scoring against real releases. If you do not use entity testing, leave this blank.',
+			position: 'above',
+			freeInteract: true,
+			completion: { type: 'manual' }
+		},
+		{
+			id: 'settings-general-summary',
+			title: 'Summary',
+			body: 'General holds the knobs that shape the whole app: interface, Arr-link defaults, the backup and logging jobs, and an optional TMDB token. Save at the top commits every change on the page at once.',
+			completion: { type: 'manual' }
+		}
+	]
+};

--- a/src/lib/client/cutscene/definitions/stages/settings/jobs.ts
+++ b/src/lib/client/cutscene/definitions/stages/settings/jobs.ts
@@ -1,0 +1,40 @@
+import type { Stage } from '$cutscene/types.ts';
+
+export const settingsJobsStage: Stage = {
+	id: 'settings-jobs',
+	name: 'Jobs',
+	description: 'The event-driven job queue that runs background work',
+	steps: [
+		{
+			id: 'settings-jobs-intro',
+			route: '/settings/jobs',
+			title: 'Background Jobs',
+			body: 'Profilarr uses a SQLite-backed job queue for background work: database syncs, format upgrades, file renames, backups, log cleanup. A single dispatcher claims jobs from the queue and runs them one at a time, strictly serially, which keeps the system deterministic. Rather than polling on an interval, the dispatcher sleeps until the next job is due and wakes up when a newly enqueued job has an earlier run time, so it costs nothing when idle.',
+			completion: { type: 'manual' }
+		},
+		{
+			id: 'settings-jobs-table',
+			target: 'jobs-table',
+			title: 'Jobs Table',
+			body: 'One row per scheduled job, with current status, when it last ran, the result of that run, and when it is due to run next. Expanding a row surfaces the details: exact timestamps, how long the last run took, and any error message the handler returned. This is the view for checking what is on the schedule and spotting anything that has failed or drifted.',
+			position: 'below',
+			freeInteract: true,
+			completion: { type: 'manual' }
+		},
+		{
+			id: 'settings-jobs-history',
+			target: 'jobs-history',
+			title: 'Recent Jobs',
+			body: 'Every row here is one execution pulled from job-run history: when it started, how long it took, and its output or error. Skipped runs, where the handler had nothing to do (for example, no expired backups to clean), are hidden by default to keep the table focused on work that actually ran; toggle "Show skipped runs" to include them.',
+			position: 'above',
+			freeInteract: true,
+			completion: { type: 'manual' }
+		},
+		{
+			id: 'settings-jobs-summary',
+			title: 'Summary',
+			body: "The queue plus a single event-driven dispatcher keeps Profilarr's background work cheap and predictable. Use the top table to see what is scheduled and Recent Jobs to audit what ran; both are read-only reporting views on top of the same queue.",
+			completion: { type: 'manual' }
+		}
+	]
+};

--- a/src/lib/client/cutscene/definitions/stages/settings/logs.ts
+++ b/src/lib/client/cutscene/definitions/stages/settings/logs.ts
@@ -1,0 +1,40 @@
+import type { Stage } from '$cutscene/types.ts';
+
+export const settingsLogsStage: Stage = {
+	id: 'settings-logs',
+	name: 'Logs',
+	description: 'Read, filter, and download the app log files',
+	steps: [
+		{
+			id: 'settings-logs-intro',
+			route: '/settings/logs',
+			title: 'Logs',
+			body: "This page is the viewer for Profilarr's own application logs. Log level, retention, and on/off controls live under General > Logging; everything here (file selection, search, filters, metadata drill-down) operates on whatever was already captured.",
+			completion: { type: 'manual' }
+		},
+		{
+			id: 'settings-logs-actions',
+			target: 'logs-actions',
+			title: 'Actions Bar',
+			body: "The actions bar has everything you need to narrow the view: a file picker (files rotate by day as `YYYY-MM-DD.log` with each file's size next to the name), free-text search across the currently loaded file, a level filter (DEBUG/INFO/WARN/ERROR, color-coded), and a source-module filter built from the unique set of sources in the current file. On the right, Refresh reloads the file, Download saves the raw file to disk, and Cleanup kicks the `logs.cleanup` job immediately instead of waiting for its next run.",
+			position: 'below',
+			freeInteract: true,
+			completion: { type: 'manual' }
+		},
+		{
+			id: 'settings-logs-table',
+			target: 'logs-table',
+			title: 'Log Entry',
+			body: 'Each row is a single log entry: timestamp, level, source module, and message. The Copy button on a row copies the full formatted entry (including meta) to your clipboard; the eye icon, when present, opens a modal with the structured metadata payload pretty-printed as JSON, which is where context like job IDs, HTTP bodies, and stack traces lives.',
+			position: 'center',
+			freeInteract: true,
+			completion: { type: 'manual' }
+		},
+		{
+			id: 'settings-logs-summary',
+			title: 'Summary',
+			body: 'Pick a log file, narrow the view with search and the level and source filters, and drill into metadata when you need the context behind a line. Deeper control over what actually gets captured (level, retention, file vs console) lives one page over under General > Logging.',
+			completion: { type: 'manual' }
+		}
+	]
+};

--- a/src/lib/client/cutscene/definitions/stages/settings/notifications.ts
+++ b/src/lib/client/cutscene/definitions/stages/settings/notifications.ts
@@ -1,0 +1,49 @@
+import type { Stage } from '$cutscene/types.ts';
+
+export const settingsNotificationsStage: Stage = {
+	id: 'settings-notifications',
+	name: 'Notifications',
+	description: 'Push alerts to external services when specific events happen',
+	steps: [
+		{
+			id: 'settings-notifications-intro',
+			route: '/settings/notifications',
+			title: 'Notifications',
+			body: 'Profilarr can push alerts out to external services when specific events happen: job success and failure, sync outcomes, backup results, and similar. A range of service types is supported (chat apps, push services, generic webhooks, and more), and multiple services can be active at once, each with its own subset of enabled event types, so you can route critical failures one way and routine completions another.',
+			completion: { type: 'manual' }
+		},
+		{
+			id: 'settings-notifications-add',
+			target: 'notifications-add',
+			title: 'Add Service',
+			body: 'Add Service opens the new-service form, where you pick a service type, fill in the credentials that type needs (webhook URL, bot token, topic, and so on), and choose which event types this service will listen for. We will not walk the form in this stage since it requires real credentials to finish, but it is the single entry point for wiring up a new destination.',
+			position: 'center',
+			freeInteract: true,
+			completion: { type: 'manual' }
+		},
+		{
+			id: 'settings-notifications-table',
+			target: 'notifications-table',
+			title: 'Services Table',
+			body: 'One row per configured service, showing its type, enabled or disabled status, and a running count of successes and failures. Per-row actions are Test (fires a sample notification to confirm credentials and network path), Edit (reopens the form), and Delete.',
+			position: 'below',
+			freeInteract: true,
+			completion: { type: 'manual' }
+		},
+		{
+			id: 'settings-notifications-history',
+			target: 'notifications-history',
+			title: 'Notification History',
+			body: 'Every delivery attempt is recorded here with its outcome, which is how you audit whether alerts actually made it through. If a service is silently failing, this is the view that shows it; pair with the Test action above to confirm you have fixed it.',
+			position: 'center',
+			freeInteract: true,
+			completion: { type: 'manual' }
+		},
+		{
+			id: 'settings-notifications-summary',
+			title: 'Summary',
+			body: 'Add a service, pick the event types it should listen for, use Test to confirm credentials work, and audit deliveries in the history panel. Multiple services can run side-by-side if you want different destinations for different severities.',
+			completion: { type: 'manual' }
+		}
+	]
+};

--- a/src/lib/client/cutscene/definitions/stages/settings/security.ts
+++ b/src/lib/client/cutscene/definitions/stages/settings/security.ts
@@ -1,0 +1,58 @@
+import type { Stage } from '$cutscene/types.ts';
+
+export const settingsSecurityStage: Stage = {
+	id: 'settings-security',
+	name: 'Security',
+	description: 'Password, API key, local-network bypass, and active sessions',
+	steps: [
+		{
+			id: 'settings-security-intro',
+			route: '/settings/security',
+			title: 'Security',
+			body: 'Your password, API key, local-network bypass, and active sessions all live on this page. Which sections are meaningful depends on the `AUTH` mode you started Profilarr with: password change applies when `AUTH=on`; with `AUTH=oidc` your identity provider owns credentials; with `AUTH=off` no auth is applied at all. API keys and sessions behave the same across modes.',
+			completion: { type: 'manual' }
+		},
+		{
+			id: 'settings-security-password',
+			target: 'security-password',
+			title: 'Change Password',
+			body: 'A three-field form: current password, new password, and confirm. Only meaningful under `AUTH=on`, where Profilarr owns the credential; under `AUTH=oidc` or `AUTH=off` this form does nothing useful because Profilarr is not the source of truth for your identity.',
+			position: 'below',
+			freeInteract: true,
+			completion: { type: 'manual' }
+		},
+		{
+			id: 'settings-security-local-bypass',
+			target: 'security-local-bypass',
+			title: 'Local Bypass',
+			body: 'When on, requests originating from local network addresses skip authentication entirely. The tradeoff: easier API access from scripts on the same machine or LAN, but anyone else on that network is now implicitly trusted. Safe when your LAN is single-user; risky on a shared or untrusted network.',
+			position: 'below',
+			freeInteract: true,
+			completion: { type: 'manual' }
+		},
+		{
+			id: 'settings-security-api-key',
+			target: 'security-api-key',
+			title: 'API Key',
+			body: 'A single API key per instance, sent via the `X-Api-Key` header, bcrypt-hashed on the server so the raw value cannot be recovered after it is generated. Generate once, copy the key immediately (it is shown once and never again), and regenerate to rotate. Regenerating invalidates anything still using the old key, so rotate before deleting old clients, not after.',
+			position: 'below',
+			freeInteract: true,
+			completion: { type: 'manual' }
+		},
+		{
+			id: 'settings-security-sessions',
+			target: 'security-sessions',
+			title: 'Active Sessions',
+			body: 'Browser sessions tied to the current Profilarr user. Each row shows browser, OS, device type, IP, and last active time, which is how you spot a session you do not recognize. Per-row Revoke ends that session specifically; "Revoke Others" in the section header ends every session except the one you are using right now.',
+			position: 'above',
+			freeInteract: true,
+			completion: { type: 'manual' }
+		},
+		{
+			id: 'settings-security-summary',
+			title: 'Summary',
+			body: 'Security is a cross-mode toolkit: use the parts that match your auth mode, rotate the API key when credentials leak, flip local bypass only when you trust the LAN, and revoke sessions you do not recognize.',
+			completion: { type: 'manual' }
+		}
+	]
+};

--- a/src/lib/client/cutscene/types.ts
+++ b/src/lib/client/cutscene/types.ts
@@ -18,7 +18,8 @@ export interface Step {
 		| 'above-left'
 		| 'above-right'
 		| 'below-left'
-		| 'below-right';
+		| 'below-right'
+		| 'center';
 	freeInteract?: boolean;
 	completion: Completion;
 }

--- a/src/lib/client/ui/card/ExpandableCard.svelte
+++ b/src/lib/client/ui/card/ExpandableCard.svelte
@@ -4,6 +4,7 @@
 	export let title: string;
 	export let description: string = '';
 	export let open: boolean = true;
+	export let onboardingId: string | undefined = undefined;
 
 	function toggle() {
 		open = !open;
@@ -11,6 +12,7 @@
 </script>
 
 <div
+	data-onboarding={onboardingId}
 	class="overflow-hidden rounded-lg border border-neutral-200 bg-white dark:border-neutral-800 dark:bg-neutral-900"
 >
 	<!-- svelte-ignore a11y-click-events-have-key-events -->

--- a/src/lib/client/ui/code/InlineCode.svelte
+++ b/src/lib/client/ui/code/InlineCode.svelte
@@ -17,7 +17,7 @@
 <code
 	class="inline-flex items-center gap-1.5 {roundedClasses[
 		rounded
-	]} bg-neutral-100 px-1.5 py-0.5 text-[0.85em] text-neutral-700 dark:bg-neutral-800 dark:text-neutral-300"
+	]} bg-neutral-100 px-1 py-px text-[0.85em] text-neutral-700 dark:bg-neutral-800 dark:text-neutral-300"
 	style="font-family: var(--font-code)"
 >
 	{#if icon}

--- a/src/routes/settings/backups/+page.svelte
+++ b/src/routes/settings/backups/+page.svelte
@@ -195,7 +195,7 @@
 	></form>
 
 	<!-- Actions Bar -->
-	<div class="mb-4">
+	<div class="mb-4" data-onboarding="backups-actions">
 		<ActionsBar>
 			<SearchAction {searchStore} placeholder="Search backups..." />
 			<Tooltip text="Upload Backup">
@@ -211,75 +211,77 @@
 	</div>
 
 	<!-- Backups Table -->
-	<Table
-		{columns}
-		data={filteredBackups}
-		emptyMessage="No backups found. Create your first backup to get started."
-		actionsHeaderAlign="center"
-		compact
-		responsive
-	>
-		<svelte:fragment slot="cell" let:row let:column>
-			{#if column.key === 'created'}
-				<span class="font-medium">{formatDateTime(row.created)}</span>
-			{:else if column.key === 'filename'}
-				<span class="font-mono text-neutral-500 dark:text-neutral-400">{row.filename}</span>
-			{:else if column.key === 'sizeFormatted'}
-				<span class="text-neutral-500 dark:text-neutral-400">{row.sizeFormatted}</span>
-			{/if}
-		</svelte:fragment>
+	<div data-onboarding="backups-table">
+		<Table
+			{columns}
+			data={filteredBackups}
+			emptyMessage="No backups found. Create your first backup to get started."
+			actionsHeaderAlign="center"
+			compact
+			responsive
+		>
+			<svelte:fragment slot="cell" let:row let:column>
+				{#if column.key === 'created'}
+					<span class="font-medium">{formatDateTime(row.created)}</span>
+				{:else if column.key === 'filename'}
+					<span class="font-mono text-neutral-500 dark:text-neutral-400">{row.filename}</span>
+				{:else if column.key === 'sizeFormatted'}
+					<span class="text-neutral-500 dark:text-neutral-400">{row.sizeFormatted}</span>
+				{/if}
+			</svelte:fragment>
 
-		<svelte:fragment slot="actions" let:row>
-			<div class="flex items-center justify-center gap-1">
-				<Button
-					icon={Download}
-					size="xs"
-					tooltip="Download"
-					on:click={() => downloadBackup(row.filename)}
-				/>
-
-				<form
-					method="POST"
-					action="?/restoreBackup"
-					use:enhance={() => {
-						return async ({ result, update }) => {
-							if (result.type === 'failure' && result.data) {
-								alertStore.add(
-									'error',
-									(result.data as { error?: string }).error || 'Failed to restore backup'
-								);
-							} else if (result.type === 'success') {
-								alertStore.add(
-									'success',
-									'Backup restored successfully. Please restart the application.'
-								);
-							}
-							await update();
-						};
-					}}
-				>
-					<input type="hidden" name="filename" value={row.filename} />
+			<svelte:fragment slot="actions" let:row>
+				<div class="flex items-center justify-center gap-1">
 					<Button
-						icon={RotateCcw}
+						icon={Download}
 						size="xs"
-						tooltip="Restore"
-						on:click={(e) => {
-							const form = (e.currentTarget as HTMLElement)?.closest('form');
-							if (form) openRestoreModal(row.filename, form);
-						}}
+						tooltip="Download"
+						on:click={() => downloadBackup(row.filename)}
 					/>
-				</form>
 
-				<Button
-					icon={Trash2}
-					size="xs"
-					iconColor="text-red-600 dark:text-red-400"
-					tooltip="Delete"
-					on:click={() => openDeleteModal(row.filename)}
-				/>
-			</div>
-		</svelte:fragment>
-	</Table>
+					<form
+						method="POST"
+						action="?/restoreBackup"
+						use:enhance={() => {
+							return async ({ result, update }) => {
+								if (result.type === 'failure' && result.data) {
+									alertStore.add(
+										'error',
+										(result.data as { error?: string }).error || 'Failed to restore backup'
+									);
+								} else if (result.type === 'success') {
+									alertStore.add(
+										'success',
+										'Backup restored successfully. Please restart the application.'
+									);
+								}
+								await update();
+							};
+						}}
+					>
+						<input type="hidden" name="filename" value={row.filename} />
+						<Button
+							icon={RotateCcw}
+							size="xs"
+							tooltip="Restore"
+							on:click={(e) => {
+								const form = (e.currentTarget as HTMLElement)?.closest('form');
+								if (form) openRestoreModal(row.filename, form);
+							}}
+						/>
+					</form>
+
+					<Button
+						icon={Trash2}
+						size="xs"
+						iconColor="text-red-600 dark:text-red-400"
+						tooltip="Delete"
+						on:click={() => openDeleteModal(row.filename)}
+					/>
+				</div>
+			</svelte:fragment>
+		</Table>
+	</div>
 </div>
 
 <!-- Delete Confirmation Modal -->

--- a/src/routes/settings/general/+page.svelte
+++ b/src/routes/settings/general/+page.svelte
@@ -282,6 +282,7 @@
 			<ExpandableCard
 				title="Interface"
 				description="Customize the look and feel of the application"
+				onboardingId="general-interface"
 			>
 				<svelte:fragment slot="header-right">
 					<!-- svelte-ignore a11y-click-events-have-key-events -->
@@ -405,6 +406,7 @@
 			<ExpandableCard
 				title="Arr Instance Defaults"
 				description="Configure default settings applied when adding new Radarr/Sonarr instances"
+				onboardingId="general-arr-defaults"
 			>
 				<div class="px-6 py-4">
 					<Toggle
@@ -427,6 +429,7 @@
 			<ExpandableCard
 				title="Backups"
 				description="Configure automatic backups, schedule, and retention policy"
+				onboardingId="general-backups"
 			>
 				<div class="grid gap-4 px-6 py-4" class:sm:grid-cols-5={backupEnabled}>
 					<div>
@@ -490,6 +493,7 @@
 			<ExpandableCard
 				title="Logging"
 				description="Configure application logs, rotation, and retention"
+				onboardingId="general-logging"
 			>
 				<svelte:fragment slot="header-right">
 					<!-- svelte-ignore a11y-click-events-have-key-events -->
@@ -596,6 +600,7 @@
 			<ExpandableCard
 				title="TMDB Configuration"
 				description="Configure TMDB API access for searching movies and TV series"
+				onboardingId="general-tmdb"
 			>
 				<svelte:fragment slot="header-right">
 					<!-- svelte-ignore a11y-click-events-have-key-events -->

--- a/src/routes/settings/jobs/+page.svelte
+++ b/src/routes/settings/jobs/+page.svelte
@@ -87,7 +87,7 @@
 	</div>
 
 	<!-- Jobs Table -->
-	<div class="mb-8">
+	<div class="mb-8" data-onboarding="jobs-table">
 		<ExpandableTable
 			{columns}
 			data={data.jobs}
@@ -197,5 +197,7 @@
 	</div>
 
 	<!-- Job History -->
-	<JobHistory jobRuns={data.jobRuns} />
+	<div data-onboarding="jobs-history">
+		<JobHistory jobRuns={data.jobRuns} />
+	</div>
 </div>

--- a/src/routes/settings/logs/+page.svelte
+++ b/src/routes/settings/logs/+page.svelte
@@ -297,21 +297,23 @@
 	</div>
 
 	<!-- Actions Bar -->
-	<LogsActionsBar
-		{searchStore}
-		logFiles={data.logFiles}
-		selectedFile={data.selectedFile}
-		{selectedLevel}
-		{selectedSources}
-		{uniqueSources}
-		{isRefreshing}
-		onChangeFile={changeLogFile}
-		onChangeLevel={(level) => (selectedLevel = level)}
-		onToggleSource={toggleSource}
-		onRefresh={refreshLogs}
-		onDownload={downloadLogs}
-		onCleanup={triggerCleanupLogs}
-	/>
+	<div data-onboarding="logs-actions">
+		<LogsActionsBar
+			{searchStore}
+			logFiles={data.logFiles}
+			selectedFile={data.selectedFile}
+			{selectedLevel}
+			{selectedSources}
+			{uniqueSources}
+			{isRefreshing}
+			onChangeFile={changeLogFile}
+			onChangeLevel={(level) => (selectedLevel = level)}
+			onToggleSource={toggleSource}
+			onRefresh={refreshLogs}
+			onDownload={downloadLogs}
+			onCleanup={triggerCleanupLogs}
+		/>
+	</div>
 
 	<form
 		bind:this={cleanupFormRef}
@@ -344,39 +346,41 @@
 	</div>
 
 	<!-- Log Table -->
-	<Table
-		data={paginatedLogs}
-		{columns}
-		emptyMessage="No logs found"
-		hoverable={true}
-		compact={true}
-		responsive
-		initialSort={{ key: 'timestamp', direction: defaultSortDirection }}
-		onSortChange={handleSortChange}
-	>
-		<svelte:fragment slot="actions" let:row>
-			<div class="flex items-center justify-end gap-1">
-				<Button
-					icon={Copy}
-					size="xs"
-					variant="secondary"
-					title="Copy log entry"
-					ariaLabel="Copy log entry"
-					on:click={() => copyLog(row)}
-				/>
-				{#if row.meta}
+	<div data-onboarding="logs-table">
+		<Table
+			data={paginatedLogs}
+			{columns}
+			emptyMessage="No logs found"
+			hoverable={true}
+			compact={true}
+			responsive
+			initialSort={{ key: 'timestamp', direction: defaultSortDirection }}
+			onSortChange={handleSortChange}
+		>
+			<svelte:fragment slot="actions" let:row>
+				<div class="flex items-center justify-end gap-1">
 					<Button
-						icon={Eye}
+						icon={Copy}
 						size="xs"
 						variant="secondary"
-						title="View metadata"
-						ariaLabel="View metadata"
-						on:click={() => viewMeta(row.meta)}
+						title="Copy log entry"
+						ariaLabel="Copy log entry"
+						on:click={() => copyLog(row)}
 					/>
-				{/if}
-			</div>
-		</svelte:fragment>
-	</Table>
+					{#if row.meta}
+						<Button
+							icon={Eye}
+							size="xs"
+							variant="secondary"
+							title="View metadata"
+							ariaLabel="View metadata"
+							on:click={() => viewMeta(row.meta)}
+						/>
+					{/if}
+				</div>
+			</svelte:fragment>
+		</Table>
+	</div>
 
 	<!-- Bottom Pagination -->
 	{#if totalPages > 1}

--- a/src/routes/settings/notifications/+page.svelte
+++ b/src/routes/settings/notifications/+page.svelte
@@ -104,138 +104,142 @@
 			</div>
 
 			<!-- Add Service Button -->
-			<Button
-				href="/settings/notifications/new"
-				icon={Plus}
-				iconColor="text-blue-600 dark:text-blue-400"
-				text="Add Service"
-				variant="secondary"
-			/>
+			<div data-onboarding="notifications-add">
+				<Button
+					href="/settings/notifications/new"
+					icon={Plus}
+					iconColor="text-blue-600 dark:text-blue-400"
+					text="Add Service"
+					variant="secondary"
+				/>
+			</div>
 		</div>
 	</div>
 
 	<!-- Services Table -->
-	<Table
-		{columns}
-		data={data.services}
-		emptyMessage="No notification services configured. Click 'Add Service' to get started."
-		compact
-		responsive
-	>
-		<svelte:fragment slot="cell" let:row let:column>
-			{#if column.key === 'name'}
-				<span class="font-medium">{row.name}</span>
-			{:else if column.key === 'service_type'}
-				<div class="flex items-center gap-2">
-					{#if serviceInfo[row.service_type]?.icon}
-						<svg
-							role="img"
-							viewBox="0 0 24 24"
-							class="h-4 w-4 text-neutral-600 dark:text-neutral-400"
-							fill="currentColor"
-						>
-							<path d={serviceInfo[row.service_type]!.icon!.path} />
-						</svg>
+	<div data-onboarding="notifications-table">
+		<Table
+			{columns}
+			data={data.services}
+			emptyMessage="No notification services configured. Click 'Add Service' to get started."
+			compact
+			responsive
+		>
+			<svelte:fragment slot="cell" let:row let:column>
+				{#if column.key === 'name'}
+					<span class="font-medium">{row.name}</span>
+				{:else if column.key === 'service_type'}
+					<div class="flex items-center gap-2">
+						{#if serviceInfo[row.service_type]?.icon}
+							<svg
+								role="img"
+								viewBox="0 0 24 24"
+								class="h-4 w-4 text-neutral-600 dark:text-neutral-400"
+								fill="currentColor"
+							>
+								<path d={serviceInfo[row.service_type]!.icon!.path} />
+							</svg>
+						{:else}
+							<Rss size={16} class="text-neutral-600 dark:text-neutral-400" />
+						{/if}
+						<span>{getServiceTypeName(row.service_type)}</span>
+					</div>
+				{:else if column.key === 'enabled'}
+					<Badge variant={row.enabled ? 'success' : 'neutral'} icon={row.enabled ? Bell : BellOff}>
+						{row.enabled ? 'Enabled' : 'Disabled'}
+					</Badge>
+				{:else if column.key === 'stats'}
+					{#if row.successCount + row.failedCount > 0}
+						<span class="text-xs">
+							<span class="text-green-600 dark:text-green-400">{row.successCount}</span>
+							/
+							<span class="text-red-600 dark:text-red-400">{row.failedCount}</span>
+						</span>
 					{:else}
-						<Rss size={16} class="text-neutral-600 dark:text-neutral-400" />
+						<span class="text-neutral-400 dark:text-neutral-500">-</span>
 					{/if}
-					<span>{getServiceTypeName(row.service_type)}</span>
-				</div>
-			{:else if column.key === 'enabled'}
-				<Badge variant={row.enabled ? 'success' : 'neutral'} icon={row.enabled ? Bell : BellOff}>
-					{row.enabled ? 'Enabled' : 'Disabled'}
-				</Badge>
-			{:else if column.key === 'stats'}
-				{#if row.successCount + row.failedCount > 0}
-					<span class="text-xs">
-						<span class="text-green-600 dark:text-green-400">{row.successCount}</span>
-						/
-						<span class="text-red-600 dark:text-red-400">{row.failedCount}</span>
-					</span>
-				{:else}
-					<span class="text-neutral-400 dark:text-neutral-500">-</span>
 				{/if}
-			{/if}
-		</svelte:fragment>
+			</svelte:fragment>
 
-		<svelte:fragment slot="actions" let:row>
-			<div class="flex items-center gap-1">
-				<!-- Test Button -->
-				<form
-					method="POST"
-					action="?/testNotification"
-					use:enhance={() => {
-						testingServiceId = row.id;
-						return async ({ result, update }) => {
-							if (result.type === 'failure' && result.data) {
-								alertStore.add(
-									'error',
-									(result.data as { error?: string }).error || 'Failed to send test notification'
-								);
-							} else if (result.type === 'success') {
-								alertStore.add('success', 'Test notification sent successfully');
-							}
-							testingServiceId = null;
-							await update();
-						};
-					}}
-				>
-					<input type="hidden" name="id" value={row.id} />
-					<Button
-						icon={Send}
-						iconColor="text-accent-600 dark:text-accent-400"
-						size="xs"
-						type="submit"
-						disabled={testingServiceId === row.id}
-						loading={testingServiceId === row.id}
-						tooltip="Send test notification"
-					/>
-				</form>
-
-				<!-- Edit Button -->
-				<Button
-					icon={Pencil}
-					size="xs"
-					href="/settings/notifications/edit/{row.id}"
-					tooltip="Edit service"
-				/>
-
-				<!-- Delete Button -->
-				<form
-					method="POST"
-					action="?/delete"
-					use:enhance={() => {
-						return async ({ result, update }) => {
-							if (result.type === 'failure' && result.data) {
-								alertStore.add(
-									'error',
-									(result.data as { error?: string }).error || 'Failed to delete service'
-								);
-							} else if (result.type === 'success') {
-								alertStore.add('success', 'Service deleted successfully');
-							}
-							await update();
-						};
-					}}
-				>
-					<input type="hidden" name="id" value={row.id} />
-					<Button
-						icon={Trash2}
-						iconColor="text-red-600 dark:text-red-400"
-						size="xs"
-						tooltip="Delete service"
-						on:click={(e) => {
-							const form = (e.target as HTMLElement)?.closest('form');
-							if (form) openDeleteModal(row.id, row.name, form);
+			<svelte:fragment slot="actions" let:row>
+				<div class="flex items-center gap-1">
+					<!-- Test Button -->
+					<form
+						method="POST"
+						action="?/testNotification"
+						use:enhance={() => {
+							testingServiceId = row.id;
+							return async ({ result, update }) => {
+								if (result.type === 'failure' && result.data) {
+									alertStore.add(
+										'error',
+										(result.data as { error?: string }).error || 'Failed to send test notification'
+									);
+								} else if (result.type === 'success') {
+									alertStore.add('success', 'Test notification sent successfully');
+								}
+								testingServiceId = null;
+								await update();
+							};
 						}}
+					>
+						<input type="hidden" name="id" value={row.id} />
+						<Button
+							icon={Send}
+							iconColor="text-accent-600 dark:text-accent-400"
+							size="xs"
+							type="submit"
+							disabled={testingServiceId === row.id}
+							loading={testingServiceId === row.id}
+							tooltip="Send test notification"
+						/>
+					</form>
+
+					<!-- Edit Button -->
+					<Button
+						icon={Pencil}
+						size="xs"
+						href="/settings/notifications/edit/{row.id}"
+						tooltip="Edit service"
 					/>
-				</form>
-			</div>
-		</svelte:fragment>
-	</Table>
+
+					<!-- Delete Button -->
+					<form
+						method="POST"
+						action="?/delete"
+						use:enhance={() => {
+							return async ({ result, update }) => {
+								if (result.type === 'failure' && result.data) {
+									alertStore.add(
+										'error',
+										(result.data as { error?: string }).error || 'Failed to delete service'
+									);
+								} else if (result.type === 'success') {
+									alertStore.add('success', 'Service deleted successfully');
+								}
+								await update();
+							};
+						}}
+					>
+						<input type="hidden" name="id" value={row.id} />
+						<Button
+							icon={Trash2}
+							iconColor="text-red-600 dark:text-red-400"
+							size="xs"
+							tooltip="Delete service"
+							on:click={(e) => {
+								const form = (e.target as HTMLElement)?.closest('form');
+								if (form) openDeleteModal(row.id, row.name, form);
+							}}
+						/>
+					</form>
+				</div>
+			</svelte:fragment>
+		</Table>
+	</div>
 
 	<!-- Notification History Component -->
-	<div class="mt-8">
+	<div class="mt-8" data-onboarding="notifications-history">
 		<NotificationHistory history={data.history} services={data.services} />
 	</div>
 </div>

--- a/src/routes/settings/security/+page.svelte
+++ b/src/routes/settings/security/+page.svelte
@@ -155,7 +155,11 @@
 
 	<div class="space-y-8">
 		<!-- Change Password -->
-		<ExpandableCard title="Change Password" description="Update your account password">
+		<ExpandableCard
+			title="Change Password"
+			description="Update your account password"
+			onboardingId="security-password"
+		>
 			<div class="p-6">
 				<form
 					method="POST"
@@ -215,6 +219,7 @@
 		<ExpandableCard
 			title="Local Bypass"
 			description="Skip authentication for requests from local network addresses"
+			onboardingId="security-local-bypass"
 		>
 			<div class="p-6">
 				<form
@@ -243,6 +248,7 @@
 		<ExpandableCard
 			title="API Key"
 			description="Authenticate API requests via the X-Api-Key header"
+			onboardingId="security-api-key"
 		>
 			<div class="p-6">
 				{#if apiKey}
@@ -331,6 +337,7 @@
 		<ExpandableCard
 			title="Active Sessions"
 			description="Manage your logged-in sessions across devices"
+			onboardingId="security-sessions"
 		>
 			<svelte:fragment slot="header-right">
 				{#if data.sessions.length > 1}


### PR DESCRIPTION
Closes #375.

Adds the final onboarding group for the Settings section, covering all six sidebar pages: General, Jobs, Logs, Backups, Notifications, Security. Expanded from the issue's original scope (Notifications, Jobs, Backups) to cover the full sidebar section. This concludes the cutscene rollout.

## Stages

| Stage | Steps |
| --- | --- |
| General | overview, interface, arr defaults, backups, logging, TMDB, summary |
| Jobs | overview, jobs table, recent jobs, summary |
| Logs | overview, actions bar, log entry, summary |
| Backups | overview, actions bar, backup row, summary |
| Notifications | overview, add service, services table, history, summary |
| Security | overview, password, local bypass, API key, sessions, summary |

## Supporting changes

- `center` position for cutscene cards: spotlights a target while floating the card in the viewport center, for wide or tall sections where above/below overflow.
- Inline code rendering in card bodies: backtick-wrapped spans in `body` strings render as `InlineCode`.
- `InlineCode` padding reduced slightly to fit inline text better.
- `ExpandableCard` takes a new `onboardingId` prop so cards can be targeted directly without wrapping divs.