### PR TITLE
feat: add optional external_url to arr instances

### DIFF
--- a/docs/api/v1/schemas/arr.yaml
+++ b/docs/api/v1/schemas/arr.yaml
@@ -20,7 +20,16 @@ ArrInstance:
       $ref: '#/ArrType'
     url:
       type: string
-      description: Instance URL
+      description: Instance URL used by Profilarr's backend for API calls
+    external_url:
+      type: string
+      nullable: true
+      description: |
+        Optional external/browser-facing URL. When set, the UI uses this for
+        "Open in Radarr/Sonarr" browser links while Profilarr's backend continues
+        to call the instance using `url`. Useful for reverse-proxied deployments
+        where the internal and external hostnames differ.
+      example: https://radarr.example.com
     tags:
       type: string
       nullable: true

--- a/src/lib/api/v1.d.ts
+++ b/src/lib/api/v1.d.ts
@@ -1124,8 +1124,16 @@ export interface components {
 			/** @description Display name */
 			name: string;
 			type: components['schemas']['ArrType'];
-			/** @description Instance URL */
+			/** @description Instance URL used by Profilarr's backend for API calls */
 			url: string;
+			/**
+			 * @description Optional external/browser-facing URL. When set, the UI uses this for
+			 *     "Open in Radarr/Sonarr" browser links while Profilarr's backend continues
+			 *     to call the instance using `url`. Useful for reverse-proxied deployments
+			 *     where the internal and external hostnames differ.
+			 * @example https://radarr.example.com
+			 */
+			external_url?: string | null;
 			/** @description JSON array of tags */
 			tags?: string | null;
 			/** @description Whether the instance is active (0 or 1) */
@@ -1922,6 +1930,7 @@ export interface operations {
 					 * @example {
 					 *       "version": "2.0.0",
 					 *       "uptime": 86400,
+					 *       "timezone": "America/New_York",
 					 *       "databases": [
 					 *         {
 					 *           "id": 1,

--- a/src/lib/client/utils/arrDisplayUrl.ts
+++ b/src/lib/client/utils/arrDisplayUrl.ts
@@ -1,0 +1,5 @@
+export function getDisplayUrl(instance: { url: string; external_url?: string | null }): string {
+	const override = instance.external_url?.trim();
+	const chosen = override && override.length > 0 ? override : instance.url;
+	return chosen.replace(/\/$/, '');
+}

--- a/src/lib/server/db/migrations.ts
+++ b/src/lib/server/db/migrations.ts
@@ -60,6 +60,7 @@ import { migration as migration055 } from './migrations/055_create_login_attempt
 import { migration as migration056 } from './migrations/056_add_local_bypass.ts';
 import { migration as migration057 } from './migrations/057_hash_api_key.ts';
 import { migration as migration058 } from './migrations/058_add_onboarding_shown.ts';
+import { migration as migration059 } from './migrations/059_add_external_url_to_arr_instances.ts';
 
 export interface Migration {
 	version: number;
@@ -338,7 +339,8 @@ export function loadMigrations(): Migration[] {
 		migration055,
 		migration056,
 		migration057,
-		migration058
+		migration058,
+		migration059
 	];
 
 	// Sort by version number

--- a/src/lib/server/db/migrations/059_add_external_url_to_arr_instances.ts
+++ b/src/lib/server/db/migrations/059_add_external_url_to_arr_instances.ts
@@ -1,0 +1,24 @@
+import type { Migration } from '../migrations.ts';
+
+/**
+ * Migration 059: Add external_url to arr_instances
+ *
+ * Optional browser-facing URL for "Open in Radarr/Sonarr" links. When set,
+ * the UI uses external_url for display links while Profilarr's backend
+ * continues to call the instance using `url`. Lets users behind a reverse
+ * proxy with SSO/OIDC point the backend at an internal hostname and the
+ * browser at the external one.
+ */
+
+export const migration: Migration = {
+	version: 59,
+	name: 'Add external_url to arr_instances',
+
+	up: `
+		ALTER TABLE arr_instances ADD COLUMN external_url TEXT;
+	`,
+
+	down: `
+		ALTER TABLE arr_instances DROP COLUMN external_url;
+	`
+};

--- a/src/lib/server/db/queries/arrInstances.ts
+++ b/src/lib/server/db/queries/arrInstances.ts
@@ -8,6 +8,7 @@ export interface ArrInstance {
 	name: string;
 	type: string;
 	url: string;
+	external_url: string | null;
 	api_key: string;
 	tags: string | null;
 	enabled: number;
@@ -23,6 +24,7 @@ export interface CreateArrInstanceInput {
 	name: string;
 	type: string;
 	url: string;
+	externalUrl?: string | null;
 	apiKey: string;
 	tags?: string[];
 	enabled?: boolean;
@@ -32,6 +34,7 @@ export interface UpdateArrInstanceInput {
 	name?: string;
 	type?: string;
 	url?: string;
+	externalUrl?: string | null;
 	apiKey?: string;
 	tags?: string[];
 	enabled?: boolean;
@@ -50,11 +53,12 @@ export const arrInstancesQueries = {
 		const enabled = input.enabled !== false ? 1 : 0;
 
 		db.execute(
-			`INSERT INTO arr_instances (name, type, url, api_key, tags, enabled)
-       VALUES (?, ?, ?, ?, ?, ?)`,
+			`INSERT INTO arr_instances (name, type, url, external_url, api_key, tags, enabled)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
 			input.name,
 			input.type,
 			input.url,
+			input.externalUrl ?? null,
 			input.apiKey,
 			tagsJson,
 			enabled
@@ -113,6 +117,10 @@ export const arrInstancesQueries = {
 		if (input.url !== undefined) {
 			updates.push('url = ?');
 			params.push(input.url);
+		}
+		if (input.externalUrl !== undefined) {
+			updates.push('external_url = ?');
+			params.push(input.externalUrl);
 		}
 		if (input.apiKey !== undefined) {
 			updates.push('api_key = ?');

--- a/src/lib/server/db/schema.sql
+++ b/src/lib/server/db/schema.sql
@@ -1,7 +1,7 @@
 -- Profilarr Database Schema
 -- This file documents the current database schema after all migrations
 -- DO NOT execute this file directly - use migrations instead
--- Last updated: 2026-02-20
+-- Last updated: 2026-04-20
 
 -- ==============================================================================
 -- TABLE: migrations
@@ -18,7 +18,7 @@ CREATE TABLE IF NOT EXISTS migrations (
 -- ==============================================================================
 -- TABLE: arr_instances
 -- Purpose: Store configuration for *arr application instances (Radarr, Sonarr, etc.)
--- Migration: 001_create_arr_instances.ts, 053_add_library_refresh_to_arr_instances.ts
+-- Migration: 001_create_arr_instances.ts, 053_add_library_refresh_to_arr_instances.ts, 059_add_external_url_to_arr_instances.ts
 -- ==============================================================================
 
 CREATE TABLE arr_instances (
@@ -29,7 +29,8 @@ CREATE TABLE arr_instances (
     type TEXT NOT NULL,                     -- Instance type: radarr, sonarr, readarr, lidarr, prowlarr
 
     -- Connection details
-    url TEXT NOT NULL,                      -- Base URL (e.g., "http://localhost:7878")
+    url TEXT NOT NULL,                      -- Base URL used by Profilarr's backend (e.g., "http://localhost:7878")
+    external_url TEXT,                      -- Optional browser-facing URL for UI links (Migration 059); falls back to url when NULL
     api_key TEXT NOT NULL,                  -- API key for authentication
 
     -- Configuration

--- a/src/routes/arr/[id]/library/+page.svelte
+++ b/src/routes/arr/[id]/library/+page.svelte
@@ -11,6 +11,7 @@
 	import { applySmartFilters } from '$ui/filter/match';
 	import type { ViewMode } from '$lib/client/stores/dataPage';
 	import { createProgressiveList } from '$lib/client/utils/progressiveList';
+	import { getDisplayUrl } from '$lib/client/utils/arrDisplayUrl.ts';
 	import InfoModal from '$ui/modal/InfoModal.svelte';
 
 	import LibraryActionBar from './components/LibraryActionBar.svelte';
@@ -280,7 +281,7 @@
 	}
 
 	function handleOpen() {
-		const baseUrl = data.instance.url.replace(/\/$/, '');
+		const baseUrl = getDisplayUrl(data.instance);
 		window.open(baseUrl, '_blank', 'noopener,noreferrer');
 	}
 
@@ -537,7 +538,7 @@
 	// Radarr Data & Columns
 	// ==========================================================================
 
-	$: baseUrl = data.instance.url.replace(/\/$/, '');
+	$: baseUrl = getDisplayUrl(data.instance);
 
 	$: radarrLibrary = library as RadarrLibraryItem[];
 	$: allMoviesWithFiles = isRadarr ? radarrLibrary.filter((m) => m.hasFile) : [];

--- a/src/routes/arr/[id]/settings/+page.server.ts
+++ b/src/routes/arr/[id]/settings/+page.server.ts
@@ -36,6 +36,8 @@ export const actions: Actions = {
 		const formData = await request.formData();
 		const name = formData.get('name')?.toString().trim();
 		const url = formData.get('url')?.toString().trim();
+		const externalUrlRaw = formData.get('external_url')?.toString().trim() ?? '';
+		const externalUrl = externalUrlRaw === '' ? null : externalUrlRaw;
 		const apiKey = formData.get('api_key')?.toString().trim() || instance.api_key;
 		const tagsJson = formData.get('tags')?.toString() || '';
 		const enabled = formData.get('enabled')?.toString() === '1';
@@ -75,6 +77,7 @@ export const actions: Actions = {
 			arrInstancesQueries.update(id, {
 				name,
 				url,
+				externalUrl,
 				apiKey,
 				tags,
 				enabled,
@@ -91,6 +94,7 @@ export const actions: Actions = {
 					name,
 					type: instance.type,
 					url,
+					externalUrl,
 					libraryRefreshInterval,
 					cleanup: cleanup ? { enabled: cleanup.enabled, cron: cleanup.cron } : null
 				}

--- a/src/routes/arr/components/InstanceForm.svelte
+++ b/src/routes/arr/components/InstanceForm.svelte
@@ -44,6 +44,7 @@
 				name: instance.name,
 				type: instance.type,
 				url: instance.url,
+				externalUrl: instance.external_url ?? '',
 				apiKey: '', // Never pre-populate for security
 				enabled: instance.enabled ? 'true' : 'false',
 				tags: JSON.stringify(parseTags(instance.tags)),
@@ -56,6 +57,7 @@
 				name: '',
 				type: initialType,
 				url: '',
+				externalUrl: '',
 				apiKey: '',
 				enabled: 'true',
 				tags: '[]',
@@ -71,6 +73,7 @@
 	$: name = ($current.name ?? '') as string;
 	$: type = ($current.type ?? '') as string;
 	$: url = ($current.url ?? '') as string;
+	$: externalUrl = ($current.externalUrl ?? '') as string;
 	$: apiKey = ($current.apiKey ?? '') as string;
 	$: enabled = ($current.enabled ?? 'true') as string;
 	$: tags = JSON.parse(($current.tags ?? '[]') as string) as string[];
@@ -197,6 +200,7 @@
 				name,
 				type,
 				url,
+				externalUrl,
 				apiKey: '',
 				enabled,
 				tags: JSON.stringify(tags),
@@ -348,6 +352,16 @@
 				description="Use container name if on the same Docker network, e.g. http://radarr:7878"
 				required
 				on:input={(e) => update('url', e.detail)}
+			/>
+			<!-- External URL Row -->
+			<FormInput
+				label="External URL"
+				name="external_url"
+				type="url"
+				value={externalUrl}
+				placeholder="https://radarr.example.com"
+				description="Optional. Used for 'Open in Radarr/Sonarr' browser links. Leave blank to reuse the URL above. Set this when Profilarr reaches the instance internally but users reach it through a reverse proxy."
+				on:input={(e) => update('externalUrl', e.detail)}
 			/>
 			<!-- API Key + Test Connection Row -->
 			<div class="flex flex-col gap-4 md:flex-row md:items-end">
@@ -501,6 +515,7 @@
 	<input type="hidden" name="name" value={name} />
 	<input type="hidden" name="type" value={type} />
 	<input type="hidden" name="url" value={url} />
+	<input type="hidden" name="external_url" value={externalUrl} />
 	<input type="hidden" name="api_key" value={apiKey} />
 	<input type="hidden" name="enabled" value={enabled === 'true' ? '1' : '0'} />
 	<input type="hidden" name="tags" value={JSON.stringify(tags)} />

--- a/src/routes/arr/new/+page.server.ts
+++ b/src/routes/arr/new/+page.server.ts
@@ -16,6 +16,8 @@ export const actions = {
 		const name = formData.get('name')?.toString().trim();
 		const type = formData.get('type')?.toString().trim();
 		const url = formData.get('url')?.toString().trim();
+		const externalUrlRaw = formData.get('external_url')?.toString().trim() ?? '';
+		const externalUrl = externalUrlRaw === '' ? null : externalUrlRaw;
 		const apiKey = formData.get('api_key')?.toString().trim();
 		const tagsJson = formData.get('tags')?.toString().trim();
 		const enabled = formData.get('enabled')?.toString() === '1';
@@ -94,6 +96,7 @@ export const actions = {
 				name,
 				type,
 				url,
+				externalUrl,
 				apiKey,
 				tags,
 				enabled
@@ -101,7 +104,7 @@ export const actions = {
 
 			await logger.info(`Created new ${type} instance: ${name}`, {
 				source: 'arr/new',
-				meta: { id, name, type, url }
+				meta: { id, name, type, url, externalUrl }
 			});
 
 			// Apply default delay profile if enabled

--- a/src/routes/arr/views/CardView.svelte
+++ b/src/routes/arr/views/CardView.svelte
@@ -4,6 +4,7 @@
 	import Card from '$ui/card/Card.svelte';
 	import CardGrid from '$ui/card/CardGrid.svelte';
 	import Label from '$ui/label/Label.svelte';
+	import { getDisplayUrl } from '$lib/client/utils/arrDisplayUrl.ts';
 	import type { ArrInstanceSummary } from '../+page.server.ts';
 	import radarrLogo from '$lib/client/assets/Radarr.svg';
 	import sonarrLogo from '$lib/client/assets/Sonarr.svg';
@@ -88,7 +89,7 @@
 							size="xs"
 							variant="ghost"
 							tooltip="Open in {formatType(instance.type)}"
-							on:click={(e) => handleExternalClick(e, instance.url)}
+							on:click={(e) => handleExternalClick(e, getDisplayUrl(instance))}
 						/>
 						<Button
 							icon={Unlink}

--- a/src/routes/arr/views/TableView.svelte
+++ b/src/routes/arr/views/TableView.svelte
@@ -3,6 +3,7 @@
 	import Table from '$ui/table/Table.svelte';
 	import Button from '$ui/button/Button.svelte';
 	import Label from '$ui/label/Label.svelte';
+	import { getDisplayUrl } from '$lib/client/utils/arrDisplayUrl.ts';
 	import type { Column } from '$ui/table/types';
 	import type { ArrInstanceSummary } from '../+page.server.ts';
 	import radarrLogo from '$lib/client/assets/Radarr.svg';
@@ -154,7 +155,7 @@
 				variant="secondary"
 				title={`Open in ${formatType(row.type)}`}
 				ariaLabel={`Open in ${formatType(row.type)}`}
-				href={row.url}
+				href={getDisplayUrl(row)}
 				target="_blank"
 				rel="noopener noreferrer"
 			/>

--- a/tests/unit/rename/processor.test.ts
+++ b/tests/unit/rename/processor.test.ts
@@ -175,6 +175,7 @@ function makeInstance(overrides: Partial<ArrInstance> = {}): ArrInstance {
 		name: 'Test Radarr',
 		type: 'radarr',
 		url: 'http://localhost:7878',
+		external_url: null,
 		api_key: 'test-key',
 		tags: null,
 		enabled: 1,


### PR DESCRIPTION
Adds an optional `external_url` column to `arr_instances` for reverse-proxied arrs where Profilarr reaches the app internally but users reach it through SSO. Browser "Open in Radarr" links resolve through a new `getDisplayUrl(instance)` helper; backend API calls keep using `url`.