### PR TITLE
feat: add drift notifications

### DIFF
--- a/docs/backend/drift.md
+++ b/docs/backend/drift.md
@@ -45,6 +45,8 @@ Current handler behavior:
 - unsupported Arr types are skipped
 - enabled jobs compare custom formats, quality profiles, and delay profiles,
   store the latest result, and return success
+- drift-detected and failed runs notify subscribed services when the current
+  drift or error hash has not already been notified
 - scheduled jobs calculate and store the next run before returning
 
 ## Latest Status
@@ -64,6 +66,25 @@ Job run history remains the operational history.
 | `last_error`               | Latest failure detail                                |
 | `error_hash`               | Stable hash of the latest failure detail             |
 | `last_notified_error_hash` | Last failure hash sent as a notification             |
+
+## Notifications
+
+Drift emits notification events through the shared notification manager:
+
+| Event                | Trigger                               | Severity  |
+| -------------------- | ------------------------------------- | --------- |
+| `arr.drift.detected` | Latest drift hash has not been sent   | `warning` |
+| `arr.drift.failed`   | Latest failure hash has not been sent | `error`   |
+
+Detected notifications emit one section block per drift category (Custom
+Format, Quality Profile, Delay Profile) listing up to 15 displayable drift
+entities total. If more entities exist, an additional `More` block summarises
+the remainder as `+N more`. Discord renders each section as a code-block field.
+Webhook receives the full payload. Summary-tier services such as Ntfy and
+Telegram show only the title because section blocks are omitted.
+
+Failed notifications use the first error line as the message and include the
+full error text in an `Error` section.
 
 ## Custom Formats
 
@@ -181,5 +202,4 @@ configuration, or triggers sync.
 
 ## TODO
 
-- Drift notifications for `detected` and `failed`.
 - Brief drift status on the sync page linking to the dedicated drift page.

--- a/docs/backend/notifications.md
+++ b/docs/backend/notifications.md
@@ -74,11 +74,11 @@ Notification types are enumerated in `src/lib/shared/notifications/types.ts`
 and consumed by the settings UI for per-service subscription. Each maps to a
 definition in `src/lib/server/notifications/definitions/`.
 
-Categories include Backups, Databases, Arr Sync, Arr Cleanup, Upgrades,
-Renames, and Announcements. The announcement event (`announcement.new`) is
-fired by the `announcements.fetch` job whenever the reconciler inserts a
-new, never-seen-before announcement id. Reappearing previously-withdrawn
-announcements do not re-notify.
+Categories include Backups, Databases, Arr Sync, Arr Cleanup, Arr Drift,
+Upgrades, Renames, and Announcements. The announcement event
+(`announcement.new`) is fired by the `announcements.fetch` job whenever the
+reconciler inserts a new, never-seen-before announcement id. Reappearing
+previously-withdrawn announcements do not re-notify.
 
 ## Notification Payload
 
@@ -238,6 +238,7 @@ tests/integration/notifications/
     upgrade.test.ts      - upgrade notification (definition + all notifiers)
     rename.test.ts       - rename notification (definition + all notifiers)
     arrSync.test.ts      - arr sync notification (definition + all notifiers)
+    arrDrift.test.ts     - arr drift notification (definition + all notifiers)
     pcdSync.test.ts      - PCD sync notification (definition + all notifiers)
 ```
 

--- a/src/lib/server/jobs/handlers/arrDrift.ts
+++ b/src/lib/server/jobs/handlers/arrDrift.ts
@@ -8,8 +8,11 @@ import { calculateNextRun } from '../scheduleUtils.ts';
 import { createArrClient } from '$arr/factory.ts';
 import type { ArrType } from '$arr/types.ts';
 import { checkArrDrift } from '$drift/check.ts';
+import { buildDriftDisplayEntities } from '$drift/display.ts';
 import { hashDriftDiff } from '$drift/hash.ts';
 import { logger } from '$logger/logger.ts';
+import { notifications } from '$notifications/definitions/index.ts';
+import { notificationManager } from '$notifications/NotificationManager.ts';
 
 const driftHandler: JobHandler = async (job) => {
 	const instanceId = Number(job.payload.instanceId);
@@ -41,6 +44,7 @@ const driftHandler: JobHandler = async (job) => {
 	const client = createArrClient(instance.type as ArrType, instance.url, instance.api_key, {
 		retries: 0
 	});
+	const previousStatus = arrDriftStatusQueries.getByInstanceId(instanceId);
 
 	try {
 		const result = await checkArrDrift(client, instanceId, instance.type);
@@ -70,6 +74,20 @@ const driftHandler: JobHandler = async (job) => {
 				source: 'jobs.handlers.arrDrift',
 				meta: logMeta
 			});
+
+			if (result.diffHash !== previousStatus?.lastNotifiedHash) {
+				await notificationManager.notify(
+					notifications.arrDriftDetected({
+						instanceName: instance.name,
+						instanceType: instance.type,
+						entities: buildDriftDisplayEntities(result.diff, instance.type)
+					})
+				);
+				arrDriftStatusQueries.update(instanceId, {
+					lastNotifiedHash: result.diffHash,
+					lastNotifiedAt: now
+				});
+			}
 		} else {
 			await logger.debug('Drift check complete', {
 				source: 'jobs.handlers.arrDrift',
@@ -101,6 +119,20 @@ const driftHandler: JobHandler = async (job) => {
 			lastError: message,
 			errorHash
 		});
+
+		if (errorHash !== previousStatus?.lastNotifiedErrorHash) {
+			await notificationManager.notify(
+				notifications.arrDriftFailed({
+					instanceName: instance.name,
+					instanceType: instance.type,
+					error: message
+				})
+			);
+			arrDriftStatusQueries.update(instanceId, {
+				lastNotifiedErrorHash: errorHash,
+				lastNotifiedAt: now
+			});
+		}
 
 		return {
 			status: 'failure',

--- a/src/lib/server/jobs/handlers/arrDrift.ts
+++ b/src/lib/server/jobs/handlers/arrDrift.ts
@@ -70,12 +70,14 @@ const driftHandler: JobHandler = async (job) => {
 
 		const totalCount = Object.values(result.counts).reduce((sum, count) => sum + (count ?? 0), 0);
 		if (result.status === 'drift_detected') {
+			const notified = result.diffHash !== previousStatus?.lastNotifiedHash;
+
 			await logger.info('Drift detected', {
 				source: 'jobs.handlers.arrDrift',
-				meta: logMeta
+				meta: { ...logMeta, notified }
 			});
 
-			if (result.diffHash !== previousStatus?.lastNotifiedHash) {
+			if (notified) {
 				await notificationManager.notify(
 					notifications.arrDriftDetected({
 						instanceName: instance.name,
@@ -104,10 +106,17 @@ const driftHandler: JobHandler = async (job) => {
 		const message = error instanceof Error ? error.message : String(error);
 		const now = new Date().toISOString();
 		const errorHash = await hashDriftDiff({ error: message });
+		const notified = errorHash !== previousStatus?.lastNotifiedErrorHash;
 
 		await logger.error('Drift check failed', {
 			source: 'jobs.handlers.arrDrift',
-			meta: { jobId: job.id, instanceId, instanceName: instance.name, error: message }
+			meta: {
+				jobId: job.id,
+				instanceId,
+				instanceName: instance.name,
+				error: message,
+				notified
+			}
 		});
 
 		arrDriftStatusQueries.upsert(instanceId, {
@@ -120,7 +129,7 @@ const driftHandler: JobHandler = async (job) => {
 			errorHash
 		});
 
-		if (errorHash !== previousStatus?.lastNotifiedErrorHash) {
+		if (notified) {
 			await notificationManager.notify(
 				notifications.arrDriftFailed({
 					instanceName: instance.name,

--- a/src/lib/server/notifications/definitions/arrDrift.ts
+++ b/src/lib/server/notifications/definitions/arrDrift.ts
@@ -1,0 +1,99 @@
+import type { Notification, NotificationBlock } from '../types.ts';
+import type { DriftDisplayEntity } from '$shared/drift.ts';
+
+export interface ArrDriftDetectedNotificationParams {
+	instanceName: string;
+	instanceType: string;
+	entities: DriftDisplayEntity[];
+	maxEntities?: number;
+}
+
+export interface ArrDriftFailedNotificationParams {
+	instanceName: string;
+	instanceType: string;
+	error: string;
+}
+
+const DEFAULT_MAX_ENTITIES = 15;
+
+function capitalize(s: string): string {
+	return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+function formatInstanceType(type: string): string {
+	return capitalize(type);
+}
+
+function instanceLabel(instanceType: string, instanceName: string): string {
+	return `${formatInstanceType(instanceType)} (${instanceName})`;
+}
+
+function firstLine(text: string): string {
+	const idx = text.indexOf('\n');
+	return idx === -1 ? text : text.slice(0, idx);
+}
+
+function buildDriftedItemBlocks(
+	entities: DriftDisplayEntity[],
+	maxEntities: number
+): NotificationBlock[] {
+	const shown = entities.slice(0, maxEntities);
+	const remaining = entities.length - shown.length;
+	const groups = new Map<string, DriftDisplayEntity[]>();
+
+	for (const entity of shown) {
+		const group = groups.get(entity.sectionLabel) ?? [];
+		group.push(entity);
+		groups.set(entity.sectionLabel, group);
+	}
+
+	const blocks: NotificationBlock[] = [];
+	for (const [label, group] of groups) {
+		blocks.push({
+			kind: 'section',
+			title: label,
+			content: group.map((entity) => `- ${entity.title}: ${entity.summary}`).join('\n')
+		});
+	}
+
+	if (remaining > 0) {
+		blocks.push({
+			kind: 'section',
+			title: 'More',
+			content: `+${remaining} more`
+		});
+	}
+
+	return blocks;
+}
+
+export function arrDriftDetected(params: ArrDriftDetectedNotificationParams): Notification {
+	const { instanceName, instanceType, entities } = params;
+	const maxEntities = params.maxEntities ?? DEFAULT_MAX_ENTITIES;
+
+	return {
+		type: 'arr.drift.detected',
+		severity: 'warning',
+		title: `Drift Detected - ${instanceLabel(instanceType, instanceName)}`,
+		message: '',
+		blocks: buildDriftedItemBlocks(entities, maxEntities)
+	};
+}
+
+export function arrDriftFailed(params: ArrDriftFailedNotificationParams): Notification {
+	const { instanceName, instanceType, error } = params;
+
+	return {
+		type: 'arr.drift.failed',
+		severity: 'error',
+		title: `Drift Check Failed - ${instanceLabel(instanceType, instanceName)}`,
+		message: firstLine(error),
+		blocks: [
+			{
+				kind: 'section',
+				title: 'Error',
+				content: error
+			}
+		]
+	};
+}

--- a/src/lib/server/notifications/definitions/index.ts
+++ b/src/lib/server/notifications/definitions/index.ts
@@ -14,6 +14,7 @@ import { rename } from './rename.ts';
 import { upgrade } from './upgrade.ts';
 import { arrSync } from './arrSync.ts';
 import { arrCleanup } from './arrCleanup.ts';
+import { arrDriftDetected, arrDriftFailed } from './arrDrift.ts';
 import { pcdUpdatesAvailable, pcdSyncSuccess, pcdSyncFailed, pcdLinkFailed } from './pcdSync.ts';
 import { backupSuccess, backupFailed } from './backup.ts';
 import { announcementNew } from './announcement.ts';
@@ -24,6 +25,8 @@ export const notifications = {
 	upgrade,
 	arrSync,
 	arrCleanup,
+	arrDriftDetected,
+	arrDriftFailed,
 	pcdUpdatesAvailable,
 	pcdSyncSuccess,
 	pcdSyncFailed,

--- a/src/lib/server/notifications/types.ts
+++ b/src/lib/server/notifications/types.ts
@@ -34,6 +34,10 @@ export const NotificationTypes = {
 	ARR_CLEANUP_PARTIAL: 'arr.cleanup.partial',
 	ARR_CLEANUP_FAILED: 'arr.cleanup.failed',
 
+	// Arr Drift
+	ARR_DRIFT_DETECTED: 'arr.drift.detected',
+	ARR_DRIFT_FAILED: 'arr.drift.failed',
+
 	// Backups
 	BACKUP_SUCCESS: 'backup.success',
 	BACKUP_FAILED: 'backup.failed',

--- a/src/lib/shared/notifications/types.ts
+++ b/src/lib/shared/notifications/types.ts
@@ -108,6 +108,20 @@ export const notificationTypes: NotificationType[] = [
 		description: 'Notification when cleanup cannot complete or no items could be deleted'
 	},
 
+	// Arr Drift
+	{
+		id: 'arr.drift.detected',
+		label: 'Arr Drift Detected',
+		category: 'Arr Drift',
+		description: 'Notification when drift is detected on an Arr instance'
+	},
+	{
+		id: 'arr.drift.failed',
+		label: 'Arr Drift Failed',
+		category: 'Arr Drift',
+		description: 'Notification when an Arr drift check fails'
+	},
+
 	// Upgrades
 	{
 		id: 'upgrade.success',

--- a/tests/integration/notifications/specs/arrDrift.test.ts
+++ b/tests/integration/notifications/specs/arrDrift.test.ts
@@ -1,0 +1,441 @@
+/**
+ * Arr drift notification - definition + Discord + Ntfy + Webhook + Telegram.
+ */
+
+import { assertEquals, assertExists } from '@std/assert';
+import { setup, teardown, test, run } from '$test-harness/runner.ts';
+import { createMockServer, type CapturedRequest } from '../harness/mock-server.ts';
+import { DiscordNotifier } from '$notifications/notifiers/discord/DiscordNotifier.ts';
+import { NtfyNotifier } from '$notifications/notifiers/ntfy/NtfyNotifier.ts';
+import { WebhookNotifier } from '$notifications/notifiers/webhook/WebhookNotifier.ts';
+import { TelegramNotifier } from '$notifications/notifiers/telegram/TelegramNotifier.ts';
+import { Colors } from '$notifications/notifiers/discord/embed.ts';
+import { arrDriftDetected, arrDriftFailed } from '$notifications/definitions/arrDrift.ts';
+import type {
+	ArrDriftDetectedNotificationParams,
+	ArrDriftFailedNotificationParams
+} from '$notifications/definitions/arrDrift.ts';
+import type { DriftDisplayEntity, DriftDisplayState } from '$shared/drift.ts';
+import { notificationTypes } from '$shared/notifications/types.ts';
+
+const MOCK_PORT = 7142;
+let captured: CapturedRequest[];
+let mockServer: Deno.HttpServer;
+
+let REAL_DISCORD: string | undefined;
+let REAL_WEBHOOK_URL: string | undefined;
+try {
+	const envPath = new URL('../.env', import.meta.url).pathname;
+	const content = await Deno.readTextFile(envPath);
+	for (const line of content.split('\n')) {
+		const trimmed = line.trim();
+		if (!trimmed || trimmed.startsWith('#')) continue;
+		const eqIdx = trimmed.indexOf('=');
+		if (eqIdx > 0) {
+			const key = trimmed.slice(0, eqIdx);
+			const value = trimmed.slice(eqIdx + 1);
+			if (key === 'TEST_DISCORD_WEBHOOK') REAL_DISCORD = value;
+			if (key === 'TEST_WEBHOOK_URL') REAL_WEBHOOK_URL = value;
+		}
+	}
+} catch {
+	/* no .env */
+}
+
+setup(() => {
+	const mock = createMockServer(MOCK_PORT);
+	captured = mock.captured;
+	mockServer = mock.server;
+});
+
+teardown(async () => {
+	await mockServer.shutdown();
+});
+
+function getAllEmbeds(): Record<string, unknown>[] {
+	const embeds: Record<string, unknown>[] = [];
+	for (const req of captured) {
+		const body = req.body as { embeds?: Record<string, unknown>[] };
+		if (body?.embeds) embeds.push(...body.embeds);
+	}
+	return embeds;
+}
+
+function makeEntity(
+	section: 'custom_formats' | 'quality_profiles' | 'delay_profiles',
+	sectionLabel: string,
+	title: string,
+	summary: string,
+	state: DriftDisplayState = 'modified'
+): DriftDisplayEntity {
+	return {
+		id: `${section}:${state}:${title}`,
+		section,
+		sectionLabel,
+		title,
+		state,
+		stateLabel: state === 'missing' ? 'Missing' : 'Modified',
+		tone: state === 'missing' ? 'danger' : 'warning',
+		summary,
+		changes: []
+	};
+}
+
+function makeDetectedParams(
+	overrides: Partial<ArrDriftDetectedNotificationParams> = {}
+): ArrDriftDetectedNotificationParams {
+	return {
+		instanceName: 'Movies',
+		instanceType: 'radarr',
+		entities: [
+			makeEntity('custom_formats', 'Custom Format', 'Streaming Tier', '2 changes detected'),
+			makeEntity('quality_profiles', 'Quality Profile', 'HD Movies', '4 changes detected'),
+			makeEntity('delay_profiles', 'Delay Profile', 'Standard Delay', '1 change detected')
+		],
+		...overrides
+	};
+}
+
+function makeFailedParams(
+	overrides: Partial<ArrDriftFailedNotificationParams> = {}
+): ArrDriftFailedNotificationParams {
+	return {
+		instanceName: 'Movies',
+		instanceType: 'radarr',
+		error: 'Connection refused\nfetch failed: ECONNREFUSED',
+		...overrides
+	};
+}
+
+// =========================================================================
+// Definition
+// =========================================================================
+
+test('detected type, severity, title, and empty message', () => {
+	const notification = arrDriftDetected(makeDetectedParams());
+
+	assertEquals(notification.type, 'arr.drift.detected');
+	assertEquals(notification.severity, 'warning');
+	assertEquals(notification.title, 'Drift Detected - Radarr (Movies)');
+	assertEquals(notification.message, '');
+});
+
+test('failed type, severity, title, and first-line message', () => {
+	const notification = arrDriftFailed(makeFailedParams());
+
+	assertEquals(notification.type, 'arr.drift.failed');
+	assertEquals(notification.severity, 'error');
+	assertEquals(notification.title, 'Drift Check Failed - Radarr (Movies)');
+	assertEquals(notification.message, 'Connection refused');
+});
+
+test('detected emits one section block per drift category', () => {
+	const notification = arrDriftDetected(makeDetectedParams());
+	const sections = notification.blocks?.filter((b) => b.kind === 'section') ?? [];
+
+	const cf = sections.find((b) => b.kind === 'section' && b.title === 'Custom Format');
+	assertExists(cf);
+	if (cf?.kind === 'section') {
+		assertEquals(cf.content, '- Streaming Tier: 2 changes detected');
+	}
+
+	const qp = sections.find((b) => b.kind === 'section' && b.title === 'Quality Profile');
+	assertExists(qp);
+	if (qp?.kind === 'section') {
+		assertEquals(qp.content, '- HD Movies: 4 changes detected');
+	}
+
+	const dp = sections.find((b) => b.kind === 'section' && b.title === 'Delay Profile');
+	assertExists(dp);
+	if (dp?.kind === 'section') {
+		assertEquals(dp.content, '- Standard Delay: 1 change detected');
+	}
+});
+
+test('detected caps at 15 entities and emits a trailing More block', () => {
+	const entities = Array.from({ length: 17 }, (_, index) =>
+		makeEntity(
+			'custom_formats',
+			'Custom Format',
+			`Format ${String(index + 1).padStart(2, '0')}`,
+			'1 change detected'
+		)
+	);
+	const notification = arrDriftDetected(makeDetectedParams({ entities }));
+	const sections = notification.blocks?.filter((b) => b.kind === 'section') ?? [];
+
+	const cf = sections.find((b) => b.kind === 'section' && b.title === 'Custom Format');
+	assertExists(cf);
+	if (cf?.kind === 'section') {
+		assertEquals(cf.content.includes('Format 15'), true);
+		assertEquals(cf.content.includes('Format 16'), false);
+		assertEquals(cf.content.includes('Format 17'), false);
+	}
+
+	const more = sections.find((b) => b.kind === 'section' && b.title === 'More');
+	assertExists(more);
+	if (more?.kind === 'section') {
+		assertEquals(more.content, '+2 more');
+	}
+});
+
+test('detected definition emits no field blocks', () => {
+	const notification = arrDriftDetected(makeDetectedParams());
+	const fields = notification.blocks?.filter((b) => b.kind === 'field') ?? [];
+	assertEquals(fields.length, 0);
+});
+
+test('failed definition emits full Error section', () => {
+	const notification = arrDriftFailed(makeFailedParams());
+	const block = notification.blocks?.find((b) => b.kind === 'section' && b.title === 'Error');
+	assertExists(block);
+	if (block?.kind === 'section') {
+		assertEquals(block.content, 'Connection refused\nfetch failed: ECONNREFUSED');
+	}
+});
+
+test('shared notification metadata includes drift events', () => {
+	const ids = notificationTypes.map((type) => type.id);
+	assertEquals(ids.includes('arr.drift.detected'), true);
+	assertEquals(ids.includes('arr.drift.failed'), true);
+});
+
+// =========================================================================
+// Discord
+// =========================================================================
+
+test('discord: detected uses warning color and renders one field per category', async () => {
+	captured.length = 0;
+	const notifier = new DiscordNotifier({
+		webhook_url: `http://localhost:${MOCK_PORT}/webhook`,
+		username: 'Profilarr',
+		enable_mentions: false
+	});
+	await notifier.notify(arrDriftDetected(makeDetectedParams()));
+
+	const embed = getAllEmbeds()[0];
+	assertEquals(embed?.color, Colors.WARNING);
+	const fields = (embed?.fields as { name: string; value: string }[]) ?? [];
+
+	const cfField = fields.find((field) => field.name === 'Custom Format');
+	assertExists(cfField);
+	assertEquals(cfField!.value.includes('Streaming Tier'), true);
+
+	const qpField = fields.find((field) => field.name === 'Quality Profile');
+	assertExists(qpField);
+	assertEquals(qpField!.value.includes('HD Movies'), true);
+
+	const dpField = fields.find((field) => field.name === 'Delay Profile');
+	assertExists(dpField);
+	assertEquals(dpField!.value.includes('Standard Delay'), true);
+});
+
+test('discord: failed uses error color and renders error section', async () => {
+	captured.length = 0;
+	const notifier = new DiscordNotifier({
+		webhook_url: `http://localhost:${MOCK_PORT}/webhook`,
+		username: 'Profilarr',
+		enable_mentions: false
+	});
+	await notifier.notify(arrDriftFailed(makeFailedParams()));
+
+	const embed = getAllEmbeds()[0];
+	assertEquals(embed?.color, Colors.ERROR);
+	const fields = (embed?.fields as { name: string; value: string }[]) ?? [];
+	const errorField = fields.find((field) => field.name === 'Error');
+	assertExists(errorField);
+	assertEquals(errorField!.value.includes('ECONNREFUSED'), true);
+});
+
+// =========================================================================
+// Ntfy
+// =========================================================================
+
+test('ntfy: detected maps to priority 4 and omits entity names', async () => {
+	captured.length = 0;
+	const notifier = new NtfyNotifier({
+		server_url: `http://localhost:${MOCK_PORT}`,
+		topic: 'test-topic'
+	});
+	await notifier.notify(arrDriftDetected(makeDetectedParams()));
+
+	const payload = captured[0]?.body as Record<string, unknown>;
+	assertEquals(payload?.priority, 4);
+	assertEquals(payload?.tags, ['warning']);
+	assertEquals((payload?.message as string).includes('Streaming Tier'), false);
+});
+
+// =========================================================================
+// Webhook
+// =========================================================================
+
+test('webhook: detected sends full notification with one section per category', async () => {
+	captured.length = 0;
+	const notifier = new WebhookNotifier({
+		webhook_url: `http://localhost:${MOCK_PORT}/webhook`
+	});
+	await notifier.notify(arrDriftDetected(makeDetectedParams()));
+
+	const payload = captured[0]?.body as Record<string, unknown>;
+	assertEquals(payload?.type, 'arr.drift.detected');
+	assertEquals(payload?.severity, 'warning');
+	const blocks = payload?.blocks as { kind: string; title?: string; content?: string }[];
+
+	const cfBlock = blocks.find(
+		(block) => block.kind === 'section' && block.title === 'Custom Format'
+	);
+	assertExists(cfBlock);
+	assertEquals(cfBlock!.content?.includes('Streaming Tier'), true);
+
+	const qpBlock = blocks.find(
+		(block) => block.kind === 'section' && block.title === 'Quality Profile'
+	);
+	assertExists(qpBlock);
+	assertEquals(qpBlock!.content?.includes('HD Movies'), true);
+});
+
+test('webhook: failed sends full notification with error detail', async () => {
+	captured.length = 0;
+	const notifier = new WebhookNotifier({
+		webhook_url: `http://localhost:${MOCK_PORT}/webhook`
+	});
+	await notifier.notify(arrDriftFailed(makeFailedParams()));
+
+	const payload = captured[0]?.body as Record<string, unknown>;
+	assertEquals(payload?.type, 'arr.drift.failed');
+	assertEquals(payload?.severity, 'error');
+	const blocks = payload?.blocks as { kind: string; title?: string; content?: string }[];
+	const errorBlock = blocks.find((block) => block.kind === 'section' && block.title === 'Error');
+	assertExists(errorBlock);
+	assertEquals(errorBlock!.content?.includes('ECONNREFUSED'), true);
+});
+
+// =========================================================================
+// Telegram
+// =========================================================================
+
+const MOCK_TOKEN = 'test-token-123';
+
+test('telegram: detected has warning prefix and omits entity names', async () => {
+	captured.length = 0;
+	const notifier = new TelegramNotifier({
+		bot_token: MOCK_TOKEN,
+		chat_id: '123456',
+		api_base_url: `http://localhost:${MOCK_PORT}`
+	});
+	await notifier.notify(arrDriftDetected(makeDetectedParams()));
+
+	const text = (captured[0]?.body as Record<string, unknown>)?.text as string;
+	assertEquals(text.startsWith('\u26A0\uFE0F'), true);
+	assertEquals(text.includes('Streaming Tier'), false);
+});
+
+// =========================================================================
+// Real sends (skipped without .env)
+// =========================================================================
+
+test('real: sends detected to Discord', async () => {
+	if (!REAL_DISCORD) return;
+	const notifier = new DiscordNotifier({
+		webhook_url: REAL_DISCORD,
+		username: 'Profilarr Test',
+		enable_mentions: false
+	});
+	await notifier.notify(arrDriftDetected(makeDetectedParams()));
+});
+
+test('real: sends detected with many entities to Discord', async () => {
+	if (!REAL_DISCORD) return;
+	await new Promise((r) => setTimeout(r, 2000));
+	const notifier = new DiscordNotifier({
+		webhook_url: REAL_DISCORD,
+		username: 'Profilarr Test',
+		enable_mentions: false
+	});
+
+	const entities: DriftDisplayEntity[] = [
+		...Array.from({ length: 5 }, (_, i) =>
+			makeEntity(
+				'custom_formats',
+				'Custom Format',
+				`Custom Format ${i + 1}`,
+				`${i + 1} change${i === 0 ? '' : 's'} detected`
+			)
+		),
+		...Array.from({ length: 3 }, (_, i) =>
+			makeEntity(
+				'quality_profiles',
+				'Quality Profile',
+				`Quality Profile ${i + 1}`,
+				`${i + 2} changes detected`
+			)
+		),
+		makeEntity('delay_profiles', 'Delay Profile', 'Standard Delay', '1 change detected')
+	];
+
+	await notifier.notify(
+		arrDriftDetected({
+			instanceName: 'Movies',
+			instanceType: 'radarr',
+			entities
+		})
+	);
+});
+
+test('real: sends detected with +N more cap to Discord', async () => {
+	if (!REAL_DISCORD) return;
+	await new Promise((r) => setTimeout(r, 2000));
+	const notifier = new DiscordNotifier({
+		webhook_url: REAL_DISCORD,
+		username: 'Profilarr Test',
+		enable_mentions: false
+	});
+
+	const entities = Array.from({ length: 20 }, (_, i) =>
+		makeEntity(
+			'custom_formats',
+			'Custom Format',
+			`Format ${String(i + 1).padStart(2, '0')}`,
+			'1 change detected'
+		)
+	);
+
+	await notifier.notify(
+		arrDriftDetected({
+			instanceName: 'Movies',
+			instanceType: 'radarr',
+			entities
+		})
+	);
+});
+
+test('real: sends failed to Discord', async () => {
+	if (!REAL_DISCORD) return;
+	await new Promise((r) => setTimeout(r, 2000));
+	const notifier = new DiscordNotifier({
+		webhook_url: REAL_DISCORD,
+		username: 'Profilarr Test',
+		enable_mentions: false
+	});
+	await notifier.notify(arrDriftFailed(makeFailedParams()));
+});
+
+test('real: sends detected to webhook', async () => {
+	if (!REAL_WEBHOOK_URL) return;
+	await new Promise((r) => setTimeout(r, 2000));
+	const notifier = new WebhookNotifier({
+		webhook_url: REAL_WEBHOOK_URL
+	});
+	await notifier.notify(arrDriftDetected(makeDetectedParams()));
+});
+
+test('real: sends failed to webhook', async () => {
+	if (!REAL_WEBHOOK_URL) return;
+	await new Promise((r) => setTimeout(r, 2000));
+	const notifier = new WebhookNotifier({
+		webhook_url: REAL_WEBHOOK_URL
+	});
+	await notifier.notify(arrDriftFailed(makeFailedParams()));
+});
+
+await run();


### PR DESCRIPTION
- Adds `arr.drift.detected` and `arr.drift.failed` notifications, deduped per instance via stored drift/error hash so sustained drift only pings once
- Includes `notified` state in the drift outcome log

Part of #307