### PR TITLE
feat: link databases asynchronously with live progress

### DIFF
--- a/src/lib/client/stores/jobStatus.ts
+++ b/src/lib/client/stores/jobStatus.ts
@@ -12,6 +12,12 @@
  * - completed -> idle after 6 seconds (then auto-disconnect)
  * - If job.started arrives during completed and < 5s elapsed, hold
  *   the completion message until 5s pass, then transition to running
+ *
+ * Optimistic running:
+ * - setRunning() lets a caller claim the running state before any SSE
+ *   event arrives (used by the link form to avoid the started-event race).
+ *   The first matching event with a jobId then claims the state for
+ *   real; later events without a matching jobId are ignored.
  */
 
 import { writable } from 'svelte/store';
@@ -29,11 +35,19 @@ export type JobStatusState =
 	  };
 
 interface StartedPayload {
+	jobId: number;
 	jobType: string;
 	displayLabel: string;
 }
 
+interface ProgressPayload {
+	jobId: number;
+	jobType: string;
+	label: string;
+}
+
 interface FinishedPayload {
+	jobId: number;
 	jobType: string;
 	displayLabel: string;
 	status: string;
@@ -44,12 +58,13 @@ const COMPLETED_DISPLAY_MS = 6_000;
 const COMPLETED_HOLDOFF_MS = 5_000;
 
 function createJobStatusStore() {
-	const { subscribe, set } = writable<JobStatusState>({ state: 'idle' });
+	const { subscribe, set, update } = writable<JobStatusState>({ state: 'idle' });
 
 	let resetTimer: ReturnType<typeof setTimeout> | null = null;
 	let holdoffTimer: ReturnType<typeof setTimeout> | null = null;
 	let completedAt = 0;
 	let pendingStartEvent: StartedPayload | null = null;
+	let currentJobId: number | null = null;
 
 	let eventSource: EventSource | null = null;
 
@@ -78,6 +93,7 @@ function createJobStatusStore() {
 			if (holdoffTimer) clearTimeout(holdoffTimer);
 			holdoffTimer = setTimeout(() => {
 				if (pendingStartEvent) {
+					currentJobId = pendingStartEvent.jobId;
 					set({
 						state: 'running',
 						jobType: pendingStartEvent.jobType,
@@ -97,10 +113,25 @@ function createJobStatusStore() {
 			clearTimeout(holdoffTimer);
 			holdoffTimer = null;
 		}
+		currentJobId = data.jobId;
 		set({ state: 'running', jobType: data.jobType, displayLabel: data.displayLabel });
 	}
 
+	function handleProgress(data: ProgressPayload) {
+		update((s) => {
+			if (s.state !== 'running') return s;
+			// Optimistic running has no jobId yet; the first progress event
+			// claims it. Once claimed, only matching events update the label.
+			if (currentJobId !== null && currentJobId !== data.jobId) return s;
+			if (currentJobId === null) currentJobId = data.jobId;
+			return { ...s, displayLabel: data.label };
+		});
+	}
+
 	function handleFinished(data: FinishedPayload) {
+		// Ignore finished events for jobs we're not tracking (stale events
+		// from prior optimistic state mismatches).
+		if (currentJobId !== null && currentJobId !== data.jobId) return;
 		clearTimers();
 		completedAt = Date.now();
 		set({
@@ -111,10 +142,10 @@ function createJobStatusStore() {
 			durationMs: data.durationMs
 		});
 		resetTimer = setTimeout(() => {
+			currentJobId = null;
 			set({ state: 'idle' });
 			completedAt = 0;
 			resetTimer = null;
-			// Auto-disconnect: no more events expected
 			closeSSE();
 		}, COMPLETED_DISPLAY_MS);
 	}
@@ -137,6 +168,14 @@ function createJobStatusStore() {
 			}
 		});
 
+		eventSource.addEventListener('job.progress', (e) => {
+			try {
+				handleProgress(JSON.parse(e.data));
+			} catch {
+				// Invalid event data
+			}
+		});
+
 		eventSource.addEventListener('job.finished', (e) => {
 			try {
 				handleFinished(JSON.parse(e.data));
@@ -150,10 +189,29 @@ function createJobStatusStore() {
 		closeSSE();
 		clearTimers();
 		completedAt = 0;
+		currentJobId = null;
 		set({ state: 'idle' });
 	}
 
-	return { subscribe, connect, disconnect };
+	function setRunning(jobType: string, displayLabel: string) {
+		// Optimistic: claim running state without a jobId. The next matching
+		// SSE event will adopt the jobId. Don't touch completedAt or timers.
+		currentJobId = null;
+		set({ state: 'running', jobType, displayLabel });
+	}
+
+	function cancelOptimistic() {
+		// Only resets if we're in an unclaimed optimistic state. Once a real
+		// event has bound a jobId, leave the state alone.
+		update((s) => {
+			if (s.state === 'running' && currentJobId === null) {
+				return { state: 'idle' };
+			}
+			return s;
+		});
+	}
+
+	return { subscribe, connect, disconnect, setRunning, cancelOptimistic };
 }
 
 export const jobStatus = createJobStatusStore();

--- a/src/lib/server/jobs/dispatcher.ts
+++ b/src/lib/server/jobs/dispatcher.ts
@@ -112,7 +112,16 @@ class JobDispatcher {
 
 		let result: JobHandlerResult;
 		try {
-			result = await handler(job);
+			result = await handler(job, {
+				progress: (label: string) => {
+					jobEvents.emit({
+						type: 'job.progress',
+						jobId: job.id,
+						jobType: job.jobType,
+						label
+					});
+				}
+			});
 		} catch (error) {
 			result = {
 				status: 'failure',

--- a/src/lib/server/jobs/display.ts
+++ b/src/lib/server/jobs/display.ts
@@ -25,6 +25,8 @@ export function formatJobTypeLabel(jobType: JobType): string {
 			return 'Arr Cleanup';
 		case 'arr.library.refresh':
 			return 'Library Refresh';
+		case 'pcd.link':
+			return 'PCD Link';
 		case 'pcd.sync':
 			return 'PCD Sync';
 		case 'backup.create':
@@ -60,6 +62,11 @@ export function buildJobDisplayName(
 	const base = formatJobTypeLabel(jobType);
 	const instanceId = readId(payload.instanceId);
 	const databaseId = readId(payload.databaseId);
+
+	if (jobType === 'pcd.link') {
+		const name = typeof payload.name === 'string' ? payload.name : null;
+		return name ? `${base} - ${name}` : base;
+	}
 
 	if (jobType === 'pcd.sync' && databaseId !== null) {
 		const name =

--- a/src/lib/server/jobs/handlers/index.ts
+++ b/src/lib/server/jobs/handlers/index.ts
@@ -3,6 +3,7 @@ import './arrRename.ts';
 import './arrCleanup.ts';
 import './arrLibraryRefresh.ts';
 import './arrSync.ts';
+import './pcdLink.ts';
 import './pcdSync.ts';
 import './backupCreate.ts';
 import './backupCleanup.ts';

--- a/src/lib/server/jobs/handlers/pcdLink.ts
+++ b/src/lib/server/jobs/handlers/pcdLink.ts
@@ -1,0 +1,103 @@
+import { jobQueueRegistry } from '../queueRegistry.ts';
+import type { JobHandler } from '../queueTypes.ts';
+import { pcdManager } from '$pcd/index.ts';
+import type { LinkOptions } from '$pcd/core/types.ts';
+import { schedulePcdSyncForDatabase } from '../schedule.ts';
+import { logger } from '$logger/logger.ts';
+import { notificationManager } from '$notifications/NotificationManager.ts';
+import { notifications } from '$notifications/definitions/index.ts';
+
+/**
+ * Single-shot in-memory store for PATs used by `pcd.link` jobs.
+ * Form action stashes the PAT here under a generated id, payload only
+ * carries the id. Avoids persisting PATs into `job_queue.payload`
+ * (SQLite-backed JSON, retained for history). If the process restarts
+ * between enqueue and execution, the PAT is lost and the link fails.
+ * Acceptable because manual link jobs run within ms of being queued.
+ */
+const linkPats = new Map<string, string>();
+
+export function stashLinkPat(pat: string): string {
+	const id = crypto.randomUUID();
+	linkPats.set(id, pat);
+	return id;
+}
+
+function consumeLinkPat(id: string): string | undefined {
+	const pat = linkPats.get(id);
+	linkPats.delete(id);
+	return pat;
+}
+
+interface LinkPayload {
+	name?: unknown;
+	repositoryUrl?: unknown;
+	branch?: unknown;
+	syncStrategy?: unknown;
+	autoPull?: unknown;
+	localOpsEnabled?: unknown;
+	gitUserName?: unknown;
+	gitUserEmail?: unknown;
+	conflictStrategy?: unknown;
+	patToken?: unknown;
+}
+
+const pcdLinkHandler: JobHandler = async (job, ctx) => {
+	const payload = job.payload as LinkPayload;
+	const name = typeof payload.name === 'string' ? payload.name : '';
+	const repositoryUrl = typeof payload.repositoryUrl === 'string' ? payload.repositoryUrl : '';
+
+	if (!name || !repositoryUrl) {
+		return { status: 'failure', error: 'Invalid link payload' };
+	}
+
+	const personalAccessToken =
+		typeof payload.patToken === 'string' ? consumeLinkPat(payload.patToken) : undefined;
+
+	const input: LinkOptions = {
+		name,
+		repositoryUrl,
+		branch: typeof payload.branch === 'string' ? payload.branch : undefined,
+		syncStrategy: typeof payload.syncStrategy === 'number' ? payload.syncStrategy : 0,
+		autoPull: payload.autoPull === true,
+		personalAccessToken,
+		localOpsEnabled: payload.localOpsEnabled === true,
+		gitUserName: typeof payload.gitUserName === 'string' ? payload.gitUserName : undefined,
+		gitUserEmail: typeof payload.gitUserEmail === 'string' ? payload.gitUserEmail : undefined,
+		conflictStrategy:
+			typeof payload.conflictStrategy === 'string' ? payload.conflictStrategy : undefined
+	};
+
+	try {
+		const instance = await pcdManager.link(input, ctx?.progress);
+
+		schedulePcdSyncForDatabase(instance.id);
+
+		await logger.info(`Linked database "${name}" via job`, {
+			source: 'PcdLinkJob',
+			meta: { jobId: job.id, databaseId: instance.id, name }
+		});
+
+		return {
+			status: 'success',
+			output: `Linked "${name}"`
+		};
+	} catch (error) {
+		const errorMessage = error instanceof Error ? error.message : String(error);
+
+		await logger.error('Database link job failed', {
+			source: 'PcdLinkJob',
+			meta: { jobId: job.id, name, repositoryUrl, error: errorMessage }
+		});
+
+		try {
+			await notificationManager.notify(notifications.pcdLinkFailed({ name, error: errorMessage }));
+		} catch {
+			// Notification failure should never block job result
+		}
+
+		return { status: 'failure', error: errorMessage };
+	}
+};
+
+jobQueueRegistry.register('pcd.link', pcdLinkHandler);

--- a/src/lib/server/jobs/jobEvents.ts
+++ b/src/lib/server/jobs/jobEvents.ts
@@ -26,7 +26,14 @@ export interface JobFinishedEvent {
 	durationMs: number;
 }
 
-export type JobEvent = JobStartedEvent | JobFinishedEvent;
+export interface JobProgressEvent {
+	type: 'job.progress';
+	jobId: number;
+	jobType: JobType;
+	label: string;
+}
+
+export type JobEvent = JobStartedEvent | JobFinishedEvent | JobProgressEvent;
 
 type JobEventCallback = (event: JobEvent) => void;
 
@@ -39,7 +46,8 @@ const JOB_RUNNING_LABELS: Partial<Record<JobType, string>> = {
 	'arr.sync.mediaManagement': 'Syncing Media Management...',
 	'arr.cleanup': 'Cleaning up...',
 	'backup.create': 'Creating backup...',
-	'backup.cleanup': 'Cleaning up backups...'
+	'backup.cleanup': 'Cleaning up backups...',
+	'pcd.link': 'Linking database...'
 };
 
 const JOB_COMPLETED_LABELS: Partial<Record<JobType, string>> = {
@@ -49,7 +57,8 @@ const JOB_COMPLETED_LABELS: Partial<Record<JobType, string>> = {
 	'arr.sync.mediaManagement': 'Media Management sync',
 	'arr.cleanup': 'Cleanup',
 	'backup.create': 'Backup',
-	'backup.cleanup': 'Backup cleanup'
+	'backup.cleanup': 'Backup cleanup',
+	'pcd.link': 'Database link'
 };
 
 const EMITTED_JOB_TYPES = new Set(Object.keys(JOB_RUNNING_LABELS));

--- a/src/lib/server/jobs/queueTypes.ts
+++ b/src/lib/server/jobs/queueTypes.ts
@@ -5,6 +5,7 @@ export type JobType =
 	| 'arr.sync.qualityProfiles'
 	| 'arr.sync.delayProfiles'
 	| 'arr.sync.mediaManagement'
+	| 'pcd.link'
 	| 'pcd.sync'
 	| 'backup.create'
 	| 'backup.cleanup'
@@ -55,4 +56,11 @@ export interface JobHandlerResult {
 	rescheduleAt?: string | null;
 }
 
-export type JobHandler = (job: JobQueueRecord) => Promise<JobHandlerResult>;
+export interface JobHandlerContext {
+	progress: (label: string) => void;
+}
+
+export type JobHandler = (
+	job: JobQueueRecord,
+	ctx?: JobHandlerContext
+) => Promise<JobHandlerResult>;

--- a/src/lib/server/notifications/definitions/index.ts
+++ b/src/lib/server/notifications/definitions/index.ts
@@ -14,7 +14,7 @@ import { rename } from './rename.ts';
 import { upgrade } from './upgrade.ts';
 import { arrSync } from './arrSync.ts';
 import { arrCleanup } from './arrCleanup.ts';
-import { pcdUpdatesAvailable, pcdSyncSuccess, pcdSyncFailed } from './pcdSync.ts';
+import { pcdUpdatesAvailable, pcdSyncSuccess, pcdSyncFailed, pcdLinkFailed } from './pcdSync.ts';
 import { backupSuccess, backupFailed } from './backup.ts';
 import { announcementNew } from './announcement.ts';
 
@@ -27,6 +27,7 @@ export const notifications = {
 	pcdUpdatesAvailable,
 	pcdSyncSuccess,
 	pcdSyncFailed,
+	pcdLinkFailed,
 	backupSuccess,
 	backupFailed,
 	announcementNew

--- a/src/lib/server/notifications/definitions/pcdSync.ts
+++ b/src/lib/server/notifications/definitions/pcdSync.ts
@@ -22,6 +22,11 @@ export interface PcdSyncFailedParams {
 	error: string;
 }
 
+export interface PcdLinkFailedParams {
+	name: string;
+	error: string;
+}
+
 function buildChangesBlock(commitMessages: string[]): NotificationBlock | null {
 	if (commitMessages.length === 0) return null;
 	return {
@@ -78,6 +83,18 @@ export function pcdSyncFailed(params: PcdSyncFailedParams): Notification {
 		type: 'pcd.sync_failed',
 		severity: 'error',
 		title: `Database Sync Failed \u2013 ${name}`,
+		message: error,
+		blocks: []
+	};
+}
+
+export function pcdLinkFailed(params: PcdLinkFailedParams): Notification {
+	const { name, error } = params;
+
+	return {
+		type: 'pcd.link_failed',
+		severity: 'error',
+		title: `Database Link Failed \u2013 ${name}`,
 		message: error,
 		blocks: []
 	};

--- a/src/lib/server/notifications/types.ts
+++ b/src/lib/server/notifications/types.ts
@@ -12,6 +12,7 @@ export const NotificationTypes = {
 	PCD_UPDATES_AVAILABLE: 'pcd.updates_available',
 	PCD_SYNC_SUCCESS: 'pcd.sync_success',
 	PCD_SYNC_FAILED: 'pcd.sync_failed',
+	PCD_LINK_FAILED: 'pcd.link_failed',
 
 	// Upgrades
 	UPGRADE_SUCCESS: 'upgrade.success',

--- a/src/lib/server/pcd/core/manager.ts
+++ b/src/lib/server/pcd/core/manager.ts
@@ -46,9 +46,14 @@ async function readSchemaVersion(pcdPath: string): Promise<string | null> {
  */
 class PCDManager {
 	/**
-	 * Link a new PCD repository
+	 * Link a new PCD repository.
+	 *
+	 * Optional progress callback receives a stage label between phases
+	 * (clone, manifest, deps, import, compile). Used by the async
+	 * `pcd.link` job handler to surface progress over SSE; sync callers
+	 * (startup auto-link, REST API) omit it.
 	 */
-	async link(options: LinkOptions): Promise<DatabaseInstance> {
+	async link(options: LinkOptions, progress?: (label: string) => void): Promise<DatabaseInstance> {
 		await logger.debug('Starting database link operation', {
 			source: 'PCDManager',
 			meta: {
@@ -63,6 +68,8 @@ class PCDManager {
 		const localPath = getPCDPath(uuid);
 
 		try {
+			progress?.('Cloning repository...');
+
 			// Clone the repository and detect if it's private
 			const isPrivate = await clone(
 				options.repositoryUrl,
@@ -71,8 +78,12 @@ class PCDManager {
 				options.personalAccessToken
 			);
 
+			progress?.('Reading manifest...');
+
 			// Validate manifest (loadManifest throws if invalid)
 			await loadManifest(localPath);
+
+			progress?.('Cloning dependencies...');
 
 			// Process dependencies (clone and validate)
 			await processDependencies(localPath, options.personalAccessToken);
@@ -99,6 +110,8 @@ class PCDManager {
 				throw new Error('Failed to retrieve created database instance');
 			}
 
+			progress?.('Importing ops...');
+
 			try {
 				await importBaseOps(id, localPath);
 			} catch (error) {
@@ -110,6 +123,8 @@ class PCDManager {
 
 			// Compile cache (only if enabled)
 			if (instance.enabled) {
+				progress?.('Compiling cache...');
+
 				try {
 					const stats = await compile(localPath, id);
 

--- a/src/lib/shared/notifications/types.ts
+++ b/src/lib/shared/notifications/types.ts
@@ -59,6 +59,12 @@ export const notificationTypes: NotificationType[] = [
 		category: 'Databases',
 		description: 'Notification when database sync fails'
 	},
+	{
+		id: 'pcd.link_failed',
+		label: 'Database Link (Failed)',
+		category: 'Databases',
+		description: 'Notification when linking a new database fails'
+	},
 
 	// Arr Sync
 	{

--- a/src/routes/databases/+page.svelte
+++ b/src/routes/databases/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
+	import { onMount } from 'svelte';
 	import { Database, Plus, Info } from 'lucide-svelte';
-	import { goto } from '$app/navigation';
+	import { goto, invalidateAll } from '$app/navigation';
 	import { enhance } from '$app/forms';
 	import EmptyState from '$ui/state/EmptyState.svelte';
 	import Modal from '$ui/modal/Modal.svelte';
@@ -13,6 +14,7 @@
 	import CardView from './views/CardView.svelte';
 	import { createDataPageStore } from '$lib/client/stores/dataPage';
 	import { alertStore } from '$alerts/store';
+	import { jobStatus } from '$stores/jobStatus';
 	import type { PageData } from './$types';
 	import type { DatabaseInstanceSummary } from './+page.server.ts';
 
@@ -39,6 +41,20 @@
 		selectedDatabase = event.detail;
 		showUnlinkModal = true;
 	}
+
+	// Refresh the list when a pcd.link job finishes so the new database appears
+	// without a manual reload.
+	onMount(() => {
+		return jobStatus.subscribe((state) => {
+			if (
+				state.state === 'completed' &&
+				state.jobType === 'pcd.link' &&
+				state.status === 'success'
+			) {
+				invalidateAll();
+			}
+		});
+	});
 </script>
 
 <svelte:head>

--- a/src/routes/databases/components/InstanceForm.svelte
+++ b/src/routes/databases/components/InstanceForm.svelte
@@ -12,6 +12,7 @@
 		ExternalLink
 	} from 'lucide-svelte';
 	import { alertStore } from '$alerts/store';
+	import { jobStatus } from '$stores/jobStatus';
 	import { isDirty, initEdit, initCreate, update, current, clear } from '$lib/client/stores/dirty';
 	import type { DatabaseInstancePublic } from '$db/queries/databaseInstances.ts';
 	import type { RepoInfo } from '$utils/git/types';
@@ -449,11 +450,27 @@
 	class="hidden"
 	use:enhance={() => {
 		saving = true;
+		if (mode === 'create') {
+			// Open SSE early and claim optimistic running state so the
+			// progress bar appears immediately, even if `job.started`
+			// fires before the EventSource finishes connecting.
+			jobStatus.connect();
+			jobStatus.setRunning('pcd.link', 'Linking database...');
+		}
 		return async ({ result, update: formUpdate }) => {
 			if (result.type === 'redirect') {
-				// For create mode, clear dirty state before redirect
 				clear();
-				alertStore.add('success', 'Database linked successfully');
+				if (mode === 'edit') {
+					alertStore.add('success', 'Database linked successfully');
+				} else if (result.location?.startsWith('/databases/bruh')) {
+					// Server bounced us to the bruh page; no link was queued.
+					jobStatus.cancelOptimistic();
+				} else {
+					alertStore.add('info', 'Database link queued');
+				}
+			} else if (mode === 'create') {
+				// Validation/conflict failure: clear the optimistic bar.
+				jobStatus.cancelOptimistic();
 			}
 			await formUpdate({ reset: false });
 			saving = false;

--- a/src/routes/databases/new/+page.server.ts
+++ b/src/routes/databases/new/+page.server.ts
@@ -1,8 +1,8 @@
 import { fail, redirect } from '@sveltejs/kit';
 import type { Actions, ServerLoad } from '@sveltejs/kit';
-import { pcdManager } from '$pcd/core/manager.ts';
 import { logger } from '$logger/logger.ts';
-import { schedulePcdSyncForDatabase } from '$lib/server/jobs/init.ts';
+import { enqueueJob } from '$jobs/queueService.ts';
+import { stashLinkPat } from '$jobs/handlers/pcdLink.ts';
 import { validateLinkInput, checkNameConflict } from '$pcd/core/validate.ts';
 
 function getFirstNonEmptyFormValue(formData: FormData, key: string): string | undefined {
@@ -101,37 +101,33 @@ export const actions = {
 			});
 		}
 
-		try {
-			const instance = await pcdManager.link(input);
+		const patToken = input.personalAccessToken
+			? stashLinkPat(input.personalAccessToken)
+			: undefined;
 
-			await logger.info(`Linked new database: ${input.name}`, {
-				source: 'databases/new',
-				meta: { id: instance.id, name: input.name, repositoryUrl: input.repositoryUrl }
-			});
-
-			schedulePcdSyncForDatabase(instance.id);
-
-			redirect(303, '/databases');
-		} catch (error) {
-			// Re-throw redirect errors (they're not actual errors)
-			if (error && typeof error === 'object' && 'status' in error && 'location' in error) {
-				throw error;
+		enqueueJob({
+			jobType: 'pcd.link',
+			runAt: new Date().toISOString(),
+			source: 'manual',
+			payload: {
+				name: input.name,
+				repositoryUrl: input.repositoryUrl,
+				branch: input.branch,
+				syncStrategy: input.syncStrategy,
+				autoPull: input.autoPull,
+				localOpsEnabled: input.localOpsEnabled,
+				gitUserName: input.gitUserName,
+				gitUserEmail: input.gitUserEmail,
+				conflictStrategy: input.conflictStrategy,
+				patToken
 			}
+		});
 
-			await logger.error('Failed to link database', {
-				source: 'databases/new',
-				meta: {
-					error: error instanceof Error ? error.message : String(error),
-					name: input.name,
-					repositoryUrl: input.repositoryUrl,
-					hasPersonalAccessToken: !!input.personalAccessToken
-				}
-			});
+		await logger.info(`Queued database link: ${input.name}`, {
+			source: 'databases/new',
+			meta: { name: input.name, repositoryUrl: input.repositoryUrl }
+		});
 
-			return fail(500, {
-				error: error instanceof Error ? error.message : 'Failed to link database',
-				values: { name: input.name, repository_url: input.repositoryUrl }
-			});
-		}
+		redirect(303, '/databases');
 	}
 } satisfies Actions;


### PR DESCRIPTION
Moves database linking off the request thread onto a new `pcd.link` job. The form redirects to `/databases` immediately; progress streams over the existing SSE pipe until the link finishes.

## Changes

- New `pcd.link` job type. Handler at `src/lib/server/jobs/handlers/pcdLink.ts` runs the existing `pcdManager.link()` with stage progress callbacks ("Cloning…", "Reading manifest…", "Cloning dependencies…", "Importing ops…", "Compiling cache…").
- New `job.progress` SSE event. Handlers receive an optional `ctx.progress(label)` callback; the dispatcher binds it to the running job.
- Client `jobStatus` store handles `job.progress` (updates the bar label in place) and exposes optimistic `setRunning` / `cancelOptimistic` so the link form can claim the bar before SSE connects, avoiding the started-event race.
- Database list page calls `invalidateAll()` when a `pcd.link` job finishes successfully so the new card appears without a manual refresh.
- New `pcd.link_failed` notification mirrors `pcd.sync_failed`. Surfaces async link failures since the form is no longer there to show an error inline.
- PAT handling: the form stashes the PAT in an in-memory map keyed by id and writes only the id into the job payload, avoiding plaintext PATs in `job_queue` / `job_run_history`.