### PR TITLE
style: align arr instance pages and stream manual run feedback

### DIFF
--- a/src/lib/client/ui/button/Button.svelte
+++ b/src/lib/client/ui/button/Button.svelte
@@ -29,7 +29,8 @@
 	export let title: string = '';
 	export let ariaLabel: string = '';
 	export let tooltip: string = '';
-	export let tooltipPosition: 'top' | 'bottom' | 'right' = 'bottom';
+	export let tooltipPosition: 'top' | 'bottom' | 'left' | 'right' = 'bottom';
+	export let tooltipAlign: 'left' | 'middle' | 'right' = 'middle';
 	export let loading: boolean = false;
 	// Optional data-onboarding attribute for cutscene targeting
 	export let onboarding: string | undefined = undefined;
@@ -97,7 +98,7 @@
 	$: iconSize = effectiveSize === 'xs' ? 12 : effectiveSize === 'sm' ? 14 : 16;
 </script>
 
-<Tooltip text={tooltip} position={tooltipPosition} {fullWidth}>
+<Tooltip text={tooltip} position={tooltipPosition} align={tooltipAlign} {fullWidth}>
 	{#if href}
 		<a
 			{href}

--- a/src/lib/client/ui/tooltip/Tooltip.svelte
+++ b/src/lib/client/ui/tooltip/Tooltip.svelte
@@ -2,7 +2,8 @@
 	import { tick } from 'svelte';
 
 	export let text: string = '';
-	export let position: 'top' | 'bottom' | 'right' = 'bottom';
+	export let position: 'top' | 'bottom' | 'left' | 'right' = 'bottom';
+	export let align: 'left' | 'middle' | 'right' = 'middle';
 	export let fullWidth: boolean = false;
 	export let mono: boolean = false;
 
@@ -20,11 +21,25 @@
 
 		// Initial position centered on trigger
 		if (position === 'top') {
-			style = `left:${centerX}px;top:${rect.top}px;transform:translate(-50%,-100%) translateY(-8px)`;
+			if (align === 'left') {
+				style = `left:${rect.left}px;top:${rect.top}px;transform:translateY(-100%) translateY(-8px)`;
+			} else if (align === 'right') {
+				style = `right:${window.innerWidth - rect.right}px;top:${rect.top}px;transform:translateY(-100%) translateY(-8px)`;
+			} else {
+				style = `left:${centerX}px;top:${rect.top}px;transform:translate(-50%,-100%) translateY(-8px)`;
+			}
 		} else if (position === 'right') {
 			style = `left:${rect.right}px;top:${rect.top + rect.height / 2}px;transform:translate(8px,-50%)`;
+		} else if (position === 'left') {
+			style = `right:${window.innerWidth - rect.left + 8}px;top:${rect.top + rect.height / 2}px;transform:translateY(-50%)`;
 		} else {
-			style = `left:${centerX}px;top:${rect.bottom}px;transform:translate(-50%,0) translateY(8px)`;
+			if (align === 'left') {
+				style = `left:${rect.left}px;top:${rect.bottom}px;transform:translateY(8px)`;
+			} else if (align === 'right') {
+				style = `right:${window.innerWidth - rect.right}px;top:${rect.bottom}px;transform:translateY(8px)`;
+			} else {
+				style = `left:${centerX}px;top:${rect.bottom}px;transform:translate(-50%,0) translateY(8px)`;
+			}
 		}
 		visible = true;
 
@@ -40,13 +55,23 @@
 			left = rect.right + 8;
 			if (left + tip.width > vw - PADDING) left = rect.left - tip.width - 8;
 			left = Math.max(PADDING, Math.min(left, vw - tip.width - PADDING));
+		} else if (position === 'left') {
+			left = rect.left - tip.width - 8;
+			if (left < PADDING) left = rect.right + 8;
+			left = Math.max(PADDING, Math.min(left, vw - tip.width - PADDING));
 		} else {
-			left = centerX - tip.width / 2;
+			if (align === 'left') {
+				left = rect.left;
+			} else if (align === 'right') {
+				left = rect.right - tip.width;
+			} else {
+				left = centerX - tip.width / 2;
+			}
 			left = Math.max(PADDING, Math.min(left, vw - tip.width - PADDING));
 		}
 
 		let top: number;
-		if (position === 'right') {
+		if (position === 'right' || position === 'left') {
 			top = rect.top + rect.height / 2 - tip.height / 2;
 			top = Math.max(PADDING, Math.min(top, vh - tip.height - PADDING));
 		} else if (position === 'top') {
@@ -57,7 +82,7 @@
 			if (top + tip.height > vh - PADDING) top = rect.top - tip.height - 8;
 		}
 
-		style = `left:${left}px;top:${top}px`;
+		style = `left:${left}px;top:${top}px;width:${tip.width}px`;
 	}
 
 	function hide() {

--- a/src/lib/server/jobs/jobEvents.ts
+++ b/src/lib/server/jobs/jobEvents.ts
@@ -46,6 +46,8 @@ const JOB_RUNNING_LABELS: Partial<Record<JobType, string>> = {
 	'arr.sync.mediaManagement': 'Syncing Media Management...',
 	'arr.cleanup': 'Cleaning up...',
 	'arr.drift': 'Checking drift...',
+	'arr.upgrade': 'Running upgrades...',
+	'arr.rename': 'Renaming files...',
 	'backup.create': 'Creating backup...',
 	'backup.cleanup': 'Cleaning up backups...',
 	'pcd.link': 'Linking database...'
@@ -58,6 +60,8 @@ const JOB_COMPLETED_LABELS: Partial<Record<JobType, string>> = {
 	'arr.sync.mediaManagement': 'Media Management sync',
 	'arr.cleanup': 'Cleanup',
 	'arr.drift': 'Drift check',
+	'arr.upgrade': 'Upgrade run',
+	'arr.rename': 'Rename run',
 	'backup.create': 'Backup',
 	'backup.cleanup': 'Backup cleanup',
 	'pcd.link': 'Database link'

--- a/src/routes/arr/[id]/drift/+page.svelte
+++ b/src/routes/arr/[id]/drift/+page.svelte
@@ -236,11 +236,16 @@
 						{data.status.lastError}
 					</div>
 				{:else if data.status.status === 'never_checked'}
-					<div
-						class="rounded-lg border border-neutral-200 bg-neutral-50 p-4 text-sm text-neutral-600 dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-400"
-					>
-						No drift check has run yet.
-					</div>
+					<ExpandableTable
+						columns={driftColumns}
+						data={emptyDriftEntities}
+						getRowId={(row) => row.id}
+						responsive
+						chevronPosition="right"
+						primaryColumnKey="title"
+						flushExpanded
+						emptyMessage="No drift check has run yet. Hit Run Now above to check."
+					/>
 				{:else if data.status.status === 'clean'}
 					<ExpandableTable
 						columns={driftColumns}

--- a/src/routes/arr/[id]/rename/+page.svelte
+++ b/src/routes/arr/[id]/rename/+page.svelte
@@ -13,7 +13,6 @@
 	import DirtyModal from '$lib/client/ui/modal/DirtyModal.svelte';
 	import StickyCard from '$ui/card/StickyCard.svelte';
 	import Button from '$ui/button/Button.svelte';
-	import Tooltip from '$ui/tooltip/Tooltip.svelte';
 
 	export let data: PageData;
 	export let form: ActionData;
@@ -89,44 +88,44 @@
 		</div>
 		<div slot="right" class="flex items-center gap-2">
 			<Button text="How it works" icon={Info} on:click={() => (showInfoModal = true)} />
-			{#if !isNewConfig}
-				<Tooltip text="Preview which files would be renamed without making changes">
-					<Button
-						text={running ? 'Running...' : 'Dry Run'}
-						icon={FlaskConical}
-						iconColor="text-amber-600 dark:text-amber-400"
-						disabled={running || saving || $isDirty}
-						on:click={() => {
-							jobStatus.connect();
-							jobStatus.setRunning('arr.rename', 'Renaming files...');
-							const f = document.getElementById('dry-run-form');
-							if (f instanceof HTMLFormElement) {
-								f.requestSubmit();
-							} else {
-								jobStatus.cancelOptimistic();
-							}
-						}}
-					/>
-				</Tooltip>
-				<Tooltip text="Rename files and folders now">
-					<Button
-						text={running ? 'Running...' : 'Run Now'}
-						icon={Play}
-						iconColor="text-green-600 dark:text-green-400"
-						disabled={running || saving || $isDirty}
-						on:click={() => {
-							jobStatus.connect();
-							jobStatus.setRunning('arr.rename', 'Renaming files...');
-							const f = document.getElementById('live-run-form');
-							if (f instanceof HTMLFormElement) {
-								f.requestSubmit();
-							} else {
-								jobStatus.cancelOptimistic();
-							}
-						}}
-					/>
-				</Tooltip>
-			{/if}
+			<Button
+				text={running ? 'Running...' : 'Dry Run'}
+				icon={FlaskConical}
+				iconColor="text-amber-600 dark:text-amber-400"
+				disabled={isNewConfig || !enabled || running || saving || $isDirty}
+				tooltip="Preview which files would be renamed without making changes"
+				tooltipPosition="bottom"
+				tooltipAlign="right"
+				on:click={() => {
+					jobStatus.connect();
+					jobStatus.setRunning('arr.rename', 'Renaming files...');
+					const f = document.getElementById('dry-run-form');
+					if (f instanceof HTMLFormElement) {
+						f.requestSubmit();
+					} else {
+						jobStatus.cancelOptimistic();
+					}
+				}}
+			/>
+			<Button
+				text={running ? 'Running...' : 'Run Now'}
+				icon={Play}
+				iconColor="text-green-600 dark:text-green-400"
+				disabled={isNewConfig || !enabled || running || saving || $isDirty}
+				tooltip="Rename files and folders now"
+				tooltipPosition="bottom"
+				tooltipAlign="right"
+				on:click={() => {
+					jobStatus.connect();
+					jobStatus.setRunning('arr.rename', 'Renaming files...');
+					const f = document.getElementById('live-run-form');
+					if (f instanceof HTMLFormElement) {
+						f.requestSubmit();
+					} else {
+						jobStatus.cancelOptimistic();
+					}
+				}}
+			/>
 			<Button
 				text="Save"
 				icon={Save}

--- a/src/routes/arr/[id]/rename/+page.svelte
+++ b/src/routes/arr/[id]/rename/+page.svelte
@@ -4,7 +4,7 @@
 	import { onMount } from 'svelte';
 	import { alertStore } from '$lib/client/alerts/store';
 	import { isDirty, initEdit, update, current, clear } from '$lib/client/stores/dirty';
-	import { Info, Save, FlaskConical, Play, Settings, History } from 'lucide-svelte';
+	import { Info, Save, FlaskConical, Play } from 'lucide-svelte';
 	import RenameSettings from './components/RenameSettings.svelte';
 	import RenameRunHistory from './components/RenameRunHistory.svelte';
 	import RenameInfoModal from './components/RenameInfoModal.svelte';
@@ -113,14 +113,8 @@
 		</div>
 	</StickyCard>
 
-	<div class="mt-6 space-y-6">
-		<section>
-			<h2
-				class="mb-3 flex items-center gap-2 text-lg font-semibold text-neutral-900 dark:text-neutral-100"
-			>
-				<Settings size={18} class="text-neutral-500 dark:text-neutral-400" />
-				Settings
-			</h2>
+	<div class="mt-4 space-y-6">
+		<section class="border-b border-neutral-200 pb-5 dark:border-neutral-800">
 			<RenameSettings
 				{enabled}
 				{renameFolders}
@@ -137,17 +131,11 @@
 				onWarning={(msg) => alertStore.add('warning', msg)}
 			/>
 		</section>
-	</div>
 
-	<section class="mt-6">
-		<h2
-			class="mb-3 flex items-center gap-2 text-lg font-semibold text-neutral-900 dark:text-neutral-100"
-		>
-			<History size={18} class="text-neutral-500 dark:text-neutral-400" />
-			Run History
-		</h2>
-		<RenameRunHistory runs={data.renameRuns} />
-	</section>
+		<section>
+			<RenameRunHistory runs={data.renameRuns} />
+		</section>
+	</div>
 
 	<!-- Hidden forms -->
 	<form

--- a/src/routes/arr/[id]/rename/+page.svelte
+++ b/src/routes/arr/[id]/rename/+page.svelte
@@ -132,7 +132,7 @@
 			/>
 		</section>
 
-		<section>
+		<section class="md:px-4">
 			<RenameRunHistory runs={data.renameRuns} />
 		</section>
 	</div>

--- a/src/routes/arr/[id]/rename/+page.svelte
+++ b/src/routes/arr/[id]/rename/+page.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
 	import type { PageData, ActionData } from './$types';
 	import { enhance } from '$app/forms';
+	import { invalidateAll } from '$app/navigation';
 	import { onMount } from 'svelte';
 	import { alertStore } from '$lib/client/alerts/store';
 	import { isDirty, initEdit, update, current, clear } from '$lib/client/stores/dirty';
+	import { jobStatus } from '$stores/jobStatus';
 	import { Info, Save, FlaskConical, Play } from 'lucide-svelte';
 	import RenameSettings from './components/RenameSettings.svelte';
 	import RenameRunHistory from './components/RenameRunHistory.svelte';
@@ -27,7 +29,21 @@
 		};
 		// Always use initEdit - isDirty should be false until user makes changes
 		initEdit(initialFormData);
-		return () => clear();
+		let previousJobState: string | null = null;
+		const unsubscribeJobStatus = jobStatus.subscribe((status) => {
+			if (
+				previousJobState === 'running' &&
+				status.state === 'completed' &&
+				status.jobType === 'arr.rename'
+			) {
+				invalidateAll();
+			}
+			previousJobState = status.state;
+		});
+		return () => {
+			unsubscribeJobStatus();
+			clear();
+		};
 	});
 
 	$: isNewConfig = !data.settings;
@@ -53,6 +69,7 @@
 			alertStore.add('success', 'Rename run queued');
 		}
 		if (form.error) {
+			jobStatus.cancelOptimistic();
 			alertStore.add('error', form.error);
 		}
 	}
@@ -80,8 +97,14 @@
 						iconColor="text-amber-600 dark:text-amber-400"
 						disabled={running || saving || $isDirty}
 						on:click={() => {
+							jobStatus.connect();
+							jobStatus.setRunning('arr.rename', 'Renaming files...');
 							const f = document.getElementById('dry-run-form');
-							if (f instanceof HTMLFormElement) f.requestSubmit();
+							if (f instanceof HTMLFormElement) {
+								f.requestSubmit();
+							} else {
+								jobStatus.cancelOptimistic();
+							}
 						}}
 					/>
 				</Tooltip>
@@ -92,14 +115,20 @@
 						iconColor="text-green-600 dark:text-green-400"
 						disabled={running || saving || $isDirty}
 						on:click={() => {
+							jobStatus.connect();
+							jobStatus.setRunning('arr.rename', 'Renaming files...');
 							const f = document.getElementById('live-run-form');
-							if (f instanceof HTMLFormElement) f.requestSubmit();
+							if (f instanceof HTMLFormElement) {
+								f.requestSubmit();
+							} else {
+								jobStatus.cancelOptimistic();
+							}
 						}}
 					/>
 				</Tooltip>
 			{/if}
 			<Button
-				text={saving ? 'Saving...' : 'Save'}
+				text="Save"
 				icon={Save}
 				iconColor="text-blue-600 dark:text-blue-400"
 				disabled={saving || running || !$isDirty}

--- a/src/routes/arr/[id]/rename/components/RenameRunHistory.svelte
+++ b/src/routes/arr/[id]/rename/components/RenameRunHistory.svelte
@@ -23,6 +23,7 @@
 	import Dropdown from '$ui/dropdown/Dropdown.svelte';
 	import DropdownItem from '$ui/dropdown/DropdownItem.svelte';
 	import ExpandableTable from '$ui/table/ExpandableTable.svelte';
+	import Pagination from '$ui/navigation/pagination/Pagination.svelte';
 	import Badge from '$ui/badge/Badge.svelte';
 	import Label from '$ui/label/Label.svelte';
 	import type { Column } from '$ui/table/types';
@@ -102,6 +103,12 @@
 	// Check if any filters are active
 	$: hasActiveFilters = dateFilter !== 'all' || statusFilter !== 'all';
 
+	const pageSize = 20;
+	let currentPage = 1;
+	$: totalPages = Math.max(1, Math.ceil(filteredRuns.length / pageSize));
+	$: if (currentPage > totalPages) currentPage = 1;
+	$: paginatedRuns = filteredRuns.slice((currentPage - 1) * pageSize, currentPage * pageSize);
+
 	let expandedIds: Set<string> = new Set();
 
 	const columns: Column<RenameJobLog>[] = [
@@ -172,7 +179,7 @@
 
 	<ExpandableTable
 		{columns}
-		data={filteredRuns}
+		data={paginatedRuns}
 		getRowId={(row) => row.id}
 		bind:expandedRows={expandedIds}
 		chevronPosition="right"
@@ -424,4 +431,8 @@
 			</div>
 		</svelte:fragment>
 	</ExpandableTable>
+
+	<div class="mt-3 flex justify-center">
+		<Pagination {currentPage} {totalPages} onPageChange={(p) => (currentPage = p)} />
+	</div>
 </div>

--- a/src/routes/arr/[id]/rename/components/RenameSettings.svelte
+++ b/src/routes/arr/[id]/rename/components/RenameSettings.svelte
@@ -88,6 +88,7 @@
 			checked={renameFolders}
 			label={renameFolders ? 'On' : 'Off'}
 			color={renameFolders ? 'accent' : 'neutral'}
+			disabled={!enabled}
 			on:change={(e) => onRenameFoldersChange?.(e.detail)}
 		/>
 	</div>
@@ -102,6 +103,7 @@
 			checked={summaryNotifications}
 			label={summaryNotifications ? 'On' : 'Off'}
 			color={summaryNotifications ? 'accent' : 'neutral'}
+			disabled={!enabled}
 			on:change={(e) => onSummaryNotificationsChange?.(e.detail)}
 		/>
 	</div>
@@ -112,7 +114,7 @@
 		>
 			Schedule
 		</span>
-		<CronInput bind:value={cronValue} {minIntervalMinutes} {onWarning} />
+		<CronInput bind:value={cronValue} disabled={!enabled} {minIntervalMinutes} {onWarning} />
 	</div>
 
 	<div data-onboarding="rename-ignore-tag">
@@ -129,6 +131,7 @@
 			size="md"
 			value={ignoreTag}
 			placeholder="no-rename"
+			disabled={!enabled}
 			on:input={(e) => onIgnoreTagChange?.(e.detail)}
 		/>
 	</div>

--- a/src/routes/arr/[id]/rename/components/RenameSettings.svelte
+++ b/src/routes/arr/[id]/rename/components/RenameSettings.svelte
@@ -4,6 +4,7 @@
 	import { serverTimezone } from '$lib/client/stores/timezone';
 	import FormInput from '$ui/form/FormInput.svelte';
 	import CronInput from '$ui/cron/CronInput.svelte';
+	import Label from '$ui/label/Label.svelte';
 	import Toggle from '$ui/toggle/Toggle.svelte';
 
 	export let enabled: boolean = false;
@@ -62,131 +63,92 @@
 	}
 </script>
 
-<div
-	class="rounded-lg border border-neutral-200 bg-white p-4 dark:border-neutral-800 dark:bg-neutral-900"
->
-	<!-- Mobile: stacked, Desktop: inline flex -->
-	<div class="flex flex-col gap-3 md:flex-row md:flex-wrap md:items-center md:gap-x-6">
-		<!-- Status -->
-		<div>
-			<span class="mb-1 block text-sm text-neutral-500 md:hidden dark:text-neutral-400">Status</span
-			>
-			<div class="md:flex md:items-center md:gap-2">
-				<span class="hidden text-sm text-neutral-500 md:inline dark:text-neutral-400">Status:</span>
-				<Toggle
-					checked={enabled}
-					label={enabled ? 'Enabled' : 'Disabled'}
-					fullWidth
-					color={enabled ? 'green' : 'red'}
-					on:change={(e) => onEnabledChange?.(e.detail)}
-				/>
-			</div>
-		</div>
-
-		<!-- Rename Folders -->
-		<div data-onboarding="rename-folders">
-			<span class="mb-1 block text-sm text-neutral-500 md:hidden dark:text-neutral-400"
-				>Folders</span
-			>
-			<div class="md:flex md:items-center md:gap-2">
-				<span class="hidden text-sm text-neutral-500 md:inline dark:text-neutral-400">Folders:</span
-				>
-				<Toggle
-					checked={renameFolders}
-					label={renameFolders ? 'On' : 'Off'}
-					fullWidth
-					color={renameFolders ? 'accent' : 'neutral'}
-					on:change={(e) => onRenameFoldersChange?.(e.detail)}
-				/>
-			</div>
-		</div>
-
-		<!-- Summary Notifications -->
-		<div data-onboarding="rename-summary">
-			<span class="mb-1 block text-sm text-neutral-500 md:hidden dark:text-neutral-400"
-				>Summary</span
-			>
-			<div class="md:flex md:items-center md:gap-2">
-				<span class="hidden text-sm text-neutral-500 md:inline dark:text-neutral-400">Summary:</span
-				>
-				<Toggle
-					checked={summaryNotifications}
-					label={summaryNotifications ? 'On' : 'Off'}
-					fullWidth
-					color={summaryNotifications ? 'accent' : 'neutral'}
-					on:change={(e) => onSummaryNotificationsChange?.(e.detail)}
-				/>
-			</div>
-		</div>
-
-		<!-- Divider (desktop only) -->
-		<div class="hidden h-6 w-px bg-neutral-200 md:block dark:bg-neutral-700"></div>
-
-		<!-- Schedule -->
-		<div data-onboarding="rename-schedule">
-			<span class="mb-1 block text-sm text-neutral-500 md:hidden dark:text-neutral-400"
-				>Schedule</span
-			>
-			<div class="md:flex md:items-center md:gap-2">
-				<span class="hidden text-sm text-neutral-500 md:inline dark:text-neutral-400"
-					>Schedule:</span
-				>
-				<CronInput bind:value={cronValue} {minIntervalMinutes} {onWarning} />
-			</div>
-		</div>
-
-		<!-- Ignore Tag -->
-		<div data-onboarding="rename-ignore-tag">
-			<span class="mb-1 block text-sm text-neutral-500 md:hidden dark:text-neutral-400"
-				>Ignore Tag</span
-			>
-			<div class="md:flex md:items-center md:gap-2">
-				<span class="hidden text-sm text-neutral-500 md:inline dark:text-neutral-400"
-					>Ignore Tag:</span
-				>
-				<FormInput
-					label="Ignore Tag"
-					hideLabel
-					lowercase
-					name="ignore-tag"
-					size="md"
-					value={ignoreTag}
-					placeholder="no-rename"
-					on:input={(e) => onIgnoreTagChange?.(e.detail)}
-				/>
-			</div>
-		</div>
-
-		<!-- Run status (right-aligned on desktop, full-width row on mobile) -->
-		{#if lastRunAt}
-			<div
-				class="flex flex-wrap items-center gap-3 border-t border-neutral-200 pt-3 text-xs text-neutral-500 md:ml-auto md:border-0 md:pt-0 dark:border-neutral-700 dark:text-neutral-400"
-			>
-				{#if !enabled}
-					<span
-						class="rounded bg-amber-100 px-1.5 py-0.5 font-medium text-amber-700 dark:bg-amber-900/50 dark:text-amber-400"
-						>Paused</span
-					>
-				{:else if timeUntilNext !== null && timeUntilNext <= 0}
-					<span
-						class="rounded bg-green-100 px-1.5 py-0.5 font-medium text-green-700 dark:bg-green-900/50 dark:text-green-400"
-						>Ready</span
-					>
-				{:else if timeUntilNext !== null}
-					<span>
-						Next: <span
-							class="rounded bg-neutral-100 px-1.5 py-0.5 font-mono text-neutral-700 dark:bg-neutral-800 dark:text-neutral-300"
-							>{formatTimeRemaining(timeUntilNext)}</span
-						>
-					</span>
-				{/if}
-				<span>
-					Last: <span
-						class="rounded bg-neutral-100 px-1.5 py-0.5 font-mono text-neutral-700 dark:bg-neutral-800 dark:text-neutral-300"
-						>{formatSmartDateTime(lastRunAt, $serverTimezone)}</span
-					>
-				</span>
-			</div>
-		{/if}
+<div class="flex flex-wrap gap-4 md:items-end md:gap-x-5 md:gap-y-3 md:px-4">
+	<div>
+		<span
+			class="mb-1 block text-[10px] font-medium tracking-wider text-neutral-400 uppercase dark:text-neutral-500"
+		>
+			Status
+		</span>
+		<Toggle
+			checked={enabled}
+			label={enabled ? 'Enabled' : 'Disabled'}
+			color={enabled ? 'green' : 'red'}
+			on:change={(e) => onEnabledChange?.(e.detail)}
+		/>
 	</div>
+
+	<div data-onboarding="rename-folders">
+		<span
+			class="mb-1 block text-[10px] font-medium tracking-wider text-neutral-400 uppercase dark:text-neutral-500"
+		>
+			Folders
+		</span>
+		<Toggle
+			checked={renameFolders}
+			label={renameFolders ? 'On' : 'Off'}
+			color={renameFolders ? 'accent' : 'neutral'}
+			on:change={(e) => onRenameFoldersChange?.(e.detail)}
+		/>
+	</div>
+
+	<div data-onboarding="rename-summary">
+		<span
+			class="mb-1 block text-[10px] font-medium tracking-wider text-neutral-400 uppercase dark:text-neutral-500"
+		>
+			Summary
+		</span>
+		<Toggle
+			checked={summaryNotifications}
+			label={summaryNotifications ? 'On' : 'Off'}
+			color={summaryNotifications ? 'accent' : 'neutral'}
+			on:change={(e) => onSummaryNotificationsChange?.(e.detail)}
+		/>
+	</div>
+
+	<div data-onboarding="rename-schedule">
+		<span
+			class="mb-1 block text-[10px] font-medium tracking-wider text-neutral-400 uppercase dark:text-neutral-500"
+		>
+			Schedule
+		</span>
+		<CronInput bind:value={cronValue} {minIntervalMinutes} {onWarning} />
+	</div>
+
+	<div data-onboarding="rename-ignore-tag">
+		<span
+			class="mb-1 block text-[10px] font-medium tracking-wider text-neutral-400 uppercase dark:text-neutral-500"
+		>
+			Ignore Tag
+		</span>
+		<FormInput
+			label="Ignore Tag"
+			hideLabel
+			lowercase
+			name="ignore-tag"
+			size="md"
+			value={ignoreTag}
+			placeholder="no-rename"
+			on:input={(e) => onIgnoreTagChange?.(e.detail)}
+		/>
+	</div>
+
+	{#if lastRunAt}
+		<div
+			class="flex w-full flex-wrap items-center gap-1.5 border-t border-neutral-200 pt-3 md:ml-auto md:w-auto md:border-0 md:pt-0 dark:border-neutral-800"
+		>
+			{#if !enabled}
+				<Label variant="warning" size="md" rounded="md">Paused</Label>
+			{:else if timeUntilNext !== null && timeUntilNext <= 0}
+				<Label variant="success" size="md" rounded="md">Ready</Label>
+			{:else if timeUntilNext !== null}
+				<Label variant="secondary" size="md" rounded="md" mono>
+					Next {formatTimeRemaining(timeUntilNext)}
+				</Label>
+			{/if}
+			<Label variant="secondary" size="md" rounded="md" mono>
+				Last {formatSmartDateTime(lastRunAt, $serverTimezone)}
+			</Label>
+		</div>
+	{/if}
 </div>

--- a/src/routes/arr/[id]/sync/+page.svelte
+++ b/src/routes/arr/[id]/sync/+page.svelte
@@ -120,22 +120,21 @@
 </svelte:head>
 
 {#key data.instance.id}
-	<div class="mt-6 space-y-6 pb-32">
-		<!-- Header -->
-		<StickyCard position="top">
-			<svelte:fragment slot="left">
-				<h1 class="text-neutral-900 dark:text-neutral-50">Sync Configuration</h1>
-				<p class="text-neutral-600 dark:text-neutral-400">
-					Configure which profiles and settings to sync to this instance.
-				</p>
-			</svelte:fragment>
-			<svelte:fragment slot="right">
-				<span data-onboarding="sync-how-it-works">
-					<Button text="How it works" icon={Info} on:click={() => (showInfoModal = true)} />
-				</span>
-			</svelte:fragment>
-		</StickyCard>
+	<StickyCard position="top">
+		<svelte:fragment slot="left">
+			<h1 class="text-neutral-900 dark:text-neutral-50">Sync Configuration</h1>
+			<p class="text-neutral-600 dark:text-neutral-400">
+				Configure which profiles and settings to sync to this instance.
+			</p>
+		</svelte:fragment>
+		<svelte:fragment slot="right">
+			<span data-onboarding="sync-how-it-works">
+				<Button text="How it works" icon={Info} on:click={() => (showInfoModal = true)} />
+			</span>
+		</svelte:fragment>
+	</StickyCard>
 
+	<div class="mt-4 space-y-6 pb-32">
 		<MediaManagement
 			databases={data.databases}
 			bind:state={mediaManagementState}

--- a/src/routes/arr/[id]/upgrades/+page.svelte
+++ b/src/routes/arr/[id]/upgrades/+page.svelte
@@ -188,7 +188,7 @@
 			/>
 		</section>
 
-		<section data-onboarding="upgrades-filters">
+		<section class="md:px-4" data-onboarding="upgrades-filters">
 			<FilterSettings
 				{filters}
 				appType={data.instance.type}
@@ -200,7 +200,7 @@
 			/>
 		</section>
 
-		<section>
+		<section class="md:px-4">
 			<RunHistory runs={data.upgradeRuns} />
 		</section>
 	</div>

--- a/src/routes/arr/[id]/upgrades/+page.svelte
+++ b/src/routes/arr/[id]/upgrades/+page.svelte
@@ -197,11 +197,11 @@
 				onFiltersChange={(v) => update('filters', JSON.stringify(v))}
 			/>
 		</section>
-	</div>
 
-	<section class="mt-6">
-		<RunHistory runs={data.upgradeRuns} />
-	</section>
+		<section>
+			<RunHistory runs={data.upgradeRuns} />
+		</section>
+	</div>
 
 	<!-- Hidden forms -->
 	<form

--- a/src/routes/arr/[id]/upgrades/+page.svelte
+++ b/src/routes/arr/[id]/upgrades/+page.svelte
@@ -8,9 +8,11 @@
 	} from '$shared/upgrades/filters';
 	import { enhance } from '$app/forms';
 	import { browser } from '$app/environment';
+	import { invalidateAll } from '$app/navigation';
 	import { onMount } from 'svelte';
 	import { alertStore } from '$lib/client/alerts/store';
 	import { isDirty, initEdit, update, current, clear } from '$lib/client/stores/dirty';
+	import { jobStatus } from '$stores/jobStatus';
 	import { Info, Save, Play, RotateCcw, FlaskConical } from 'lucide-svelte';
 	import CoreSettings from './components/CoreSettings.svelte';
 	import FilterSettings from './components/FilterSettings.svelte';
@@ -32,7 +34,21 @@
 		};
 		// Always use initEdit - isDirty should be false until user makes changes
 		initEdit(initialFormData);
-		return () => clear();
+		let previousJobState: string | null = null;
+		const unsubscribeJobStatus = jobStatus.subscribe((status) => {
+			if (
+				previousJobState === 'running' &&
+				status.state === 'completed' &&
+				status.jobType === 'arr.upgrade'
+			) {
+				invalidateAll();
+			}
+			previousJobState = status.state;
+		});
+		return () => {
+			unsubscribeJobStatus();
+			clear();
+		};
 	});
 
 	// Track if config exists
@@ -98,6 +114,7 @@
 			alertStore.add('success', 'Dry run cache cleared');
 		}
 		if (form.error) {
+			jobStatus.cancelOptimistic();
 			alertStore.add('error', form.error);
 		}
 	}
@@ -117,50 +134,60 @@
 		</div>
 		<div slot="right" class="flex flex-wrap items-center gap-2">
 			<Button text="Info" icon={Info} href="/arr/upgrades/info" />
-			{#if !isNewConfig && enabled}
+			<Button
+				text={clearing ? 'Clearing...' : 'Reset Cache'}
+				icon={RotateCcw}
+				disabled={isNewConfig || !enabled || clearing || running || saving}
+				tooltip="Clear dry run exclusion cache so items can be re-selected"
+				tooltipPosition="bottom"
+				tooltipAlign="right"
+				on:click={() => {
+					const f = document.getElementById('clear-cache-form');
+					if (f instanceof HTMLFormElement) f.requestSubmit();
+				}}
+			/>
+			<Button
+				text={running ? 'Running...' : 'Dry Run'}
+				icon={FlaskConical}
+				iconColor="text-amber-600 dark:text-amber-400"
+				disabled={isNewConfig || !enabled || running || saving || clearing || $isDirty}
+				tooltip="Search indexers without downloading (limited to once every 10 min)"
+				tooltipPosition="bottom"
+				tooltipAlign="right"
+				on:click={() => {
+					jobStatus.connect();
+					jobStatus.setRunning('arr.upgrade', 'Running upgrades...');
+					const f = document.getElementById('dry-run-form');
+					if (f instanceof HTMLFormElement) {
+						f.requestSubmit();
+					} else {
+						jobStatus.cancelOptimistic();
+					}
+				}}
+			/>
+			{#if isDev}
 				<Button
-					text={clearing ? 'Clearing...' : 'Reset Cache'}
-					icon={RotateCcw}
-					disabled={clearing || running || saving}
-					tooltip="Clear dry run exclusion cache so items can be re-selected"
+					text={running ? 'Running...' : 'Live Run'}
+					icon={Play}
+					iconColor="text-red-600 dark:text-red-400"
+					disabled={isNewConfig || !enabled || running || saving || $isDirty}
+					tooltip="Run a live search that will download upgrades"
 					tooltipPosition="bottom"
 					tooltipAlign="right"
 					on:click={() => {
-						const f = document.getElementById('clear-cache-form');
-						if (f instanceof HTMLFormElement) f.requestSubmit();
+						jobStatus.connect();
+						jobStatus.setRunning('arr.upgrade', 'Running upgrades...');
+						const f = document.getElementById('live-run-form');
+						if (f instanceof HTMLFormElement) {
+							f.requestSubmit();
+						} else {
+							jobStatus.cancelOptimistic();
+						}
 					}}
 				/>
-				<Button
-					text={running ? 'Running...' : 'Dry Run'}
-					icon={FlaskConical}
-					iconColor="text-amber-600 dark:text-amber-400"
-					disabled={running || saving || clearing || $isDirty}
-					tooltip="Search indexers without downloading (limited to once every 10 min)"
-					tooltipPosition="bottom"
-					tooltipAlign="right"
-					on:click={() => {
-						const f = document.getElementById('dry-run-form');
-						if (f instanceof HTMLFormElement) f.requestSubmit();
-					}}
-				/>
-				{#if isDev}
-					<Button
-						text={running ? 'Running...' : 'Live Run'}
-						icon={Play}
-						iconColor="text-red-600 dark:text-red-400"
-						disabled={running || saving || $isDirty}
-						tooltip="Run a live search that will download upgrades"
-						tooltipPosition="bottom"
-						tooltipAlign="right"
-						on:click={() => {
-							const f = document.getElementById('live-run-form');
-							if (f instanceof HTMLFormElement) f.requestSubmit();
-						}}
-					/>
-				{/if}
 			{/if}
 			<Button
-				text={saving ? 'Saving...' : 'Save'}
+				text="Save"
 				icon={Save}
 				iconColor="text-blue-600 dark:text-blue-400"
 				disabled={saving || running || !$isDirty}

--- a/src/routes/arr/[id]/upgrades/+page.svelte
+++ b/src/routes/arr/[id]/upgrades/+page.svelte
@@ -18,7 +18,6 @@
 	import DirtyModal from '$ui/modal/DirtyModal.svelte';
 	import StickyCard from '$ui/card/StickyCard.svelte';
 	import Button from '$ui/button/Button.svelte';
-	import Tooltip from '$ui/tooltip/Tooltip.svelte';
 
 	export let data: PageData;
 	export let form: ActionData;
@@ -119,42 +118,45 @@
 		<div slot="right" class="flex flex-wrap items-center gap-2">
 			<Button text="Info" icon={Info} href="/arr/upgrades/info" />
 			{#if !isNewConfig && enabled}
-				<Tooltip text="Clear dry run exclusion cache so items can be re-selected">
-					<Button
-						text={clearing ? 'Clearing...' : 'Reset Cache'}
-						icon={RotateCcw}
-						disabled={clearing || running || saving}
-						on:click={() => {
-							const f = document.getElementById('clear-cache-form');
-							if (f instanceof HTMLFormElement) f.requestSubmit();
-						}}
-					/>
-				</Tooltip>
-				<Tooltip text="Search indexers without downloading (limited to once every 10 min)">
-					<Button
-						text={running ? 'Running...' : 'Dry Run'}
-						icon={FlaskConical}
-						iconColor="text-amber-600 dark:text-amber-400"
-						disabled={running || saving || clearing || $isDirty}
-						on:click={() => {
-							const f = document.getElementById('dry-run-form');
-							if (f instanceof HTMLFormElement) f.requestSubmit();
-						}}
-					/>
-				</Tooltip>
+				<Button
+					text={clearing ? 'Clearing...' : 'Reset Cache'}
+					icon={RotateCcw}
+					disabled={clearing || running || saving}
+					tooltip="Clear dry run exclusion cache so items can be re-selected"
+					tooltipPosition="bottom"
+					tooltipAlign="right"
+					on:click={() => {
+						const f = document.getElementById('clear-cache-form');
+						if (f instanceof HTMLFormElement) f.requestSubmit();
+					}}
+				/>
+				<Button
+					text={running ? 'Running...' : 'Dry Run'}
+					icon={FlaskConical}
+					iconColor="text-amber-600 dark:text-amber-400"
+					disabled={running || saving || clearing || $isDirty}
+					tooltip="Search indexers without downloading (limited to once every 10 min)"
+					tooltipPosition="bottom"
+					tooltipAlign="right"
+					on:click={() => {
+						const f = document.getElementById('dry-run-form');
+						if (f instanceof HTMLFormElement) f.requestSubmit();
+					}}
+				/>
 				{#if isDev}
-					<Tooltip text="Run a live search that will download upgrades">
-						<Button
-							text={running ? 'Running...' : 'Live Run'}
-							icon={Play}
-							iconColor="text-red-600 dark:text-red-400"
-							disabled={running || saving || $isDirty}
-							on:click={() => {
-								const f = document.getElementById('live-run-form');
-								if (f instanceof HTMLFormElement) f.requestSubmit();
-							}}
-						/>
-					</Tooltip>
+					<Button
+						text={running ? 'Running...' : 'Live Run'}
+						icon={Play}
+						iconColor="text-red-600 dark:text-red-400"
+						disabled={running || saving || $isDirty}
+						tooltip="Run a live search that will download upgrades"
+						tooltipPosition="bottom"
+						tooltipAlign="right"
+						on:click={() => {
+							const f = document.getElementById('live-run-form');
+							if (f instanceof HTMLFormElement) f.requestSubmit();
+						}}
+					/>
 				{/if}
 			{/if}
 			<Button

--- a/src/routes/arr/[id]/upgrades/+page.svelte
+++ b/src/routes/arr/[id]/upgrades/+page.svelte
@@ -11,16 +11,7 @@
 	import { onMount } from 'svelte';
 	import { alertStore } from '$lib/client/alerts/store';
 	import { isDirty, initEdit, update, current, clear } from '$lib/client/stores/dirty';
-	import {
-		Info,
-		Save,
-		Play,
-		RotateCcw,
-		Settings,
-		SlidersHorizontal,
-		History,
-		FlaskConical
-	} from 'lucide-svelte';
+	import { Info, Save, Play, RotateCcw, FlaskConical } from 'lucide-svelte';
 	import CoreSettings from './components/CoreSettings.svelte';
 	import FilterSettings from './components/FilterSettings.svelte';
 	import RunHistory from './components/RunHistory.svelte';
@@ -179,14 +170,8 @@
 		</div>
 	</StickyCard>
 
-	<div class="mt-6 space-y-6">
-		<section>
-			<h2
-				class="mb-3 flex items-center gap-2 text-lg font-semibold text-neutral-900 dark:text-neutral-100"
-			>
-				<Settings size={18} class="text-neutral-500 dark:text-neutral-400" />
-				Settings
-			</h2>
+	<div class="mt-4 space-y-6">
+		<section class="border-b border-neutral-200 pb-5 dark:border-neutral-800">
 			<CoreSettings
 				{enabled}
 				{cron}
@@ -202,12 +187,6 @@
 		</section>
 
 		<section data-onboarding="upgrades-filters">
-			<h2
-				class="mb-3 flex items-center gap-2 text-lg font-semibold text-neutral-900 dark:text-neutral-100"
-			>
-				<SlidersHorizontal size={18} class="text-neutral-500 dark:text-neutral-400" />
-				Filters
-			</h2>
 			<FilterSettings
 				{filters}
 				appType={data.instance.type}
@@ -221,12 +200,6 @@
 	</div>
 
 	<section class="mt-6">
-		<h2
-			class="mb-3 flex items-center gap-2 text-lg font-semibold text-neutral-900 dark:text-neutral-100"
-		>
-			<History size={18} class="text-neutral-500 dark:text-neutral-400" />
-			Run History
-		</h2>
 		<RunHistory runs={data.upgradeRuns} />
 	</section>
 

--- a/src/routes/arr/[id]/upgrades/components/CoreSettings.svelte
+++ b/src/routes/arr/[id]/upgrades/components/CoreSettings.svelte
@@ -5,6 +5,7 @@
 	import { serverTimezone } from '$lib/client/stores/timezone';
 	import DropdownSelect from '$ui/dropdown/DropdownSelect.svelte';
 	import CronInput from '$ui/cron/CronInput.svelte';
+	import Label from '$ui/label/Label.svelte';
 	import Toggle from '$ui/toggle/Toggle.svelte';
 
 	export let enabled: boolean = true;
@@ -62,69 +63,61 @@
 	}
 </script>
 
-<div
-	class="rounded-lg border border-neutral-200 bg-white p-4 dark:border-neutral-800 dark:bg-neutral-900"
->
-	<div class="flex flex-wrap gap-4 md:items-end md:gap-6">
-		<!-- Status -->
-		<div>
-			<span class="mb-1 block text-xs text-neutral-500 dark:text-neutral-400">Status</span>
-			<Toggle
-				checked={enabled}
-				label={enabled ? 'Enabled' : 'Disabled'}
-				color={enabled ? 'green' : 'red'}
-				on:change={(e) => onEnabledChange?.(e.detail)}
-			/>
-		</div>
-
-		<!-- Schedule -->
-		<div data-onboarding="upgrades-schedule">
-			<span class="mb-1 block text-xs text-neutral-500 dark:text-neutral-400">Schedule</span>
-			<CronInput bind:value={cronValue} {minIntervalMinutes} {onWarning} />
-		</div>
-
-		<!-- Filter Mode -->
-		<div data-onboarding="upgrades-filter-mode">
-			<span class="mb-1 block text-xs text-neutral-500 dark:text-neutral-400">Mode</span>
-			<DropdownSelect
-				value={filterMode}
-				options={modeOptions}
-				minWidth="10rem"
-				responsiveDropdown
-				on:change={(e) => onFilterModeChange?.(e.detail as FilterMode)}
-			/>
-		</div>
-
-		<!-- Run status -->
-		{#if lastRunAt}
-			<div
-				class="flex w-full flex-wrap items-center gap-3 border-t border-neutral-200 pt-3 text-xs text-neutral-500 md:ml-auto md:w-auto md:border-0 md:pt-0 dark:border-neutral-700 dark:text-neutral-400"
-			>
-				{#if !enabled}
-					<span
-						class="rounded bg-amber-100 px-1.5 py-0.5 font-medium text-amber-700 dark:bg-amber-900/50 dark:text-amber-400"
-						>Paused</span
-					>
-				{:else if timeUntilNext !== null && timeUntilNext <= 0}
-					<span
-						class="rounded bg-green-100 px-1.5 py-0.5 font-medium text-green-700 dark:bg-green-900/50 dark:text-green-400"
-						>Ready</span
-					>
-				{:else if timeUntilNext !== null}
-					<span>
-						Next: <span
-							class="rounded bg-neutral-100 px-1.5 py-0.5 font-mono text-neutral-700 dark:bg-neutral-800 dark:text-neutral-300"
-							>{formatTimeRemaining(timeUntilNext)}</span
-						>
-					</span>
-				{/if}
-				<span>
-					Last: <span
-						class="rounded bg-neutral-100 px-1.5 py-0.5 font-mono text-neutral-700 dark:bg-neutral-800 dark:text-neutral-300"
-						>{formatSmartDateTime(lastRunAt, $serverTimezone)}</span
-					>
-				</span>
-			</div>
-		{/if}
+<div class="flex flex-wrap gap-4 md:items-end md:gap-x-5 md:gap-y-3 md:px-4">
+	<div>
+		<span
+			class="mb-1 block text-[10px] font-medium tracking-wider text-neutral-400 uppercase dark:text-neutral-500"
+		>
+			Status
+		</span>
+		<Toggle
+			checked={enabled}
+			label={enabled ? 'Enabled' : 'Disabled'}
+			color={enabled ? 'green' : 'red'}
+			on:change={(e) => onEnabledChange?.(e.detail)}
+		/>
 	</div>
+
+	<div data-onboarding="upgrades-schedule">
+		<span
+			class="mb-1 block text-[10px] font-medium tracking-wider text-neutral-400 uppercase dark:text-neutral-500"
+		>
+			Schedule
+		</span>
+		<CronInput bind:value={cronValue} {minIntervalMinutes} {onWarning} />
+	</div>
+
+	<div data-onboarding="upgrades-filter-mode">
+		<span
+			class="mb-1 block text-[10px] font-medium tracking-wider text-neutral-400 uppercase dark:text-neutral-500"
+		>
+			Mode
+		</span>
+		<DropdownSelect
+			value={filterMode}
+			options={modeOptions}
+			minWidth="10rem"
+			responsiveDropdown
+			on:change={(e) => onFilterModeChange?.(e.detail as FilterMode)}
+		/>
+	</div>
+
+	{#if lastRunAt}
+		<div
+			class="flex w-full flex-wrap items-center gap-1.5 border-t border-neutral-200 pt-3 md:ml-auto md:w-auto md:border-0 md:pt-0 dark:border-neutral-800"
+		>
+			{#if !enabled}
+				<Label variant="warning" size="md" rounded="md">Paused</Label>
+			{:else if timeUntilNext !== null && timeUntilNext <= 0}
+				<Label variant="success" size="md" rounded="md">Ready</Label>
+			{:else if timeUntilNext !== null}
+				<Label variant="secondary" size="md" rounded="md" mono>
+					Next {formatTimeRemaining(timeUntilNext)}
+				</Label>
+			{/if}
+			<Label variant="secondary" size="md" rounded="md" mono>
+				Last {formatSmartDateTime(lastRunAt, $serverTimezone)}
+			</Label>
+		</div>
+	{/if}
 </div>

--- a/src/routes/arr/[id]/upgrades/components/FilterSettings.svelte
+++ b/src/routes/arr/[id]/upgrades/components/FilterSettings.svelte
@@ -351,7 +351,7 @@
 	}
 </script>
 
-<div class="-mx-4 bg-neutral-50 px-4 pt-2 pb-6 md:-mx-8 md:px-8 dark:bg-neutral-900">
+<div class="-mx-4 bg-neutral-50 px-4 pt-2 pb-2 md:-mx-8 md:px-8 dark:bg-neutral-900">
 	<div class="mb-4">
 		<ActionsBar>
 			<SearchAction {searchStore} placeholder="Search filters..." />

--- a/src/routes/arr/[id]/upgrades/components/FilterSettings.svelte
+++ b/src/routes/arr/[id]/upgrades/components/FilterSettings.svelte
@@ -521,15 +521,12 @@
 								value={row.selector}
 								options={selectors.map((s) => ({
 									value: s.id,
-									label: `${s.label} - ${s.description}`,
-									shortLabel: s.label
+									label: s.label
 								}))}
 								minWidth="14rem"
-								compactDropdownThreshold={7}
 								fullWidth
 								responsiveButton
 								responsiveDropdown
-								mobileDropdownShortLabels
 								fixed
 								on:change={(e) => {
 									row.selector = e.detail;

--- a/src/routes/arr/[id]/upgrades/components/FilterSettings.svelte
+++ b/src/routes/arr/[id]/upgrades/components/FilterSettings.svelte
@@ -423,33 +423,29 @@
 					<!-- Mobile: buttons below name -->
 					<div class="flex flex-wrap items-center gap-1 md:hidden">
 						<Button
-							text={row.enabled ? 'Disable' : 'Enable'}
 							icon={Power}
 							iconColor={row.enabled
 								? 'text-green-600 dark:text-green-400'
 								: 'text-neutral-400 dark:text-neutral-500'}
-							responsive
+							tooltip={row.enabled ? 'Disable' : 'Enable'}
 							on:click={() => toggleEnabled(row.id)}
 						/>
 						<Button
-							text="Copy"
 							icon={ClipboardCopy}
 							iconColor="text-amber-600 dark:text-amber-400"
-							responsive
+							tooltip="Copy"
 							on:click={() => copyFilter(row.id)}
 						/>
 						<Button
-							text="Duplicate"
 							icon={Copy}
 							iconColor="text-violet-600 dark:text-violet-400"
-							responsive
+							tooltip="Duplicate"
 							on:click={() => duplicateFilter(row.id)}
 						/>
 						<Button
-							text="Delete"
 							icon={Trash2}
 							iconColor="text-red-600 dark:text-red-400"
-							responsive
+							tooltip="Delete"
 							on:click={() => confirmDelete(row)}
 						/>
 					</div>
@@ -461,29 +457,29 @@
 		<svelte:fragment slot="actions" let:row>
 			<div class="hidden items-center gap-1 md:flex">
 				<Button
-					text={row.enabled ? 'Disable' : 'Enable'}
 					icon={Power}
 					iconColor={row.enabled
 						? 'text-green-600 dark:text-green-400'
 						: 'text-neutral-400 dark:text-neutral-500'}
+					tooltip={row.enabled ? 'Disable' : 'Enable'}
 					on:click={() => toggleEnabled(row.id)}
 				/>
 				<Button
-					text="Copy"
 					icon={ClipboardCopy}
 					iconColor="text-amber-600 dark:text-amber-400"
+					tooltip="Copy"
 					on:click={() => copyFilter(row.id)}
 				/>
 				<Button
-					text="Duplicate"
 					icon={Copy}
 					iconColor="text-violet-600 dark:text-violet-400"
+					tooltip="Duplicate"
 					on:click={() => duplicateFilter(row.id)}
 				/>
 				<Button
-					text="Delete"
 					icon={Trash2}
 					iconColor="text-red-600 dark:text-red-400"
+					tooltip="Delete"
 					on:click={() => confirmDelete(row)}
 				/>
 			</div>

--- a/src/routes/arr/[id]/upgrades/components/FilterSettings.svelte
+++ b/src/routes/arr/[id]/upgrades/components/FilterSettings.svelte
@@ -43,7 +43,6 @@
 	import SearchAction from '$ui/actions/SearchAction.svelte';
 	import ExpandableTable from '$ui/table/ExpandableTable.svelte';
 	import Button from '$ui/button/Button.svelte';
-	import Card from '$ui/card/Card.svelte';
 	import Modal from '$ui/modal/Modal.svelte';
 	import PasteModal from '$ui/modal/PasteModal.svelte';
 	import type { Column } from '$ui/table/types';
@@ -487,6 +486,117 @@
 
 		<svelte:fragment slot="expanded" let:row>
 			<div class="space-y-4 p-3 md:p-6">
+				<div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-5">
+					<div data-onboarding="upgrades-cutoff">
+						<label
+							for="cutoff-{row.id}"
+							class="block text-sm font-medium text-neutral-600 dark:text-neutral-400"
+						>
+							Cutoff %
+						</label>
+						<div class="mt-1">
+							<NumberInput
+								name="cutoff-{row.id}"
+								bind:value={row.cutoff}
+								min={0}
+								max={100}
+								font="mono"
+								responsive
+								on:change={handleChange}
+							/>
+						</div>
+						<p class="mt-1 text-xs text-neutral-500 dark:text-neutral-400">
+							Score threshold for "cutoff met"
+						</p>
+					</div>
+					<div data-onboarding="upgrades-method">
+						<label
+							for="selector-{row.id}"
+							class="mb-1 block text-sm font-medium text-neutral-600 dark:text-neutral-400"
+						>
+							Method
+						</label>
+						<div class="mt-1">
+							<DropdownSelect
+								value={row.selector}
+								options={selectors.map((s) => ({
+									value: s.id,
+									label: `${s.label} - ${s.description}`,
+									shortLabel: s.label
+								}))}
+								minWidth="14rem"
+								compactDropdownThreshold={7}
+								fullWidth
+								responsiveButton
+								responsiveDropdown
+								mobileDropdownShortLabels
+								fixed
+								on:change={(e) => {
+									row.selector = e.detail;
+									handleChange();
+								}}
+							/>
+						</div>
+						<p class="mt-1 text-xs text-neutral-500 dark:text-neutral-400">
+							{selectorShortDescriptions[row.selector] ?? 'Selection order'}
+						</p>
+					</div>
+					<div data-onboarding="upgrades-count">
+						<label
+							for="count-{row.id}"
+							class="block text-sm font-medium text-neutral-600 dark:text-neutral-400"
+						>
+							Count
+						</label>
+						<div class="mt-1">
+							<NumberInput
+								name="count-{row.id}"
+								bind:value={row.count}
+								min={1}
+								max={countMax}
+								font="mono"
+								responsive
+								on:change={handleChange}
+							/>
+						</div>
+						<p class="mt-1 text-xs text-neutral-500 dark:text-neutral-400">
+							Items per run (max {countMax} at this schedule)
+						</p>
+					</div>
+					<div data-onboarding="upgrades-cooldown" class="lg:col-span-2">
+						<label
+							for="tag-{row.id}"
+							class="block text-sm font-medium text-neutral-600 dark:text-neutral-400"
+						>
+							Cooldown Tag
+						</label>
+						<div class="mt-1">
+							<FormInput
+								label="Cooldown tag"
+								hideLabel
+								lowercase
+								name="tag-{row.id}"
+								placeholder={resolveTagLabel(row)}
+								bind:value={row.tag}
+								responsive
+								on:input={handleChange}
+							/>
+						</div>
+						{#if getSharedTagFilters(row).length > 0}
+							<p class="mt-1 text-xs text-neutral-500 dark:text-neutral-400">
+								Shared with: {getSharedTagFilters(row).join(', ')}
+							</p>
+						{:else}
+							<p class="mt-1 text-xs text-neutral-500 dark:text-neutral-400">
+								Tag applied in your arr instance for cooldown tracking. Avoid reusing tags you use
+								elsewhere.
+							</p>
+						{/if}
+					</div>
+				</div>
+
+				<hr class="-mx-3 border-t border-neutral-200 md:-mx-6 dark:border-neutral-800" />
+
 				<div data-onboarding="upgrades-filter-rules">
 					<FilterGroupComponent
 						group={row.group}
@@ -497,119 +607,6 @@
 						on:change={handleChange}
 					/>
 				</div>
-
-				<!-- Selection Settings -->
-				<Card flush padding="md">
-					<h3 class="mb-3 text-sm font-medium text-neutral-700 dark:text-neutral-300">Settings</h3>
-					<div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
-						<div data-onboarding="upgrades-cutoff">
-							<label
-								for="cutoff-{row.id}"
-								class="block text-sm font-medium text-neutral-600 dark:text-neutral-400"
-							>
-								Cutoff %
-							</label>
-							<div class="mt-1">
-								<NumberInput
-									name="cutoff-{row.id}"
-									bind:value={row.cutoff}
-									min={0}
-									max={100}
-									font="mono"
-									responsive
-									on:change={handleChange}
-								/>
-							</div>
-							<p class="mt-1 text-xs text-neutral-500 dark:text-neutral-400">
-								Score threshold for "cutoff met"
-							</p>
-						</div>
-						<div data-onboarding="upgrades-method">
-							<label
-								for="selector-{row.id}"
-								class="mb-1 block text-sm font-medium text-neutral-600 dark:text-neutral-400"
-							>
-								Method
-							</label>
-							<div class="mt-1">
-								<DropdownSelect
-									value={row.selector}
-									options={selectors.map((s) => ({
-										value: s.id,
-										label: `${s.label} - ${s.description}`,
-										shortLabel: s.label
-									}))}
-									minWidth="14rem"
-									compactDropdownThreshold={7}
-									fullWidth
-									responsiveButton
-									responsiveDropdown
-									mobileDropdownShortLabels
-									fixed
-									on:change={(e) => {
-										row.selector = e.detail;
-										handleChange();
-									}}
-								/>
-							</div>
-							<p class="mt-1 text-xs text-neutral-500 dark:text-neutral-400">
-								{selectorShortDescriptions[row.selector] ?? 'Selection order'}
-							</p>
-						</div>
-						<div data-onboarding="upgrades-count">
-							<label
-								for="count-{row.id}"
-								class="block text-sm font-medium text-neutral-600 dark:text-neutral-400"
-							>
-								Count
-							</label>
-							<div class="mt-1">
-								<NumberInput
-									name="count-{row.id}"
-									bind:value={row.count}
-									min={1}
-									max={countMax}
-									font="mono"
-									responsive
-									on:change={handleChange}
-								/>
-							</div>
-							<p class="mt-1 text-xs text-neutral-500 dark:text-neutral-400">
-								Items per run (max {countMax} at this schedule)
-							</p>
-						</div>
-						<div data-onboarding="upgrades-cooldown">
-							<label
-								for="tag-{row.id}"
-								class="block text-sm font-medium text-neutral-600 dark:text-neutral-400"
-							>
-								Cooldown Tag
-							</label>
-							<div class="mt-1">
-								<FormInput
-									label="Cooldown tag"
-									hideLabel
-									lowercase
-									name="tag-{row.id}"
-									placeholder={resolveTagLabel(row)}
-									bind:value={row.tag}
-									responsive
-									on:input={handleChange}
-								/>
-							</div>
-							{#if getSharedTagFilters(row).length > 0}
-								<p class="mt-1 text-xs text-neutral-500 dark:text-neutral-400">
-									Shared with: {getSharedTagFilters(row).join(', ')}
-								</p>
-							{:else}
-								<p class="mt-1 text-xs text-neutral-500 dark:text-neutral-400">
-									Tag applied in your arr instance for cooldown tracking. Avoid reusing tags you use
-									elsewhere.
-								</p>
-							{/if}
-						</div>
-					</div>
-				</Card>
 			</div></svelte:fragment
 		>
 	</ExpandableTable>

--- a/src/routes/arr/[id]/upgrades/components/RunHistory.svelte
+++ b/src/routes/arr/[id]/upgrades/components/RunHistory.svelte
@@ -30,6 +30,7 @@
 	import Dropdown from '$ui/dropdown/Dropdown.svelte';
 	import DropdownItem from '$ui/dropdown/DropdownItem.svelte';
 	import ExpandableTable from '$ui/table/ExpandableTable.svelte';
+	import Pagination from '$ui/navigation/pagination/Pagination.svelte';
 	import Score from '$ui/arr/Score.svelte';
 	import Badge from '$ui/badge/Badge.svelte';
 	import Label from '$ui/label/Label.svelte';
@@ -120,6 +121,12 @@
 
 	// Check if any filters are active
 	$: hasActiveFilters = dateFilter !== 'all' || filterFilter !== 'all' || statusFilter !== 'all';
+
+	const pageSize = 20;
+	let currentPage = 1;
+	$: totalPages = Math.max(1, Math.ceil(filteredRuns.length / pageSize));
+	$: if (currentPage > totalPages) currentPage = 1;
+	$: paginatedRuns = filteredRuns.slice((currentPage - 1) * pageSize, currentPage * pageSize);
 
 	let expandedIds: Set<string> = new Set();
 
@@ -281,7 +288,7 @@
 
 	<ExpandableTable
 		{columns}
-		data={filteredRuns}
+		data={paginatedRuns}
 		getRowId={(row) => row.id}
 		bind:expandedRows={expandedIds}
 		chevronPosition="right"
@@ -576,4 +583,8 @@
 			</div>
 		</svelte:fragment>
 	</ExpandableTable>
+
+	<div class="mt-3 flex justify-center">
+		<Pagination {currentPage} {totalPages} onPageChange={(p) => (currentPage = p)} />
+	</div>
 </div>

--- a/src/routes/arr/components/InstanceForm.svelte
+++ b/src/routes/arr/components/InstanceForm.svelte
@@ -262,35 +262,34 @@
 	}
 </script>
 
-<div class="space-y-6" class:mt-6={mode === 'edit'}>
-	<!-- Header -->
-	<StickyCard position="top">
-		<svelte:fragment slot="left">
-			<h1 class="text-neutral-900 dark:text-neutral-50">{title}</h1>
-			<p class="text-neutral-600 dark:text-neutral-400">{description}</p>
-		</svelte:fragment>
-		<svelte:fragment slot="right">
-			{#if mode === 'edit'}
-				<Button
-					text="Delete"
-					icon={Trash2}
-					iconColor="text-red-600 dark:text-red-400"
-					disabled={saving || deleting}
-					on:click={() => (showDeleteModal = true)}
-				/>
-			{/if}
-			<div data-onboarding="arr-save">
-				<Button
-					text={saving ? 'Saving...' : 'Save'}
-					icon={Save}
-					iconColor="text-blue-600 dark:text-blue-400"
-					disabled={saving || !canSubmit}
-					on:click={handleSave}
-				/>
-			</div>
-		</svelte:fragment>
-	</StickyCard>
+<StickyCard position="top">
+	<svelte:fragment slot="left">
+		<h1 class="text-neutral-900 dark:text-neutral-50">{title}</h1>
+		<p class="text-neutral-600 dark:text-neutral-400">{description}</p>
+	</svelte:fragment>
+	<svelte:fragment slot="right">
+		{#if mode === 'edit'}
+			<Button
+				text="Delete"
+				icon={Trash2}
+				iconColor="text-red-600 dark:text-red-400"
+				disabled={saving || deleting}
+				on:click={() => (showDeleteModal = true)}
+			/>
+		{/if}
+		<div data-onboarding="arr-save">
+			<Button
+				text={saving ? 'Saving...' : 'Save'}
+				icon={Save}
+				iconColor="text-blue-600 dark:text-blue-400"
+				disabled={saving || !canSubmit}
+				on:click={handleSave}
+			/>
+		</div>
+	</svelte:fragment>
+</StickyCard>
 
+<div class="mt-4 space-y-6">
 	<div
 		class="space-y-4 rounded-lg border border-neutral-200 bg-white p-4 dark:border-neutral-800 dark:bg-neutral-900"
 	>


### PR DESCRIPTION
## Summary

- Aligned upgrades and rename settings headers with drift: uppercase microlabels, `Label` badges instead of raw spans, no card wrapper, full-bleed section dividers.
- Lifted sticky cards above scroll wrappers on sync and arr settings so top spacing matches drift/upgrades/rename.
- Paginated upgrade and rename run history (20/page, centered control, always shown).
- Streamed manual upgrade and rename runs via the existing SSE infrastructure (`arr.upgrade` and `arr.rename` added to `JOB_RUNNING_LABELS`/`JOB_COMPLETED_LABELS`). Pages auto-refresh history on completion. Cancels optimistically on form error.
- Restructured filter expanded view: Selection settings lifted above the rules editor with a full-bleed divider; bordered card dropped; Cooldown Tag spans 2 of 5 grid columns at lg+.
- Filter row actions (Disable/Copy/Duplicate/Delete) converted to icon-only buttons with tooltips.
- Tooltip: added `left` position, `align` prop (`left | middle | right`) for top/bottom positions, and a width-lock to fix near-viewport-edge measurement clipping.
- Run / Save buttons stay visible and disable when the feature is off or there's no config (instead of disappearing entirely).
- Drift "never checked" state uses the same empty-table treatment as the disabled and clean states.
- Disabled the dependent rename controls when Status is off (mirrors drift's Schedule).
- Method dropdown options simplified (drop description after the hyphen, drop compact + mobile short-label modes).