### PR TITLE
fix: allow single sonarr result expansion

### DIFF
--- a/src/routes/arr/[id]/library/components/SonarrTableView.svelte
+++ b/src/routes/arr/[id]/library/components/SonarrTableView.svelte
@@ -167,11 +167,11 @@
 	}
 
 	let expandedRows: Set<string | number> = new Set();
+	let previousExpandAll = expandAll;
 
-	$: if (expandAll) {
-		expandedRows = new Set(data.map((row) => row.id));
-	} else if (!expandAll && expandedRows.size === data.length) {
-		expandedRows = new Set();
+	$: if (expandAll !== previousExpandAll) {
+		expandedRows = expandAll ? new Set(data.map((row) => row.id)) : new Set();
+		previousExpandAll = expandAll;
 	}
 
 	$: if (expandedRows.size > 0) {


### PR DESCRIPTION
Fixes the Sonarr library table expand state so filtered searches with one visible series keep manual row expansion independent from expand-all.