### PR TITLE
fix: help popup clipped by overflow-hidden on mobile navbar

### DIFF
--- a/src/lib/client/ui/navigation/navbar/navbar.svelte
+++ b/src/lib/client/ui/navigation/navbar/navbar.svelte
@@ -13,7 +13,7 @@
 </script>
 
 <nav
-	class="fixed top-0 left-0 z-50 w-full overflow-hidden border-r-0 border-b border-neutral-200 bg-neutral-50 transition-[width,height] duration-200 ease-in-out md:z-[80] md:border-r dark:border-neutral-800 dark:bg-neutral-900
+	class="fixed top-0 left-0 z-50 w-full border-r-0 border-b border-neutral-200 bg-neutral-50 transition-[width,height] duration-200 ease-in-out md:z-[80] md:overflow-hidden md:border-r dark:border-neutral-800 dark:bg-neutral-900
 		{collapsed ? 'md:h-screen md:w-10' : 'md:h-16 md:w-80'}"
 >
 	<!-- Mobile -->


### PR DESCRIPTION
The navbar had `overflow-hidden` applied unconditionally, clipping the help button dropdown on mobile. Scoped it to `md:overflow-hidden` since it's only needed on desktop to mask content during the sidebar collapse animation.