### PR TITLE
feat: add delay profile drift detection

### DIFF
--- a/docs/backend/drift.md
+++ b/docs/backend/drift.md
@@ -5,6 +5,7 @@
 `src/lib/server/db/queries/arrDriftStatus.ts`,
 `src/lib/server/drift/customFormats.ts`,
 `src/lib/server/drift/qualityProfiles.ts`,
+`src/lib/server/drift/delayProfiles.ts`,
 `src/lib/server/drift/display.ts`,
 `src/routes/arr/[id]/drift/+page.svelte`,
 `src/routes/arr/[id]/drift/+page.server.ts`,
@@ -35,8 +36,8 @@ Current handler behavior:
 - missing instances fail
 - missing or disabled settings cancel the job
 - unsupported Arr types are skipped
-- enabled jobs compare custom formats and quality profiles, store the latest
-  result, and return success
+- enabled jobs compare custom formats, quality profiles, and delay profiles,
+  store the latest result, and return success
 - scheduled jobs calculate and store the next run before returning
 
 ## Latest Status
@@ -94,6 +95,21 @@ Comparison rules:
 - report unmanaged custom format scoring rows with nonzero scores because they
   affect profile behavior
 
+## Delay Profiles
+
+Delay profile drift compares the selected Profilarr delay profile against Arr's
+default delay profile (`id=1`). This mirrors sync, which always overwrites the
+default Arr profile instead of creating or matching by name.
+
+Comparison rules:
+
+- build expected delay profile with the same transformer used by sync
+- no selected delay profile is clean
+- report the selected delay profile as missing if Arr does not return `id=1`
+- ignore non-default extra Arr delay profiles
+- compare id, derived protocol, delays, bypass fields, minimum custom format
+  score, order, and tags
+
 ## Display Formatter
 
 `src/lib/server/drift/display.ts` maps the raw `diff_json` stored in
@@ -119,6 +135,9 @@ For quality profiles the formatter turns settings, language, qualities, and
 custom format score paths into labeled changes. Quality profile score rows show
 expected and actual score values, missing custom formats, missing score rows,
 and unmanaged nonzero score rows.
+
+For delay profiles the formatter turns the derived protocol, delays, bypass
+flags, minimum score, order, and tags into friendly field rows.
 
 Display types live in `src/lib/shared/drift.ts`.
 
@@ -155,6 +174,6 @@ configuration, or triggers sync.
 
 ## TODO
 
-- Delay profile and media management comparison plus their display formatting.
+- Media management comparison plus display formatting.
 - Drift notifications for `detected` and `failed`.
 - Brief drift status on the sync page linking to the dedicated drift page.

--- a/src/lib/server/drift/check.ts
+++ b/src/lib/server/drift/check.ts
@@ -2,6 +2,7 @@ import type { BaseArrClient } from '$arr/base.ts';
 import type { DriftCounts, DriftDiff } from '$shared/drift.ts';
 import type { SyncArrType } from '$sync/mappings.ts';
 import { compareCustomFormatDrift, buildExpectedCustomFormats } from './customFormats.ts';
+import { checkDelayProfileDrift } from './delayProfiles.ts';
 import { hashDriftDiff } from './hash.ts';
 import { checkQualityProfileDrift } from './qualityProfiles.ts';
 
@@ -13,13 +14,14 @@ export interface DriftCheckResult {
 }
 
 export async function checkArrDrift(
-	client: Pick<BaseArrClient, 'getCustomFormats' | 'getQualityProfiles'>,
+	client: Pick<BaseArrClient, 'getCustomFormats' | 'getQualityProfiles' | 'getDelayProfiles'>,
 	instanceId: number,
 	arrType: SyncArrType
 ): Promise<DriftCheckResult> {
-	const [expectedCustomFormats, actualCustomFormats] = await Promise.all([
+	const [expectedCustomFormats, actualCustomFormats, delayProfiles] = await Promise.all([
 		buildExpectedCustomFormats(instanceId, arrType),
-		client.getCustomFormats()
+		client.getCustomFormats(),
+		checkDelayProfileDrift(client, instanceId)
 	]);
 	const customFormats = compareCustomFormatDrift(expectedCustomFormats, actualCustomFormats);
 	const qualityProfiles = await checkQualityProfileDrift(
@@ -30,11 +32,13 @@ export async function checkArrDrift(
 	);
 	const counts: DriftCounts = {
 		custom_formats: customFormats.count,
-		quality_profiles: qualityProfiles.count
+		quality_profiles: qualityProfiles.count,
+		delay_profiles: delayProfiles.count
 	};
 	const diff: DriftDiff = {
 		custom_formats: customFormats.diff,
-		quality_profiles: qualityProfiles.diff
+		quality_profiles: qualityProfiles.diff,
+		delay_profiles: delayProfiles.diff
 	};
 	const total = Object.values(counts).reduce((sum, count) => sum + (count ?? 0), 0);
 

--- a/src/lib/server/drift/delayProfiles.ts
+++ b/src/lib/server/drift/delayProfiles.ts
@@ -1,0 +1,179 @@
+import { arrSyncQueries } from '$db/queries/arrSync.ts';
+import type { BaseArrClient } from '$arr/base.ts';
+import type { ArrDelayProfile } from '$arr/types.ts';
+import { getCache } from '$pcd/index.ts';
+import { getByName as getDelayProfileByName } from '$pcd/entities/delayProfiles/index.ts';
+import { transformDelayProfile } from '$sync/delayProfiles/transformer.ts';
+import type { DriftFieldDiff } from './customFormats.ts';
+import { stringifyCanonical } from './hash.ts';
+
+type DelayProtocol =
+	| 'prefer_usenet'
+	| 'prefer_torrent'
+	| 'only_usenet'
+	| 'only_torrent'
+	| 'unknown';
+
+export interface DelayProfileMissingDiff {
+	name: string;
+}
+
+export interface DelayProfileModifiedDiff {
+	name: string;
+	fields: DriftFieldDiff[];
+}
+
+export interface DelayProfileDriftDiff {
+	missing: DelayProfileMissingDiff[];
+	modified: DelayProfileModifiedDiff[];
+}
+
+export interface DelayProfileDriftResult {
+	count: number;
+	diff: DelayProfileDriftDiff;
+}
+
+export interface DelayProfileDriftExpected {
+	name: string;
+	profile: ArrDelayProfile;
+}
+
+interface NormalizedDelayProfile {
+	id: number;
+	protocol: DelayProtocol;
+	usenetDelay: number;
+	torrentDelay: number;
+	bypassIfHighestQuality: boolean;
+	bypassIfAboveCustomFormatScore: boolean;
+	minimumCustomFormatScore: number;
+	order: number;
+	tags: number[];
+}
+
+const FIELD_ORDER = [
+	'id',
+	'protocol',
+	'usenetDelay',
+	'torrentDelay',
+	'bypassIfHighestQuality',
+	'bypassIfAboveCustomFormatScore',
+	'minimumCustomFormatScore',
+	'order',
+	'tags'
+] as const;
+
+function valuesEqual(expected: unknown, actual: unknown): boolean {
+	return stringifyCanonical(expected) === stringifyCanonical(actual);
+}
+
+function protocol(profile: ArrDelayProfile): DelayProtocol {
+	if (profile.enableUsenet && profile.enableTorrent) {
+		if (profile.preferredProtocol === 'usenet') return 'prefer_usenet';
+		if (profile.preferredProtocol === 'torrent') return 'prefer_torrent';
+		return 'unknown';
+	}
+
+	if (profile.enableUsenet && !profile.enableTorrent) {
+		return profile.preferredProtocol === 'usenet' ? 'only_usenet' : 'unknown';
+	}
+
+	if (!profile.enableUsenet && profile.enableTorrent) {
+		return profile.preferredProtocol === 'torrent' ? 'only_torrent' : 'unknown';
+	}
+
+	return 'unknown';
+}
+
+function normalizeProfile(profile: ArrDelayProfile): NormalizedDelayProfile {
+	return {
+		id: profile.id,
+		protocol: protocol(profile),
+		usenetDelay: profile.usenetDelay ?? 0,
+		torrentDelay: profile.torrentDelay ?? 0,
+		bypassIfHighestQuality: Boolean(profile.bypassIfHighestQuality),
+		bypassIfAboveCustomFormatScore: Boolean(profile.bypassIfAboveCustomFormatScore),
+		minimumCustomFormatScore: profile.minimumCustomFormatScore ?? 0,
+		order: profile.order,
+		tags: [...(profile.tags ?? [])].sort((a, b) => a - b)
+	};
+}
+
+function compareProfiles(
+	expected: NormalizedDelayProfile,
+	actual: NormalizedDelayProfile
+): DriftFieldDiff[] {
+	const diffs: DriftFieldDiff[] = [];
+
+	for (const field of FIELD_ORDER) {
+		if (!valuesEqual(expected[field], actual[field])) {
+			diffs.push({
+				path: field,
+				expected: expected[field],
+				actual: actual[field]
+			});
+		}
+	}
+
+	return diffs;
+}
+
+export function compareDelayProfileDrift(
+	expected: DelayProfileDriftExpected | null,
+	actualProfiles: ArrDelayProfile[]
+): DelayProfileDriftResult {
+	const diff: DelayProfileDriftDiff = { missing: [], modified: [] };
+	if (!expected) {
+		return { count: 0, diff };
+	}
+
+	const actual = actualProfiles.find((profile) => profile.id === 1);
+	if (!actual) {
+		diff.missing.push({ name: expected.name });
+		return { count: 1, diff };
+	}
+
+	const fields = compareProfiles(normalizeProfile(expected.profile), normalizeProfile(actual));
+	if (fields.length > 0) {
+		diff.modified.push({ name: expected.name, fields });
+	}
+
+	return {
+		count: diff.missing.length + diff.modified.length,
+		diff
+	};
+}
+
+export async function buildExpectedDelayProfile(
+	instanceId: number
+): Promise<DelayProfileDriftExpected | null> {
+	const syncConfig = arrSyncQueries.getDelayProfilesSync(instanceId);
+	if (!syncConfig.databaseId || !syncConfig.profileName) return null;
+
+	const cache = getCache(syncConfig.databaseId);
+	if (!cache) {
+		throw new Error(`PCD cache not found for database ${syncConfig.databaseId}`);
+	}
+
+	const profile = await getDelayProfileByName(cache, syncConfig.profileName);
+	if (!profile) {
+		throw new Error(
+			`Delay profile "${syncConfig.profileName}" not found in database ${syncConfig.databaseId}`
+		);
+	}
+
+	return {
+		name: syncConfig.profileName,
+		profile: transformDelayProfile(profile)
+	};
+}
+
+export async function checkDelayProfileDrift(
+	client: Pick<BaseArrClient, 'getDelayProfiles'>,
+	instanceId: number
+): Promise<DelayProfileDriftResult> {
+	const expected = await buildExpectedDelayProfile(instanceId);
+	if (!expected) return compareDelayProfileDrift(null, []);
+
+	const actualProfiles = await client.getDelayProfiles();
+	return compareDelayProfileDrift(expected, actualProfiles);
+}

--- a/src/lib/server/drift/display.ts
+++ b/src/lib/server/drift/display.ts
@@ -26,6 +26,11 @@ interface QualityProfileDiff {
 	modified?: unknown[];
 }
 
+interface DelayProfileDiff {
+	missing?: unknown[];
+	modified?: unknown[];
+}
+
 interface DriftFieldDiff {
 	path: string;
 	expected: unknown;
@@ -38,6 +43,11 @@ interface CustomFormatModifiedDiff {
 }
 
 interface QualityProfileModifiedDiff {
+	name: string;
+	fields: DriftFieldDiff[];
+}
+
+interface DelayProfileModifiedDiff {
 	name: string;
 	fields: DriftFieldDiff[];
 }
@@ -78,7 +88,8 @@ export function buildDriftDisplayEntities(
 	const syncArrType = arrType === 'radarr' || arrType === 'sonarr' ? arrType : undefined;
 	return [
 		...buildCustomFormatEntities(diff.custom_formats, syncArrType),
-		...buildQualityProfileEntities(diff.quality_profiles, syncArrType)
+		...buildQualityProfileEntities(diff.quality_profiles, syncArrType),
+		...buildDelayProfileEntities(diff.delay_profiles)
 	];
 }
 
@@ -202,6 +213,61 @@ function buildQualityProfileEntities(
 	return entities;
 }
 
+function buildDelayProfileEntities(raw: unknown): DriftDisplayEntity[] {
+	const diff = asDelayProfileDiff(raw);
+	if (!diff) return [];
+
+	const entities: DriftDisplayEntity[] = [];
+
+	for (const item of diff.missing ?? []) {
+		const name = recordString(item, 'name');
+		if (!name) continue;
+
+		entities.push({
+			id: `delay_profiles:missing:${name}`,
+			section: 'delay_profiles',
+			sectionLabel: 'Delay Profile',
+			title: name,
+			state: 'missing',
+			stateLabel: 'Missing',
+			tone: 'danger',
+			summary: 'Profilarr expects this delay profile on Arr default profile, but Arr does not have it.',
+			changes: [
+				{
+					id: `delay_profiles:missing:${name}:profile`,
+					label: 'Delay profile',
+					detail: 'Default profile missing from Arr',
+					expected: value('Present'),
+					actual: value('Missing', { tone: 'danger' }),
+					tone: 'danger'
+				}
+			]
+		});
+	}
+
+	for (const item of diff.modified ?? []) {
+		const modified = asModifiedDelayProfile(item);
+		if (!modified) continue;
+		if (modified.fields.length === 0) continue;
+
+		const changes = modified.fields.map(formatDelayProfileFieldDiff);
+
+		entities.push({
+			id: `delay_profiles:modified:${modified.name}`,
+			section: 'delay_profiles',
+			sectionLabel: 'Delay Profile',
+			title: modified.name,
+			state: 'modified',
+			stateLabel: 'Modified',
+			tone: 'warning',
+			summary: `${changes.length} ${changes.length === 1 ? 'change' : 'changes'} detected`,
+			changes
+		});
+	}
+
+	return entities;
+}
+
 function formatQualityProfileFieldDiff(
 	field: DriftFieldDiff,
 	index: number,
@@ -269,6 +335,75 @@ function formatQualityProfileFieldDiff(
 		id: `quality-profile-field:${index}`,
 		label: qualityProfileFieldLabel(field.path),
 		detail: 'Profile setting changed',
+		expected: formatGenericValue(field.expected),
+		actual: formatGenericValue(field.actual),
+		tone: field.actual === null || field.actual === undefined ? 'danger' : 'warning'
+	};
+}
+
+function formatDelayProfileFieldDiff(field: DriftFieldDiff, index: number): DriftDisplayChange {
+	if (field.path === 'protocol') {
+		return {
+			id: `delay-profile-protocol:${index}`,
+			label: 'Protocol',
+			detail: 'Protocol preference changed',
+			expected: formatDelayProtocolValue(field.expected),
+			actual: formatDelayProtocolValue(field.actual),
+			tone: 'warning'
+		};
+	}
+
+	if (field.path === 'usenetDelay' || field.path === 'torrentDelay') {
+		return {
+			id: `delay-profile-delay:${index}`,
+			label: delayProfileFieldLabel(field.path),
+			detail: 'Delay changed',
+			expected: formatMinutesValue(field.expected),
+			actual: formatMinutesValue(field.actual),
+			tone: 'warning'
+		};
+	}
+
+	if (
+		field.path === 'bypassIfHighestQuality' ||
+		field.path === 'bypassIfAboveCustomFormatScore'
+	) {
+		return {
+			id: `delay-profile-bypass:${index}`,
+			label: delayProfileFieldLabel(field.path),
+			detail: 'Bypass behavior changed',
+			expected: formatBooleanValue(field.expected),
+			actual: formatBooleanValue(field.actual),
+			tone: 'warning'
+		};
+	}
+
+	if (field.path === 'minimumCustomFormatScore') {
+		return {
+			id: `delay-profile-minimum-score:${index}`,
+			label: 'Minimum Custom Format Score',
+			detail: 'Bypass score threshold changed',
+			expected: formatGenericValue(field.expected),
+			actual: formatGenericValue(field.actual),
+			tone: 'warning'
+		};
+	}
+
+	if (field.path === 'tags') {
+		return {
+			id: `delay-profile-tags:${index}`,
+			label: 'Tags',
+			detail: 'Default profile tags changed',
+			expected: formatTagIdsValue(field.expected),
+			actual: formatTagIdsValue(field.actual),
+			tone: 'warning'
+		};
+	}
+
+	return {
+		id: `delay-profile-field:${index}`,
+		label: delayProfileFieldLabel(field.path),
+		detail: 'Delay profile setting changed',
 		expected: formatGenericValue(field.expected),
 		actual: formatGenericValue(field.actual),
 		tone: field.actual === null || field.actual === undefined ? 'danger' : 'warning'
@@ -463,6 +598,14 @@ function asQualityProfileDiff(raw: unknown): QualityProfileDiff | null {
 	};
 }
 
+function asDelayProfileDiff(raw: unknown): DelayProfileDiff | null {
+	if (!isRecord(raw)) return null;
+	return {
+		missing: Array.isArray(raw.missing) ? raw.missing : [],
+		modified: Array.isArray(raw.modified) ? raw.modified : []
+	};
+}
+
 function asModifiedCustomFormat(raw: unknown): CustomFormatModifiedDiff | null {
 	if (!isRecord(raw)) return null;
 	const name = recordString(raw, 'name');
@@ -473,6 +616,15 @@ function asModifiedCustomFormat(raw: unknown): CustomFormatModifiedDiff | null {
 }
 
 function asModifiedQualityProfile(raw: unknown): QualityProfileModifiedDiff | null {
+	if (!isRecord(raw)) return null;
+	const name = recordString(raw, 'name');
+	if (!name || !Array.isArray(raw.fields)) return null;
+
+	const fields = raw.fields.filter(isFieldDiff);
+	return { name, fields };
+}
+
+function asModifiedDelayProfile(raw: unknown): DelayProfileModifiedDiff | null {
 	if (!isRecord(raw)) return null;
 	const name = recordString(raw, 'name');
 	if (!name || !Array.isArray(raw.fields)) return null;
@@ -616,6 +768,32 @@ function formatQualityProfileFormatItemValue(raw: unknown): DriftDisplayValue {
 	return formatGenericValue(raw);
 }
 
+function formatDelayProtocolValue(raw: unknown): DriftDisplayValue {
+	const labels: Record<string, string> = {
+		prefer_usenet: 'Prefer Usenet',
+		prefer_torrent: 'Prefer Torrent',
+		only_usenet: 'Only Usenet',
+		only_torrent: 'Only Torrent',
+		unknown: 'Unknown'
+	};
+	if (raw === null || raw === undefined) return value('Missing', { tone: 'danger' });
+	if (typeof raw === 'string') return value(labels[raw] ?? titleize(raw));
+	return formatGenericValue(raw);
+}
+
+function formatMinutesValue(raw: unknown): DriftDisplayValue {
+	if (raw === null || raw === undefined) return value('Missing', { tone: 'danger' });
+	if (typeof raw !== 'number') return formatGenericValue(raw);
+	return value(`${raw} ${raw === 1 ? 'minute' : 'minutes'}`, { mono: true });
+}
+
+function formatTagIdsValue(raw: unknown): DriftDisplayValue {
+	if (raw === null || raw === undefined) return value('Missing', { tone: 'danger' });
+	if (!Array.isArray(raw)) return formatGenericValue(raw);
+	if (raw.length === 0) return value('None');
+	return value(raw.map((tag) => String(tag)).join(', '), { mono: true });
+}
+
 function formatLanguageValue(raw: unknown, arrType: SyncArrType | undefined): DriftDisplayValue {
 	if (raw === null || raw === undefined) return value('Missing', { tone: 'danger' });
 	if (!isRecord(raw)) return formatGenericValue(raw);
@@ -664,6 +842,22 @@ function qualityProfileFieldLabel(path: string): string {
 		minFormatScore: 'Minimum Format Score',
 		minUpgradeFormatScore: 'Minimum Upgrade Score Increment',
 		upgradeAllowed: 'Upgrade Allowed'
+	};
+
+	return labels[path] ?? titleize(path);
+}
+
+function delayProfileFieldLabel(path: string): string {
+	const labels: Record<string, string> = {
+		bypassIfAboveCustomFormatScore: 'Bypass if Above Custom Format Score',
+		bypassIfHighestQuality: 'Bypass if Highest Quality',
+		id: 'ID',
+		minimumCustomFormatScore: 'Minimum Custom Format Score',
+		order: 'Order',
+		protocol: 'Protocol',
+		tags: 'Tags',
+		torrentDelay: 'Torrent Delay',
+		usenetDelay: 'Usenet Delay'
 	};
 
 	return labels[path] ?? titleize(path);

--- a/src/lib/server/drift/display.ts
+++ b/src/lib/server/drift/display.ts
@@ -231,7 +231,8 @@ function buildDelayProfileEntities(raw: unknown): DriftDisplayEntity[] {
 			state: 'missing',
 			stateLabel: 'Missing',
 			tone: 'danger',
-			summary: 'Profilarr expects this delay profile on Arr default profile, but Arr does not have it.',
+			summary:
+				'Profilarr expects this delay profile on Arr default profile, but Arr does not have it.',
 			changes: [
 				{
 					id: `delay_profiles:missing:${name}:profile`,
@@ -364,10 +365,7 @@ function formatDelayProfileFieldDiff(field: DriftFieldDiff, index: number): Drif
 		};
 	}
 
-	if (
-		field.path === 'bypassIfHighestQuality' ||
-		field.path === 'bypassIfAboveCustomFormatScore'
-	) {
+	if (field.path === 'bypassIfHighestQuality' || field.path === 'bypassIfAboveCustomFormatScore') {
 		return {
 			id: `delay-profile-bypass:${index}`,
 			label: delayProfileFieldLabel(field.path),

--- a/src/lib/server/sync/delayProfiles/index.ts
+++ b/src/lib/server/sync/delayProfiles/index.ts
@@ -1,6 +1,6 @@
 /**
  * Delay profiles sync module
- * Exports handler and syncer for delay profile syncing
+ * Exports handler, syncer, and transformer for delay profile syncing
  */
 
 // Handler (for registry)
@@ -8,3 +8,6 @@ export { delayProfilesHandler } from './handler.ts';
 
 // Syncer
 export { DelayProfileSyncer } from './syncer.ts';
+
+// Transformer
+export { transformDelayProfile } from './transformer.ts';

--- a/src/lib/server/sync/delayProfiles/syncer.ts
+++ b/src/lib/server/sync/delayProfiles/syncer.ts
@@ -9,9 +9,8 @@ import { BaseSyncer, type SyncResult } from '../base.ts';
 import { arrSyncQueries } from '$db/queries/arrSync.ts';
 import { getCache } from '$pcd/index.ts';
 import { getByName as getDelayProfileByName } from '$pcd/entities/delayProfiles/index.ts';
-import type { DelayProfilesRow } from '$shared/pcd/display.ts';
-import type { ArrDelayProfile } from '$arr/types.ts';
 import { logger } from '$logger/logger.ts';
+import { transformDelayProfile } from './transformer.ts';
 
 export class DelayProfileSyncer extends BaseSyncer {
 	protected get syncType(): string {
@@ -50,7 +49,7 @@ export class DelayProfileSyncer extends BaseSyncer {
 			return { success: false, itemsSynced: 0, error: 'Profile not found in PCD' };
 		}
 
-		const transformed = this.transform(profile);
+		const transformed = transformDelayProfile(profile);
 		await this.client.updateDelayProfile(1, transformed);
 
 		await logger.info(`Synced delay profile "${profile.name}" to "${this.instanceName}"`, {
@@ -62,49 +61,6 @@ export class DelayProfileSyncer extends BaseSyncer {
 			success: true,
 			itemsSynced: 1,
 			items: [{ name: profile.name, action: 'updated' as const }]
-		};
-	}
-
-	private transform(profile: DelayProfilesRow): ArrDelayProfile {
-		let enableUsenet = true;
-		let enableTorrent = true;
-		let preferredProtocol = 'usenet';
-
-		switch (profile.preferred_protocol) {
-			case 'prefer_usenet':
-				enableUsenet = true;
-				enableTorrent = true;
-				preferredProtocol = 'usenet';
-				break;
-			case 'prefer_torrent':
-				enableUsenet = true;
-				enableTorrent = true;
-				preferredProtocol = 'torrent';
-				break;
-			case 'only_usenet':
-				enableUsenet = true;
-				enableTorrent = false;
-				preferredProtocol = 'usenet';
-				break;
-			case 'only_torrent':
-				enableUsenet = false;
-				enableTorrent = true;
-				preferredProtocol = 'torrent';
-				break;
-		}
-
-		return {
-			id: 1,
-			enableUsenet,
-			enableTorrent,
-			preferredProtocol,
-			usenetDelay: profile.usenet_delay ?? 0,
-			torrentDelay: profile.torrent_delay ?? 0,
-			bypassIfHighestQuality: profile.bypass_if_highest_quality,
-			bypassIfAboveCustomFormatScore: profile.bypass_if_above_custom_format_score,
-			minimumCustomFormatScore: profile.minimum_custom_format_score ?? 0,
-			order: 2147483647, // Default profile order
-			tags: [] // Default profile must have empty tags
 		};
 	}
 

--- a/src/lib/server/sync/delayProfiles/transformer.ts
+++ b/src/lib/server/sync/delayProfiles/transformer.ts
@@ -1,0 +1,45 @@
+import type { ArrDelayProfile } from '$arr/types.ts';
+import type { DelayProfilesRow } from '$shared/pcd/display.ts';
+
+export function transformDelayProfile(profile: DelayProfilesRow): ArrDelayProfile {
+	let enableUsenet = true;
+	let enableTorrent = true;
+	let preferredProtocol = 'usenet';
+
+	switch (profile.preferred_protocol) {
+		case 'prefer_usenet':
+			enableUsenet = true;
+			enableTorrent = true;
+			preferredProtocol = 'usenet';
+			break;
+		case 'prefer_torrent':
+			enableUsenet = true;
+			enableTorrent = true;
+			preferredProtocol = 'torrent';
+			break;
+		case 'only_usenet':
+			enableUsenet = true;
+			enableTorrent = false;
+			preferredProtocol = 'usenet';
+			break;
+		case 'only_torrent':
+			enableUsenet = false;
+			enableTorrent = true;
+			preferredProtocol = 'torrent';
+			break;
+	}
+
+	return {
+		id: 1,
+		enableUsenet,
+		enableTorrent,
+		preferredProtocol,
+		usenetDelay: profile.usenet_delay ?? 0,
+		torrentDelay: profile.torrent_delay ?? 0,
+		bypassIfHighestQuality: profile.bypass_if_highest_quality,
+		bypassIfAboveCustomFormatScore: profile.bypass_if_above_custom_format_score,
+		minimumCustomFormatScore: profile.minimum_custom_format_score ?? 0,
+		order: 2147483647,
+		tags: []
+	};
+}

--- a/src/lib/server/sync/entitySync.ts
+++ b/src/lib/server/sync/entitySync.ts
@@ -39,8 +39,8 @@ import {
 } from '$pcd/entities/mediaManagement/media-settings/read.ts';
 import type { ArrPropersAndRepacks } from '$arr/types.ts';
 import { colonReplacementToDb, multiEpisodeStyleToDb } from '$shared/pcd/mediaManagement.ts';
-import type { DelayProfilesRow } from '$shared/pcd/display.ts';
-import type { ArrDelayProfile, RadarrNamingConfig, SonarrNamingConfig } from '$arr/types.ts';
+import type { RadarrNamingConfig, SonarrNamingConfig } from '$arr/types.ts';
+import { transformDelayProfile } from './delayProfiles/transformer.ts';
 
 interface SyncResult {
 	success: boolean;
@@ -304,43 +304,6 @@ export async function syncDelayProfile(
 	} finally {
 		client.close();
 	}
-}
-
-function transformDelayProfile(profile: DelayProfilesRow): ArrDelayProfile {
-	let enableUsenet = true;
-	let enableTorrent = true;
-	let preferredProtocol = 'usenet';
-
-	switch (profile.preferred_protocol) {
-		case 'prefer_usenet':
-			preferredProtocol = 'usenet';
-			break;
-		case 'prefer_torrent':
-			preferredProtocol = 'torrent';
-			break;
-		case 'only_usenet':
-			enableTorrent = false;
-			preferredProtocol = 'usenet';
-			break;
-		case 'only_torrent':
-			enableUsenet = false;
-			preferredProtocol = 'torrent';
-			break;
-	}
-
-	return {
-		id: 1,
-		enableUsenet,
-		enableTorrent,
-		preferredProtocol,
-		usenetDelay: profile.usenet_delay ?? 0,
-		torrentDelay: profile.torrent_delay ?? 0,
-		bypassIfHighestQuality: profile.bypass_if_highest_quality,
-		bypassIfAboveCustomFormatScore: profile.bypass_if_above_custom_format_score,
-		minimumCustomFormatScore: profile.minimum_custom_format_score ?? 0,
-		order: 2147483647,
-		tags: []
-	};
 }
 
 /**

--- a/tests/unit/drift/delayProfiles.test.ts
+++ b/tests/unit/drift/delayProfiles.test.ts
@@ -1,0 +1,156 @@
+import { assertEquals } from '@std/assert';
+import { BaseTest } from '../base/BaseTest.ts';
+import {
+	compareDelayProfileDrift,
+	type DelayProfileDriftDiff,
+	type DelayProfileDriftExpected
+} from '$drift/delayProfiles.ts';
+import { hashDriftDiff } from '$drift/hash.ts';
+import type { ArrDelayProfile } from '$arr/types.ts';
+
+function arrDelayProfile(input: Partial<ArrDelayProfile> = {}): ArrDelayProfile {
+	return {
+		id: input.id ?? 1,
+		enableUsenet: input.enableUsenet ?? true,
+		enableTorrent: input.enableTorrent ?? true,
+		preferredProtocol: input.preferredProtocol ?? 'usenet',
+		usenetDelay: input.usenetDelay ?? 10,
+		torrentDelay: input.torrentDelay ?? 20,
+		bypassIfHighestQuality: input.bypassIfHighestQuality ?? true,
+		bypassIfAboveCustomFormatScore: input.bypassIfAboveCustomFormatScore ?? true,
+		minimumCustomFormatScore: input.minimumCustomFormatScore ?? 500,
+		order: input.order ?? 2147483647,
+		tags: input.tags ?? []
+	};
+}
+
+function expectedDelayProfile(
+	input: Partial<ArrDelayProfile> & { name?: string } = {}
+): DelayProfileDriftExpected {
+	return {
+		name: input.name ?? 'Standard Delay',
+		profile: arrDelayProfile(input)
+	};
+}
+
+class DelayProfileDriftTest extends BaseTest {
+	runTests(): void {
+		this.test('clean when expected and actual default delay profile match', () => {
+			const result = compareDelayProfileDrift(expectedDelayProfile(), [arrDelayProfile()]);
+
+			assertEquals(result.count, 0);
+			assertEquals(result.diff, { missing: [], modified: [] });
+		});
+
+		this.test('clean when no delay profile is configured', () => {
+			const result = compareDelayProfileDrift(null, [
+				arrDelayProfile({ id: 1 }),
+				arrDelayProfile({ id: 2, usenetDelay: 999 })
+			]);
+
+			assertEquals(result.count, 0);
+			assertEquals(result.diff, { missing: [], modified: [] });
+		});
+
+		this.test('reports missing Arr default delay profile', () => {
+			const result = compareDelayProfileDrift(expectedDelayProfile(), [
+				arrDelayProfile({ id: 2 })
+			]);
+
+			assertEquals(result.count, 1);
+			assertEquals(result.diff.missing, [{ name: 'Standard Delay' }]);
+			assertEquals(result.diff.modified, []);
+		});
+
+		this.test('reports protocol mismatch from managed Arr protocol fields', () => {
+			const result = compareDelayProfileDrift(expectedDelayProfile(), [
+				arrDelayProfile({
+					enableUsenet: false,
+					enableTorrent: true,
+					preferredProtocol: 'torrent'
+				})
+			]);
+
+			assertEquals(result.count, 1);
+			assertEquals(result.diff.modified, [
+				{
+					name: 'Standard Delay',
+					fields: [{ path: 'protocol', expected: 'prefer_usenet', actual: 'only_torrent' }]
+				}
+			]);
+		});
+
+		this.test('reports managed delay profile field mismatches', () => {
+			const result = compareDelayProfileDrift(expectedDelayProfile(), [
+				arrDelayProfile({
+					enableUsenet: false,
+					enableTorrent: true,
+					preferredProtocol: 'torrent',
+					usenetDelay: 5,
+					torrentDelay: 0,
+					bypassIfHighestQuality: false,
+					bypassIfAboveCustomFormatScore: false,
+					minimumCustomFormatScore: 0,
+					order: 2,
+					tags: [9]
+				})
+			]);
+
+			assertEquals(result.count, 1);
+			assertEquals(result.diff.modified, [
+				{
+					name: 'Standard Delay',
+					fields: [
+						{ path: 'protocol', expected: 'prefer_usenet', actual: 'only_torrent' },
+						{ path: 'usenetDelay', expected: 10, actual: 5 },
+						{ path: 'torrentDelay', expected: 20, actual: 0 },
+						{ path: 'bypassIfHighestQuality', expected: true, actual: false },
+						{ path: 'bypassIfAboveCustomFormatScore', expected: true, actual: false },
+						{ path: 'minimumCustomFormatScore', expected: 500, actual: 0 },
+						{ path: 'order', expected: 2147483647, actual: 2 },
+						{ path: 'tags', expected: [], actual: [9] }
+					]
+				}
+			]);
+		});
+
+		this.test('ignores non-default extra Arr delay profiles', () => {
+			const result = compareDelayProfileDrift(expectedDelayProfile(), [
+				arrDelayProfile(),
+				arrDelayProfile({ id: 2, usenetDelay: 999, tags: [1, 2] })
+			]);
+
+			assertEquals(result.count, 0);
+			assertEquals(result.diff, { missing: [], modified: [] });
+		});
+
+		this.test('hash is stable for equivalent object key order', async () => {
+			const first: DelayProfileDriftDiff = {
+				missing: [],
+				modified: [
+					{
+						name: 'Standard Delay',
+						fields: [{ path: 'usenetDelay', expected: 10, actual: 5 }]
+					}
+				]
+			};
+			const second = {
+				modified: [
+					{
+						fields: [{ actual: 5, expected: 10, path: 'usenetDelay' }],
+						name: 'Standard Delay'
+					}
+				],
+				missing: []
+			};
+
+			assertEquals(
+				await hashDriftDiff({ delay_profiles: first }),
+				await hashDriftDiff({ delay_profiles: second })
+			);
+		});
+	}
+}
+
+const delayProfileDriftTest = new DelayProfileDriftTest();
+delayProfileDriftTest.runTests();

--- a/tests/unit/drift/delayProfiles.test.ts
+++ b/tests/unit/drift/delayProfiles.test.ts
@@ -53,9 +53,7 @@ class DelayProfileDriftTest extends BaseTest {
 		});
 
 		this.test('reports missing Arr default delay profile', () => {
-			const result = compareDelayProfileDrift(expectedDelayProfile(), [
-				arrDelayProfile({ id: 2 })
-			]);
+			const result = compareDelayProfileDrift(expectedDelayProfile(), [arrDelayProfile({ id: 2 })]);
 
 			assertEquals(result.count, 1);
 			assertEquals(result.diff.missing, [{ name: 'Standard Delay' }]);


### PR DESCRIPTION
- Compares the selected PCD delay profile against Arr default profile id=1
- Refactors delay profile transform logic into a shared transformer used by batch sync, entity sync, and drift

Part of #307