### PR TITLE
docs: clarify drift scope

### DIFF
--- a/docs/backend/drift.md
+++ b/docs/backend/drift.md
@@ -15,6 +15,13 @@ Drift detection checks whether an Arr instance still matches the configuration
 Profilarr would sync now. It is observational: it does not write to Arr, repair
 config, delete stale items, or replace cleanup.
 
+Drift detection intentionally focuses on actively managed sync behavior:
+custom formats, quality profiles, and the default delay profile. Media
+management is treated as bootstrap configuration and is not checked for drift.
+Users often make local Arr-side edits to naming, media settings, and quality
+definitions after initial sync, so surfacing those edits as drift would be noisy
+and low value.
+
 ## Job
 
 The scheduled job type is `arr.drift` with payload `{ instanceId }`.
@@ -174,6 +181,5 @@ configuration, or triggers sync.
 
 ## TODO
 
-- Media management comparison plus display formatting.
 - Drift notifications for `detected` and `failed`.
 - Brief drift status on the sync page linking to the dedicated drift page.

--- a/docs/backend/sync.md
+++ b/docs/backend/sync.md
@@ -262,6 +262,10 @@ Drift detection checks whether Arr still matches what Profilarr would sync now.
 It may reuse sync transformers to build expected state, but it does not sync,
 repair, or cleanup.
 
+Drift does not check media management. Naming, media settings, and quality
+definitions are treated as bootstrap configuration because users commonly tune
+them directly in Arr after initial sync.
+
 ## Impact Analysis
 
 **Source:** `affectedArrs.ts`


### PR DESCRIPTION
- Documents media management as out of scope for drift detection
- Removes media management drift comparison from the drift TODO

Part of #307