### PR TITLE
fix: adjust card view breakpoints

### DIFF
--- a/src/routes/arr/views/CardView.svelte
+++ b/src/routes/arr/views/CardView.svelte
@@ -53,7 +53,7 @@
 	}
 </script>
 
-<CardGrid columns={3} flush>
+<CardGrid columns={1} className="lg:grid-cols-2 2xl:grid-cols-3" flush>
 	{#each instances as instance}
 		<Card href="/arr/{instance.id}" hoverable>
 			<svelte:fragment slot="header">

--- a/src/routes/databases/views/CardView.svelte
+++ b/src/routes/databases/views/CardView.svelte
@@ -55,7 +55,7 @@
 	}
 </script>
 
-<CardGrid columns={3} flush>
+<CardGrid columns={1} className="xl:grid-cols-2 2xl:grid-cols-3" flush>
 	{#each databases as database}
 		<Card href="/databases/{database.id}" hoverable>
 			<svelte:fragment slot="header">


### PR DESCRIPTION
Summary: Adjust Arr and database card breakpoints so dense cards switch to single-column sooner.