### PR TITLE
docs(cutscene): explain why sync requires media management and delays

### DIFF
--- a/docs/frontend/cutscene.md
+++ b/docs/frontend/cutscene.md
@@ -141,7 +141,7 @@ like Help where a "you're done" modal would be redundant.
 | `database-manage`           | Overview            | 6     | `hasDatabase`                     | Tabs and features of a connected database                      |
 | `arr-link`                  | Link                | 5     |                                   | Connect a Radarr or Sonarr instance                            |
 | `arr-manage`                | Overview            | 7     | `hasArrInstance`                  | Tabs and features of a connected Arr instance                  |
-| `arr-sync`                  | Sync                | 7     | `hasArrInstance`                  | Configure what gets synced and when                            |
+| `arr-sync`                  | Sync                | 8     | `hasArrInstance`                  | Configure what gets synced and when                            |
 | `arr-upgrades`              | Upgrades            | 11    | `hasArrInstance`                  | Automated searching for better quality releases                |
 | `arr-renames`               | Rename              | 7     | `hasArrInstance`                  | Automated file and folder renaming                             |
 | `cf-general`                | General             | 6     | `hasDatabase`                     | Identity, rename behavior, and references                      |

--- a/src/lib/client/cutscene/definitions/stages/arrs/sync.ts
+++ b/src/lib/client/cutscene/definitions/stages/arrs/sync.ts
@@ -44,6 +44,12 @@ export const arrSyncStage: Stage = {
 			completion: { type: 'manual' }
 		},
 		{
+			id: 'sync-required',
+			title: 'Required Syncing',
+			body: "Quality profiles can't sync until media management and delay profiles have been saved. The custom formats and scoring inside a profile are written to work with specific naming, file size tiers, and protocol delays, so syncing a profile without those in place can produce results that look right but behave incorrectly. If you'd rather not use the database's recommended setup, create your own naming scheme or settings in the database and sync those. Profilarr just needs you to commit to one or the other.",
+			completion: { type: 'manual' }
+		},
+		{
 			id: 'sync-trigger',
 			target: 'sync-trigger',
 			title: 'Triggers',

--- a/src/lib/client/cutscene/definitions/stages/arrs/sync.ts
+++ b/src/lib/client/cutscene/definitions/stages/arrs/sync.ts
@@ -46,7 +46,7 @@ export const arrSyncStage: Stage = {
 		{
 			id: 'sync-required',
 			title: 'Required Syncing',
-			body: "Quality profiles can't sync until media management and delay profiles have been saved. The custom formats and scoring inside a profile are written to work with specific naming, file size tiers, and protocol delays, so syncing a profile without those in place can produce results that look right but behave incorrectly. If you'd rather not use the database's recommended setup, create your own naming scheme or settings in the database and sync those. Profilarr just needs you to commit to one or the other.",
+			body: "Quality profiles can't sync until media management and delay profiles have been saved. The custom formats and scoring inside a profile are tuned to work with specific naming, file size tiers, and protocol delays. Without those in place, the profile still syncs, but matching, scoring, and renaming break in ways that are hard to spot until something goes wrong. You're welcome to use your own naming scheme or settings if you create and sync them through the database. Just know that the recommended setup exists for a reason, and deviating from it without understanding what each piece does will produce broken results.",
 			completion: { type: 'manual' }
 		},
 		{


### PR DESCRIPTION
Adds a new `sync-required` step after `sync-quality-profiles` in the `arr-sync` cutscene stage. Explains why media management and delay profiles must be saved before quality profiles can sync, and that users who don't want the database's defaults can sync their own naming scheme or settings instead.