### PR TITLE
feat: add quality profile drift comparison 

### DIFF
--- a/docs/backend/drift.md
+++ b/docs/backend/drift.md
@@ -3,6 +3,8 @@
 **Source:** `src/lib/server/jobs/handlers/arrDrift.ts`,
 `src/lib/server/db/queries/arrDriftSettings.ts`,
 `src/lib/server/db/queries/arrDriftStatus.ts`,
+`src/lib/server/drift/customFormats.ts`,
+`src/lib/server/drift/qualityProfiles.ts`,
 `src/lib/server/drift/display.ts`,
 `src/routes/arr/[id]/drift/+page.svelte`,
 `src/routes/arr/[id]/drift/+page.server.ts`,
@@ -33,7 +35,8 @@ Current handler behavior:
 - missing instances fail
 - missing or disabled settings cancel the job
 - unsupported Arr types are skipped
-- enabled jobs compare custom formats, store the latest result, and return success
+- enabled jobs compare custom formats and quality profiles, store the latest
+  result, and return success
 - scheduled jobs calculate and store the next run before returning
 
 ## Latest Status
@@ -69,6 +72,28 @@ Comparison rules:
 - compare normalized specifications and fields
 - ignore unmanaged extra Arr custom formats
 
+## Quality Profiles
+
+Quality profile drift compares selected Profilarr-managed profiles by name.
+Expected profiles are built through the same quality profile transformer used
+by sync, with actual Arr custom format ids used to resolve scoring rows.
+
+Comparison rules:
+
+- report selected quality profiles missing from Arr
+- ignore Arr profile ids
+- compare `upgradeAllowed`, `cutoff`, `minFormatScore`,
+  `cutoffFormatScore`, and `minUpgradeFormatScore`
+- compare Radarr language; ignore language for Sonarr
+- compare normalized quality item order, grouping, and allowed flags
+- compare custom format scores for custom formats managed by that profile,
+  including explicit zero scores
+- report an expected managed custom format as missing from scoring if the custom
+  format is missing from Arr
+- ignore unmanaged custom format scoring rows with score 0
+- report unmanaged custom format scoring rows with nonzero scores because they
+  affect profile behavior
+
 ## Display Formatter
 
 `src/lib/server/drift/display.ts` maps the raw `diff_json` stored in
@@ -89,6 +114,11 @@ For custom formats the formatter resolves Arr enum ids back to friendly names
 modifiers), formats sizes in human-readable bytes, and turns specification
 paths into labeled changes (negate / required / per-field changes / missing
 condition / extra condition).
+
+For quality profiles the formatter turns settings, language, qualities, and
+custom format score paths into labeled changes. Quality profile score rows show
+expected and actual score values, missing custom formats, missing score rows,
+and unmanaged nonzero score rows.
 
 Display types live in `src/lib/shared/drift.ts`.
 
@@ -125,7 +155,6 @@ configuration, or triggers sync.
 
 ## TODO
 
-- Quality profile, delay profile, and media management comparison plus their
-  display formatting.
+- Delay profile and media management comparison plus their display formatting.
 - Drift notifications for `detected` and `failed`.
 - Brief drift status on the sync page linking to the dedicated drift page.

--- a/src/lib/server/drift/check.ts
+++ b/src/lib/server/drift/check.ts
@@ -1,8 +1,9 @@
 import type { BaseArrClient } from '$arr/base.ts';
 import type { DriftCounts, DriftDiff } from '$shared/drift.ts';
 import type { SyncArrType } from '$sync/mappings.ts';
-import { checkCustomFormatDrift } from './customFormats.ts';
+import { compareCustomFormatDrift, buildExpectedCustomFormats } from './customFormats.ts';
 import { hashDriftDiff } from './hash.ts';
+import { checkQualityProfileDrift } from './qualityProfiles.ts';
 
 export interface DriftCheckResult {
 	status: 'clean' | 'drift_detected';
@@ -12,16 +13,28 @@ export interface DriftCheckResult {
 }
 
 export async function checkArrDrift(
-	client: Pick<BaseArrClient, 'getCustomFormats'>,
+	client: Pick<BaseArrClient, 'getCustomFormats' | 'getQualityProfiles'>,
 	instanceId: number,
 	arrType: SyncArrType
 ): Promise<DriftCheckResult> {
-	const customFormats = await checkCustomFormatDrift(client, instanceId, arrType);
+	const [expectedCustomFormats, actualCustomFormats] = await Promise.all([
+		buildExpectedCustomFormats(instanceId, arrType),
+		client.getCustomFormats()
+	]);
+	const customFormats = compareCustomFormatDrift(expectedCustomFormats, actualCustomFormats);
+	const qualityProfiles = await checkQualityProfileDrift(
+		client,
+		instanceId,
+		arrType,
+		actualCustomFormats
+	);
 	const counts: DriftCounts = {
-		custom_formats: customFormats.count
+		custom_formats: customFormats.count,
+		quality_profiles: qualityProfiles.count
 	};
 	const diff: DriftDiff = {
-		custom_formats: customFormats.diff
+		custom_formats: customFormats.diff,
+		quality_profiles: qualityProfiles.diff
 	};
 	const total = Object.values(counts).reduce((sum, count) => sum + (count ?? 0), 0);
 

--- a/src/lib/server/drift/display.ts
+++ b/src/lib/server/drift/display.ts
@@ -11,11 +11,17 @@ import type {
 	DriftDiff,
 	DriftDisplayChange,
 	DriftDisplayEntity,
+	DriftDisplayQualityItem,
 	DriftDisplayTone,
 	DriftDisplayValue
 } from '$shared/drift.ts';
 
 interface CustomFormatDiff {
+	missing?: unknown[];
+	modified?: unknown[];
+}
+
+interface QualityProfileDiff {
 	missing?: unknown[];
 	modified?: unknown[];
 }
@@ -27,6 +33,11 @@ interface DriftFieldDiff {
 }
 
 interface CustomFormatModifiedDiff {
+	name: string;
+	fields: DriftFieldDiff[];
+}
+
+interface QualityProfileModifiedDiff {
 	name: string;
 	fields: DriftFieldDiff[];
 }
@@ -65,7 +76,10 @@ export function buildDriftDisplayEntities(
 	arrType: string | undefined
 ): DriftDisplayEntity[] {
 	const syncArrType = arrType === 'radarr' || arrType === 'sonarr' ? arrType : undefined;
-	return buildCustomFormatEntities(diff.custom_formats, syncArrType);
+	return [
+		...buildCustomFormatEntities(diff.custom_formats, syncArrType),
+		...buildQualityProfileEntities(diff.quality_profiles, syncArrType)
+	];
 }
 
 function buildCustomFormatEntities(
@@ -126,6 +140,174 @@ function buildCustomFormatEntities(
 	}
 
 	return entities;
+}
+
+function buildQualityProfileEntities(
+	raw: unknown,
+	arrType: SyncArrType | undefined
+): DriftDisplayEntity[] {
+	const diff = asQualityProfileDiff(raw);
+	if (!diff) return [];
+
+	const entities: DriftDisplayEntity[] = [];
+
+	for (const item of diff.missing ?? []) {
+		const name = recordString(item, 'name');
+		if (!name) continue;
+
+		entities.push({
+			id: `quality_profiles:missing:${name}`,
+			section: 'quality_profiles',
+			sectionLabel: 'Quality Profile',
+			title: name,
+			state: 'missing',
+			stateLabel: 'Missing',
+			tone: 'danger',
+			summary: 'Profilarr expects this quality profile, but Arr does not have it.',
+			changes: [
+				{
+					id: `quality_profiles:missing:${name}:profile`,
+					label: 'Quality profile',
+					detail: 'Missing from Arr',
+					expected: value('Present'),
+					actual: value('Missing', { tone: 'danger' }),
+					tone: 'danger'
+				}
+			]
+		});
+	}
+
+	for (const item of diff.modified ?? []) {
+		const modified = asModifiedQualityProfile(item);
+		if (!modified) continue;
+		if (modified.fields.length === 0) continue;
+
+		const changes = modified.fields.map((field, index) =>
+			formatQualityProfileFieldDiff(field, index, arrType)
+		);
+
+		entities.push({
+			id: `quality_profiles:modified:${modified.name}`,
+			section: 'quality_profiles',
+			sectionLabel: 'Quality Profile',
+			title: modified.name,
+			state: 'modified',
+			stateLabel: 'Modified',
+			tone: 'warning',
+			summary: `${changes.length} ${changes.length === 1 ? 'change' : 'changes'} detected`,
+			changes
+		});
+	}
+
+	return entities;
+}
+
+function formatQualityProfileFieldDiff(
+	field: DriftFieldDiff,
+	index: number,
+	arrType: SyncArrType | undefined
+): DriftDisplayChange {
+	const formatMatch = /^formatItems\[(.+)\]$/.exec(field.path);
+	if (formatMatch) {
+		const formatName = formatMatch[1];
+		const actualState = recordString(field.actual, 'state');
+		const isMissing = field.actual === null || actualState === 'missing_custom_format';
+		const isExtra = recordString(field.expected, 'state') === 'unmanaged';
+		let detail = `${formatName} score changed`;
+		if (isExtra) {
+			detail = `${formatName} has an unmanaged nonzero score`;
+		} else if (actualState === 'missing_custom_format') {
+			detail = `${formatName} custom format is missing from Arr`;
+		} else if (isMissing) {
+			detail = `${formatName} is missing from scoring`;
+		}
+
+		return {
+			id: `quality-profile-format-item:${index}`,
+			label: 'Custom format score',
+			detail,
+			expected: formatQualityProfileFormatItemValue(field.expected),
+			actual: formatQualityProfileFormatItemValue(field.actual),
+			tone: isMissing ? 'danger' : 'warning'
+		};
+	}
+
+	if (field.path === 'items') {
+		return {
+			id: `quality-profile-items:${index}`,
+			label: 'Qualities',
+			detail: 'Quality list differs from Profilarr expected layout',
+			expected: formatQualityItemsValue(field.expected),
+			actual: formatQualityItemsValue(field.actual),
+			tone: 'warning'
+		};
+	}
+
+	if (field.path === 'language') {
+		return {
+			id: `quality-profile-language:${index}`,
+			label: 'Language',
+			detail: 'Profile language changed',
+			expected: formatLanguageValue(field.expected, arrType),
+			actual: formatLanguageValue(field.actual, arrType),
+			tone: 'warning'
+		};
+	}
+
+	if (field.path === 'upgradeAllowed') {
+		return {
+			id: `quality-profile-upgrade-allowed:${index}`,
+			label: 'Upgrade Allowed',
+			detail: 'Upgrade behavior changed',
+			expected: formatBooleanValue(field.expected),
+			actual: formatBooleanValue(field.actual),
+			tone: 'warning'
+		};
+	}
+
+	return {
+		id: `quality-profile-field:${index}`,
+		label: qualityProfileFieldLabel(field.path),
+		detail: 'Profile setting changed',
+		expected: formatGenericValue(field.expected),
+		actual: formatGenericValue(field.actual),
+		tone: field.actual === null || field.actual === undefined ? 'danger' : 'warning'
+	};
+}
+
+function asQualityItems(raw: unknown): DriftDisplayQualityItem[] | null {
+	if (!Array.isArray(raw)) return null;
+	const items: DriftDisplayQualityItem[] = [];
+	for (const item of raw) {
+		const parsed = asQualityItem(item);
+		if (!parsed) return null;
+		items.push(parsed);
+	}
+	return items;
+}
+
+function asQualityItem(raw: unknown): DriftDisplayQualityItem | null {
+	if (!isRecord(raw)) return null;
+	const type = recordString(raw, 'type');
+	const name = recordString(raw, 'name');
+	if ((type !== 'quality' && type !== 'group') || !name || typeof raw.id !== 'number') {
+		return null;
+	}
+
+	const item: DriftDisplayQualityItem = {
+		type,
+		id: raw.id,
+		name,
+		allowed: raw.allowed !== false,
+		upgradeUntil: raw.upgradeUntil === true
+	};
+
+	if (type === 'group') {
+		const members = asQualityItems(raw.items);
+		item.items = members ?? [];
+	}
+
+	return item;
 }
 
 function formatCustomFormatFieldDiff(
@@ -273,7 +455,24 @@ function asCustomFormatDiff(raw: unknown): CustomFormatDiff | null {
 	};
 }
 
+function asQualityProfileDiff(raw: unknown): QualityProfileDiff | null {
+	if (!isRecord(raw)) return null;
+	return {
+		missing: Array.isArray(raw.missing) ? raw.missing : [],
+		modified: Array.isArray(raw.modified) ? raw.modified : []
+	};
+}
+
 function asModifiedCustomFormat(raw: unknown): CustomFormatModifiedDiff | null {
+	if (!isRecord(raw)) return null;
+	const name = recordString(raw, 'name');
+	if (!name || !Array.isArray(raw.fields)) return null;
+
+	const fields = raw.fields.filter(isFieldDiff);
+	return { name, fields };
+}
+
+function asModifiedQualityProfile(raw: unknown): QualityProfileModifiedDiff | null {
 	if (!isRecord(raw)) return null;
 	const name = recordString(raw, 'name');
 	if (!name || !Array.isArray(raw.fields)) return null;
@@ -387,6 +586,49 @@ function formatGenericValue(raw: unknown): DriftDisplayValue {
 	return value('Structured value');
 }
 
+function formatQualityItemsValue(raw: unknown): DriftDisplayValue {
+	const items = asQualityItems(raw);
+	if (!items) return formatGenericValue(raw);
+
+	return value(`${items.length} top-level ${items.length === 1 ? 'item' : 'items'}`, {
+		qualityList: items
+	});
+}
+
+function formatQualityProfileFormatItemValue(raw: unknown): DriftDisplayValue {
+	if (raw === null || raw === undefined) {
+		return value('Missing from scoring array', { tone: 'danger' });
+	}
+	if (!isRecord(raw)) return formatGenericValue(raw);
+
+	const name = recordString(raw, 'name') ?? 'Custom format';
+	const state = recordString(raw, 'state');
+	if (state === 'missing_custom_format') {
+		return value(`${name}: custom format missing`, { tone: 'danger' });
+	}
+	if (state === 'unmanaged') {
+		return value(`${name}: 0 (unmanaged)`, { mono: true });
+	}
+	if (typeof raw.score === 'number') {
+		return value(`${name}: ${raw.score}`, { mono: true });
+	}
+
+	return formatGenericValue(raw);
+}
+
+function formatLanguageValue(raw: unknown, arrType: SyncArrType | undefined): DriftDisplayValue {
+	if (raw === null || raw === undefined) return value('Missing', { tone: 'danger' });
+	if (!isRecord(raw)) return formatGenericValue(raw);
+
+	const id = raw.id;
+	const name = recordString(raw, 'name');
+	if (typeof id === 'number') {
+		return value(name ?? languageName(arrType, id) ?? String(id));
+	}
+
+	return formatGenericValue(raw);
+}
+
 function formatBooleanValue(raw: unknown): DriftDisplayValue {
 	if (raw === null || raw === undefined) return value('Missing', { tone: 'danger' });
 	return value(raw ? 'Enabled' : 'Disabled', {
@@ -414,6 +656,17 @@ function fieldLabel(implementation: string, field: string): string {
 	if (field === 'max') return 'Maximum';
 	if (field === 'exceptLanguage') return 'Except Language';
 	return titleize(field);
+}
+
+function qualityProfileFieldLabel(path: string): string {
+	const labels: Record<string, string> = {
+		cutoffFormatScore: 'Cutoff Format Score',
+		minFormatScore: 'Minimum Format Score',
+		minUpgradeFormatScore: 'Minimum Upgrade Score Increment',
+		upgradeAllowed: 'Upgrade Allowed'
+	};
+
+	return labels[path] ?? titleize(path);
 }
 
 function implementationLabel(implementation: string): string {
@@ -484,12 +737,17 @@ function looksTechnical(value: string): boolean {
 
 function value(
 	text: string,
-	options: { mono?: boolean; tone?: DriftDisplayTone } = {}
+	options: {
+		mono?: boolean;
+		tone?: DriftDisplayTone;
+		qualityList?: DriftDisplayQualityItem[];
+	} = {}
 ): DriftDisplayValue {
 	return {
 		text,
 		mono: options.mono,
-		tone: options.tone
+		tone: options.tone,
+		qualityList: options.qualityList
 	};
 }
 

--- a/src/lib/server/drift/qualityProfiles.ts
+++ b/src/lib/server/drift/qualityProfiles.ts
@@ -1,0 +1,361 @@
+import { arrSyncQueries } from '$db/queries/arrSync.ts';
+import type { BaseArrClient } from '$arr/base.ts';
+import type {
+	ArrCustomFormat,
+	ArrLanguage,
+	ArrQualityProfile,
+	ArrQualityProfilePayload,
+	QualityProfileFormatItem
+} from '$arr/types.ts';
+import { getCache } from '$pcd/index.ts';
+import { getCustomFormatsForProfile } from '$pcd/references.ts';
+import {
+	fetchQualityProfileFromPcd,
+	getQualityApiMappings,
+	transformQualityProfile
+} from '$sync/qualityProfiles/transformer.ts';
+import type { SyncArrType } from '$sync/mappings.ts';
+import type { DriftFieldDiff } from './customFormats.ts';
+import { stringifyCanonical } from './hash.ts';
+
+export interface QualityProfileMissingDiff {
+	name: string;
+}
+
+export interface QualityProfileModifiedDiff {
+	name: string;
+	fields: DriftFieldDiff[];
+}
+
+export interface QualityProfileDriftDiff {
+	missing: QualityProfileMissingDiff[];
+	modified: QualityProfileModifiedDiff[];
+}
+
+export interface QualityProfileDriftResult {
+	count: number;
+	diff: QualityProfileDriftDiff;
+}
+
+export interface QualityProfileDriftExpected {
+	profile: ArrQualityProfilePayload;
+	managedCustomFormatNames: string[];
+	managedCustomFormatScores?: { name: string; score: number }[];
+}
+
+interface ActualQualityProfile extends ArrQualityProfile {
+	language?: ArrLanguage;
+	minUpgradeFormatScore?: number;
+}
+
+interface QualityProfileItemLike {
+	quality?: { id: number; name: string; source?: string; resolution?: number };
+	items?: QualityProfileItemLike[] | unknown[];
+	allowed?: boolean;
+	id?: number;
+	name?: string;
+}
+
+interface NormalizedQualityItem {
+	type: 'quality' | 'group';
+	id: number;
+	name: string;
+	allowed: boolean;
+	upgradeUntil?: boolean;
+	items?: NormalizedQualityItem[];
+}
+
+function compareByString(a: string, b: string): number {
+	return a.localeCompare(b);
+}
+
+function valuesEqual(expected: unknown, actual: unknown): boolean {
+	return stringifyCanonical(expected) === stringifyCanonical(actual);
+}
+
+function profileName(profile: QualityProfileDriftExpected): string {
+	return profile.profile.name;
+}
+
+function formatItemById(
+	formatItems: QualityProfileFormatItem[] | undefined
+): Map<number, QualityProfileFormatItem> {
+	return new Map((formatItems ?? []).map((item) => [item.format, item]));
+}
+
+function customFormatsByName(formats: ArrCustomFormat[]): Map<string, ArrCustomFormat> {
+	return new Map(formats.map((format) => [format.name, format]));
+}
+
+function customFormatsById(formats: ArrCustomFormat[]): Map<number, ArrCustomFormat> {
+	const map = new Map<number, ArrCustomFormat>();
+	for (const format of formats) {
+		if (format.id !== undefined) map.set(format.id, format);
+	}
+	return map;
+}
+
+function normalizeQualityItem(
+	item: QualityProfileItemLike,
+	cutoff: number | undefined
+): NormalizedQualityItem {
+	if (item.quality) {
+		return {
+			type: 'quality',
+			id: item.quality.id,
+			name: item.quality.name,
+			allowed: Boolean(item.allowed),
+			upgradeUntil: item.quality.id === cutoff
+		};
+	}
+
+	return {
+		type: 'group',
+		id: item.id ?? 0,
+		name: item.name ?? '',
+		allowed: Boolean(item.allowed),
+		upgradeUntil: (item.id ?? 0) === cutoff,
+		items: (item.items ?? []).map((child) =>
+			normalizeQualityItem(child as QualityProfileItemLike, cutoff)
+		)
+	};
+}
+
+function normalizedItems(profile: {
+	items?: QualityProfileItemLike[];
+	cutoff?: number;
+}): NormalizedQualityItem[] {
+	return (profile.items ?? []).map((item) => normalizeQualityItem(item, profile.cutoff));
+}
+
+function languageDiff(
+	expected: ArrQualityProfilePayload,
+	actual: ActualQualityProfile,
+	arrType: SyncArrType
+): DriftFieldDiff | null {
+	if (arrType !== 'radarr') return null;
+
+	const expectedLanguage = expected.language ?? null;
+	const actualLanguage = actual.language ?? null;
+	if (valuesEqual(expectedLanguage, actualLanguage)) return null;
+
+	return {
+		path: 'language',
+		expected: expectedLanguage,
+		actual: actualLanguage
+	};
+}
+
+function settingDiffs(
+	expected: ArrQualityProfilePayload,
+	actual: ActualQualityProfile,
+	arrType: SyncArrType
+): DriftFieldDiff[] {
+	const diffs: DriftFieldDiff[] = [];
+	const fields = [
+		'cutoffFormatScore',
+		'minFormatScore',
+		'minUpgradeFormatScore',
+		'upgradeAllowed'
+	] as const;
+
+	for (const field of fields) {
+		if (expected[field] !== actual[field]) {
+			diffs.push({ path: field, expected: expected[field], actual: actual[field] });
+		}
+	}
+
+	const language = languageDiff(expected, actual, arrType);
+	if (language) diffs.push(language);
+
+	return diffs;
+}
+
+function qualityItemsDiff(
+	expected: ArrQualityProfilePayload,
+	actual: ActualQualityProfile
+): DriftFieldDiff | null {
+	const expectedItems = normalizedItems(expected);
+	const actualItems = normalizedItems({ items: actual.items ?? [], cutoff: actual.cutoff });
+	if (valuesEqual(expectedItems, actualItems)) return null;
+
+	return {
+		path: 'items',
+		expected: expectedItems,
+		actual: actualItems
+	};
+}
+
+function expectedFormatScore(expected: QualityProfileDriftExpected, formatName: string): number {
+	const managedScore = expected.managedCustomFormatScores?.find((item) => item.name === formatName);
+	if (managedScore) return managedScore.score;
+	return expected.profile.formatItems.find((item) => item.name === formatName)?.score ?? 0;
+}
+
+function formatItemDiffs(
+	expected: QualityProfileDriftExpected,
+	actual: ActualQualityProfile,
+	actualCustomFormats: ArrCustomFormat[]
+): DriftFieldDiff[] {
+	const diffs: DriftFieldDiff[] = [];
+	const formatsByName = customFormatsByName(actualCustomFormats);
+	const formatsById = customFormatsById(actualCustomFormats);
+	const actualItemsById = formatItemById(actual.formatItems);
+	const managedNames = new Set(expected.managedCustomFormatNames);
+
+	for (const formatName of [...managedNames].sort(compareByString)) {
+		const expectedScore = expectedFormatScore(expected, formatName);
+		const arrFormat = formatsByName.get(formatName);
+		const path = `formatItems[${formatName}]`;
+		const expectedValue = { name: formatName, score: expectedScore };
+
+		if (!arrFormat || arrFormat.id === undefined) {
+			diffs.push({
+				path,
+				expected: expectedValue,
+				actual: { name: formatName, state: 'missing_custom_format' }
+			});
+			continue;
+		}
+
+		const actualItem = actualItemsById.get(arrFormat.id);
+		if (!actualItem) {
+			diffs.push({ path, expected: expectedValue, actual: null });
+			continue;
+		}
+
+		if (actualItem.score !== expectedScore) {
+			diffs.push({
+				path,
+				expected: expectedValue,
+				actual: { name: formatName, score: actualItem.score }
+			});
+		}
+	}
+
+	const sortedActualItems = [...(actual.formatItems ?? [])].sort((a, b) =>
+		compareByString(a.name, b.name)
+	);
+	for (const actualItem of sortedActualItems) {
+		const arrFormat = formatsById.get(actualItem.format);
+		const name = arrFormat?.name ?? actualItem.name;
+		if (!name || managedNames.has(name) || actualItem.score === 0) continue;
+
+		diffs.push({
+			path: `formatItems[${name}]`,
+			expected: { name, score: 0, state: 'unmanaged' },
+			actual: { name, score: actualItem.score }
+		});
+	}
+
+	return diffs;
+}
+
+function compareProfile(
+	expected: QualityProfileDriftExpected,
+	actual: ActualQualityProfile,
+	actualCustomFormats: ArrCustomFormat[],
+	arrType: SyncArrType
+): DriftFieldDiff[] {
+	const items = qualityItemsDiff(expected.profile, actual);
+	const diffs = [
+		...settingDiffs(expected.profile, actual, arrType),
+		...(items ? [items] : []),
+		...formatItemDiffs(expected, actual, actualCustomFormats)
+	];
+
+	return diffs.sort((a, b) => compareByString(a.path, b.path));
+}
+
+export function compareQualityProfileDrift(
+	expectedProfiles: QualityProfileDriftExpected[],
+	actualProfiles: ArrQualityProfile[],
+	actualCustomFormats: ArrCustomFormat[],
+	arrType: SyncArrType
+): QualityProfileDriftResult {
+	const actualByName = new Map(
+		actualProfiles.map((profile) => [profile.name, profile as ActualQualityProfile])
+	);
+	const diff: QualityProfileDriftDiff = { missing: [], modified: [] };
+
+	for (const expected of [...expectedProfiles].sort((a, b) =>
+		compareByString(profileName(a), profileName(b))
+	)) {
+		const actual = actualByName.get(expected.profile.name);
+		if (!actual) {
+			diff.missing.push({ name: expected.profile.name });
+			continue;
+		}
+
+		const fields = compareProfile(expected, actual, actualCustomFormats, arrType);
+		if (fields.length > 0) {
+			diff.modified.push({ name: expected.profile.name, fields });
+		}
+	}
+
+	return {
+		count: diff.missing.length + diff.modified.length,
+		diff
+	};
+}
+
+export async function buildExpectedQualityProfiles(
+	instanceId: number,
+	arrType: SyncArrType,
+	actualCustomFormats: ArrCustomFormat[]
+): Promise<QualityProfileDriftExpected[]> {
+	const syncConfig = arrSyncQueries.getQualityProfilesSync(instanceId);
+	if (syncConfig.selections.length === 0) return [];
+
+	const expected: QualityProfileDriftExpected[] = [];
+	const formatIdMap = new Map<string, number>();
+	for (const format of actualCustomFormats) {
+		if (format.id !== undefined) formatIdMap.set(format.name, format.id);
+	}
+
+	for (const selection of syncConfig.selections) {
+		const cache = getCache(selection.databaseId);
+		if (!cache) {
+			throw new Error(`PCD cache not found for database ${selection.databaseId}`);
+		}
+
+		const pcdProfile = await fetchQualityProfileFromPcd(cache, selection.profileName, arrType);
+		if (!pcdProfile) {
+			throw new Error(
+				`Quality profile "${selection.profileName}" not found in database ${selection.databaseId}`
+			);
+		}
+
+		const [qualityMappings, managedCustomFormatNames] = await Promise.all([
+			getQualityApiMappings(cache, arrType),
+			getCustomFormatsForProfile(cache, selection.profileName, arrType)
+		]);
+
+		const profile = transformQualityProfile(pcdProfile, arrType, qualityMappings, formatIdMap);
+		profile.name = pcdProfile.name;
+		expected.push({
+			profile,
+			managedCustomFormatNames,
+			managedCustomFormatScores: pcdProfile.customFormats.map((format) => ({
+				name: format.formatName,
+				score: format.score
+			}))
+		});
+	}
+
+	return expected;
+}
+
+export async function checkQualityProfileDrift(
+	client: Pick<BaseArrClient, 'getQualityProfiles'>,
+	instanceId: number,
+	arrType: SyncArrType,
+	actualCustomFormats: ArrCustomFormat[]
+): Promise<QualityProfileDriftResult> {
+	const [expectedProfiles, actualProfiles] = await Promise.all([
+		buildExpectedQualityProfiles(instanceId, arrType, actualCustomFormats),
+		client.getQualityProfiles()
+	]);
+
+	return compareQualityProfileDrift(expectedProfiles, actualProfiles, actualCustomFormats, arrType);
+}

--- a/src/lib/server/jobs/handlers/arrDrift.ts
+++ b/src/lib/server/jobs/handlers/arrDrift.ts
@@ -64,7 +64,7 @@ const driftHandler: JobHandler = async (job) => {
 			errorHash: null
 		});
 
-		const customFormatCount = result.counts.custom_formats ?? 0;
+		const totalCount = Object.values(result.counts).reduce((sum, count) => sum + (count ?? 0), 0);
 		if (result.status === 'drift_detected') {
 			await logger.info('Drift detected', {
 				source: 'jobs.handlers.arrDrift',
@@ -80,9 +80,9 @@ const driftHandler: JobHandler = async (job) => {
 		return {
 			status: 'success',
 			output:
-				customFormatCount === 0
+				totalCount === 0
 					? 'No drift detected'
-					: `Detected ${customFormatCount} custom format drift item(s)`,
+					: `Detected ${totalCount} drift item(s)`,
 			rescheduleAt: job.source === 'schedule' ? (nextRunAt ?? undefined) : undefined
 		};
 	} catch (error) {

--- a/src/lib/server/jobs/handlers/arrDrift.ts
+++ b/src/lib/server/jobs/handlers/arrDrift.ts
@@ -79,10 +79,7 @@ const driftHandler: JobHandler = async (job) => {
 
 		return {
 			status: 'success',
-			output:
-				totalCount === 0
-					? 'No drift detected'
-					: `Detected ${totalCount} drift item(s)`,
+			output: totalCount === 0 ? 'No drift detected' : `Detected ${totalCount} drift item(s)`,
 			rescheduleAt: job.source === 'schedule' ? (nextRunAt ?? undefined) : undefined
 		};
 	} catch (error) {

--- a/src/lib/shared/drift.ts
+++ b/src/lib/shared/drift.ts
@@ -18,6 +18,16 @@ export interface DriftDisplayValue {
 	text: string;
 	mono?: boolean;
 	tone?: DriftDisplayTone;
+	qualityList?: DriftDisplayQualityItem[];
+}
+
+export interface DriftDisplayQualityItem {
+	type: 'quality' | 'group';
+	id: number;
+	name: string;
+	allowed: boolean;
+	upgradeUntil?: boolean;
+	items?: DriftDisplayQualityItem[];
 }
 
 export interface DriftDisplayChange {

--- a/src/lib/shared/features.ts
+++ b/src/lib/shared/features.ts
@@ -13,5 +13,5 @@ export const FEATURES = {
 	/** Database tweaks UI */
 	tweaks: false,
 	/** Arr drift detection */
-	drift: false
+	drift: true
 } as const;

--- a/src/lib/shared/features.ts
+++ b/src/lib/shared/features.ts
@@ -13,5 +13,5 @@ export const FEATURES = {
 	/** Database tweaks UI */
 	tweaks: false,
 	/** Arr drift detection */
-	drift: true
+	drift: false
 } as const;

--- a/src/routes/arr/[id]/drift/components/DriftFieldDiffTable.svelte
+++ b/src/routes/arr/[id]/drift/components/DriftFieldDiffTable.svelte
@@ -3,6 +3,7 @@
 	import Label from '$ui/label/Label.svelte';
 	import type { Column } from '$ui/table/types';
 	import type { DriftDisplayChange, DriftDisplayTone, DriftDisplayValue } from '$shared/drift.ts';
+	import QualityListDiff from './QualityListDiff.svelte';
 
 	export let changes: DriftDisplayChange[];
 
@@ -42,17 +43,25 @@
 			</div>
 		{:else if column.key === 'expected'}
 			{#if row.expected}
-				<Label variant={valueVariant(row.expected)} size="md" rounded="md" mono={row.expected.mono}>
-					{row.expected.text}
-				</Label>
+				{#if row.expected.qualityList}
+					<QualityListDiff items={row.expected.qualityList} />
+				{:else}
+					<Label variant={valueVariant(row.expected)} size="md" rounded="md" mono={row.expected.mono}>
+						{row.expected.text}
+					</Label>
+				{/if}
 			{:else}
 				<span class="text-xs text-neutral-400 dark:text-neutral-500">None</span>
 			{/if}
 		{:else if column.key === 'actual'}
 			{#if row.actual}
-				<Label variant={valueVariant(row.actual)} size="md" rounded="md" mono={row.actual.mono}>
-					{row.actual.text}
-				</Label>
+				{#if row.actual.qualityList}
+					<QualityListDiff items={row.actual.qualityList} />
+				{:else}
+					<Label variant={valueVariant(row.actual)} size="md" rounded="md" mono={row.actual.mono}>
+						{row.actual.text}
+					</Label>
+				{/if}
 			{:else}
 				<span class="text-xs text-neutral-400 dark:text-neutral-500">None</span>
 			{/if}

--- a/src/routes/arr/[id]/drift/components/DriftFieldDiffTable.svelte
+++ b/src/routes/arr/[id]/drift/components/DriftFieldDiffTable.svelte
@@ -46,7 +46,12 @@
 				{#if row.expected.qualityList}
 					<QualityListDiff items={row.expected.qualityList} />
 				{:else}
-					<Label variant={valueVariant(row.expected)} size="md" rounded="md" mono={row.expected.mono}>
+					<Label
+						variant={valueVariant(row.expected)}
+						size="md"
+						rounded="md"
+						mono={row.expected.mono}
+					>
 						{row.expected.text}
 					</Label>
 				{/if}

--- a/src/routes/arr/[id]/drift/components/QualityListDiff.svelte
+++ b/src/routes/arr/[id]/drift/components/QualityListDiff.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import ExpandableTable from '$ui/table/ExpandableTable.svelte';
+	import Table from '$ui/table/Table.svelte';
 	import Label from '$ui/label/Label.svelte';
 	import type { Column } from '$ui/table/types';
 	import type { DriftDisplayQualityItem } from '$shared/drift.ts';
@@ -10,11 +11,20 @@
 		position: number;
 	}
 
-	$: rows = items.map<QualityRow>((item, index) => ({ ...item, position: index + 1 }));
+	$: rows = [...items].reverse().map<QualityRow>((item, index) => ({
+		...item,
+		position: index + 1,
+		items: item.items ? [...item.items].reverse() : item.items
+	}));
 
 	const columns: Column<QualityRow>[] = [
 		{ key: 'position', header: '#', width: 'w-12' },
 		{ key: 'name', header: 'Quality / Group' }
+	];
+
+	const memberColumns: Column<QualityRow>[] = [
+		{ key: 'position', header: '#', width: 'w-12' },
+		{ key: 'name', header: 'Quality' }
 	];
 
 	function disableExpand(row: QualityRow): boolean {
@@ -24,6 +34,10 @@
 	function rowKey(row: QualityRow): string {
 		return `${row.type}:${row.id}:${row.position}`;
 	}
+
+	function memberRows(members: DriftDisplayQualityItem[]): QualityRow[] {
+		return members.map((member, i) => ({ ...member, position: i + 1 }));
+	}
 </script>
 
 <ExpandableTable
@@ -32,6 +46,7 @@
 	getRowId={rowKey}
 	disableExpandWhen={disableExpand}
 	compact
+	flushExpanded
 	chevronPosition="right"
 	emptyMessage="No qualities"
 >
@@ -42,11 +57,7 @@
 			</span>
 		{:else if column.key === 'name'}
 			<div class="flex items-center justify-between gap-2">
-				<span
-					class="text-sm font-medium {row.allowed
-						? 'text-neutral-900 dark:text-neutral-100'
-						: 'text-neutral-400 line-through dark:text-neutral-500'}"
-				>
+				<span class="text-sm font-medium text-neutral-900 dark:text-neutral-100">
 					{row.name}
 				</span>
 				<div class="flex shrink-0 items-center gap-1.5">
@@ -62,18 +73,26 @@
 	</svelte:fragment>
 
 	<svelte:fragment slot="expanded" let:row>
-		{#if row.type === 'group' && row.items}
-			<div class="space-y-2 text-sm">
-				{#each row.items as member}
-					<div class="flex items-center justify-between gap-2">
-						<span class="font-medium text-neutral-700 dark:text-neutral-200">
-							{member.name}
-						</span>
-						{#if member.upgradeUntil}
-							<Label variant="info" size="sm" rounded="md">Upgrade Until</Label>
+		{#if row.type === 'group' && row.items && row.items.length > 0}
+			<div class="p-4">
+				<Table columns={memberColumns} data={memberRows(row.items)} compact hoverable={false}>
+					<svelte:fragment slot="cell" let:row let:column>
+						{#if column.key === 'position'}
+							<span class="text-sm text-neutral-500 tabular-nums dark:text-neutral-400">
+								{row.position}
+							</span>
+						{:else if column.key === 'name'}
+							<div class="flex items-center justify-between gap-2">
+								<span class="text-sm font-medium text-neutral-900 dark:text-neutral-100">
+									{row.name}
+								</span>
+								{#if row.upgradeUntil}
+									<Label variant="info" size="sm" rounded="md">Upgrade Until</Label>
+								{/if}
+							</div>
 						{/if}
-					</div>
-				{/each}
+					</svelte:fragment>
+				</Table>
 			</div>
 		{/if}
 	</svelte:fragment>

--- a/src/routes/arr/[id]/drift/components/QualityListDiff.svelte
+++ b/src/routes/arr/[id]/drift/components/QualityListDiff.svelte
@@ -1,0 +1,80 @@
+<script lang="ts">
+	import ExpandableTable from '$ui/table/ExpandableTable.svelte';
+	import Label from '$ui/label/Label.svelte';
+	import type { Column } from '$ui/table/types';
+	import type { DriftDisplayQualityItem } from '$shared/drift.ts';
+
+	export let items: DriftDisplayQualityItem[] = [];
+
+	interface QualityRow extends DriftDisplayQualityItem {
+		position: number;
+	}
+
+	$: rows = items.map<QualityRow>((item, index) => ({ ...item, position: index + 1 }));
+
+	const columns: Column<QualityRow>[] = [
+		{ key: 'position', header: '#', width: 'w-12' },
+		{ key: 'name', header: 'Quality / Group' }
+	];
+
+	function disableExpand(row: QualityRow): boolean {
+		return row.type !== 'group' || !row.items || row.items.length === 0;
+	}
+
+	function rowKey(row: QualityRow): string {
+		return `${row.type}:${row.id}:${row.position}`;
+	}
+</script>
+
+<ExpandableTable
+	{columns}
+	data={rows}
+	getRowId={rowKey}
+	disableExpandWhen={disableExpand}
+	compact
+	chevronPosition="right"
+	emptyMessage="No qualities"
+>
+	<svelte:fragment slot="cell" let:row let:column>
+		{#if column.key === 'position'}
+			<span class="text-sm text-neutral-500 tabular-nums dark:text-neutral-400">
+				{row.position}
+			</span>
+		{:else if column.key === 'name'}
+			<div class="flex items-center justify-between gap-2">
+				<span
+					class="text-sm font-medium {row.allowed
+						? 'text-neutral-900 dark:text-neutral-100'
+						: 'text-neutral-400 line-through dark:text-neutral-500'}"
+				>
+					{row.name}
+				</span>
+				<div class="flex shrink-0 items-center gap-1.5">
+					<Label variant={row.allowed ? 'success' : 'secondary'} size="sm" rounded="md">
+						{row.allowed ? 'Enabled' : 'Disabled'}
+					</Label>
+					{#if row.upgradeUntil}
+						<Label variant="info" size="sm" rounded="md">Upgrade Until</Label>
+					{/if}
+				</div>
+			</div>
+		{/if}
+	</svelte:fragment>
+
+	<svelte:fragment slot="expanded" let:row>
+		{#if row.type === 'group' && row.items}
+			<div class="space-y-2 text-sm">
+				{#each row.items as member}
+					<div class="flex items-center justify-between gap-2">
+						<span class="font-medium text-neutral-700 dark:text-neutral-200">
+							{member.name}
+						</span>
+						{#if member.upgradeUntil}
+							<Label variant="info" size="sm" rounded="md">Upgrade Until</Label>
+						{/if}
+					</div>
+				{/each}
+			</div>
+		{/if}
+	</svelte:fragment>
+</ExpandableTable>

--- a/tests/unit/drift/qualityProfiles.test.ts
+++ b/tests/unit/drift/qualityProfiles.test.ts
@@ -1,0 +1,527 @@
+import { assertEquals } from '@std/assert';
+import { BaseTest } from '../base/BaseTest.ts';
+import {
+	compareQualityProfileDrift,
+	type QualityProfileDriftDiff,
+	type QualityProfileDriftExpected
+} from '$drift/qualityProfiles.ts';
+import { hashDriftDiff } from '$drift/hash.ts';
+import type {
+	ArrCustomFormat,
+	ArrLanguage,
+	ArrQualityProfile,
+	ArrQualityProfileItem,
+	ArrQualityProfilePayload
+} from '$arr/types.ts';
+
+type ActualQualityProfile = ArrQualityProfile & {
+	language?: ArrLanguage;
+	minUpgradeFormatScore?: number;
+};
+
+const qualityItem = (name: string, id: number, allowed = true): ArrQualityProfileItem => ({
+	quality: { id, name, source: 'web', resolution: 1080 },
+	items: [],
+	allowed
+});
+
+const groupItem = (
+	name: string,
+	id: number,
+	members: ArrQualityProfileItem[],
+	allowed = true
+): ArrQualityProfileItem => ({
+	id,
+	name,
+	items: members,
+	allowed
+});
+
+function customFormat(name: string, id: number): ArrCustomFormat {
+	return {
+		id,
+		name,
+		includeCustomFormatWhenRenaming: false,
+		specifications: []
+	};
+}
+
+function expectedProfile(
+	input: Partial<ArrQualityProfilePayload> & {
+		name?: string;
+		managedCustomFormatNames?: string[];
+	}
+): QualityProfileDriftExpected {
+	const name = input.name ?? 'HD Movies';
+	const profile: ArrQualityProfilePayload = {
+		name,
+		items: input.items ?? [qualityItem('WEBDL-1080p', 3), qualityItem('Bluray-1080p', 7)],
+		language: input.language ?? { id: 1, name: 'English' },
+		upgradeAllowed: input.upgradeAllowed ?? true,
+		cutoff: input.cutoff ?? 7,
+		minFormatScore: input.minFormatScore ?? 0,
+		cutoffFormatScore: input.cutoffFormatScore ?? 1000,
+		minUpgradeFormatScore: input.minUpgradeFormatScore ?? 1,
+		formatItems: input.formatItems ?? [
+			{ format: 100, name: 'Streaming Tier', score: 100 },
+			{ format: 200, name: 'HDR10', score: 50 }
+		]
+	};
+
+	return {
+		profile,
+		managedCustomFormatNames: input.managedCustomFormatNames ?? ['Streaming Tier', 'HDR10']
+	};
+}
+
+function actualProfile(
+	input: Partial<ActualQualityProfile> & { name?: string }
+): ActualQualityProfile {
+	return {
+		id: input.id ?? 999,
+		name: input.name ?? 'HD Movies',
+		items: input.items ?? [qualityItem('WEBDL-1080p', 3), qualityItem('Bluray-1080p', 7)],
+		language: input.language ?? { id: 1, name: 'English' },
+		upgradeAllowed: input.upgradeAllowed ?? true,
+		cutoff: input.cutoff ?? 7,
+		minFormatScore: input.minFormatScore ?? 0,
+		cutoffFormatScore: input.cutoffFormatScore ?? 1000,
+		minUpgradeFormatScore: input.minUpgradeFormatScore ?? 1,
+		formatItems: input.formatItems ?? [
+			{ format: 1, name: 'Streaming Tier', score: 100 },
+			{ format: 2, name: 'HDR10', score: 50 }
+		]
+	};
+}
+
+class QualityProfileDriftTest extends BaseTest {
+	runTests(): void {
+		this.test('clean when expected and actual quality profiles match', () => {
+			const result = compareQualityProfileDrift(
+				[expectedProfile({})],
+				[actualProfile({})],
+				[customFormat('Streaming Tier', 1), customFormat('HDR10', 2)],
+				'radarr'
+			);
+
+			assertEquals(result.count, 0);
+			assertEquals(result.diff, { missing: [], modified: [] });
+		});
+
+		this.test('reports selected quality profile missing from Arr', () => {
+			const result = compareQualityProfileDrift(
+				[expectedProfile({ name: 'HD Movies' })],
+				[],
+				[customFormat('Streaming Tier', 1), customFormat('HDR10', 2)],
+				'radarr'
+			);
+
+			assertEquals(result.count, 1);
+			assertEquals(result.diff.missing, [{ name: 'HD Movies' }]);
+			assertEquals(result.diff.modified, []);
+		});
+
+		this.test('ignores profile ids and resolves custom format rows through actual Arr ids', () => {
+			const result = compareQualityProfileDrift(
+				[
+					expectedProfile({
+						formatItems: [{ format: 999, name: 'Streaming Tier', score: 100 }],
+						managedCustomFormatNames: ['Streaming Tier']
+					})
+				],
+				[
+					actualProfile({
+						id: 1234,
+						formatItems: [{ format: 1, name: 'Streaming Tier', score: 100 }]
+					})
+				],
+				[customFormat('Streaming Tier', 1)],
+				'radarr'
+			);
+
+			assertEquals(result.count, 0);
+		});
+
+		this.test('reports managed profile setting mismatches', () => {
+			const result = compareQualityProfileDrift(
+				[expectedProfile({})],
+				[
+					actualProfile({
+						upgradeAllowed: false,
+						cutoff: 3,
+						minFormatScore: 10,
+						cutoffFormatScore: 500,
+						minUpgradeFormatScore: 25
+					})
+				],
+				[customFormat('Streaming Tier', 1), customFormat('HDR10', 2)],
+				'radarr'
+			);
+
+			assertEquals(result.count, 1);
+			assertEquals(result.diff.modified, [
+				{
+					name: 'HD Movies',
+					fields: [
+						{ path: 'cutoffFormatScore', expected: 1000, actual: 500 },
+						{
+							path: 'items',
+							expected: [
+								{ type: 'quality', id: 3, name: 'WEBDL-1080p', allowed: true, upgradeUntil: false },
+								{ type: 'quality', id: 7, name: 'Bluray-1080p', allowed: true, upgradeUntil: true }
+							],
+							actual: [
+								{ type: 'quality', id: 3, name: 'WEBDL-1080p', allowed: true, upgradeUntil: true },
+								{ type: 'quality', id: 7, name: 'Bluray-1080p', allowed: true, upgradeUntil: false }
+							]
+						},
+						{ path: 'minFormatScore', expected: 0, actual: 10 },
+						{ path: 'minUpgradeFormatScore', expected: 1, actual: 25 },
+						{ path: 'upgradeAllowed', expected: true, actual: false }
+					]
+				}
+			]);
+		});
+
+		this.test('compares Radarr language', () => {
+			const result = compareQualityProfileDrift(
+				[expectedProfile({ language: { id: 1, name: 'English' } })],
+				[actualProfile({ language: { id: 2, name: 'French' } })],
+				[customFormat('Streaming Tier', 1), customFormat('HDR10', 2)],
+				'radarr'
+			);
+
+			assertEquals(result.count, 1);
+			assertEquals(result.diff.modified, [
+				{
+					name: 'HD Movies',
+					fields: [
+						{
+							path: 'language',
+							expected: { id: 1, name: 'English' },
+							actual: { id: 2, name: 'French' }
+						}
+					]
+				}
+			]);
+		});
+
+		this.test('ignores Sonarr language', () => {
+			const result = compareQualityProfileDrift(
+				[expectedProfile({ language: undefined })],
+				[actualProfile({ language: { id: 2, name: 'French' } })],
+				[customFormat('Streaming Tier', 1), customFormat('HDR10', 2)],
+				'sonarr'
+			);
+
+			assertEquals(result.count, 0);
+		});
+
+		this.test('reports quality structure mismatch', () => {
+			const expectedItems = [
+				groupItem(
+					'HD Group',
+					1001,
+					[qualityItem('WEBDL-1080p', 3), qualityItem('Bluray-1080p', 7)],
+					true
+				),
+				qualityItem('WEBDL-720p', 5, false)
+			];
+			const actualItems = [
+				groupItem(
+					'HD Group',
+					1001,
+					[qualityItem('Bluray-1080p', 7), qualityItem('WEBDL-1080p', 3)],
+					true
+				),
+				qualityItem('WEBDL-720p', 5, true)
+			];
+
+			const result = compareQualityProfileDrift(
+				[expectedProfile({ items: expectedItems })],
+				[actualProfile({ items: actualItems })],
+				[customFormat('Streaming Tier', 1), customFormat('HDR10', 2)],
+				'radarr'
+			);
+
+			assertEquals(result.count, 1);
+			assertEquals(result.diff.modified[0].fields, [
+				{
+					path: 'items',
+					expected: [
+						{
+							type: 'group',
+							id: 1001,
+							name: 'HD Group',
+							allowed: true,
+							upgradeUntil: false,
+							items: [
+								{ type: 'quality', id: 3, name: 'WEBDL-1080p', allowed: true, upgradeUntil: false },
+								{ type: 'quality', id: 7, name: 'Bluray-1080p', allowed: true, upgradeUntil: true }
+							]
+						},
+						{ type: 'quality', id: 5, name: 'WEBDL-720p', allowed: false, upgradeUntil: false }
+					],
+					actual: [
+						{
+							type: 'group',
+							id: 1001,
+							name: 'HD Group',
+							allowed: true,
+							upgradeUntil: false,
+							items: [
+								{ type: 'quality', id: 7, name: 'Bluray-1080p', allowed: true, upgradeUntil: true },
+								{ type: 'quality', id: 3, name: 'WEBDL-1080p', allowed: true, upgradeUntil: false }
+							]
+						},
+						{ type: 'quality', id: 5, name: 'WEBDL-720p', allowed: true, upgradeUntil: false }
+					]
+				}
+			]);
+		});
+
+		this.test('reports managed custom format missing from scoring array defensively', () => {
+			const result = compareQualityProfileDrift(
+				[
+					expectedProfile({
+						formatItems: [{ format: 1, name: 'Streaming Tier', score: 100 }],
+						managedCustomFormatNames: ['Streaming Tier']
+					})
+				],
+				[actualProfile({ formatItems: [] })],
+				[customFormat('Streaming Tier', 1)],
+				'radarr'
+			);
+
+			assertEquals(result.count, 1);
+			assertEquals(result.diff.modified, [
+				{
+					name: 'HD Movies',
+					fields: [
+						{
+							path: 'formatItems[Streaming Tier]',
+							expected: { name: 'Streaming Tier', score: 100 },
+							actual: null
+						}
+					]
+				}
+			]);
+		});
+
+		this.test(
+			'reports managed custom format missing from Arr under quality profile scoring',
+			() => {
+				const result = compareQualityProfileDrift(
+					[
+						expectedProfile({
+							formatItems: [{ format: 1, name: 'Streaming Tier', score: 100 }],
+							managedCustomFormatNames: ['Streaming Tier']
+						})
+					],
+					[actualProfile({ formatItems: [] })],
+					[],
+					'radarr'
+				);
+
+				assertEquals(result.count, 1);
+				assertEquals(result.diff.modified, [
+					{
+						name: 'HD Movies',
+						fields: [
+							{
+								path: 'formatItems[Streaming Tier]',
+								expected: { name: 'Streaming Tier', score: 100 },
+								actual: { name: 'Streaming Tier', state: 'missing_custom_format' }
+							}
+						]
+					}
+				]);
+			}
+		);
+
+		this.test('reports managed custom format score mismatch', () => {
+			const result = compareQualityProfileDrift(
+				[
+					expectedProfile({
+						formatItems: [{ format: 1, name: 'Streaming Tier', score: 100 }],
+						managedCustomFormatNames: ['Streaming Tier']
+					})
+				],
+				[actualProfile({ formatItems: [{ format: 1, name: 'Streaming Tier', score: 75 }] })],
+				[customFormat('Streaming Tier', 1)],
+				'radarr'
+			);
+
+			assertEquals(result.count, 1);
+			assertEquals(result.diff.modified, [
+				{
+					name: 'HD Movies',
+					fields: [
+						{
+							path: 'formatItems[Streaming Tier]',
+							expected: { name: 'Streaming Tier', score: 100 },
+							actual: { name: 'Streaming Tier', score: 75 }
+						}
+					]
+				}
+			]);
+		});
+
+		this.test('ignores unmanaged Arr custom format scoring rows with zero score', () => {
+			const result = compareQualityProfileDrift(
+				[
+					expectedProfile({
+						formatItems: [{ format: 1, name: 'Streaming Tier', score: 100 }],
+						managedCustomFormatNames: ['Streaming Tier']
+					})
+				],
+				[
+					actualProfile({
+						formatItems: [
+							{ format: 1, name: 'Streaming Tier', score: 100 },
+							{ format: 2, name: 'Unmanaged', score: 0 }
+						]
+					})
+				],
+				[customFormat('Streaming Tier', 1), customFormat('Unmanaged', 2)],
+				'radarr'
+			);
+
+			assertEquals(result.count, 0);
+		});
+
+		this.test('reports unmanaged Arr custom format scoring rows with nonzero score', () => {
+			const result = compareQualityProfileDrift(
+				[
+					expectedProfile({
+						formatItems: [{ format: 1, name: 'Streaming Tier', score: 100 }],
+						managedCustomFormatNames: ['Streaming Tier']
+					})
+				],
+				[
+					actualProfile({
+						formatItems: [
+							{ format: 1, name: 'Streaming Tier', score: 100 },
+							{ format: 2, name: 'Unmanaged', score: 999 }
+						]
+					})
+				],
+				[customFormat('Streaming Tier', 1), customFormat('Unmanaged', 2)],
+				'radarr'
+			);
+
+			assertEquals(result.count, 1);
+			assertEquals(result.diff.modified, [
+				{
+					name: 'HD Movies',
+					fields: [
+						{
+							path: 'formatItems[Unmanaged]',
+							expected: { name: 'Unmanaged', score: 0, state: 'unmanaged' },
+							actual: { name: 'Unmanaged', score: 999 }
+						}
+					]
+				}
+			]);
+		});
+
+		this.test('compares managed custom format with expected zero score', () => {
+			const result = compareQualityProfileDrift(
+				[
+					expectedProfile({
+						formatItems: [{ format: 1, name: 'Streaming Tier', score: 0 }],
+						managedCustomFormatNames: ['Streaming Tier']
+					})
+				],
+				[actualProfile({ formatItems: [{ format: 1, name: 'Streaming Tier', score: 10 }] })],
+				[customFormat('Streaming Tier', 1)],
+				'radarr'
+			);
+
+			assertEquals(result.count, 1);
+			assertEquals(result.diff.modified, [
+				{
+					name: 'HD Movies',
+					fields: [
+						{
+							path: 'formatItems[Streaming Tier]',
+							expected: { name: 'Streaming Tier', score: 0 },
+							actual: { name: 'Streaming Tier', score: 10 }
+						}
+					]
+				}
+			]);
+		});
+
+		this.test('sorts profiles and fields for stable drift output', () => {
+			const result = compareQualityProfileDrift(
+				[expectedProfile({ name: 'Z Profile' }), expectedProfile({ name: 'A Profile' })],
+				[
+					actualProfile({
+						name: 'Z Profile',
+						cutoff: 3,
+						minFormatScore: 10
+					}),
+					actualProfile({
+						name: 'A Profile',
+						upgradeAllowed: false
+					})
+				],
+				[customFormat('Streaming Tier', 1), customFormat('HDR10', 2)],
+				'radarr'
+			);
+
+			assertEquals(
+				result.diff.modified.map((item) => item.name),
+				['A Profile', 'Z Profile']
+			);
+			assertEquals(
+				result.diff.modified
+					.find((item) => item.name === 'Z Profile')
+					?.fields.map((field) => field.path),
+				['items', 'minFormatScore']
+			);
+		});
+
+		this.test('hash is stable for equivalent object key order', async () => {
+			const first: QualityProfileDriftDiff = {
+				missing: [],
+				modified: [
+					{
+						name: 'HD Movies',
+						fields: [
+							{
+								path: 'formatItems[Streaming Tier]',
+								expected: { name: 'Streaming Tier', score: 100 },
+								actual: { name: 'Streaming Tier', score: 75 }
+							}
+						]
+					}
+				]
+			};
+			const second = {
+				modified: [
+					{
+						fields: [
+							{
+								actual: { score: 75, name: 'Streaming Tier' },
+								expected: { score: 100, name: 'Streaming Tier' },
+								path: 'formatItems[Streaming Tier]'
+							}
+						],
+						name: 'HD Movies'
+					}
+				],
+				missing: []
+			};
+
+			assertEquals(
+				await hashDriftDiff({ quality_profiles: first }),
+				await hashDriftDiff({ quality_profiles: second })
+			);
+		});
+	}
+}
+
+const qualityProfileDriftTest = new QualityProfileDriftTest();
+qualityProfileDriftTest.runTests();


### PR DESCRIPTION
Part of #307 

Implements quality profile drift comparison. 
- Cutoff treated as upgrade until label in qualities diff
- CFs with score 0 are silently ignored if unamanged
- CFs with score non 0 are flagged as drifted if unmanaged