### PR TITLE
feat: add referenced smart filters

### DIFF
--- a/src/lib/server/pcd/entities/customFormats/list.ts
+++ b/src/lib/server/pcd/entities/customFormats/list.ts
@@ -5,6 +5,7 @@
 import { sql } from 'kysely';
 import type { PCDCache } from '$pcd/index.ts';
 import type { Tag, CustomFormatTableRow, ConditionRef } from '$shared/pcd/display.ts';
+import { getProfileRefCountsForCustomFormats } from '$pcd/references.ts';
 
 /**
  * Get custom formats with full data for table/card views
@@ -49,6 +50,8 @@ export async function list(cache: PCDCache): Promise<CustomFormatTableRow[]> {
 		.groupBy('custom_format_name')
 		.execute();
 
+	const referenceCounts = await getProfileRefCountsForCustomFormats(cache, formatNames);
+
 	// Build test count map
 	const testCountMap = new Map<string, number>();
 	for (const tc of testCounts) {
@@ -88,6 +91,7 @@ export async function list(cache: PCDCache): Promise<CustomFormatTableRow[]> {
 		description: format.description,
 		tags: tagsMap.get(format.name) || [],
 		conditions: conditionsMap.get(format.name) || [],
-		testCount: testCountMap.get(format.name) || 0
+		testCount: testCountMap.get(format.name) || 0,
+		referenceCount: referenceCounts.get(format.name) || 0
 	}));
 }

--- a/src/lib/server/pcd/entities/regularExpressions/read.ts
+++ b/src/lib/server/pcd/entities/regularExpressions/read.ts
@@ -5,6 +5,7 @@
 import { sql } from 'kysely';
 import type { PCDCache } from '$pcd/index.ts';
 import type { Tag, RegularExpressionWithTags } from '$shared/pcd/display.ts';
+import { getConditionRefCountsForRegexes } from '$pcd/references.ts';
 
 /**
  * List all regular expressions with tags
@@ -22,6 +23,7 @@ export async function list(cache: PCDCache): Promise<RegularExpressionWithTags[]
 	if (expressions.length === 0) return [];
 
 	const expressionNames = expressions.map((e) => e.name);
+	const referenceCounts = await getConditionRefCountsForRegexes(cache, expressionNames);
 
 	// Get all tags for all expressions
 	const allTags = await db
@@ -48,7 +50,8 @@ export async function list(cache: PCDCache): Promise<RegularExpressionWithTags[]
 	// Build the final result
 	return expressions.map((expression) => ({
 		...expression,
-		tags: tagsMap.get(expression.name) || []
+		tags: tagsMap.get(expression.name) || [],
+		referenceCount: referenceCounts.get(expression.name) || 0
 	}));
 }
 
@@ -76,9 +79,11 @@ export async function get(cache: PCDCache, id: number): Promise<RegularExpressio
 		.select(['t.name', 't.created_at'])
 		.where('ret.regular_expression_name', '=', regex.name)
 		.execute();
+	const referenceCounts = await getConditionRefCountsForRegexes(cache, [regex.name]);
 
 	return {
 		...regex,
-		tags
+		tags,
+		referenceCount: referenceCounts.get(regex.name) || 0
 	};
 }

--- a/src/lib/server/pcd/references.ts
+++ b/src/lib/server/pcd/references.ts
@@ -105,6 +105,36 @@ export async function getProfileRefsForCustomFormat(
 	return [...map.values()];
 }
 
+/**
+ * Count quality profiles that reference each custom format.
+ * Uses the same one-row-per-profile semantics as getProfileRefsForCustomFormat.
+ */
+export async function getProfileRefCountsForCustomFormats(
+	cache: PCDCache,
+	cfNames: string[]
+): Promise<Map<string, number>> {
+	if (cfNames.length === 0) return new Map();
+
+	const rows = await cache.kb
+		.selectFrom('quality_profile_custom_formats as qpcf')
+		.innerJoin('quality_profiles as qp', 'qp.name', 'qpcf.quality_profile_name')
+		.select(['qpcf.custom_format_name', 'qp.id as profile_id'])
+		.where('qpcf.custom_format_name', 'in', cfNames)
+		.execute();
+
+	const refs = new Map<string, Set<number>>();
+	for (const row of rows) {
+		let profileIds = refs.get(row.custom_format_name);
+		if (!profileIds) {
+			profileIds = new Set();
+			refs.set(row.custom_format_name, profileIds);
+		}
+		profileIds.add(row.profile_id);
+	}
+
+	return new Map([...refs.entries()].map(([name, profileIds]) => [name, profileIds.size]));
+}
+
 export interface ConditionRef {
 	cfId: number;
 	cfName: string;
@@ -142,4 +172,34 @@ export async function getConditionRefsForRegex(
 		negate: !!r.negate,
 		required: !!r.required
 	}));
+}
+
+/**
+ * Count custom format condition references for each regular expression.
+ * Uses the same row semantics as getConditionRefsForRegex.
+ */
+export async function getConditionRefCountsForRegexes(
+	cache: PCDCache,
+	regexNames: string[]
+): Promise<Map<string, number>> {
+	if (regexNames.length === 0) return new Map();
+
+	const rows = await cache.kb
+		.selectFrom('condition_patterns as cp')
+		.innerJoin('custom_format_conditions as cfc', (join) =>
+			join
+				.onRef('cp.custom_format_name', '=', 'cfc.custom_format_name')
+				.onRef('cp.condition_name', '=', 'cfc.name')
+		)
+		.innerJoin('custom_formats as cf', 'cf.name', 'cp.custom_format_name')
+		.select(['cp.regular_expression_name'])
+		.where('cp.regular_expression_name', 'in', regexNames)
+		.execute();
+
+	const counts = new Map<string, number>();
+	for (const row of rows) {
+		counts.set(row.regular_expression_name, (counts.get(row.regular_expression_name) ?? 0) + 1);
+	}
+
+	return counts;
 }

--- a/src/lib/shared/pcd/display.ts
+++ b/src/lib/shared/pcd/display.ts
@@ -25,6 +25,7 @@ export interface Tag {
 /** Regular expression with tags (from JOIN) */
 export type RegularExpressionWithTags = RegularExpressionsRow & {
 	tags: Tag[];
+	referenceCount: number;
 };
 
 // ============================================================================
@@ -142,6 +143,7 @@ export type CustomFormatTableRow = Omit<
 	tags: Tag[];
 	conditions: ConditionRef[];
 	testCount: number;
+	referenceCount: number;
 };
 
 /** Custom format general information (for general tab) */

--- a/src/routes/custom-formats/[databaseId]/+page.svelte
+++ b/src/routes/custom-formats/[databaseId]/+page.svelte
@@ -90,6 +90,13 @@
 			suggestions: () => ['yes', 'no']
 		},
 		{
+			key: 'referenced',
+			label: 'Referenced',
+			type: 'text',
+			accessor: (item) => (item.referenceCount > 0 ? 'yes' : 'no'),
+			suggestions: () => ['yes', 'no']
+		},
+		{
 			key: 'description',
 			label: 'Description',
 			type: 'text',

--- a/src/routes/regular-expressions/[databaseId]/+page.svelte
+++ b/src/routes/regular-expressions/[databaseId]/+page.svelte
@@ -92,6 +92,13 @@
 			suggestions: () => ['yes', 'no']
 		},
 		{
+			key: 'referenced',
+			label: 'Referenced',
+			type: 'text',
+			accessor: (item) => (item.referenceCount > 0 ? 'yes' : 'no'),
+			suggestions: () => ['yes', 'no']
+		},
+		{
 			key: 'pattern',
 			label: 'Pattern',
 			type: 'text',


### PR DESCRIPTION
## Summary
- Add referenced smart filters to filter out unreferenced custom formats and regex patterns.