### PR TITLE
feat: add drift detection foundation

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -86,6 +86,7 @@ publishes a release.
 - [backend/api.md](./backend/api.md): API v1 routes, contract-first workflow, OpenAPI spec
 - [backend/database.md](./backend/database.md): App database, migrations, query layer, schema reference
 - [backend/datetime.md](./backend/datetime.md): Date/time handling, UTC storage, query normalization, timezone display
+- [backend/drift.md](./backend/drift.md): Arr drift detection, latest status storage, comparison model
 - [backend/jobs.md](./backend/jobs.md): Job queue, dispatcher, handlers, scheduling
 - [backend/logger.md](./backend/logger.md): Logger singleton, log levels, output formats, usage
 - [backend/notifications.md](./backend/notifications.md): Notification manager, definitions, notifiers

--- a/docs/backend/database.md
+++ b/docs/backend/database.md
@@ -101,6 +101,8 @@ All use raw SQL with `?` parameter binding and typed input/output interfaces.
 | `arrInstances`          | Arr instance CRUD                                                   |
 | `arrSync`               | Sync config and status per instance                                 |
 | `arrCleanupSettings`    | Stale config cleanup settings                                       |
+| `arrDriftSettings`      | Drift detection scheduling settings                                |
+| `arrDriftStatus`        | Latest drift detection result per Arr instance                      |
 | `arrRenameSettings`     | Rename job settings per instance                                    |
 | `authSettings`          | Session duration, API key                                           |
 | `sessions`              | Session CRUD and cleanup                                            |

--- a/docs/backend/database.md
+++ b/docs/backend/database.md
@@ -101,7 +101,7 @@ All use raw SQL with `?` parameter binding and typed input/output interfaces.
 | `arrInstances`          | Arr instance CRUD                                                   |
 | `arrSync`               | Sync config and status per instance                                 |
 | `arrCleanupSettings`    | Stale config cleanup settings                                       |
-| `arrDriftSettings`      | Drift detection scheduling settings                                |
+| `arrDriftSettings`      | Drift detection scheduling settings                                 |
 | `arrDriftStatus`        | Latest drift detection result per Arr instance                      |
 | `arrRenameSettings`     | Rename job settings per instance                                    |
 | `authSettings`          | Session duration, API key                                           |

--- a/docs/backend/drift.md
+++ b/docs/backend/drift.md
@@ -40,18 +40,18 @@ Job run history remains the operational history.
 Current implementation creates and exposes the table/query layer. The no-op job
 handler does not write drift result rows yet.
 
-| Field                         | Purpose                                      |
-| ----------------------------- | -------------------------------------------- |
-| `status`                      | `never_checked`, `clean`, `drift_detected`, `failed` |
-| `last_checked_at`             | Last completed check time                    |
-| `counts_json`                 | Count summary by drift section               |
-| `diff_json`                   | Structured latest drift result               |
-| `diff_hash`                   | Stable hash of the structured drift result   |
-| `last_notified_hash`          | Last drift hash sent as a notification       |
-| `last_notified_at`            | Last drift notification time                 |
-| `last_error`                  | Latest failure detail                        |
-| `error_hash`                  | Stable hash of the latest failure detail     |
-| `last_notified_error_hash`    | Last failure hash sent as a notification     |
+| Field                      | Purpose                                              |
+| -------------------------- | ---------------------------------------------------- |
+| `status`                   | `never_checked`, `clean`, `drift_detected`, `failed` |
+| `last_checked_at`          | Last completed check time                            |
+| `counts_json`              | Count summary by drift section                       |
+| `diff_json`                | Structured latest drift result                       |
+| `diff_hash`                | Stable hash of the structured drift result           |
+| `last_notified_hash`       | Last drift hash sent as a notification               |
+| `last_notified_at`         | Last drift notification time                         |
+| `last_error`               | Latest failure detail                                |
+| `error_hash`               | Stable hash of the latest failure detail             |
+| `last_notified_error_hash` | Last failure hash sent as a notification             |
 
 ## TODO
 

--- a/docs/backend/drift.md
+++ b/docs/backend/drift.md
@@ -1,0 +1,58 @@
+# Drift Detection
+
+**Source:** `src/lib/server/jobs/handlers/arrDrift.ts`,
+`src/lib/server/db/queries/arrDriftSettings.ts`,
+`src/lib/server/db/queries/arrDriftStatus.ts`
+
+Drift detection checks whether an Arr instance still matches the configuration
+Profilarr would sync now. It is observational: it does not write to Arr, repair
+config, delete stale items, or replace cleanup.
+
+## Job
+
+The scheduled job type is `arr.drift` with payload `{ instanceId }`.
+
+Scheduling is per Arr instance and uses `arr_drift_settings`:
+
+| Field         | Purpose                               |
+| ------------- | ------------------------------------- |
+| `enabled`     | Master switch for drift detection     |
+| `cron`        | Cron expression for scheduled checks  |
+| `next_run_at` | Next scheduled run stored as UTC text |
+
+The job queue uses dedupe key `arr.drift:{instanceId}` so each instance has at
+most one scheduled drift job.
+
+Current handler behavior:
+
+- invalid instance ids fail
+- missing instances fail
+- missing or disabled settings cancel the job
+- unsupported Arr types are skipped
+- enabled jobs skip with `Drift comparison not implemented`
+- scheduled jobs calculate and store the next run before returning
+
+## Latest Status
+
+Drift stores only the latest result per Arr instance in `arr_drift_status`.
+Job run history remains the operational history.
+
+Current implementation creates and exposes the table/query layer. The no-op job
+handler does not write drift result rows yet.
+
+| Field                         | Purpose                                      |
+| ----------------------------- | -------------------------------------------- |
+| `status`                      | `never_checked`, `clean`, `drift_detected`, `failed` |
+| `last_checked_at`             | Last completed check time                    |
+| `counts_json`                 | Count summary by drift section               |
+| `diff_json`                   | Structured latest drift result               |
+| `diff_hash`                   | Stable hash of the structured drift result   |
+| `last_notified_hash`          | Last drift hash sent as a notification       |
+| `last_notified_at`            | Last drift notification time                 |
+| `last_error`                  | Latest failure detail                        |
+| `error_hash`                  | Stable hash of the latest failure detail     |
+| `last_notified_error_hash`    | Last failure hash sent as a notification     |
+
+## TODO
+
+Implement comparison logic, notifications, and the sync page drift UI.

--- a/docs/backend/jobs.md
+++ b/docs/backend/jobs.md
@@ -26,6 +26,7 @@
   - [Arr Upgrade](#arr-upgrade)
   - [Arr Rename](#arr-rename)
   - [Arr Cleanup](#arr-cleanup)
+  - [Arr Drift](#arr-drift)
   - [Arr Library Refresh](#arr-library-refresh)
   - [PCD Sync](#pcd-sync)
   - [Backup Create](#backup-create)
@@ -37,8 +38,9 @@
 
 Profilarr uses an event-driven job queue for background tasks: syncing
 configuration to Arr instances, creating backups, running upgrades, renaming
-files, and cleaning up old data. The system is built around a SQLite-backed
-queue with a single-threaded dispatcher that processes jobs sequentially.
+files, checking drift, and cleaning up old data. The system is built around a
+SQLite-backed queue with a single-threaded dispatcher that processes jobs
+sequentially.
 
 The dispatcher does not poll. It calculates the delay until the next job is due
 and sets a timeout. When a new job is enqueued, the dispatcher is notified and
@@ -60,6 +62,7 @@ concurrency and makes the system deterministic.
 | `arr.upgrade`              | Automated quality upgrades             | `{ instanceId }` | Yes       |
 | `arr.rename`               | Bulk file/folder rename                | `{ instanceId }` | Yes       |
 | `arr.cleanup`              | Remove stale configs from Arr          | `{ instanceId }` | Yes       |
+| `arr.drift`                | Check Arr config drift                 | `{ instanceId }` | Yes       |
 | `arr.library.refresh`      | Refresh cached library data            | `{ instanceId }` | Yes       |
 | `pcd.sync`                 | Check/pull PCD database updates        | `{ databaseId }` | Yes       |
 | `backup.create`            | Create backup archive                  | `{}`             | Yes       |
@@ -134,9 +137,9 @@ marked finished. This creates the recurring loop for scheduled jobs.
 
 ### Cron
 
-Used by sync, upgrade, rename, and cleanup jobs. The cron expression is stored
-in the config table for each instance. `calculateNextRun()` uses the `croner`
-library to compute the next occurrence.
+Used by sync, upgrade, rename, cleanup, and drift jobs. The cron expression is
+stored in the config table for each instance. `calculateNextRun()` uses the
+`croner` library to compute the next occurrence.
 
 Cron expressions are validated with a minimum interval check to prevent
 accidental sub-minute schedules. For simple `*/N * * * *` patterns, the interval
@@ -385,6 +388,13 @@ config and triggers rename commands. Supports dry-run mode and folder renaming.
 Scans Arr instances for stale custom formats and quality profiles that exist in
 the Arr but are no longer in the PCD config, then deletes them. Also scans for
 removed entities (TMDB/TVDB items no longer in the database).
+
+### Arr Drift
+
+**Handler:** `arrDrift.ts`
+
+Checks whether an Arr instance still matches what Profilarr would sync now.
+While `FEATURES.drift` is false, drift jobs exit without contacting Arr.
 
 ### Arr Library Refresh
 

--- a/docs/backend/sync.md
+++ b/docs/backend/sync.md
@@ -26,6 +26,7 @@ updates for items that already exist.
 - [Cleanup](#cleanup)
   - [Config Cleanup](#config-cleanup)
   - [Entity Cleanup](#entity-cleanup)
+- [Drift Detection](#drift-detection)
 - [Impact Analysis](#impact-analysis)
 - [Error Handling and Recovery](#error-handling-and-recovery)
 - [Logging and Notifications](#logging-and-notifications)
@@ -252,6 +253,14 @@ Detects media removed from TMDB/TVDB by reading the Arr health API. Health
 messages with source `RemovedMovieCheck` (Radarr) or `RemovedSeriesCheck`
 (Sonarr) contain external IDs. The system extracts these IDs via regex, matches
 them against the library, and offers scan/delete operations.
+
+## Drift Detection
+
+See [drift.md](./drift.md).
+
+Drift detection checks whether Arr still matches what Profilarr would sync now.
+It may reuse sync transformers to build expected state, but it does not sync,
+repair, or cleanup.
 
 ## Impact Analysis
 

--- a/src/lib/server/db/migrations.ts
+++ b/src/lib/server/db/migrations.ts
@@ -66,6 +66,7 @@ import { migration as migration061 } from './migrations/061_create_announcements
 import { migration as migration062 } from './migrations/062_drop_onboarding_shown.ts';
 import { migration as migration063 } from './migrations/063_create_database_announcements.ts';
 import { migration as migration064 } from './migrations/064_add_fail_on_referenced_delete.ts';
+import { migration as migration065 } from './migrations/065_create_arr_drift_tables.ts';
 
 export interface Migration {
 	version: number;
@@ -350,7 +351,8 @@ export function loadMigrations(): Migration[] {
 		migration061,
 		migration062,
 		migration063,
-		migration064
+		migration064,
+		migration065
 	];
 
 	// Sort by version number

--- a/src/lib/server/db/migrations/065_create_arr_drift_tables.ts
+++ b/src/lib/server/db/migrations/065_create_arr_drift_tables.ts
@@ -1,0 +1,57 @@
+import type { Migration } from '../migrations.ts';
+
+/**
+ * Migration 065: Create Arr drift tables
+ *
+ * Stores per-instance drift scheduling config and the latest drift result.
+ */
+
+export const migration: Migration = {
+	version: 65,
+	name: 'Create Arr drift tables',
+
+	up: `
+		CREATE TABLE arr_drift_settings (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			arr_instance_id INTEGER NOT NULL UNIQUE,
+			enabled INTEGER NOT NULL DEFAULT 0,
+			cron TEXT NOT NULL DEFAULT '0 0 * * *',
+			next_run_at TEXT,
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			FOREIGN KEY (arr_instance_id) REFERENCES arr_instances(id) ON DELETE CASCADE
+		);
+
+		CREATE INDEX idx_arr_drift_settings_instance ON arr_drift_settings(arr_instance_id);
+
+		CREATE TABLE arr_drift_status (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			arr_instance_id INTEGER NOT NULL UNIQUE,
+			status TEXT NOT NULL DEFAULT 'never_checked' CHECK (
+				status IN ('never_checked', 'clean', 'drift_detected', 'failed')
+			),
+			last_checked_at TEXT,
+			counts_json TEXT NOT NULL DEFAULT '{}',
+			diff_json TEXT NOT NULL DEFAULT '{}',
+			diff_hash TEXT,
+			last_notified_hash TEXT,
+			last_notified_at TEXT,
+			last_error TEXT,
+			error_hash TEXT,
+			last_notified_error_hash TEXT,
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			FOREIGN KEY (arr_instance_id) REFERENCES arr_instances(id) ON DELETE CASCADE
+		);
+
+		CREATE INDEX idx_arr_drift_status_instance ON arr_drift_status(arr_instance_id);
+	`,
+
+	down: `
+		DROP INDEX IF EXISTS idx_arr_drift_status_instance;
+		DROP TABLE IF EXISTS arr_drift_status;
+
+		DROP INDEX IF EXISTS idx_arr_drift_settings_instance;
+		DROP TABLE IF EXISTS arr_drift_settings;
+	`
+};

--- a/src/lib/server/db/queries/arrDriftSettings.ts
+++ b/src/lib/server/db/queries/arrDriftSettings.ts
@@ -1,0 +1,143 @@
+import { db } from '../db.ts';
+import { toUTC } from '$shared/utils/dates.ts';
+
+interface DriftSettingsRow {
+	id: number;
+	arr_instance_id: number;
+	enabled: number;
+	cron: string;
+	next_run_at: string | null;
+	created_at: string;
+	updated_at: string;
+}
+
+export interface DriftSettings {
+	id: number;
+	arrInstanceId: number;
+	enabled: boolean;
+	cron: string;
+	nextRunAt: string | null;
+	createdAt: string;
+	updatedAt: string;
+}
+
+export interface DriftSettingsInput {
+	enabled?: boolean;
+	cron?: string;
+	nextRunAt?: string | null;
+}
+
+function rowToSettings(row: DriftSettingsRow): DriftSettings {
+	return {
+		id: row.id,
+		arrInstanceId: row.arr_instance_id,
+		enabled: row.enabled === 1,
+		cron: row.cron,
+		nextRunAt: toUTC(row.next_run_at),
+		createdAt: toUTC(row.created_at)!,
+		updatedAt: toUTC(row.updated_at)!
+	};
+}
+
+export const arrDriftSettingsQueries = {
+	getByInstanceId(arrInstanceId: number): DriftSettings | undefined {
+		const row = db.queryFirst<DriftSettingsRow>(
+			'SELECT * FROM arr_drift_settings WHERE arr_instance_id = ?',
+			arrInstanceId
+		);
+		return row ? rowToSettings(row) : undefined;
+	},
+
+	getAll(): DriftSettings[] {
+		const rows = db.query<DriftSettingsRow>('SELECT * FROM arr_drift_settings');
+		return rows.map(rowToSettings);
+	},
+
+	getEnabled(): DriftSettings[] {
+		const rows = db.query<DriftSettingsRow>('SELECT * FROM arr_drift_settings WHERE enabled = 1');
+		return rows.map(rowToSettings);
+	},
+
+	upsert(arrInstanceId: number, input: DriftSettingsInput): DriftSettings {
+		const existing = this.getByInstanceId(arrInstanceId);
+		if (existing) {
+			this.update(arrInstanceId, input);
+			return this.getByInstanceId(arrInstanceId)!;
+		}
+
+		const enabled = input.enabled !== undefined ? (input.enabled ? 1 : 0) : 0;
+		const cron = input.cron ?? '0 0 * * *';
+		const nextRunAt = input.nextRunAt ?? null;
+
+		db.execute(
+			`INSERT INTO arr_drift_settings (arr_instance_id, enabled, cron, next_run_at)
+			 VALUES (?, ?, ?, ?)`,
+			arrInstanceId,
+			enabled,
+			cron,
+			nextRunAt
+		);
+
+		return this.getByInstanceId(arrInstanceId)!;
+	},
+
+	update(arrInstanceId: number, input: DriftSettingsInput): boolean {
+		const updates: string[] = [];
+		const params: Array<string | number | null> = [];
+
+		if (input.enabled !== undefined) {
+			updates.push('enabled = ?');
+			params.push(input.enabled ? 1 : 0);
+		}
+		if (input.cron !== undefined) {
+			updates.push('cron = ?');
+			params.push(input.cron);
+		}
+		if (input.nextRunAt !== undefined) {
+			updates.push('next_run_at = ?');
+			params.push(input.nextRunAt);
+		}
+
+		if (updates.length === 0) {
+			return false;
+		}
+
+		updates.push('updated_at = CURRENT_TIMESTAMP');
+		params.push(arrInstanceId);
+
+		const affected = db.execute(
+			`UPDATE arr_drift_settings SET ${updates.join(', ')} WHERE arr_instance_id = ?`,
+			...params
+		);
+
+		return affected > 0;
+	},
+
+	delete(arrInstanceId: number): boolean {
+		const affected = db.execute(
+			'DELETE FROM arr_drift_settings WHERE arr_instance_id = ?',
+			arrInstanceId
+		);
+		return affected > 0;
+	},
+
+	updateNextRunAt(arrInstanceId: number, nextRunAt: string | null): void {
+		db.execute(
+			'UPDATE arr_drift_settings SET next_run_at = ?, updated_at = CURRENT_TIMESTAMP WHERE arr_instance_id = ?',
+			nextRunAt,
+			arrInstanceId
+		);
+	},
+
+	getDueConfigs(): DriftSettings[] {
+		const rows = db.query<DriftSettingsRow>(`
+			SELECT * FROM arr_drift_settings
+			WHERE enabled = 1
+			AND (
+				next_run_at IS NULL
+				OR datetime('now') >= datetime(replace(replace(next_run_at, 'T', ' '), 'Z', ''))
+			)
+		`);
+		return rows.map(rowToSettings);
+	}
+};

--- a/src/lib/server/db/queries/arrDriftStatus.ts
+++ b/src/lib/server/db/queries/arrDriftStatus.ts
@@ -1,0 +1,175 @@
+import { db } from '../db.ts';
+import { toUTC } from '$shared/utils/dates.ts';
+import type { DriftCounts, DriftDiff, DriftRunStatus } from '$shared/drift.ts';
+
+interface DriftStatusRow {
+	id: number;
+	arr_instance_id: number;
+	status: DriftRunStatus;
+	last_checked_at: string | null;
+	counts_json: string;
+	diff_json: string;
+	diff_hash: string | null;
+	last_notified_hash: string | null;
+	last_notified_at: string | null;
+	last_error: string | null;
+	error_hash: string | null;
+	last_notified_error_hash: string | null;
+	created_at: string;
+	updated_at: string;
+}
+
+export interface DriftStatusRecord {
+	id: number;
+	arrInstanceId: number;
+	status: DriftRunStatus;
+	lastCheckedAt: string | null;
+	counts: DriftCounts;
+	diff: DriftDiff;
+	diffHash: string | null;
+	lastNotifiedHash: string | null;
+	lastNotifiedAt: string | null;
+	lastError: string | null;
+	errorHash: string | null;
+	lastNotifiedErrorHash: string | null;
+	createdAt: string;
+	updatedAt: string;
+}
+
+export interface DriftStatusInput {
+	status?: DriftRunStatus;
+	lastCheckedAt?: string | null;
+	counts?: DriftCounts;
+	diff?: DriftDiff;
+	diffHash?: string | null;
+	lastNotifiedHash?: string | null;
+	lastNotifiedAt?: string | null;
+	lastError?: string | null;
+	errorHash?: string | null;
+	lastNotifiedErrorHash?: string | null;
+}
+
+function parseJson<T>(raw: string, fallback: T): T {
+	try {
+		const parsed = JSON.parse(raw);
+		return parsed && typeof parsed === 'object' ? (parsed as T) : fallback;
+	} catch {
+		return fallback;
+	}
+}
+
+function rowToStatus(row: DriftStatusRow): DriftStatusRecord {
+	return {
+		id: row.id,
+		arrInstanceId: row.arr_instance_id,
+		status: row.status,
+		lastCheckedAt: toUTC(row.last_checked_at),
+		counts: parseJson<DriftCounts>(row.counts_json, {}),
+		diff: parseJson<DriftDiff>(row.diff_json, {}),
+		diffHash: row.diff_hash,
+		lastNotifiedHash: row.last_notified_hash,
+		lastNotifiedAt: toUTC(row.last_notified_at),
+		lastError: row.last_error,
+		errorHash: row.error_hash,
+		lastNotifiedErrorHash: row.last_notified_error_hash,
+		createdAt: toUTC(row.created_at)!,
+		updatedAt: toUTC(row.updated_at)!
+	};
+}
+
+export const arrDriftStatusQueries = {
+	getByInstanceId(arrInstanceId: number): DriftStatusRecord | undefined {
+		const row = db.queryFirst<DriftStatusRow>(
+			'SELECT * FROM arr_drift_status WHERE arr_instance_id = ?',
+			arrInstanceId
+		);
+		return row ? rowToStatus(row) : undefined;
+	},
+
+	getAll(): DriftStatusRecord[] {
+		const rows = db.query<DriftStatusRow>('SELECT * FROM arr_drift_status');
+		return rows.map(rowToStatus);
+	},
+
+	ensure(arrInstanceId: number): DriftStatusRecord {
+		const existing = this.getByInstanceId(arrInstanceId);
+		if (existing) return existing;
+
+		db.execute('INSERT INTO arr_drift_status (arr_instance_id) VALUES (?)', arrInstanceId);
+		return this.getByInstanceId(arrInstanceId)!;
+	},
+
+	upsert(arrInstanceId: number, input: DriftStatusInput): DriftStatusRecord {
+		this.ensure(arrInstanceId);
+		this.update(arrInstanceId, input);
+		return this.getByInstanceId(arrInstanceId)!;
+	},
+
+	update(arrInstanceId: number, input: DriftStatusInput): boolean {
+		const updates: string[] = [];
+		const params: Array<string | number | null> = [];
+
+		if (input.status !== undefined) {
+			updates.push('status = ?');
+			params.push(input.status);
+		}
+		if (input.lastCheckedAt !== undefined) {
+			updates.push('last_checked_at = ?');
+			params.push(input.lastCheckedAt);
+		}
+		if (input.counts !== undefined) {
+			updates.push('counts_json = ?');
+			params.push(JSON.stringify(input.counts));
+		}
+		if (input.diff !== undefined) {
+			updates.push('diff_json = ?');
+			params.push(JSON.stringify(input.diff));
+		}
+		if (input.diffHash !== undefined) {
+			updates.push('diff_hash = ?');
+			params.push(input.diffHash);
+		}
+		if (input.lastNotifiedHash !== undefined) {
+			updates.push('last_notified_hash = ?');
+			params.push(input.lastNotifiedHash);
+		}
+		if (input.lastNotifiedAt !== undefined) {
+			updates.push('last_notified_at = ?');
+			params.push(input.lastNotifiedAt);
+		}
+		if (input.lastError !== undefined) {
+			updates.push('last_error = ?');
+			params.push(input.lastError);
+		}
+		if (input.errorHash !== undefined) {
+			updates.push('error_hash = ?');
+			params.push(input.errorHash);
+		}
+		if (input.lastNotifiedErrorHash !== undefined) {
+			updates.push('last_notified_error_hash = ?');
+			params.push(input.lastNotifiedErrorHash);
+		}
+
+		if (updates.length === 0) {
+			return false;
+		}
+
+		updates.push('updated_at = CURRENT_TIMESTAMP');
+		params.push(arrInstanceId);
+
+		const affected = db.execute(
+			`UPDATE arr_drift_status SET ${updates.join(', ')} WHERE arr_instance_id = ?`,
+			...params
+		);
+
+		return affected > 0;
+	},
+
+	delete(arrInstanceId: number): boolean {
+		const affected = db.execute(
+			'DELETE FROM arr_drift_status WHERE arr_instance_id = ?',
+			arrInstanceId
+		);
+		return affected > 0;
+	}
+};

--- a/src/lib/server/db/schema.sql
+++ b/src/lib/server/db/schema.sql
@@ -653,6 +653,75 @@ CREATE TABLE arr_cleanup_settings (
 CREATE INDEX idx_arr_cleanup_settings_instance ON arr_cleanup_settings(arr_instance_id);
 
 -- ==============================================================================
+-- TABLE: arr_drift_settings
+-- Purpose: Store drift detection scheduling configuration per arr instance
+-- Migration: 065_create_arr_drift_tables.ts
+-- ==============================================================================
+
+CREATE TABLE arr_drift_settings (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+
+    -- Relationship (one config per arr instance)
+    arr_instance_id INTEGER NOT NULL UNIQUE,
+
+    -- Settings
+    enabled INTEGER NOT NULL DEFAULT 0,          -- Master on/off switch
+    cron TEXT NOT NULL DEFAULT '0 0 * * *',      -- Cron expression (default: daily midnight)
+
+    -- State tracking
+    next_run_at TEXT,                            -- Next scheduled drift check
+
+    -- Metadata
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+
+    FOREIGN KEY (arr_instance_id) REFERENCES arr_instances(id) ON DELETE CASCADE
+);
+
+-- Arr drift settings indexes (Migration: 065_create_arr_drift_tables.ts)
+CREATE INDEX idx_arr_drift_settings_instance ON arr_drift_settings(arr_instance_id);
+
+-- ==============================================================================
+-- TABLE: arr_drift_status
+-- Purpose: Store latest drift detection result per arr instance
+-- Migration: 065_create_arr_drift_tables.ts
+-- ==============================================================================
+
+CREATE TABLE arr_drift_status (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+
+    -- Relationship (one latest result per arr instance)
+    arr_instance_id INTEGER NOT NULL UNIQUE,
+
+    -- Latest state
+    status TEXT NOT NULL DEFAULT 'never_checked' CHECK (
+        status IN ('never_checked', 'clean', 'drift_detected', 'failed')
+    ),
+    last_checked_at TEXT,
+    counts_json TEXT NOT NULL DEFAULT '{}',
+    diff_json TEXT NOT NULL DEFAULT '{}',
+    diff_hash TEXT,
+
+    -- Notification dedupe
+    last_notified_hash TEXT,
+    last_notified_at TEXT,
+
+    -- Failure state
+    last_error TEXT,
+    error_hash TEXT,
+    last_notified_error_hash TEXT,
+
+    -- Metadata
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+
+    FOREIGN KEY (arr_instance_id) REFERENCES arr_instances(id) ON DELETE CASCADE
+);
+
+-- Arr drift status indexes (Migration: 065_create_arr_drift_tables.ts)
+CREATE INDEX idx_arr_drift_status_instance ON arr_drift_status(arr_instance_id);
+
+-- ==============================================================================
 -- TABLE: upgrade_runs
 -- Purpose: Store upgrade run history for each arr instance
 -- Migration: 026_create_upgrade_runs.ts

--- a/src/lib/server/jobs/cleanup.ts
+++ b/src/lib/server/jobs/cleanup.ts
@@ -27,6 +27,7 @@ export function cleanupJobsForArrInstance(instanceId: number): number {
 		'arr.sync.delayProfiles',
 		'arr.sync.mediaManagement',
 		'arr.cleanup',
+		'arr.drift',
 		'arr.library.refresh'
 	];
 

--- a/src/lib/server/jobs/display.ts
+++ b/src/lib/server/jobs/display.ts
@@ -23,6 +23,8 @@ export function formatJobTypeLabel(jobType: JobType): string {
 			return 'Arr Upgrade';
 		case 'arr.cleanup':
 			return 'Arr Cleanup';
+		case 'arr.drift':
+			return 'Arr Drift';
 		case 'arr.library.refresh':
 			return 'Library Refresh';
 		case 'pcd.link':
@@ -81,6 +83,7 @@ export function buildJobDisplayName(
 			jobType === 'arr.rename' ||
 			jobType === 'arr.upgrade' ||
 			jobType === 'arr.cleanup' ||
+			jobType === 'arr.drift' ||
 			jobType === 'arr.library.refresh') &&
 		instanceId !== null
 	) {

--- a/src/lib/server/jobs/handlers/arrDrift.ts
+++ b/src/lib/server/jobs/handlers/arrDrift.ts
@@ -1,0 +1,42 @@
+import { jobQueueRegistry } from '../queueRegistry.ts';
+import type { JobHandler } from '../queueTypes.ts';
+import { arrDriftSettingsQueries } from '$db/queries/arrDriftSettings.ts';
+import { arrInstancesQueries } from '$db/queries/arrInstances.ts';
+import { FEATURES } from '$shared/features.ts';
+import { calculateNextRun } from '../scheduleUtils.ts';
+
+const driftHandler: JobHandler = async (job) => {
+	const instanceId = Number(job.payload.instanceId);
+	if (!Number.isFinite(instanceId)) {
+		return { status: 'failure', error: 'Invalid instance ID' };
+	}
+
+	const instance = arrInstancesQueries.getById(instanceId);
+	if (!instance) {
+		return { status: 'failure', error: 'Arr instance not found' };
+	}
+
+	const settings = arrDriftSettingsQueries.getByInstanceId(instanceId);
+	if (!settings || !settings.enabled) {
+		return { status: 'cancelled', output: 'Drift detection disabled' };
+	}
+
+	if (!FEATURES.drift) {
+		return { status: 'cancelled', output: 'Drift detection feature disabled' };
+	}
+
+	if (instance.type !== 'radarr' && instance.type !== 'sonarr') {
+		return { status: 'skipped', output: `Drift detection not supported for ${instance.type}` };
+	}
+
+	const nextRunAt = calculateNextRun(settings.cron);
+	if (nextRunAt) arrDriftSettingsQueries.updateNextRunAt(instanceId, nextRunAt);
+
+	return {
+		status: 'skipped',
+		output: 'Drift comparison not implemented',
+		rescheduleAt: job.source === 'schedule' ? (nextRunAt ?? undefined) : undefined
+	};
+};
+
+jobQueueRegistry.register('arr.drift', driftHandler);

--- a/src/lib/server/jobs/handlers/index.ts
+++ b/src/lib/server/jobs/handlers/index.ts
@@ -1,6 +1,7 @@
 import './arrUpgrade.ts';
 import './arrRename.ts';
 import './arrCleanup.ts';
+import './arrDrift.ts';
 import './arrLibraryRefresh.ts';
 import './arrSync.ts';
 import './pcdLink.ts';

--- a/src/lib/server/jobs/init.ts
+++ b/src/lib/server/jobs/init.ts
@@ -26,6 +26,7 @@ export {
 	scheduleUpgradeForInstance,
 	scheduleRenameForInstance,
 	scheduleCleanupForInstance,
+	scheduleDriftForInstance,
 	scheduleLibraryRefreshForInstance,
 	schedulePcdSyncForDatabase,
 	scheduleBackupJobs,

--- a/src/lib/server/jobs/jobEvents.ts
+++ b/src/lib/server/jobs/jobEvents.ts
@@ -45,6 +45,7 @@ const JOB_RUNNING_LABELS: Partial<Record<JobType, string>> = {
 	'arr.sync.delayProfiles': 'Syncing Delay Profiles...',
 	'arr.sync.mediaManagement': 'Syncing Media Management...',
 	'arr.cleanup': 'Cleaning up...',
+	'arr.drift': 'Checking drift...',
 	'backup.create': 'Creating backup...',
 	'backup.cleanup': 'Cleaning up backups...',
 	'pcd.link': 'Linking database...'
@@ -56,6 +57,7 @@ const JOB_COMPLETED_LABELS: Partial<Record<JobType, string>> = {
 	'arr.sync.delayProfiles': 'Delay Profiles sync',
 	'arr.sync.mediaManagement': 'Media Management sync',
 	'arr.cleanup': 'Cleanup',
+	'arr.drift': 'Drift check',
 	'backup.create': 'Backup',
 	'backup.cleanup': 'Backup cleanup',
 	'pcd.link': 'Database link'

--- a/src/lib/server/jobs/queueTypes.ts
+++ b/src/lib/server/jobs/queueTypes.ts
@@ -10,6 +10,7 @@ export type JobType =
 	| 'backup.create'
 	| 'backup.cleanup'
 	| 'arr.cleanup'
+	| 'arr.drift'
 	| 'arr.library.refresh'
 	| 'logs.cleanup'
 	| 'announcements.fetch';

--- a/src/lib/server/jobs/schedule.ts
+++ b/src/lib/server/jobs/schedule.ts
@@ -4,9 +4,11 @@ import { arrSyncQueries } from '$db/queries/arrSync.ts';
 import { upgradeConfigsQueries } from '$db/queries/upgradeConfigs.ts';
 import { arrRenameSettingsQueries } from '$db/queries/arrRenameSettings.ts';
 import { arrCleanupSettingsQueries } from '$db/queries/arrCleanupSettings.ts';
+import { arrDriftSettingsQueries } from '$db/queries/arrDriftSettings.ts';
 import { databaseInstancesQueries } from '$db/queries/databaseInstances.ts';
 import { backupSettingsQueries } from '$db/queries/backupSettings.ts';
 import { logSettingsQueries } from '$db/queries/logSettings.ts';
+import { FEATURES } from '$shared/features.ts';
 import { calculateNextRun } from '$lib/server/sync/utils.ts';
 import { calculateNextRunFromMinutes, calculateNextRunFromSchedule } from './scheduleUtils.ts';
 import { jobDispatcher } from './dispatcher.ts';
@@ -138,6 +140,38 @@ export function scheduleCleanupForInstance(instanceId: number): void {
 	notify(job.runAt);
 }
 
+export function scheduleDriftForInstance(instanceId: number): void {
+	if (!FEATURES.drift) {
+		jobQueueQueries.unscheduleByDedupeKey(`arr.drift:${instanceId}`);
+		return;
+	}
+
+	const settings = arrDriftSettingsQueries.getByInstanceId(instanceId);
+	if (!settings || !settings.enabled) {
+		jobQueueQueries.unscheduleByDedupeKey(`arr.drift:${instanceId}`);
+		return;
+	}
+
+	let nextRun = settings.nextRunAt;
+	if (!nextRun) {
+		nextRun = calculateNextRun(settings.cron) ?? null;
+	}
+	if (!nextRun) {
+		jobQueueQueries.unscheduleByDedupeKey(`arr.drift:${instanceId}`);
+		return;
+	}
+
+	const job = jobQueueQueries.upsertScheduled({
+		jobType: 'arr.drift',
+		runAt: nextRun,
+		payload: { instanceId },
+		source: 'schedule',
+		dedupeKey: `arr.drift:${instanceId}`
+	});
+
+	notify(job.runAt);
+}
+
 export function scheduleLibraryRefreshForInstance(instanceId: number): void {
 	const instance = arrInstancesQueries.getById(instanceId);
 	if (!instance || instance.enabled === 0 || instance.library_refresh_interval <= 0) {
@@ -252,6 +286,7 @@ export function scheduleAllJobs(): void {
 		scheduleUpgradeForInstance(instance.id);
 		scheduleRenameForInstance(instance.id);
 		scheduleCleanupForInstance(instance.id);
+		scheduleDriftForInstance(instance.id);
 		scheduleLibraryRefreshForInstance(instance.id);
 	}
 

--- a/src/lib/shared/drift.ts
+++ b/src/lib/shared/drift.ts
@@ -1,0 +1,11 @@
+export type DriftRunStatus = 'never_checked' | 'clean' | 'drift_detected' | 'failed';
+
+export type DriftSection =
+	| 'custom_formats'
+	| 'quality_profiles'
+	| 'delay_profiles'
+	| 'media_management';
+
+export type DriftCounts = Partial<Record<DriftSection, number>>;
+
+export type DriftDiff = Record<string, unknown>;

--- a/src/lib/shared/features.ts
+++ b/src/lib/shared/features.ts
@@ -11,5 +11,7 @@ export const FEATURES = {
 	/** Cutscene onboarding system */
 	cutscene: true,
 	/** Database tweaks UI */
-	tweaks: false
+	tweaks: false,
+	/** Arr drift detection */
+	drift: false
 } as const;


### PR DESCRIPTION
- Add drift feature flag, docs, database tables, and query helpers for settings and latest status.
- Wire arr.drift into scheduling, display, cleanup, and a no-op handler while comparison/UI/notifications remain future work.

Part of #307
