### PR TITLE
style: arr/database card & table overhaul

### DIFF
--- a/src/routes/arr/+page.server.ts
+++ b/src/routes/arr/+page.server.ts
@@ -1,15 +1,77 @@
 import { fail, redirect } from '@sveltejs/kit';
 import type { Actions, ServerLoad } from '@sveltejs/kit';
 import { arrInstancesQueries } from '$db/queries/arrInstances.ts';
+import type { ArrInstancePublic } from '$db/queries/arrInstances.ts';
+import { arrSyncQueries } from '$db/queries/arrSync.ts';
+import { upgradeConfigsQueries } from '$db/queries/upgradeConfigs.ts';
+import { arrRenameSettingsQueries } from '$db/queries/arrRenameSettings.ts';
+import { arrCleanupSettingsQueries } from '$db/queries/arrCleanupSettings.ts';
 import { cleanupJobsForArrInstance } from '$lib/server/jobs/cleanup.ts';
 import { logger } from '$logger/logger.ts';
+
+export type CompositeSyncStatus = 'idle' | 'pending' | 'in_progress' | 'failed' | 'not_configured';
+
+export interface ArrInstanceSummary extends ArrInstancePublic {
+	syncedProfileNames: string[];
+	compositeSyncStatus: CompositeSyncStatus;
+	delayProfileName: string | null;
+	namingConfigName: string | null;
+	qualityDefinitionsConfigName: string | null;
+	mediaSettingsConfigName: string | null;
+	upgradeEnabled: boolean;
+	renameEnabled: boolean;
+	cleanupEnabled: boolean;
+}
+
+function computeCompositeSyncStatus(statuses: string[]): CompositeSyncStatus {
+	if (statuses.some((s) => s === 'failed')) return 'failed';
+	if (statuses.some((s) => s === 'in_progress')) return 'in_progress';
+	if (statuses.some((s) => s === 'pending')) return 'pending';
+	return 'idle';
+}
 
 export const load: ServerLoad = () => {
 	const instances = arrInstancesQueries.getAll();
 
-	return {
-		instances: instances.map(({ api_key, ...safe }) => safe)
-	};
+	const summaries: ArrInstanceSummary[] = instances.map(({ api_key, ...safe }) => {
+		const syncStatus = arrSyncQueries.getSyncConfigStatus(safe.id);
+		const qpSync = arrSyncQueries.getQualityProfilesSync(safe.id);
+		const dpSync = arrSyncQueries.getDelayProfilesSync(safe.id);
+		const mmSync = arrSyncQueries.getMediaManagementSync(safe.id);
+		const upgradeConfig = upgradeConfigsQueries.getByArrInstanceId(safe.id);
+		const renameConfig = arrRenameSettingsQueries.getByInstanceId(safe.id);
+		const cleanupConfig = arrCleanupSettingsQueries.getByInstanceId(safe.id);
+
+		const hasSyncConfig =
+			qpSync.selections.length > 0 ||
+			dpSync.profileName !== null ||
+			mmSync.namingDatabaseId !== null ||
+			mmSync.qualityDefinitionsDatabaseId !== null ||
+			mmSync.mediaSettingsDatabaseId !== null;
+
+		const compositeSyncStatus = hasSyncConfig
+			? computeCompositeSyncStatus([
+					syncStatus.qualityProfiles.syncStatus,
+					syncStatus.delayProfiles.syncStatus,
+					syncStatus.mediaManagement.syncStatus
+				])
+			: 'not_configured';
+
+		return {
+			...safe,
+			syncedProfileNames: qpSync.selections.map((s) => s.profileName),
+			compositeSyncStatus,
+			delayProfileName: dpSync.profileName,
+			namingConfigName: mmSync.namingConfigName,
+			qualityDefinitionsConfigName: mmSync.qualityDefinitionsConfigName,
+			mediaSettingsConfigName: mmSync.mediaSettingsConfigName,
+			upgradeEnabled: upgradeConfig?.enabled ?? false,
+			renameEnabled: renameConfig?.enabled ?? false,
+			cleanupEnabled: cleanupConfig?.enabled ?? false
+		};
+	});
+
+	return { instances: summaries };
 };
 
 export const actions = {

--- a/src/routes/arr/+page.svelte
+++ b/src/routes/arr/+page.svelte
@@ -14,7 +14,7 @@
 	import { createDataPageStore } from '$lib/client/stores/dataPage';
 	import { alertStore } from '$alerts/store';
 	import type { PageData } from './$types';
-	import type { ArrInstancePublic } from '$db/queries/arrInstances.ts';
+	import type { ArrInstanceSummary } from './+page.server.ts';
 
 	export let data: PageData;
 
@@ -30,11 +30,11 @@
 	// Modal state
 	let showDeleteModal = false;
 	let showInfoModal = false;
-	let selectedInstance: ArrInstancePublic | null = null;
+	let selectedInstance: ArrInstanceSummary | null = null;
 	let deleteFormElement: HTMLFormElement;
 
 	// Handle delete from view components
-	function handleDelete(event: CustomEvent<ArrInstancePublic>) {
+	function handleDelete(event: CustomEvent<ArrInstanceSummary>) {
 		selectedInstance = event.detail;
 		showDeleteModal = true;
 	}

--- a/src/routes/arr/views/CardView.svelte
+++ b/src/routes/arr/views/CardView.svelte
@@ -52,7 +52,7 @@
 	}
 </script>
 
-<CardGrid columns={4} flush>
+<CardGrid columns={3} flush>
 	{#each instances as instance}
 		<Card href="/arr/{instance.id}" hoverable>
 			<svelte:fragment slot="header">

--- a/src/routes/arr/views/CardView.svelte
+++ b/src/routes/arr/views/CardView.svelte
@@ -73,18 +73,9 @@
 						<h3 class="truncate text-sm font-semibold text-neutral-900 dark:text-neutral-100">
 							{instance.name}
 						</h3>
-						<span class="relative flex h-2 w-2 flex-shrink-0">
-							<span
-								class="absolute inline-flex h-full w-full animate-ping rounded-full opacity-75 {instance.enabled
-									? 'bg-emerald-400'
-									: 'bg-red-400'}"
-							></span>
-							<span
-								class="relative inline-flex h-2 w-2 rounded-full {instance.enabled
-									? 'bg-emerald-500'
-									: 'bg-red-500'}"
-							></span>
-						</span>
+						<Label variant={instance.enabled ? 'success' : 'secondary'} size="sm" rounded="md">
+							{instance.enabled ? 'Enabled' : 'Disabled'}
+						</Label>
 					</div>
 					<div class="flex shrink-0 items-center gap-0.5" on:click|stopPropagation|preventDefault>
 						<Button

--- a/src/routes/arr/views/CardView.svelte
+++ b/src/routes/arr/views/CardView.svelte
@@ -1,30 +1,27 @@
 <script lang="ts">
-	import { ExternalLink, Unlink } from 'lucide-svelte';
+	import { ExternalLink, Unlink, ArrowUpCircle, Type, Trash2 } from 'lucide-svelte';
 	import Button from '$ui/button/Button.svelte';
 	import Card from '$ui/card/Card.svelte';
 	import CardGrid from '$ui/card/CardGrid.svelte';
 	import Label from '$ui/label/Label.svelte';
-	import type { ArrInstancePublic } from '$db/queries/arrInstances.ts';
+	import type { ArrInstanceSummary } from '../+page.server.ts';
 	import radarrLogo from '$lib/client/assets/Radarr.svg';
 	import sonarrLogo from '$lib/client/assets/Sonarr.svg';
 	import { createEventDispatcher } from 'svelte';
 
-	export let instances: ArrInstancePublic[];
+	export let instances: ArrInstanceSummary[];
 
 	const dispatch = createEventDispatcher<{
-		delete: ArrInstancePublic;
+		delete: ArrInstanceSummary;
 	}>();
 
-	// Logo lookup by type
 	const logos: Record<string, string> = {
 		radarr: radarrLogo,
 		sonarr: sonarrLogo
 	};
 
-	// Track loaded images
 	let loadedImages: Set<number> = new Set();
 
-	// Get logo path based on arr type
 	function getLogoPath(type: string): string {
 		return logos[type] || '';
 	}
@@ -34,8 +31,11 @@
 		loadedImages = loadedImages;
 	}
 
-	// Handle delete click
-	function handleDeleteClick(e: MouseEvent, instance: ArrInstancePublic) {
+	function formatType(type: string): string {
+		return type.charAt(0).toUpperCase() + type.slice(1);
+	}
+
+	function handleDeleteClick(e: MouseEvent, instance: ArrInstanceSummary) {
 		e.stopPropagation();
 		e.preventDefault();
 		dispatch('delete', instance);
@@ -48,63 +48,138 @@
 	}
 </script>
 
-<CardGrid columns={1} flush>
+<CardGrid columns={4} flush>
 	{#each instances as instance}
 		<Card href="/arr/{instance.id}" hoverable>
-			<div class="flex items-center gap-4">
-				<!-- Left: Logo + Name -->
-				<div class="flex min-w-0 flex-1 items-center gap-3">
-					<div class="relative h-10 w-10 flex-shrink-0">
-						{#if !loadedImages.has(instance.id)}
-							<div
-								class="absolute inset-0 animate-pulse rounded-lg bg-neutral-200 dark:bg-neutral-700"
-							></div>
-						{/if}
-						<img
-							src={getLogoPath(instance.type)}
-							alt={`${instance.type} logo`}
-							class="h-10 w-10 rounded-lg {loadedImages.has(instance.id)
-								? 'opacity-100'
-								: 'opacity-0'}"
-							on:load={() => handleImageLoad(instance.id)}
-						/>
-					</div>
-					<div class="min-w-0">
+			<svelte:fragment slot="header">
+				<!-- svelte-ignore a11y-click-events-have-key-events a11y-no-static-element-interactions -->
+				<div class="flex items-center justify-between gap-2">
+					<div class="flex min-w-0 items-center gap-2">
+						<div class="relative h-6 w-6 flex-shrink-0">
+							{#if !loadedImages.has(instance.id)}
+								<div
+									class="absolute inset-0 animate-pulse rounded bg-neutral-200 dark:bg-neutral-700"
+								></div>
+							{/if}
+							<img
+								src={getLogoPath(instance.type)}
+								alt={`${instance.type} logo`}
+								class="h-6 w-6 rounded {loadedImages.has(instance.id)
+									? 'opacity-100'
+									: 'opacity-0'}"
+								on:load={() => handleImageLoad(instance.id)}
+							/>
+						</div>
 						<h3 class="truncate text-sm font-semibold text-neutral-900 dark:text-neutral-100">
 							{instance.name}
 						</h3>
-						<div class="mt-1 flex flex-col items-start gap-1">
-							{#if instance.enabled}
-								<Label variant="success" size="sm" rounded="md">Enabled</Label>
-							{:else}
-								<Label variant="secondary" size="sm" rounded="md">Disabled</Label>
-							{/if}
-							<Label variant="secondary" size="sm" rounded="md" mono>{instance.url}</Label>
-						</div>
+						<span class="relative flex h-2 w-2 flex-shrink-0">
+							<span
+								class="absolute inline-flex h-full w-full animate-ping rounded-full opacity-75 {instance.enabled
+									? 'bg-emerald-400'
+									: 'bg-red-400'}"
+							></span>
+							<span
+								class="relative inline-flex h-2 w-2 rounded-full {instance.enabled
+									? 'bg-emerald-500'
+									: 'bg-red-500'}"
+							></span>
+						</span>
+					</div>
+					<div class="flex shrink-0 items-center gap-0.5" on:click|stopPropagation|preventDefault>
+						<Button
+							icon={ExternalLink}
+							size="xs"
+							variant="ghost"
+							tooltip="Open in {formatType(instance.type)}"
+							on:click={(e) => handleExternalClick(e, instance.url)}
+						/>
+						<Button
+							icon={Unlink}
+							size="xs"
+							variant="ghost"
+							iconColor="text-red-600 dark:text-red-400"
+							tooltip="Unlink instance"
+							on:click={(e) => handleDeleteClick(e, instance)}
+						/>
 					</div>
 				</div>
+			</svelte:fragment>
 
-				<!-- svelte-ignore a11y-click-events-have-key-events a11y-no-static-element-interactions -->
-				<div class="flex flex-shrink-0 items-center gap-1" on:click|stopPropagation|preventDefault>
-					<Button
-						icon={ExternalLink}
-						size="xs"
-						variant="secondary"
-						title="Open in Arr"
-						ariaLabel="Open in Arr"
-						on:click={(e) => handleExternalClick(e, instance.url)}
-					/>
-					<Button
-						icon={Unlink}
-						size="xs"
-						variant="secondary"
-						iconColor="text-red-600 dark:text-red-400"
-						title="Unlink instance"
-						ariaLabel="Unlink instance"
-						on:click={(e) => handleDeleteClick(e, instance)}
-					/>
+			<div class="flex flex-1 flex-col gap-2">
+				<div>
+					<span class="text-xs font-medium text-neutral-500 dark:text-neutral-400"
+						>Quality Profiles:</span
+					>
+					{#if instance.syncedProfileNames.length > 0}
+						<div class="mt-1 flex flex-wrap gap-1">
+							{#each instance.syncedProfileNames as name}
+								<Label variant="secondary" size="sm" rounded="md">{name}</Label>
+							{/each}
+						</div>
+					{:else}
+						<span class="ml-1 text-xs text-neutral-400 dark:text-neutral-500">None</span>
+					{/if}
+				</div>
+				<div>
+					<span class="text-xs font-medium text-neutral-500 dark:text-neutral-400"
+						>Delay Profile:</span
+					>
+					{#if instance.delayProfileName}
+						<span class="ml-1"
+							><Label variant="secondary" size="sm" rounded="md">{instance.delayProfileName}</Label
+							></span
+						>
+					{:else}
+						<span class="ml-1 text-xs text-neutral-400 dark:text-neutral-500">None</span>
+					{/if}
+				</div>
+				<div>
+					<span class="text-xs font-medium text-neutral-500 dark:text-neutral-400"
+						>Media Management:</span
+					>
+					{#if instance.namingConfigName || instance.qualityDefinitionsConfigName || instance.mediaSettingsConfigName}
+						<div class="mt-1 flex flex-wrap gap-1">
+							{#if instance.namingConfigName}
+								<Label variant="secondary" size="sm" rounded="md"
+									>Naming: {instance.namingConfigName}</Label
+								>
+							{/if}
+							{#if instance.qualityDefinitionsConfigName}
+								<Label variant="secondary" size="sm" rounded="md"
+									>Quality Definitions: {instance.qualityDefinitionsConfigName}</Label
+								>
+							{/if}
+							{#if instance.mediaSettingsConfigName}
+								<Label variant="secondary" size="sm" rounded="md"
+									>Media Settings: {instance.mediaSettingsConfigName}</Label
+								>
+							{/if}
+						</div>
+					{:else}
+						<span class="ml-1 text-xs text-neutral-400 dark:text-neutral-500">None</span>
+					{/if}
 				</div>
 			</div>
+
+			<svelte:fragment slot="footer">
+				<div class="flex items-center gap-3 text-xs text-neutral-600 dark:text-neutral-400">
+					<div class="flex items-center gap-1">
+						<ArrowUpCircle size={12} class="text-amber-500 dark:text-amber-400" />
+						<span>Upgrades: {instance.upgradeEnabled ? 'On' : 'Off'}</span>
+					</div>
+					<span class="text-neutral-300 dark:text-neutral-600">&middot;</span>
+					<div class="flex items-center gap-1">
+						<Type size={12} class="text-blue-500 dark:text-blue-400" />
+						<span>Renames: {instance.renameEnabled ? 'On' : 'Off'}</span>
+					</div>
+					<span class="text-neutral-300 dark:text-neutral-600">&middot;</span>
+					<div class="flex items-center gap-1">
+						<Trash2 size={12} class="text-rose-500 dark:text-rose-400" />
+						<span>Cleanup: {instance.cleanupEnabled ? 'On' : 'Off'}</span>
+					</div>
+				</div>
+			</svelte:fragment>
 		</Card>
 	{/each}
 </CardGrid>

--- a/src/routes/arr/views/CardView.svelte
+++ b/src/routes/arr/views/CardView.svelte
@@ -31,6 +31,10 @@
 		loadedImages = loadedImages;
 	}
 
+	function checkLoaded(node: HTMLImageElement, id: number) {
+		if (node.complete) handleImageLoad(id);
+	}
+
 	function formatType(type: string): string {
 		return type.charAt(0).toUpperCase() + type.slice(1);
 	}
@@ -68,6 +72,7 @@
 									? 'opacity-100'
 									: 'opacity-0'}"
 								on:load={() => handleImageLoad(instance.id)}
+								use:checkLoaded={instance.id}
 							/>
 						</div>
 						<h3 class="truncate text-sm font-semibold text-neutral-900 dark:text-neutral-100">

--- a/src/routes/arr/views/TableView.svelte
+++ b/src/routes/arr/views/TableView.svelte
@@ -15,16 +15,13 @@
 		delete: ArrInstanceSummary;
 	}>();
 
-	// Logo lookup by type
 	const logos: Record<string, string> = {
 		radarr: radarrLogo,
 		sonarr: sonarrLogo
 	};
 
-	// Track loaded images
 	let loadedImages: Set<number> = new Set();
 
-	// Get logo path based on arr type
 	function getLogoPath(type: string): string {
 		return logos[type] || '';
 	}
@@ -34,7 +31,6 @@
 		loadedImages = loadedImages;
 	}
 
-	// Format type for display with proper casing
 	function formatType(type: string): string {
 		return type.charAt(0).toUpperCase() + type.slice(1);
 	}
@@ -43,18 +39,21 @@
 		return `/arr/${instance.id}`;
 	}
 
-	// Handle delete click
 	function handleDeleteClick(e: Event, instance: ArrInstanceSummary) {
 		e.stopPropagation();
 		e.preventDefault();
 		dispatch('delete', instance);
 	}
 
-	// Define table columns
 	const columns: Column<ArrInstanceSummary>[] = [
 		{ key: 'name', header: 'Name', align: 'left' },
-		{ key: 'url', header: 'URL', align: 'left' },
-		{ key: 'enabled', header: 'Enabled', align: 'center', width: 'w-24' }
+		{ key: 'qualityProfiles', header: 'Quality Profiles', align: 'left' },
+		{ key: 'delayProfile', header: 'Delay Profile', align: 'left' },
+		{ key: 'mediaManagement', header: 'Media Management', align: 'left' },
+		{ key: 'upgrades', header: 'Upgrades', align: 'center', width: 'w-24' },
+		{ key: 'renames', header: 'Renames', align: 'center', width: 'w-24' },
+		{ key: 'cleanup', header: 'Cleanup', align: 'center', width: 'w-24' },
+		{ key: 'enabled', header: 'Status', align: 'center', width: 'w-24' }
 	];
 </script>
 
@@ -62,27 +61,87 @@
 	<svelte:fragment slot="cell" let:row let:column>
 		{#if column.key === 'name'}
 			<div class="flex items-center gap-3">
-				<div class="relative h-8 w-8">
+				<div class="relative h-6 w-6 flex-shrink-0">
 					{#if !loadedImages.has(row.id)}
 						<div
-							class="absolute inset-0 animate-pulse rounded-lg bg-neutral-200 dark:bg-neutral-700"
+							class="absolute inset-0 animate-pulse rounded bg-neutral-200 dark:bg-neutral-700"
 						></div>
 					{/if}
 					<img
 						src={getLogoPath(row.type)}
 						alt={`${formatType(row.type)} logo`}
-						class="h-8 w-8 rounded-lg {loadedImages.has(row.id) ? 'opacity-100' : 'opacity-0'}"
+						class="h-6 w-6 rounded {loadedImages.has(row.id) ? 'opacity-100' : 'opacity-0'}"
 						on:load={() => handleImageLoad(row.id)}
 					/>
 				</div>
-				<div class="flex items-center gap-2">
-					<div class="font-medium text-neutral-900 dark:text-neutral-50">
-						{row.name}
-					</div>
-				</div>
+				<span class="font-medium text-neutral-900 dark:text-neutral-50">{row.name}</span>
+				<span class="relative flex h-2 w-2 flex-shrink-0">
+					<span
+						class="absolute inline-flex h-full w-full animate-ping rounded-full opacity-75 {row.enabled
+							? 'bg-emerald-400'
+							: 'bg-red-400'}"
+					></span>
+					<span
+						class="relative inline-flex h-2 w-2 rounded-full {row.enabled
+							? 'bg-emerald-500'
+							: 'bg-red-500'}"
+					></span>
+				</span>
 			</div>
-		{:else if column.key === 'url'}
-			<Label variant="secondary" size="sm" rounded="md" mono>{row.url}</Label>
+		{:else if column.key === 'qualityProfiles'}
+			{#if row.syncedProfileNames.length > 0}
+				<div class="flex flex-wrap gap-1">
+					{#each row.syncedProfileNames as name}
+						<Label variant="secondary" size="sm" rounded="md">{name}</Label>
+					{/each}
+				</div>
+			{:else}
+				<span class="text-xs text-neutral-400 dark:text-neutral-500">None</span>
+			{/if}
+		{:else if column.key === 'delayProfile'}
+			{#if row.delayProfileName}
+				<Label variant="secondary" size="sm" rounded="md">{row.delayProfileName}</Label>
+			{:else}
+				<span class="text-xs text-neutral-400 dark:text-neutral-500">None</span>
+			{/if}
+		{:else if column.key === 'mediaManagement'}
+			{#if row.namingConfigName || row.qualityDefinitionsConfigName || row.mediaSettingsConfigName}
+				<div class="flex flex-wrap gap-1">
+					{#if row.namingConfigName}
+						<Label variant="secondary" size="sm" rounded="md">Naming: {row.namingConfigName}</Label>
+					{/if}
+					{#if row.qualityDefinitionsConfigName}
+						<Label variant="secondary" size="sm" rounded="md"
+							>Quality Definitions: {row.qualityDefinitionsConfigName}</Label
+						>
+					{/if}
+					{#if row.mediaSettingsConfigName}
+						<Label variant="secondary" size="sm" rounded="md"
+							>Media Settings: {row.mediaSettingsConfigName}</Label
+						>
+					{/if}
+				</div>
+			{:else}
+				<span class="text-xs text-neutral-400 dark:text-neutral-500">None</span>
+			{/if}
+		{:else if column.key === 'upgrades'}
+			<div class="flex justify-center">
+				<Label variant={row.upgradeEnabled ? 'success' : 'secondary'} size="sm" rounded="md"
+					>{row.upgradeEnabled ? 'On' : 'Off'}</Label
+				>
+			</div>
+		{:else if column.key === 'renames'}
+			<div class="flex justify-center">
+				<Label variant={row.renameEnabled ? 'success' : 'secondary'} size="sm" rounded="md"
+					>{row.renameEnabled ? 'On' : 'Off'}</Label
+				>
+			</div>
+		{:else if column.key === 'cleanup'}
+			<div class="flex justify-center">
+				<Label variant={row.cleanupEnabled ? 'success' : 'secondary'} size="sm" rounded="md"
+					>{row.cleanupEnabled ? 'On' : 'Off'}</Label
+				>
+			</div>
 		{:else if column.key === 'enabled'}
 			<div class="flex justify-center">
 				{#if row.enabled}

--- a/src/routes/arr/views/TableView.svelte
+++ b/src/routes/arr/views/TableView.svelte
@@ -31,6 +31,10 @@
 		loadedImages = loadedImages;
 	}
 
+	function checkLoaded(node: HTMLImageElement, id: number) {
+		if (node.complete) handleImageLoad(id);
+	}
+
 	function formatType(type: string): string {
 		return type.charAt(0).toUpperCase() + type.slice(1);
 	}
@@ -72,6 +76,7 @@
 						alt={`${formatType(row.type)} logo`}
 						class="h-6 w-6 rounded {loadedImages.has(row.id) ? 'opacity-100' : 'opacity-0'}"
 						on:load={() => handleImageLoad(row.id)}
+						use:checkLoaded={row.id}
 					/>
 				</div>
 				<span class="font-medium text-neutral-900 dark:text-neutral-50">{row.name}</span>

--- a/src/routes/arr/views/TableView.svelte
+++ b/src/routes/arr/views/TableView.svelte
@@ -75,18 +75,6 @@
 					/>
 				</div>
 				<span class="font-medium text-neutral-900 dark:text-neutral-50">{row.name}</span>
-				<span class="relative flex h-2 w-2 flex-shrink-0">
-					<span
-						class="absolute inline-flex h-full w-full animate-ping rounded-full opacity-75 {row.enabled
-							? 'bg-emerald-400'
-							: 'bg-red-400'}"
-					></span>
-					<span
-						class="relative inline-flex h-2 w-2 rounded-full {row.enabled
-							? 'bg-emerald-500'
-							: 'bg-red-500'}"
-					></span>
-				</span>
 			</div>
 		{:else if column.key === 'qualityProfiles'}
 			{#if row.syncedProfileNames.length > 0}

--- a/src/routes/arr/views/TableView.svelte
+++ b/src/routes/arr/views/TableView.svelte
@@ -4,15 +4,15 @@
 	import Button from '$ui/button/Button.svelte';
 	import Label from '$ui/label/Label.svelte';
 	import type { Column } from '$ui/table/types';
-	import type { ArrInstancePublic } from '$db/queries/arrInstances.ts';
+	import type { ArrInstanceSummary } from '../+page.server.ts';
 	import radarrLogo from '$lib/client/assets/Radarr.svg';
 	import sonarrLogo from '$lib/client/assets/Sonarr.svg';
 	import { createEventDispatcher } from 'svelte';
 
-	export let instances: ArrInstancePublic[];
+	export let instances: ArrInstanceSummary[];
 
 	const dispatch = createEventDispatcher<{
-		delete: ArrInstancePublic;
+		delete: ArrInstanceSummary;
 	}>();
 
 	// Logo lookup by type
@@ -39,19 +39,19 @@
 		return type.charAt(0).toUpperCase() + type.slice(1);
 	}
 
-	function getRowHref(instance: ArrInstancePublic): string {
+	function getRowHref(instance: ArrInstanceSummary): string {
 		return `/arr/${instance.id}`;
 	}
 
 	// Handle delete click
-	function handleDeleteClick(e: Event, instance: ArrInstancePublic) {
+	function handleDeleteClick(e: Event, instance: ArrInstanceSummary) {
 		e.stopPropagation();
 		e.preventDefault();
 		dispatch('delete', instance);
 	}
 
 	// Define table columns
-	const columns: Column<ArrInstancePublic>[] = [
+	const columns: Column<ArrInstanceSummary>[] = [
 		{ key: 'name', header: 'Name', align: 'left' },
 		{ key: 'url', header: 'URL', align: 'left' },
 		{ key: 'enabled', header: 'Enabled', align: 'center', width: 'w-24' }

--- a/src/routes/databases/+page.server.ts
+++ b/src/routes/databases/+page.server.ts
@@ -1,14 +1,68 @@
 import { fail, redirect } from '@sveltejs/kit';
 import type { Actions, ServerLoad } from '@sveltejs/kit';
 import { pcdManager } from '$pcd/core/manager.ts';
+import type { DatabaseInstancePublic } from '$db/queries/databaseInstances.ts';
+import { db } from '$db/db.ts';
 import { logger } from '$logger/logger.ts';
+
+export interface DatabaseInstanceSummary extends DatabaseInstancePublic {
+	qualityProfileCount: number;
+	customFormatCount: number;
+	delayProfileCount: number;
+	linkedArrCount: number;
+}
 
 export const load: ServerLoad = () => {
 	const databases = pcdManager.getAllPublic();
 
-	return {
-		databases
-	};
+	const summaries: DatabaseInstanceSummary[] = databases.map((database) => {
+		const cache = pcdManager.getCache(database.id);
+
+		let qualityProfileCount = 0;
+		let customFormatCount = 0;
+		let delayProfileCount = 0;
+
+		if (cache) {
+			qualityProfileCount =
+				cache.queryOne<{ count: number }>('SELECT COUNT(*) as count FROM quality_profiles')
+					?.count ?? 0;
+			customFormatCount =
+				cache.queryOne<{ count: number }>('SELECT COUNT(*) as count FROM custom_formats')?.count ??
+				0;
+			delayProfileCount =
+				cache.queryOne<{ count: number }>('SELECT COUNT(*) as count FROM delay_profiles')?.count ??
+				0;
+		}
+
+		const linkedArrCount =
+			db.queryFirst<{ count: number }>(
+				`SELECT COUNT(DISTINCT instance_id) as count FROM (
+				SELECT instance_id FROM arr_sync_quality_profiles WHERE database_id = ?
+				UNION
+				SELECT instance_id FROM arr_sync_delay_profiles_config WHERE database_id = ?
+				UNION
+				SELECT instance_id FROM arr_sync_media_management
+					WHERE naming_database_id = ?
+					OR quality_definitions_database_id = ?
+					OR media_settings_database_id = ?
+			)`,
+				database.id,
+				database.id,
+				database.id,
+				database.id,
+				database.id
+			)?.count ?? 0;
+
+		return {
+			...database,
+			qualityProfileCount,
+			customFormatCount,
+			delayProfileCount,
+			linkedArrCount
+		};
+	});
+
+	return { databases: summaries };
 };
 
 export const actions = {

--- a/src/routes/databases/+page.svelte
+++ b/src/routes/databases/+page.svelte
@@ -14,7 +14,7 @@
 	import { createDataPageStore } from '$lib/client/stores/dataPage';
 	import { alertStore } from '$alerts/store';
 	import type { PageData } from './$types';
-	import type { DatabaseInstancePublic } from '$db/queries/databaseInstances.ts';
+	import type { DatabaseInstanceSummary } from './+page.server.ts';
 
 	export let data: PageData;
 
@@ -30,12 +30,12 @@
 	// Modal state
 	let showUnlinkModal = false;
 	let showInfoModal = false;
-	let selectedDatabase: DatabaseInstancePublic | null = null;
+	let selectedDatabase: DatabaseInstanceSummary | null = null;
 	let unlinkFormElement: HTMLFormElement;
 	let unlinkLoading = false;
 
 	// Handle unlink from view components
-	function handleUnlink(event: CustomEvent<DatabaseInstancePublic>) {
+	function handleUnlink(event: CustomEvent<DatabaseInstanceSummary>) {
 		selectedDatabase = event.detail;
 		showUnlinkModal = true;
 	}

--- a/src/routes/databases/components/DatabaseAvatar.svelte
+++ b/src/routes/databases/components/DatabaseAvatar.svelte
@@ -17,7 +17,13 @@
 	let imgEl: HTMLImageElement | null = null;
 	let lastSrc = '';
 
+	const LOGO_OVERRIDES: Record<string, string> = {
+		'https://github.com/Dictionarry-Hub/trash-pcd':
+			'https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/trash-guides.png'
+	};
+
 	function getGitHubAvatar(url: string): string {
+		if (LOGO_OVERRIDES[url]) return LOGO_OVERRIDES[url];
 		const match = url.match(/github\.com\/([^\/]+)\//);
 		if (match) {
 			return `/databases/avatar/${match[1]}`;

--- a/src/routes/databases/views/CardView.svelte
+++ b/src/routes/databases/views/CardView.svelte
@@ -1,24 +1,29 @@
 <script lang="ts">
-	import { ExternalLink, Unlink, Lock, Code } from 'lucide-svelte';
+	import {
+		ExternalLink,
+		Unlink,
+		Lock,
+		Code,
+		RefreshCw,
+		Clock,
+		GitPullRequest
+	} from 'lucide-svelte';
 	import Button from '$ui/button/Button.svelte';
 	import Card from '$ui/card/Card.svelte';
 	import CardGrid from '$ui/card/CardGrid.svelte';
 	import Label from '$ui/label/Label.svelte';
-	import type { DatabaseInstancePublic } from '$db/queries/databaseInstances.ts';
+	import type { DatabaseInstanceSummary } from '../+page.server.ts';
 	import { formatDateTime } from '$shared/utils/dates';
 	import { serverTimezone } from '$lib/client/stores/timezone';
 	import { createEventDispatcher } from 'svelte';
 	import DatabaseAvatar from '../components/DatabaseAvatar.svelte';
 
-	export let databases: DatabaseInstancePublic[];
+	export let databases: DatabaseInstanceSummary[];
 
 	const dispatch = createEventDispatcher<{
-		unlink: DatabaseInstancePublic;
+		unlink: DatabaseInstanceSummary;
 	}>();
 
-	// Avatar handled by DatabaseAvatar component
-
-	// Format sync strategy for display
 	function formatSyncStrategy(minutes: number): string {
 		if (minutes === 0) return 'Manual';
 		if (minutes < 60) return `Every ${minutes} min`;
@@ -27,7 +32,6 @@
 		return `Every ${minutes / 1440}d`;
 	}
 
-	// Format last synced date
 	function formatLastSynced(date: string | null): string {
 		if (!date) return 'Never';
 		return formatDateTime(date, $serverTimezone, {
@@ -38,8 +42,7 @@
 		});
 	}
 
-	// Handle unlink click
-	function handleUnlinkClick(e: MouseEvent, database: DatabaseInstancePublic) {
+	function handleUnlinkClick(e: MouseEvent, database: DatabaseInstanceSummary) {
 		e.stopPropagation();
 		e.preventDefault();
 		dispatch('unlink', database);
@@ -52,17 +55,17 @@
 	}
 </script>
 
-<CardGrid columns={1} flush>
+<CardGrid columns={3} flush>
 	{#each databases as database}
 		<Card href="/databases/{database.id}" hoverable>
-			<div class="flex items-center gap-3">
-				<!-- Top row: Avatar, Name, Action buttons -->
-				<DatabaseAvatar name={database.name} repoUrl={database.repository_url} size="md" />
-				<div class="min-w-0 flex-1">
-					<div class="flex items-center gap-2">
-						<span class="truncate font-medium text-neutral-900 dark:text-neutral-100">
+			<svelte:fragment slot="header">
+				<!-- svelte-ignore a11y-click-events-have-key-events a11y-no-static-element-interactions -->
+				<div class="flex items-center justify-between gap-2">
+					<div class="flex min-w-0 items-center gap-2">
+						<DatabaseAvatar name={database.name} repoUrl={database.repository_url} size="sm" />
+						<h3 class="truncate text-sm font-semibold text-neutral-900 dark:text-neutral-100">
 							{database.name}
-						</span>
+						</h3>
 						{#if database.is_private}
 							<Label variant="secondary" size="sm" rounded="md" mono>
 								<Lock size={12} />
@@ -76,40 +79,59 @@
 							</Label>
 						{/if}
 					</div>
-					<div class="mt-3 flex flex-wrap items-center gap-2">
-						<Label variant="secondary" size="sm" rounded="md" mono>
-							{database.repository_url.replace('https://github.com/', '')}
-						</Label>
-						<Label variant="secondary" size="sm" rounded="md" mono>
-							{formatSyncStrategy(database.sync_strategy)}
-						</Label>
-						<Label variant="secondary" size="sm" rounded="md" mono>
-							{formatLastSynced(database.last_synced_at)}
-						</Label>
+					<div class="flex shrink-0 items-center gap-0.5" on:click|stopPropagation|preventDefault>
+						<Button
+							icon={ExternalLink}
+							size="xs"
+							variant="ghost"
+							tooltip="View on GitHub"
+							on:click={(e) => handleExternalClick(e, database.repository_url)}
+						/>
+						<Button
+							icon={Unlink}
+							size="xs"
+							variant="ghost"
+							iconColor="text-red-600 dark:text-red-400"
+							tooltip="Unlink database"
+							on:click={(e) => handleUnlinkClick(e, database)}
+						/>
 					</div>
 				</div>
+			</svelte:fragment>
 
-				<!-- svelte-ignore a11y-click-events-have-key-events a11y-no-static-element-interactions -->
-				<div class="flex flex-shrink-0 items-center gap-1" on:click|stopPropagation|preventDefault>
-					<Button
-						icon={ExternalLink}
-						size="xs"
-						variant="secondary"
-						title="View on GitHub"
-						ariaLabel="View on GitHub"
-						on:click={(e) => handleExternalClick(e, database.repository_url)}
-					/>
-					<Button
-						icon={Unlink}
-						size="xs"
-						variant="secondary"
-						iconColor="text-red-600 dark:text-red-400"
-						title="Unlink database"
-						ariaLabel="Unlink database"
-						on:click={(e) => handleUnlinkClick(e, database)}
-					/>
-				</div>
+			<div class="flex flex-wrap gap-1">
+				<Label variant="secondary" size="sm" rounded="md" mono>
+					{database.repository_url.replace('https://github.com/', '')}
+				</Label>
+				<Label variant="secondary" size="sm" rounded="md"
+					>{database.qualityProfileCount} Quality Profiles</Label
+				>
+				<Label variant="secondary" size="sm" rounded="md"
+					>{database.customFormatCount} Custom Formats</Label
+				>
+				<Label variant="secondary" size="sm" rounded="md"
+					>{database.delayProfileCount} Delay Profiles</Label
+				>
 			</div>
+
+			<svelte:fragment slot="footer">
+				<div class="flex items-center gap-3 text-xs text-neutral-600 dark:text-neutral-400">
+					<div class="flex items-center gap-1">
+						<RefreshCw size={12} class="text-blue-500 dark:text-blue-400" />
+						<span>Sync Strategy: {formatSyncStrategy(database.sync_strategy)}</span>
+					</div>
+					<span class="text-neutral-300 dark:text-neutral-600">&middot;</span>
+					<div class="flex items-center gap-1">
+						<Clock size={12} class="text-amber-500 dark:text-amber-400" />
+						<span>Last Synced: {formatLastSynced(database.last_synced_at)}</span>
+					</div>
+					<span class="text-neutral-300 dark:text-neutral-600">&middot;</span>
+					<div class="flex items-center gap-1">
+						<GitPullRequest size={12} class="text-violet-500 dark:text-violet-400" />
+						<span>Auto Pull: {database.auto_pull ? 'On' : 'Off'}</span>
+					</div>
+				</div>
+			</svelte:fragment>
 		</Card>
 	{/each}
 </CardGrid>

--- a/src/routes/databases/views/TableView.svelte
+++ b/src/routes/databases/views/TableView.svelte
@@ -4,21 +4,18 @@
 	import Button from '$ui/button/Button.svelte';
 	import Label from '$ui/label/Label.svelte';
 	import type { Column } from '$ui/table/types';
-	import type { DatabaseInstancePublic } from '$db/queries/databaseInstances.ts';
+	import type { DatabaseInstanceSummary } from '../+page.server.ts';
 	import { formatDateTime } from '$shared/utils/dates';
 	import { serverTimezone } from '$lib/client/stores/timezone';
 	import { createEventDispatcher } from 'svelte';
 	import DatabaseAvatar from '../components/DatabaseAvatar.svelte';
 
-	export let databases: DatabaseInstancePublic[];
+	export let databases: DatabaseInstanceSummary[];
 
 	const dispatch = createEventDispatcher<{
-		unlink: DatabaseInstancePublic;
+		unlink: DatabaseInstanceSummary;
 	}>();
 
-	// Avatar handled by DatabaseAvatar component
-
-	// Format sync strategy for display
 	function formatSyncStrategy(minutes: number): string {
 		if (minutes === 0) return 'Manual';
 		if (minutes < 60) return `Every ${minutes} min`;
@@ -27,7 +24,6 @@
 		return `Every ${minutes / 1440}d`;
 	}
 
-	// Format last synced date
 	function formatLastSynced(date: string | null): string {
 		if (!date) return 'Never';
 		return formatDateTime(date, $serverTimezone, {
@@ -38,21 +34,20 @@
 		});
 	}
 
-	function getRowHref(database: DatabaseInstancePublic): string {
+	function getRowHref(database: DatabaseInstanceSummary): string {
 		return `/databases/${database.id}`;
 	}
 
-	// Handle unlink click
-	function handleUnlinkClick(e: Event, database: DatabaseInstancePublic) {
+	function handleUnlinkClick(e: Event, database: DatabaseInstanceSummary) {
 		e.stopPropagation();
 		e.preventDefault();
 		dispatch('unlink', database);
 	}
 
-	// Define table columns
-	const columns: Column<DatabaseInstancePublic>[] = [
+	const columns: Column<DatabaseInstanceSummary>[] = [
 		{ key: 'name', header: 'Name', align: 'left' },
 		{ key: 'repository_url', header: 'Repository', align: 'left' },
+		{ key: 'content', header: 'Content', align: 'left' },
 		{ key: 'sync_strategy', header: 'Sync', align: 'left', width: 'w-32' },
 		{ key: 'last_synced_at', header: 'Last Synced', align: 'left', width: 'w-40' }
 	];
@@ -85,6 +80,12 @@
 			<Label variant="secondary" size="sm" rounded="md" mono>
 				{row.repository_url.replace('https://github.com/', '')}
 			</Label>
+		{:else if column.key === 'content'}
+			<div class="flex flex-wrap gap-1">
+				<Label variant="secondary" size="sm" rounded="md">{row.qualityProfileCount} Profiles</Label>
+				<Label variant="secondary" size="sm" rounded="md">{row.customFormatCount} Formats</Label>
+				<Label variant="secondary" size="sm" rounded="md">{row.delayProfileCount} Delay</Label>
+			</div>
 		{:else if column.key === 'sync_strategy'}
 			<Label variant="secondary" size="sm" rounded="md" mono>
 				{formatSyncStrategy(row.sync_strategy)}


### PR DESCRIPTION
Redesign arr and database list views with richer data and consistent card/table patterns.

**Arr views**
- Card view uses Card header/body/footer slots with 3-column grid
- Body shows synced quality profiles, delay profile, and media management config names
- Footer shows upgrade/rename/cleanup enabled status with colored icons
- Table view adds columns for sync config and job status, removes URL column

**Database views**
- Card view uses Card header/body/footer slots with 3-column grid
- Body shows repo URL and entity counts (quality profiles, custom formats, delay profiles)
- Footer shows sync strategy, last synced, and auto-pull status with colored icons
- Table view adds content counts column

**Shared fixes**
- Fix logo not loading on hard refresh (SSR hydration timing)
- Override trash-pcd avatar with Trash Guides icon