### PR TITLE
fix: show drift run status

### DIFF
--- a/docs/backend/jobs.md
+++ b/docs/backend/jobs.md
@@ -273,8 +273,8 @@ Immutable log of every job execution.
 ## Real-Time Updates (SSE)
 
 The job system pushes real-time status updates to connected browsers via
-Server-Sent Events. Enabled for sync job types (`arr.sync.*`) and backup job
-types (`backup.create`, `backup.cleanup`).
+Server-Sent Events. Enabled for job types with running labels, currently sync,
+cleanup, drift, backup, and PCD link jobs.
 
 ### Server Side
 

--- a/src/routes/arr/[id]/drift/+page.svelte
+++ b/src/routes/arr/[id]/drift/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { enhance } from '$app/forms';
+	import { invalidateAll } from '$app/navigation';
 	import type { ActionData, PageData } from './$types';
 	import { onDestroy, onMount } from 'svelte';
 	import { alertStore } from '$lib/client/alerts/store';
@@ -54,7 +55,19 @@
 		interval = setInterval(() => {
 			now = Date.now();
 		}, 1000);
+		let previousJobState: string | null = null;
+		const unsubscribeJobStatus = jobStatus.subscribe((status) => {
+			if (
+				previousJobState === 'running' &&
+				status.state === 'completed' &&
+				status.jobType === 'arr.drift'
+			) {
+				invalidateAll();
+			}
+			previousJobState = status.state;
+		});
 		return () => {
+			unsubscribeJobStatus();
 			clear();
 			if (interval) clearInterval(interval);
 		};

--- a/src/routes/arr/[id]/drift/+page.svelte
+++ b/src/routes/arr/[id]/drift/+page.svelte
@@ -4,6 +4,7 @@
 	import { onDestroy, onMount } from 'svelte';
 	import { alertStore } from '$lib/client/alerts/store';
 	import { initEdit, update as updateDirty, clear, isDirty } from '$lib/client/stores/dirty';
+	import { jobStatus } from '$stores/jobStatus';
 	import { formatSmartDateTime } from '$shared/utils/dates';
 	import { serverTimezone } from '$lib/client/stores/timezone';
 	import Button from '$ui/button/Button.svelte';
@@ -79,6 +80,7 @@
 			initEdit({ enabled, cron });
 		}
 		if (form.error) {
+			jobStatus.cancelOptimistic();
 			alertStore.add('error', form.error);
 		}
 	}
@@ -118,9 +120,13 @@
 				iconColor="text-green-600 dark:text-green-400"
 				disabled={saving || running || $isDirty || !data.featureEnabled || !enabled}
 				on:click={() => {
+					jobStatus.connect();
+					jobStatus.setRunning('arr.drift', 'Checking drift...');
 					const runForm = document.getElementById('drift-run-form');
 					if (runForm instanceof HTMLFormElement) {
 						runForm.requestSubmit();
+					} else {
+						jobStatus.cancelOptimistic();
 					}
 				}}
 			/>


### PR DESCRIPTION
Shows global job status while a manual drift check runs.

- Connects the Drift page Run Now action to job SSE.
- Refreshes the Drift page when the manual drift job completes.