### PR TITLE
fix: version display spacing and identity labels

### DIFF
--- a/docs/backend/announcements.md
+++ b/docs/backend/announcements.md
@@ -16,6 +16,7 @@
   - [Development](#development)
 - [Database Schema](#database-schema)
 - [Publishing an Announcement](#publishing-an-announcement)
+- [Testing Locally](#testing-locally)
 - [Database Announcements](#database-announcements)
 
 ## Overview
@@ -299,6 +300,34 @@ don't re-fetch.
    and that every announcement has a matching body file (and vice versa).
 
 Instances pick it up on the next fetch (every 30 minutes) or on restart.
+
+## Testing Locally
+
+Point dev at fixture files instead of the live bulletin:
+
+```bash
+# Terminal 1
+deno task dev:bulletin
+
+# Terminal 2
+PROFILARR_BULLETIN_URL=http://localhost:6970 deno task dev
+```
+
+To preview the sidebar and About-page under a different channel, hand-edit
+`src/lib/shared/build.ts` and refresh. Do not commit — the Dockerfile
+overwrites this file on every image build.
+
+```ts
+// stable, up to date against the live bulletin
+export const build: BuildInfo = { version: '1.1.4', channel: 'stable', commit: 'abc1234' };
+
+// develop
+export const build: BuildInfo = {
+	version: '<short-sha>',
+	channel: 'develop',
+	commit: '<short-sha>'
+};
+```
 
 ## Database Announcements
 

--- a/src/lib/client/ui/navigation/pageNav/version.svelte
+++ b/src/lib/client/ui/navigation/pageNav/version.svelte
@@ -5,9 +5,9 @@
 	import Card from '$ui/card/Card.svelte';
 
 	const CHANNEL_LABELS = {
-		stable: 'Stable',
-		develop: 'Develop',
-		dev: 'Unstable'
+		stable: 'stable',
+		develop: 'develop',
+		dev: 'unstable'
 	} as const;
 
 	const platform = getPlatformLabel();

--- a/src/lib/client/ui/navigation/pageNav/version.svelte
+++ b/src/lib/client/ui/navigation/pageNav/version.svelte
@@ -20,6 +20,10 @@
 			: build.channel === 'develop'
 				? build.version
 				: null;
+
+	const line = buildString
+		? `${platform} · ${channelLabel} · ${buildString}`
+		: `${platform} · ${channelLabel}`;
 </script>
 
 <Card padding="sm" flush className="mt-2">
@@ -28,10 +32,7 @@
 
 		<div class="flex-1">
 			<div class="text-xs font-semibold text-neutral-900 dark:text-neutral-50">profilarr</div>
-			<div class="font-mono text-[10px] text-neutral-600 dark:text-neutral-400">
-				{platform} · {channelLabel}{#if buildString}
-					· {buildString}{/if}
-			</div>
+			<div class="font-mono text-[10px] text-neutral-600 dark:text-neutral-400">{line}</div>
 		</div>
 	</div>
 </Card>

--- a/src/lib/client/ui/version/BuildIdentity.svelte
+++ b/src/lib/client/ui/version/BuildIdentity.svelte
@@ -2,13 +2,13 @@
 	import { build } from '$lib/shared/build.ts';
 	import Label from '$ui/label/Label.svelte';
 
-	/** Shared identity block: channel chip + build chip + optional status chip. */
+	/**
+	 * Single-label build identity. Renders `Channel · build` in mono, coloured
+	 * `info` when up to date and `secondary` otherwise (or when no status is
+	 * available — e.g. local dev).
+	 */
 
-	export let compact: boolean = false;
-	/** Supplied by the About page's server load. Not needed in compact mode. */
 	export let status: 'up-to-date' | 'out-of-date' | 'dev-build' | null = null;
-	/** Latest stable version string for "Update available: v2.4.0" copy. */
-	export let latestVersion: string | null = null;
 
 	const CHANNEL_LABELS = {
 		stable: 'Stable',
@@ -16,17 +16,8 @@
 		dev: 'Unstable'
 	} as const;
 
-	const CHANNEL_VARIANTS = {
-		stable: 'success',
-		develop: 'warning',
-		dev: 'info'
-	} as const;
-
+	// v<semver> for stable, raw SHA for develop, nothing for dev.
 	$: channelLabel = CHANNEL_LABELS[build.channel];
-	$: channelVariant = CHANNEL_VARIANTS[build.channel];
-
-	// Build string: v<semver> for stable, raw SHA for develop. Dev channel
-	// omits the build chip entirely (channel chip alone conveys it).
 	$: buildString =
 		build.channel === 'stable'
 			? `v${build.version}`
@@ -34,43 +25,9 @@
 				? build.version
 				: null;
 
-	type StatusChip = {
-		text: string;
-		variant: 'success' | 'warning' | 'info';
-	};
-
-	function resolveStatus(): StatusChip | null {
-		if (!status || status === 'dev-build') return null;
-		if (status === 'up-to-date') return { text: 'Up to date', variant: 'success' };
-		if (status === 'out-of-date' && build.channel === 'stable' && latestVersion) {
-			return { text: `Update available: v${latestVersion}`, variant: 'warning' };
-		}
-		if (status === 'out-of-date' && build.channel === 'develop') {
-			return { text: 'New commit available', variant: 'info' };
-		}
-		return null;
-	}
-
-	$: statusChip = resolveStatus();
+	$: variant = status === 'up-to-date' ? 'info' : 'secondary';
 </script>
 
-{#if compact}
-	<div class="flex items-center gap-1.5">
-		<Label variant={channelVariant} size="sm" rounded="md">{channelLabel}</Label>
-		{#if buildString}
-			<span class="font-mono text-[10px] text-neutral-600 dark:text-neutral-400">
-				{buildString}
-			</span>
-		{/if}
-	</div>
-{:else}
-	<div class="flex flex-wrap items-center gap-2">
-		<Label variant={channelVariant} size="md" rounded="md">{channelLabel}</Label>
-		{#if buildString}
-			<Label variant="secondary" size="md" rounded="md" mono>{buildString}</Label>
-		{/if}
-		{#if statusChip}
-			<Label variant={statusChip.variant} size="md" rounded="md">{statusChip.text}</Label>
-		{/if}
-	</div>
-{/if}
+<Label {variant} size="md" rounded="md" mono>
+	{buildString ? `${channelLabel} · ${buildString}` : channelLabel}
+</Label>

--- a/src/lib/client/ui/version/BuildIdentity.svelte
+++ b/src/lib/client/ui/version/BuildIdentity.svelte
@@ -2,11 +2,7 @@
 	import { build } from '$lib/shared/build.ts';
 	import Label from '$ui/label/Label.svelte';
 
-	/**
-	 * Single-label build identity. Renders `Channel · build` in mono, coloured
-	 * `info` when up to date and `secondary` otherwise (or when no status is
-	 * available — e.g. local dev).
-	 */
+	/** `channel · build` in mono, plus an "Up to date" chip when applicable. */
 
 	export let status: 'up-to-date' | 'out-of-date' | 'dev-build' | null = null;
 
@@ -25,9 +21,14 @@
 				? build.version
 				: null;
 
-	$: variant = status === 'up-to-date' ? 'info' : 'secondary';
+	$: upToDate = status === 'up-to-date';
 </script>
 
-<Label {variant} size="md" rounded="md" mono>
-	{buildString ? `${channelLabel} · ${buildString}` : channelLabel}
-</Label>
+<div class="flex flex-wrap items-center gap-2">
+	<Label variant="secondary" size="md" rounded="md" mono>
+		{buildString ? `${channelLabel} · ${buildString}` : channelLabel}
+	</Label>
+	{#if upToDate}
+		<Label variant="success" size="md" rounded="md">Up to date</Label>
+	{/if}
+</div>

--- a/src/routes/settings/about/+page.server.ts
+++ b/src/routes/settings/about/+page.server.ts
@@ -63,7 +63,6 @@ export const load = () => {
 	return {
 		version: build.version,
 		versionStatus,
-		latestStable: stableLatest,
 		timezone: config.timezone,
 		paths: {
 			base: config.paths.base,

--- a/src/routes/settings/about/+page.svelte
+++ b/src/routes/settings/about/+page.svelte
@@ -132,7 +132,7 @@
 						</span>
 					{:else if column.key === 'value'}
 						{#if row.key === 'version'}
-							<BuildIdentity status={data.versionStatus} latestVersion={data.latestStable} />
+							<BuildIdentity status={data.versionStatus} />
 						{:else if row.type === 'code'}
 							<Label variant="secondary" size="md" rounded="md" mono>
 								{row.value}


### PR DESCRIPTION
Follow-ups to #467.

## Fixed

- **Sidebar spacing**: the mono `platform · channel · build` line had uneven dots because whitespace inside a Svelte `{#if}` block was collapsing asymmetrically. Switched to a single JS template literal.
- **False "New commit available"**: on develop, any SHA mismatch was flagged as out-of-date, but the bulletin's pointer lags up to an hour after each merge — so freshly-released develop users saw the chip even though they were ahead. Develop now only surfaces a positive "Up to date" chip when commits match; silent otherwise.

## Refined

- About-page Version row: one mono secondary `Channel · build` label with a separate success "Up to date" chip beside it when applicable. Title-case channel names (Stable / Develop / Unstable).
- Sidebar: lowercase channel names (stable / develop / unstable) to match the mono line's density.
- `docs/backend/announcements.md`: added a short "Testing Locally" section.