### PR TITLE
feat: add custom format drift comparison

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -12,6 +12,7 @@
 		"$server/": "./src/server/",
 		"$db/": "./src/lib/server/db/",
 		"$jobs/": "./src/lib/server/jobs/",
+		"$drift/": "./src/lib/server/drift/",
 		"$pcd/": "./src/lib/server/pcd/",
 		"$arr/": "./src/lib/server/utils/arr/",
 		"$http/": "./src/lib/server/utils/http/",

--- a/docs/backend/drift.md
+++ b/docs/backend/drift.md
@@ -29,16 +29,13 @@ Current handler behavior:
 - missing instances fail
 - missing or disabled settings cancel the job
 - unsupported Arr types are skipped
-- enabled jobs skip with `Drift comparison not implemented`
+- enabled jobs compare custom formats, store the latest result, and return success
 - scheduled jobs calculate and store the next run before returning
 
 ## Latest Status
 
 Drift stores only the latest result per Arr instance in `arr_drift_status`.
 Job run history remains the operational history.
-
-Current implementation creates and exposes the table/query layer. The no-op job
-handler does not write drift result rows yet.
 
 | Field                      | Purpose                                              |
 | -------------------------- | ---------------------------------------------------- |
@@ -53,6 +50,22 @@ handler does not write drift result rows yet.
 | `error_hash`               | Stable hash of the latest failure detail             |
 | `last_notified_error_hash` | Last failure hash sent as a notification             |
 
+## Custom Formats
+
+Custom format drift compares Profilarr-managed custom formats referenced by
+synced quality profile selections.
+
+Comparison rules:
+
+- build expected custom formats with the same transformer used by sync
+- fetch actual custom formats from Arr
+- match by custom format name
+- ignore Arr ids
+- compare `includeCustomFormatWhenRenaming`
+- compare normalized specifications and fields
+- ignore unmanaged extra Arr custom formats
+
 ## TODO
 
-Implement comparison logic, notifications, and the sync page drift UI.
+Implement quality profile, delay profile, and media management comparison,
+notifications, and the sync page drift UI.

--- a/src/lib/server/drift/check.ts
+++ b/src/lib/server/drift/check.ts
@@ -1,0 +1,34 @@
+import type { BaseArrClient } from '$arr/base.ts';
+import type { DriftCounts, DriftDiff } from '$shared/drift.ts';
+import type { SyncArrType } from '$sync/mappings.ts';
+import { checkCustomFormatDrift } from './customFormats.ts';
+import { hashDriftDiff } from './hash.ts';
+
+export interface DriftCheckResult {
+	status: 'clean' | 'drift_detected';
+	counts: DriftCounts;
+	diff: DriftDiff;
+	diffHash: string;
+}
+
+export async function checkArrDrift(
+	client: Pick<BaseArrClient, 'getCustomFormats'>,
+	instanceId: number,
+	arrType: SyncArrType
+): Promise<DriftCheckResult> {
+	const customFormats = await checkCustomFormatDrift(client, instanceId, arrType);
+	const counts: DriftCounts = {
+		custom_formats: customFormats.count
+	};
+	const diff: DriftDiff = {
+		custom_formats: customFormats.diff
+	};
+	const total = Object.values(counts).reduce((sum, count) => sum + (count ?? 0), 0);
+
+	return {
+		status: total === 0 ? 'clean' : 'drift_detected',
+		counts,
+		diff,
+		diffHash: await hashDriftDiff(diff)
+	};
+}

--- a/src/lib/server/drift/customFormats.ts
+++ b/src/lib/server/drift/customFormats.ts
@@ -1,0 +1,273 @@
+import { arrSyncQueries } from '$db/queries/arrSync.ts';
+import { getCache } from '$pcd/index.ts';
+import { getCustomFormatsForProfile } from '$pcd/references.ts';
+import type { BaseArrClient } from '$arr/base.ts';
+import type { SyncArrType } from '$sync/mappings.ts';
+import {
+	fetchCustomFormatFromPcd,
+	transformCustomFormat,
+	type ArrCustomFormat,
+	type ArrCustomFormatSpecification
+} from '$sync/customFormats/transformer.ts';
+import { stringifyCanonical } from './hash.ts';
+
+export interface DriftFieldDiff {
+	path: string;
+	expected: unknown;
+	actual: unknown;
+}
+
+export interface CustomFormatMissingDiff {
+	name: string;
+}
+
+export interface CustomFormatModifiedDiff {
+	name: string;
+	fields: DriftFieldDiff[];
+}
+
+export interface CustomFormatDriftDiff {
+	missing: CustomFormatMissingDiff[];
+	modified: CustomFormatModifiedDiff[];
+}
+
+export interface CustomFormatDriftResult {
+	count: number;
+	diff: CustomFormatDriftDiff;
+}
+
+type NormalizedField = {
+	name: string;
+	value: unknown;
+};
+
+type NormalizedSpecification = {
+	name: string;
+	implementation: string;
+	negate: boolean;
+	required: boolean;
+	fields: NormalizedField[];
+};
+
+type NormalizedCustomFormat = {
+	name: string;
+	includeCustomFormatWhenRenaming: boolean;
+	specifications: NormalizedSpecification[];
+};
+
+function compareByString(a: string, b: string): number {
+	return a.localeCompare(b);
+}
+
+function fieldKey(field: NormalizedField): string {
+	return field.name;
+}
+
+function specificationKey(specification: Pick<NormalizedSpecification, 'implementation' | 'name'>) {
+	return `${specification.implementation}:${specification.name}`;
+}
+
+function normalizeSpecification(
+	specification: ArrCustomFormatSpecification
+): NormalizedSpecification {
+	return {
+		name: specification.name,
+		implementation: specification.implementation,
+		negate: Boolean(specification.negate),
+		required: Boolean(specification.required),
+		fields: [...(specification.fields ?? [])]
+			.map((field) => ({
+				name: field.name,
+				value: field.value
+			}))
+			.sort((a, b) => compareByString(fieldKey(a), fieldKey(b)))
+	};
+}
+
+function normalizeCustomFormat(format: ArrCustomFormat): NormalizedCustomFormat {
+	return {
+		name: format.name,
+		includeCustomFormatWhenRenaming: Boolean(format.includeCustomFormatWhenRenaming),
+		specifications: [...(format.specifications ?? [])]
+			.map(normalizeSpecification)
+			.sort((a, b) => compareByString(specificationKey(a), specificationKey(b)))
+	};
+}
+
+function valuesEqual(expected: unknown, actual: unknown): boolean {
+	return stringifyCanonical(expected) === stringifyCanonical(actual);
+}
+
+function compareFields(
+	expected: NormalizedSpecification,
+	actual: NormalizedSpecification
+): DriftFieldDiff[] {
+	const diffs: DriftFieldDiff[] = [];
+	const actualFields = new Map(actual.fields.map((field) => [fieldKey(field), field]));
+	const expectedFields = new Map(expected.fields.map((field) => [fieldKey(field), field]));
+	const specPath = `specifications[${specificationKey(expected)}]`;
+
+	for (const expectedField of expected.fields) {
+		const actualField = actualFields.get(fieldKey(expectedField));
+		const path = `${specPath}.fields[${fieldKey(expectedField)}]`;
+		if (!actualField) {
+			diffs.push({ path, expected: expectedField.value, actual: null });
+			continue;
+		}
+		if (!valuesEqual(expectedField.value, actualField.value)) {
+			diffs.push({ path, expected: expectedField.value, actual: actualField.value });
+		}
+	}
+
+	for (const actualField of actual.fields) {
+		if (expectedFields.has(fieldKey(actualField))) continue;
+		diffs.push({
+			path: `${specPath}.fields[${fieldKey(actualField)}]`,
+			expected: null,
+			actual: actualField.value
+		});
+	}
+
+	return diffs;
+}
+
+function compareSpecifications(
+	expected: NormalizedCustomFormat,
+	actual: NormalizedCustomFormat
+): DriftFieldDiff[] {
+	const diffs: DriftFieldDiff[] = [];
+	const actualSpecs = new Map(actual.specifications.map((spec) => [specificationKey(spec), spec]));
+	const expectedSpecs = new Map(
+		expected.specifications.map((spec) => [specificationKey(spec), spec])
+	);
+
+	for (const expectedSpec of expected.specifications) {
+		const actualSpec = actualSpecs.get(specificationKey(expectedSpec));
+		const specPath = `specifications[${specificationKey(expectedSpec)}]`;
+		if (!actualSpec) {
+			diffs.push({ path: specPath, expected: expectedSpec, actual: null });
+			continue;
+		}
+		if (expectedSpec.negate !== actualSpec.negate) {
+			diffs.push({
+				path: `${specPath}.negate`,
+				expected: expectedSpec.negate,
+				actual: actualSpec.negate
+			});
+		}
+		if (expectedSpec.required !== actualSpec.required) {
+			diffs.push({
+				path: `${specPath}.required`,
+				expected: expectedSpec.required,
+				actual: actualSpec.required
+			});
+		}
+		diffs.push(...compareFields(expectedSpec, actualSpec));
+	}
+
+	for (const actualSpec of actual.specifications) {
+		if (expectedSpecs.has(specificationKey(actualSpec))) continue;
+		diffs.push({
+			path: `specifications[${specificationKey(actualSpec)}]`,
+			expected: null,
+			actual: actualSpec
+		});
+	}
+
+	return diffs;
+}
+
+function compareCustomFormat(
+	expected: NormalizedCustomFormat,
+	actual: NormalizedCustomFormat
+): DriftFieldDiff[] {
+	const diffs: DriftFieldDiff[] = [];
+
+	if (expected.includeCustomFormatWhenRenaming !== actual.includeCustomFormatWhenRenaming) {
+		diffs.push({
+			path: 'includeCustomFormatWhenRenaming',
+			expected: expected.includeCustomFormatWhenRenaming,
+			actual: actual.includeCustomFormatWhenRenaming
+		});
+	}
+
+	diffs.push(...compareSpecifications(expected, actual));
+	return diffs;
+}
+
+export function compareCustomFormatDrift(
+	expectedFormats: ArrCustomFormat[],
+	actualFormats: ArrCustomFormat[]
+): CustomFormatDriftResult {
+	const actualByName = new Map(
+		actualFormats.map((format) => [format.name, normalizeCustomFormat(format)])
+	);
+	const diff: CustomFormatDriftDiff = { missing: [], modified: [] };
+
+	for (const expectedRaw of [...expectedFormats].sort((a, b) => compareByString(a.name, b.name))) {
+		const expected = normalizeCustomFormat(expectedRaw);
+		const actual = actualByName.get(expected.name);
+		if (!actual) {
+			diff.missing.push({ name: expected.name });
+			continue;
+		}
+
+		const fields = compareCustomFormat(expected, actual);
+		if (fields.length > 0) {
+			diff.modified.push({ name: expected.name, fields });
+		}
+	}
+
+	return {
+		count: diff.missing.length + diff.modified.length,
+		diff
+	};
+}
+
+export async function buildExpectedCustomFormats(
+	instanceId: number,
+	arrType: SyncArrType
+): Promise<ArrCustomFormat[]> {
+	const syncConfig = arrSyncQueries.getQualityProfilesSync(instanceId);
+	if (syncConfig.selections.length === 0) return [];
+
+	const expected = new Map<string, ArrCustomFormat>();
+
+	for (const selection of syncConfig.selections) {
+		const cache = getCache(selection.databaseId);
+		if (!cache) {
+			throw new Error(`PCD cache not found for database ${selection.databaseId}`);
+		}
+
+		const formatNames = await getCustomFormatsForProfile(cache, selection.profileName, arrType);
+		for (const formatName of formatNames) {
+			if (expected.has(formatName)) continue;
+
+			const pcdFormat = await fetchCustomFormatFromPcd(cache, formatName);
+			if (!pcdFormat) {
+				throw new Error(
+					`Custom format "${formatName}" not found in database ${selection.databaseId}`
+				);
+			}
+
+			const arrFormat = transformCustomFormat(pcdFormat, arrType);
+			arrFormat.name = formatName;
+			expected.set(formatName, arrFormat);
+		}
+	}
+
+	return [...expected.values()];
+}
+
+export async function checkCustomFormatDrift(
+	client: Pick<BaseArrClient, 'getCustomFormats'>,
+	instanceId: number,
+	arrType: SyncArrType
+): Promise<CustomFormatDriftResult> {
+	const [expectedFormats, actualFormats] = await Promise.all([
+		buildExpectedCustomFormats(instanceId, arrType),
+		client.getCustomFormats()
+	]);
+
+	return compareCustomFormatDrift(expectedFormats, actualFormats);
+}

--- a/src/lib/server/drift/customFormats.ts
+++ b/src/lib/server/drift/customFormats.ts
@@ -95,7 +95,17 @@ function normalizeCustomFormat(format: ArrCustomFormat): NormalizedCustomFormat 
 }
 
 function valuesEqual(expected: unknown, actual: unknown): boolean {
+	if (
+		(expected === null || expected === undefined || expected === false) &&
+		(actual === null || actual === undefined || actual === false)
+	) {
+		return true;
+	}
 	return stringifyCanonical(expected) === stringifyCanonical(actual);
+}
+
+function isAbsentDefault(value: unknown): boolean {
+	return value === null || value === undefined || value === false;
 }
 
 function compareFields(
@@ -111,6 +121,7 @@ function compareFields(
 		const actualField = actualFields.get(fieldKey(expectedField));
 		const path = `${specPath}.fields[${fieldKey(expectedField)}]`;
 		if (!actualField) {
+			if (isAbsentDefault(expectedField.value)) continue;
 			diffs.push({ path, expected: expectedField.value, actual: null });
 			continue;
 		}
@@ -121,6 +132,7 @@ function compareFields(
 
 	for (const actualField of actual.fields) {
 		if (expectedFields.has(fieldKey(actualField))) continue;
+		if (isAbsentDefault(actualField.value)) continue;
 		diffs.push({
 			path: `${specPath}.fields[${fieldKey(actualField)}]`,
 			expected: null,

--- a/src/lib/server/drift/hash.ts
+++ b/src/lib/server/drift/hash.ts
@@ -1,0 +1,28 @@
+function canonicalize(value: unknown): unknown {
+	if (Array.isArray(value)) {
+		return value.map(canonicalize);
+	}
+
+	if (value && typeof value === 'object') {
+		const record = value as Record<string, unknown>;
+		const result: Record<string, unknown> = {};
+		for (const key of Object.keys(record).sort()) {
+			result[key] = canonicalize(record[key]);
+		}
+		return result;
+	}
+
+	return value;
+}
+
+export function stringifyCanonical(value: unknown): string {
+	return JSON.stringify(canonicalize(value));
+}
+
+export async function hashDriftDiff(diff: unknown): Promise<string> {
+	const data = new TextEncoder().encode(stringifyCanonical(diff));
+	const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+	return Array.from(new Uint8Array(hashBuffer))
+		.map((byte) => byte.toString(16).padStart(2, '0'))
+		.join('');
+}

--- a/src/lib/server/jobs/handlers/arrDrift.ts
+++ b/src/lib/server/jobs/handlers/arrDrift.ts
@@ -1,9 +1,15 @@
 import { jobQueueRegistry } from '../queueRegistry.ts';
 import type { JobHandler } from '../queueTypes.ts';
 import { arrDriftSettingsQueries } from '$db/queries/arrDriftSettings.ts';
+import { arrDriftStatusQueries } from '$db/queries/arrDriftStatus.ts';
 import { arrInstancesQueries } from '$db/queries/arrInstances.ts';
 import { FEATURES } from '$shared/features.ts';
 import { calculateNextRun } from '../scheduleUtils.ts';
+import { createArrClient } from '$arr/factory.ts';
+import type { ArrType } from '$arr/types.ts';
+import { checkArrDrift } from '$drift/check.ts';
+import { hashDriftDiff } from '$drift/hash.ts';
+import { logger } from '$logger/logger.ts';
 
 const driftHandler: JobHandler = async (job) => {
 	const instanceId = Number(job.payload.instanceId);
@@ -32,11 +38,61 @@ const driftHandler: JobHandler = async (job) => {
 	const nextRunAt = calculateNextRun(settings.cron);
 	if (nextRunAt) arrDriftSettingsQueries.updateNextRunAt(instanceId, nextRunAt);
 
-	return {
-		status: 'skipped',
-		output: 'Drift comparison not implemented',
-		rescheduleAt: job.source === 'schedule' ? (nextRunAt ?? undefined) : undefined
-	};
+	const client = createArrClient(instance.type as ArrType, instance.url, instance.api_key, {
+		retries: 0
+	});
+
+	try {
+		const result = await checkArrDrift(client, instanceId, instance.type);
+		const now = new Date().toISOString();
+
+		arrDriftStatusQueries.upsert(instanceId, {
+			status: result.status,
+			lastCheckedAt: now,
+			counts: result.counts,
+			diff: result.diff,
+			diffHash: result.diffHash,
+			lastError: null,
+			errorHash: null
+		});
+
+		const customFormatCount = result.counts.custom_formats ?? 0;
+		return {
+			status: 'success',
+			output:
+				customFormatCount === 0
+					? 'No drift detected'
+					: `Detected ${customFormatCount} custom format drift item(s)`,
+			rescheduleAt: job.source === 'schedule' ? (nextRunAt ?? undefined) : undefined
+		};
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		const now = new Date().toISOString();
+		const errorHash = await hashDriftDiff({ error: message });
+
+		await logger.error('Drift check failed', {
+			source: 'DriftJob',
+			meta: { jobId: job.id, instanceId, instanceName: instance.name, error: message }
+		});
+
+		arrDriftStatusQueries.upsert(instanceId, {
+			status: 'failed',
+			lastCheckedAt: now,
+			counts: {},
+			diff: {},
+			diffHash: null,
+			lastError: message,
+			errorHash
+		});
+
+		return {
+			status: 'failure',
+			error: message,
+			rescheduleAt: job.source === 'schedule' ? (nextRunAt ?? undefined) : undefined
+		};
+	} finally {
+		client.close();
+	}
 };
 
 jobQueueRegistry.register('arr.drift', driftHandler);

--- a/src/lib/server/jobs/handlers/arrDrift.ts
+++ b/src/lib/server/jobs/handlers/arrDrift.ts
@@ -45,6 +45,14 @@ const driftHandler: JobHandler = async (job) => {
 	try {
 		const result = await checkArrDrift(client, instanceId, instance.type);
 		const now = new Date().toISOString();
+		const logMeta = {
+			jobId: job.id,
+			instanceId,
+			instanceName: instance.name,
+			status: result.status,
+			counts: result.counts,
+			diffHash: result.diffHash
+		};
 
 		arrDriftStatusQueries.upsert(instanceId, {
 			status: result.status,
@@ -57,6 +65,18 @@ const driftHandler: JobHandler = async (job) => {
 		});
 
 		const customFormatCount = result.counts.custom_formats ?? 0;
+		if (result.status === 'drift_detected') {
+			await logger.info('Drift detected', {
+				source: 'jobs.handlers.arrDrift',
+				meta: logMeta
+			});
+		} else {
+			await logger.debug('Drift check complete', {
+				source: 'jobs.handlers.arrDrift',
+				meta: logMeta
+			});
+		}
+
 		return {
 			status: 'success',
 			output:
@@ -71,7 +91,7 @@ const driftHandler: JobHandler = async (job) => {
 		const errorHash = await hashDriftDiff({ error: message });
 
 		await logger.error('Drift check failed', {
-			source: 'DriftJob',
+			source: 'jobs.handlers.arrDrift',
 			meta: { jobId: job.id, instanceId, instanceName: instance.name, error: message }
 		});
 

--- a/src/lib/shared/features.ts
+++ b/src/lib/shared/features.ts
@@ -13,5 +13,5 @@ export const FEATURES = {
 	/** Database tweaks UI */
 	tweaks: false,
 	/** Arr drift detection */
-	drift: false
+	drift: true
 } as const;

--- a/src/lib/shared/features.ts
+++ b/src/lib/shared/features.ts
@@ -13,5 +13,5 @@ export const FEATURES = {
 	/** Database tweaks UI */
 	tweaks: false,
 	/** Arr drift detection */
-	drift: true
+	drift: false
 } as const;

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -27,6 +27,7 @@ const config = {
 			$server: './src/server',
 			$db: './src/lib/server/db',
 			$jobs: './src/lib/server/jobs',
+			$drift: './src/lib/server/drift',
 			$pcd: './src/lib/server/pcd',
 			$arr: './src/lib/server/utils/arr',
 			$http: './src/lib/server/utils/http',

--- a/tests/runner.ts
+++ b/tests/runner.ts
@@ -19,7 +19,7 @@
  *   deno task test unit upgrades       tests/unit/upgrades/ only
  *   deno task test unit filters        Single file (tests/unit/upgrades/filters.test.ts)
  *
- *   Directory aliases:  auth, upgrades, jobs, logger, rename, sanitize
+ *   Directory aliases:  auth, upgrades, drift, jobs, logger, rename, sanitize
  *   File aliases:       filters, normalize, selectors, backup, cleanup, processor
  *
  * ─── Integration Tests ───────────────────────────────────────────────────
@@ -108,6 +108,7 @@ const UNIT_ALIASES: Record<string, string> = {
 	// Directories
 	auth: 'tests/unit/auth',
 	upgrades: 'tests/unit/upgrades',
+	drift: 'tests/unit/drift',
 	jobs: 'tests/unit/jobs',
 	logger: 'tests/unit/logger',
 	rename: 'tests/unit/rename',

--- a/tests/unit/drift/customFormats.test.ts
+++ b/tests/unit/drift/customFormats.test.ts
@@ -1,0 +1,229 @@
+import { assertEquals } from '@std/assert';
+import { BaseTest } from '../base/BaseTest.ts';
+import { compareCustomFormatDrift, type CustomFormatDriftDiff } from '$drift/customFormats.ts';
+import { hashDriftDiff } from '$drift/hash.ts';
+import type { ArrCustomFormat } from '$sync/customFormats/transformer.ts';
+
+function customFormat(input: Partial<ArrCustomFormat> & { name: string }): ArrCustomFormat {
+	return {
+		name: input.name,
+		includeCustomFormatWhenRenaming: input.includeCustomFormatWhenRenaming,
+		specifications: input.specifications ?? [
+			{
+				name: 'Title Match',
+				implementation: 'ReleaseTitleSpecification',
+				negate: false,
+				required: true,
+				fields: [{ name: 'value', value: 'AMZN' }]
+			}
+		]
+	};
+}
+
+class CustomFormatDriftTest extends BaseTest {
+	runTests(): void {
+		this.test('clean when expected and actual custom formats match', () => {
+			const result = compareCustomFormatDrift(
+				[customFormat({ name: 'Streaming Tier' })],
+				[customFormat({ name: 'Streaming Tier' })]
+			);
+
+			assertEquals(result.count, 0);
+			assertEquals(result.diff, { missing: [], modified: [] });
+		});
+
+		this.test('ignores arr ids', () => {
+			const result = compareCustomFormatDrift(
+				[customFormat({ name: 'Streaming Tier', id: 1 })],
+				[customFormat({ name: 'Streaming Tier', id: 999 })]
+			);
+
+			assertEquals(result.count, 0);
+		});
+
+		this.test('reports missing expected custom format', () => {
+			const result = compareCustomFormatDrift([customFormat({ name: 'Streaming Tier' })], []);
+
+			assertEquals(result.count, 1);
+			assertEquals(result.diff.missing, [{ name: 'Streaming Tier' }]);
+			assertEquals(result.diff.modified, []);
+		});
+
+		this.test('reports include in rename mismatch', () => {
+			const result = compareCustomFormatDrift(
+				[customFormat({ name: 'Streaming Tier', includeCustomFormatWhenRenaming: true })],
+				[customFormat({ name: 'Streaming Tier', includeCustomFormatWhenRenaming: false })]
+			);
+
+			assertEquals(result.count, 1);
+			assertEquals(result.diff.modified, [
+				{
+					name: 'Streaming Tier',
+					fields: [
+						{
+							path: 'includeCustomFormatWhenRenaming',
+							expected: true,
+							actual: false
+						}
+					]
+				}
+			]);
+		});
+
+		this.test('ignores specification order', () => {
+			const first = {
+				name: 'Title Match',
+				implementation: 'ReleaseTitleSpecification',
+				negate: false,
+				required: true,
+				fields: [{ name: 'value', value: 'AMZN' }]
+			};
+			const second = {
+				name: 'Group Match',
+				implementation: 'ReleaseGroupSpecification',
+				negate: false,
+				required: false,
+				fields: [{ name: 'value', value: 'GROUP' }]
+			};
+
+			const result = compareCustomFormatDrift(
+				[customFormat({ name: 'Streaming Tier', specifications: [first, second] })],
+				[customFormat({ name: 'Streaming Tier', specifications: [second, first] })]
+			);
+
+			assertEquals(result.count, 0);
+		});
+
+		this.test('ignores field order', () => {
+			const result = compareCustomFormatDrift(
+				[
+					customFormat({
+						name: 'Size Tier',
+						specifications: [
+							{
+								name: 'Size',
+								implementation: 'SizeSpecification',
+								negate: false,
+								required: true,
+								fields: [
+									{ name: 'min', value: 1 },
+									{ name: 'max', value: 2 }
+								]
+							}
+						]
+					})
+				],
+				[
+					customFormat({
+						name: 'Size Tier',
+						specifications: [
+							{
+								name: 'Size',
+								implementation: 'SizeSpecification',
+								negate: false,
+								required: true,
+								fields: [
+									{ name: 'max', value: 2 },
+									{ name: 'min', value: 1 }
+								]
+							}
+						]
+					})
+				]
+			);
+
+			assertEquals(result.count, 0);
+		});
+
+		this.test('reports field value mismatch with stable path', () => {
+			const result = compareCustomFormatDrift(
+				[customFormat({ name: 'Streaming Tier' })],
+				[
+					customFormat({
+						name: 'Streaming Tier',
+						specifications: [
+							{
+								name: 'Title Match',
+								implementation: 'ReleaseTitleSpecification',
+								negate: false,
+								required: true,
+								fields: [{ name: 'value', value: 'NF' }]
+							}
+						]
+					})
+				]
+			);
+
+			assertEquals(result.count, 1);
+			assertEquals(result.diff.modified, [
+				{
+					name: 'Streaming Tier',
+					fields: [
+						{
+							path: 'specifications[ReleaseTitleSpecification:Title Match].fields[value]',
+							expected: 'AMZN',
+							actual: 'NF'
+						}
+					]
+				}
+			]);
+		});
+
+		this.test('ignores unmanaged extra arr custom format', () => {
+			const result = compareCustomFormatDrift(
+				[customFormat({ name: 'Streaming Tier' })],
+				[customFormat({ name: 'Streaming Tier' }), customFormat({ name: 'Unmanaged' })]
+			);
+
+			assertEquals(result.count, 0);
+		});
+
+		this.test('hash is stable for equivalent object key order', async () => {
+			const first: CustomFormatDriftDiff = {
+				missing: [],
+				modified: [
+					{
+						name: 'Streaming Tier',
+						fields: [
+							{
+								path: 'includeCustomFormatWhenRenaming',
+								expected: true,
+								actual: false
+							}
+						]
+					}
+				]
+			};
+			const second = {
+				modified: [
+					{
+						fields: [
+							{
+								actual: false,
+								expected: true,
+								path: 'includeCustomFormatWhenRenaming'
+							}
+						],
+						name: 'Streaming Tier'
+					}
+				],
+				missing: []
+			};
+
+			assertEquals(
+				await hashDriftDiff({ custom_formats: first }),
+				await hashDriftDiff({ custom_formats: second })
+			);
+		});
+
+		this.test('clean with no expected custom formats', () => {
+			const result = compareCustomFormatDrift([], [customFormat({ name: 'Unmanaged' })]);
+
+			assertEquals(result.count, 0);
+			assertEquals(result.diff, { missing: [], modified: [] });
+		});
+	}
+}
+
+const customFormatDriftTest = new CustomFormatDriftTest();
+customFormatDriftTest.runTests();

--- a/tests/unit/drift/customFormats.test.ts
+++ b/tests/unit/drift/customFormats.test.ts
@@ -135,6 +135,94 @@ class CustomFormatDriftTest extends BaseTest {
 			assertEquals(result.count, 0);
 		});
 
+		this.test('treats missing optional false fields as clean', () => {
+			const result = compareCustomFormatDrift(
+				[
+					customFormat({
+						name: 'Not Original or English',
+						specifications: [
+							{
+								name: 'English',
+								implementation: 'LanguageSpecification',
+								negate: true,
+								required: false,
+								fields: [{ name: 'value', value: 1 }]
+							}
+						]
+					})
+				],
+				[
+					customFormat({
+						name: 'Not Original or English',
+						specifications: [
+							{
+								name: 'English',
+								implementation: 'LanguageSpecification',
+								negate: true,
+								required: false,
+								fields: [
+									{ name: 'value', value: 1 },
+									{ name: 'exceptLanguage', value: false }
+								]
+							}
+						]
+					})
+				]
+			);
+
+			assertEquals(result.count, 0);
+		});
+
+		this.test('reports optional true fields missing from expected', () => {
+			const result = compareCustomFormatDrift(
+				[
+					customFormat({
+						name: 'Not Original or English',
+						specifications: [
+							{
+								name: 'English',
+								implementation: 'LanguageSpecification',
+								negate: true,
+								required: false,
+								fields: [{ name: 'value', value: 1 }]
+							}
+						]
+					})
+				],
+				[
+					customFormat({
+						name: 'Not Original or English',
+						specifications: [
+							{
+								name: 'English',
+								implementation: 'LanguageSpecification',
+								negate: true,
+								required: false,
+								fields: [
+									{ name: 'value', value: 1 },
+									{ name: 'exceptLanguage', value: true }
+								]
+							}
+						]
+					})
+				]
+			);
+
+			assertEquals(result.count, 1);
+			assertEquals(result.diff.modified, [
+				{
+					name: 'Not Original or English',
+					fields: [
+						{
+							path: 'specifications[LanguageSpecification:English].fields[exceptLanguage]',
+							expected: null,
+							actual: true
+						}
+					]
+				}
+			]);
+		});
+
 		this.test('reports field value mismatch with stable path', () => {
 			const result = compareCustomFormatDrift(
 				[customFormat({ name: 'Streaming Tier' })],


### PR DESCRIPTION
Adds custom format drift comparison for managed Arr sync selections, storing latest counts, structured diffs, stable hashes, and job result logs.

- Compares expected custom formats from sync transformers against Arr state, ignoring Arr ids and optional false defaults.
- Persists clean, detected, and failed drift results behind FEATURES.drift for later UI and notifications.

Part of #307 