### PR TITLE
fix: keep generated draft ops with rename groups

### DIFF
--- a/src/lib/server/pcd/ops/draftChanges.ts
+++ b/src/lib/server/pcd/ops/draftChanges.ts
@@ -741,6 +741,9 @@ export function listDraftEntityChanges(databaseId: number): DraftEntityChange[] 
 	const resolveAlias = (entity: string, value: string): string => {
 		return originalName.get(`${entity}:${value}`) ?? value;
 	};
+	const scopedGroupKey = (baseKey: string, groupId?: string): string => {
+		return groupId ? `${baseKey}::${groupId}` : baseKey;
+	};
 	const groups = new Map<string, DraftEntityChange>();
 	const aggregates = new Map<string, Map<string, FieldAggregate>>();
 	const entityCreates = new Map<string, boolean>();
@@ -755,8 +758,7 @@ export function listDraftEntityChanges(databaseId: number): DraftEntityChange[] 
 		const desiredState = parseJson<Record<string, unknown>>(op.desired_state);
 		const stableKey = metadata.stable_key?.value ?? metadata.name;
 		const baseKey = `${metadata.entity}:${resolveAlias(metadata.entity, stableKey)}`;
-		const groupKey =
-			metadata.generated && metadata.group_id ? `${baseKey}::${metadata.group_id}` : baseKey;
+		const groupKey = scopedGroupKey(baseKey, metadata.group_id);
 
 		if (metadata.depends_on && metadata.depends_on.length > 0) {
 			const depSet = dependencies.get(groupKey) ?? new Set<string>();
@@ -765,9 +767,14 @@ export function listDraftEntityChanges(databaseId: number): DraftEntityChange[] 
 					dependency.entity ?? (dependency.key ? ENTITY_BY_STABLE_KEY[dependency.key] : undefined);
 				const depValue = dependency.value;
 				if (!depEntity || !depValue) continue;
-				const depKey = `${depEntity}:${resolveAlias(depEntity, depValue)}`;
-				if (depKey === groupKey) continue;
-				depSet.add(depKey);
+				const depBaseKey = `${depEntity}:${resolveAlias(depEntity, depValue)}`;
+				const depKeys = metadata.group_id
+					? [scopedGroupKey(depBaseKey, metadata.group_id), depBaseKey]
+					: [depBaseKey];
+				for (const depKey of depKeys) {
+					if (depKey === groupKey) continue;
+					depSet.add(depKey);
+				}
 			}
 			if (depSet.size > 0) {
 				dependencies.set(groupKey, depSet);

--- a/tests/integration/conflicts/harness/setup.ts
+++ b/tests/integration/conflicts/harness/setup.ts
@@ -13,6 +13,7 @@ export interface CreateDatabaseInstanceOpts {
 	localPath: string;
 	conflictStrategy?: 'override' | 'align' | 'ask';
 	enabled?: boolean;
+	canWriteToBase?: boolean;
 }
 
 /**
@@ -27,13 +28,15 @@ export function createDatabaseInstance(dbPath: string, opts: CreateDatabaseInsta
 			`INSERT INTO database_instances (
 				uuid, name, repository_url, local_path,
 				sync_strategy, auto_pull, enabled, is_private,
-				local_ops_enabled, conflict_strategy
-			) VALUES (?, ?, '', ?, 60, 0, ?, 0, 1, ?)`,
+				personal_access_token, local_ops_enabled, conflict_strategy
+			) VALUES (?, ?, '', ?, 60, 0, ?, 0, ?, ?, ?)`,
 			[
 				opts.uuid,
 				opts.name ?? 'test-db',
 				opts.localPath,
 				opts.enabled !== false ? 1 : 0,
+				opts.canWriteToBase ? 'test-token' : null,
+				opts.canWriteToBase ? 0 : 1,
 				opts.conflictStrategy ?? 'ask'
 			]
 		);

--- a/tests/integration/conflicts/specs/regex-delete-rename-generated-draft.test.ts
+++ b/tests/integration/conflicts/specs/regex-delete-rename-generated-draft.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Integration test: deleting a regex and renaming another regex into the same
+ * name must not orphan generated custom-format condition draft ops.
+ */
+
+import { assertEquals, assertExists, assert } from '@std/assert';
+import { TestClient } from '$test-harness/client.ts';
+import { startServer, stopServer, getDbPath } from '$test-harness/server.ts';
+import { setup, teardown, test, run } from '$test-harness/runner.ts';
+import {
+	createPcdRepo,
+	createDatabaseInstance,
+	insertOp,
+	queryOpsByDatabase
+} from '../harness/setup.ts';
+
+const PORT = 7034;
+const ORIGIN = `http://localhost:${PORT}`;
+
+let client: TestClient;
+let dbId: number;
+
+setup(async () => {
+	await startServer(PORT, { AUTH: 'off', ORIGIN }, 'preview');
+	client = new TestClient(ORIGIN);
+
+	const basePath = `./dist/integration-${PORT}`;
+	const dbPath = getDbPath(PORT);
+
+	const pcdPath = await createPcdRepo(basePath, 'regex-delete-rename-generated-draft');
+	dbId = createDatabaseInstance(dbPath, {
+		name: 'regex-delete-rename-generated-draft',
+		uuid: 'regex-delete-rename-generated-draft',
+		localPath: pcdPath,
+		conflictStrategy: 'ask',
+		canWriteToBase: true
+	});
+
+	insertOp(dbPath, {
+		databaseId: dbId,
+		origin: 'base',
+		state: 'published',
+		sql: `INSERT INTO regular_expressions (name, pattern, description)
+		      VALUES ('E', '^(ENJOi|EUBDS)$', '');`,
+		sequence: 1
+	});
+
+	insertOp(dbPath, {
+		databaseId: dbId,
+		origin: 'base',
+		state: 'published',
+		sql: `INSERT INTO regular_expressions (name, pattern, description)
+		      VALUES ('E (2)', '^(Erai-raws)$', '');`,
+		sequence: 2
+	});
+
+	insertOp(dbPath, {
+		databaseId: dbId,
+		origin: 'base',
+		state: 'published',
+		sql: `INSERT INTO custom_formats (name, description, include_in_rename)
+		      VALUES ('LQ', '', 0);`,
+		sequence: 3
+	});
+
+	insertOp(dbPath, {
+		databaseId: dbId,
+		origin: 'base',
+		state: 'published',
+		sql: `INSERT INTO custom_format_conditions
+		        (custom_format_name, name, type, arr_type, negate, required)
+		      VALUES ('LQ', 'Release Group', 'release_group', 'all', 0, 0);`,
+		sequence: 4
+	});
+
+	insertOp(dbPath, {
+		databaseId: dbId,
+		origin: 'base',
+		state: 'published',
+		sql: `INSERT INTO condition_patterns
+		        (custom_format_name, condition_name, regular_expression_name)
+		      VALUES ('LQ', 'Release Group', 'E (2)');`,
+		sequence: 5
+	});
+
+	const draftId = insertOp(dbPath, {
+		databaseId: dbId,
+		origin: 'base',
+		state: 'draft',
+		sql: 'SELECT 1;',
+		sequence: 0
+	});
+
+	await client.postForm(
+		`/databases/${dbId}/changes?/drop`,
+		{ opIds: String(draftId) },
+		{ headers: { Origin: ORIGIN } }
+	);
+
+	const deleteResponse = await client.postForm(
+		`/regular-expressions/${dbId}/1?/delete`,
+		{ layer: 'base' },
+		{ headers: { Origin: ORIGIN } }
+	);
+	assert(
+		deleteResponse.status >= 200 && deleteResponse.status < 400,
+		`Expected 2xx/3xx from delete action, got ${deleteResponse.status}`
+	);
+
+	const renameResponse = await client.postForm(
+		`/regular-expressions/${dbId}/2?/update`,
+		{
+			name: 'E',
+			pattern: '^(Erai-raws)$',
+			description: '',
+			tags: '[]',
+			regex101Id: '',
+			layer: 'base'
+		},
+		{ headers: { Origin: ORIGIN } }
+	);
+	assert(
+		renameResponse.status >= 200 && renameResponse.status < 400,
+		`Expected 2xx/3xx from rename action, got ${renameResponse.status}`
+	);
+});
+
+teardown(async () => {
+	await stopServer(PORT);
+});
+
+test('draft changes keep delete and rename groups separate and exportable', async () => {
+	const draftOps = queryOpsByDatabase(getDbPath(PORT), dbId, {
+		origin: 'base',
+		state: 'draft'
+	});
+	const deleteOp = draftOps.find((o) => {
+		const meta = JSON.parse(o.metadata ?? '{}');
+		return meta.entity === 'regular_expression' && meta.operation === 'delete' && meta.name === 'E';
+	});
+	const renameOp = draftOps.find((o) => {
+		const meta = JSON.parse(o.metadata ?? '{}');
+		return (
+			meta.entity === 'regular_expression' &&
+			meta.operation === 'update' &&
+			meta.previousName === 'E (2)' &&
+			meta.name === 'E'
+		);
+	});
+	const generatedOp = draftOps.find((o) => {
+		const meta = JSON.parse(o.metadata ?? '{}');
+		return meta.entity === 'custom_format' && meta.generated === true && meta.name === 'LQ';
+	});
+
+	assertExists(deleteOp, 'Expected draft delete op for regex E');
+	assertExists(renameOp, 'Expected draft rename op for regex E (2) -> E');
+	assertExists(generatedOp, 'Expected generated draft condition update for custom format LQ');
+
+	const deleteGroupId = JSON.parse(deleteOp.metadata ?? '{}').group_id;
+	const renameGroupId = JSON.parse(renameOp.metadata ?? '{}').group_id;
+	const generatedGroupId = JSON.parse(generatedOp.metadata ?? '{}').group_id;
+	assertExists(deleteGroupId, 'Delete op should have a group_id');
+	assertExists(renameGroupId, 'Rename op should have a group_id');
+	assertEquals(generatedGroupId, renameGroupId, 'Generated op should share the rename group');
+	assert(deleteGroupId !== renameGroupId, 'Delete and rename actions should have distinct groups');
+
+	const response = await client.get(`/databases/${dbId}/changes/data`);
+	assertEquals(response.status, 200);
+	const payload = await response.json();
+	const changes = payload.draftChanges as Array<{
+		key: string;
+		entity: string;
+		name: string;
+		groupId?: string;
+		generated?: boolean;
+		ops: Array<{ id: number }>;
+	}>;
+
+	const deleteChange = changes.find(
+		(change) =>
+			change.entity === 'regular_expression' &&
+			change.groupId === deleteGroupId &&
+			change.generated !== true
+	);
+	const renameChange = changes.find(
+		(change) =>
+			change.entity === 'regular_expression' &&
+			change.groupId === renameGroupId &&
+			change.generated !== true
+	);
+	const generatedChange = changes.find(
+		(change) =>
+			change.entity === 'custom_format' &&
+			change.groupId === renameGroupId &&
+			change.generated === true
+	);
+
+	assertExists(deleteChange, 'Delete action should have its own selectable change row');
+	assertExists(renameChange, 'Rename action should have its own selectable change row');
+	assertExists(generatedChange, 'Generated condition change should stay attached to rename group');
+	assert(
+		renameChange.ops.some((op) => op.id === renameOp.id),
+		'Rename row should contain the rename op'
+	);
+	assert(
+		!renameChange.ops.some((op) => op.id === deleteOp.id),
+		'Rename row should not contain the delete op'
+	);
+});
+
+await run();


### PR DESCRIPTION
## Summary
- add a regression for deleting a regex and renaming another into the same name
- scope draft change grouping by group_id so generated condition ops stay attached to the rename action