### PR TITLE
chore: speed up and stabilize CI and integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [develop, 'hotfix/*']
-    tags: ['v*']
+    branches: ['hotfix/*']
     paths-ignore:
       ['docs/**', '*.md', '!SECURITY.md', '.github/issue_template/**', '.github/assets/**']
   pull_request:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,9 +130,6 @@ jobs:
           key: deno-${{ runner.os }}-${{ hashFiles('deno.lock') }}
           restore-keys: deno-${{ runner.os }}-
 
-      - name: Clear corrupted native libraries
-        run: rm -rf ~/.cache/deno/plug
-
       - run: deno install --node-modules-dir
 
       - name: Run unit tests
@@ -185,9 +182,6 @@ jobs:
           key: deno-${{ runner.os }}-${{ hashFiles('deno.lock') }}
           restore-keys: deno-${{ runner.os }}-
 
-      - name: Clear corrupted native libraries
-        run: rm -rf ~/.cache/deno/plug
-
       - run: deno install --node-modules-dir
 
       - name: Download build artifact
@@ -198,12 +192,6 @@ jobs:
 
       - name: Make binary executable
         run: chmod +x dist/build/profilarr
-
-      - name: Warm native library cache
-        run: |
-          mkdir -p /tmp/ffi-warmup/data/databases /tmp/ffi-warmup/logs /tmp/ffi-warmup/backups
-          APP_BASE_PATH=/tmp/ffi-warmup PORT=9999 timeout 30 ./dist/build/profilarr || true
-          rm -rf /tmp/ffi-warmup
 
       - name: Cache Docker images
         id: docker-cache
@@ -251,13 +239,22 @@ jobs:
           key: deno-${{ runner.os }}-${{ hashFiles('deno.lock') }}
           restore-keys: deno-${{ runner.os }}-
 
-      - name: Clear corrupted native libraries
-        run: rm -rf ~/.cache/deno/plug
-
       - run: deno install --node-modules-dir
 
-      - name: Install Playwright browsers
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('deno.lock') }}
+
+      - name: Install Playwright browsers + system deps
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium
+
+      - name: Install Playwright system deps only (browsers cached)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
 
       - name: Download build artifact
         uses: actions/download-artifact@v8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,6 +184,29 @@ jobs:
 
       - run: deno install --node-modules-dir
 
+      # Dedicated cache for the FFI plug binaries (sqlite, bcrypt). The main
+      # `Cache deps` covers ~/.cache/deno but is shared across jobs and gets
+      # overwritten by Build (which never populates plug). This cache uses a
+      # separate key so it survives independently. Without this, the 30+
+      # parallel integration spec processes race to download plug binaries
+      # into the same path on a cold cache and corrupt each other.
+      - name: Cache FFI plug
+        id: plug-cache
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/deno/plug
+          key: deno-plug-${{ runner.os }}-${{ hashFiles('deno.lock') }}-v1
+
+      - name: Pre-warm FFI plug
+        if: steps.plug-cache.outputs.cache-hit != 'true'
+        run: |
+          deno eval --ext=ts '
+            import { hash } from "@felix/bcrypt";
+            import { Database } from "@db/sqlite";
+            await hash("warmup");
+            new Database(":memory:").close();
+          '
+
       - name: Download build artifact
         uses: actions/download-artifact@v8
         with:

--- a/docs/backend/database.md
+++ b/docs/backend/database.md
@@ -26,13 +26,14 @@ The database initializes early in the server startup sequence
 3. `runMigrations()` -- apply pending schema changes
 4. Load log settings, initialize PCD manager, start job queue
 
-Three pragmas are set on every connection:
+Four pragmas are set on every connection:
 
-| Pragma         | Value    | Purpose                             |
-| -------------- | -------- | ----------------------------------- |
-| `foreign_keys` | `ON`     | Enforce referential integrity       |
-| `journal_mode` | `WAL`    | Write-Ahead Logging for concurrency |
-| `synchronous`  | `NORMAL` | Balanced performance/safety         |
+| Pragma         | Value    | Purpose                                                 |
+| -------------- | -------- | ------------------------------------------------------- |
+| `foreign_keys` | `ON`     | Enforce referential integrity                           |
+| `journal_mode` | `WAL`    | Write-Ahead Logging for concurrency                     |
+| `synchronous`  | `NORMAL` | Balanced performance/safety                             |
+| `busy_timeout` | `5000`   | Wait up to 5s for a write lock instead of `SQLITE_BUSY` |
 
 The manager includes **HMR recovery** for development: `isHealthy()` runs
 `SELECT 1` to verify the connection is alive. If the check fails during

--- a/src/lib/server/db/db.ts
+++ b/src/lib/server/db/db.ts
@@ -74,6 +74,13 @@ class DatabaseManager {
 			// Set synchronous to NORMAL for better performance
 			this.db.exec('PRAGMA synchronous = NORMAL');
 
+			// Wait up to 5s for a write lock instead of failing immediately
+			// with "database is locked" when another writer is active. WAL
+			// allows concurrent reads but writers still serialize; this lets
+			// SQLite handle the wait internally instead of bubbling SQLITE_BUSY
+			// up to handlers (e.g. announcements.fetch racing API writes).
+			this.db.exec('PRAGMA busy_timeout = 5000');
+
 			this.initialized = true;
 
 			await logger.debug('Database initialized', {

--- a/tests/integration/harness/runner.ts
+++ b/tests/integration/harness/runner.ts
@@ -3,6 +3,8 @@
  * No Deno.test() — just runs functions and reports results.
  */
 
+import { dumpAllServerDiagnostics, dumpDeadServerDiagnostics } from './server.ts';
+
 const c = {
 	reset: '\x1b[0m',
 	grey: '\x1b[90m',
@@ -49,6 +51,7 @@ export async function run(): Promise<void> {
 			await setupFn();
 		} catch (error) {
 			console.error(`\n${c.red}${c.bold}Setup failed:${c.reset}`, error);
+			dumpAllServerDiagnostics('after setup failure');
 			if (teardownFn) {
 				try {
 					await teardownFn();
@@ -74,6 +77,7 @@ export async function run(): Promise<void> {
 			console.log(`${c.red}✗ fail${c.reset}`);
 			failed++;
 			failures.push({ name: t.name, error });
+			dumpDeadServerDiagnostics('server crashed during test');
 		}
 	}
 

--- a/tests/integration/harness/server.ts
+++ b/tests/integration/harness/server.ts
@@ -259,13 +259,17 @@ function captureStream(
 }
 
 /**
- * Print everything we captured for a server that failed to come up. Called
- * from the catch in startServer; never blocks subsequent test cleanup.
+ * Print everything we captured for a server. Called from the catch in
+ * startServer (reason="failed to become ready") and from harness setup/test
+ * failure paths (reason="post-failure dump"). Never blocks cleanup.
  */
-function dumpDiagnostics(instance: ServerInstance): void {
+function dumpDiagnostics(
+	instance: ServerInstance,
+	reason: string = 'failed to become ready'
+): void {
 	const elapsed = Date.now() - instance.startedAt;
 	console.error(
-		`\n──── DIAG [:${instance.port}] failed to become ready (${elapsed}ms) ─────────────────`
+		`\n──── DIAG [:${instance.port}] ${reason} (${elapsed}ms since start) ─────────────────`
 	);
 	console.error(
 		`  pid=${instance.process.pid} ` +
@@ -277,4 +281,36 @@ function dumpDiagnostics(instance: ServerInstance): void {
 	console.error(`  --- stderr (${instance.stderrBuf.length} lines) ---`);
 	for (const line of instance.stderrBuf.slice(-200)) console.error(`  | ${line}`);
 	console.error(`──── end DIAG [:${instance.port}] ─────────────────────────────────────────\n`);
+}
+
+/**
+ * Dump diagnostics for every running server instance in this process. Called
+ * from harness/runner.ts when a setup or test fails so the spec's stderr
+ * captures whatever the server logged before it died (or what it's still
+ * doing if it's still alive).
+ */
+export function dumpAllServerDiagnostics(reason: string = 'post-failure dump'): void {
+	if (instances.size === 0) return;
+	for (const instance of instances.values()) {
+		dumpDiagnostics(instance, reason);
+	}
+}
+
+/**
+ * Dump diagnostics only for server instances that have already exited
+ * (process.status resolved). Used after a test failure to surface a server
+ * crash without spamming output when the server is still healthy and the
+ * test failed for normal assertion reasons.
+ *
+ * Returns true if any server diagnostics were dumped.
+ */
+export function dumpDeadServerDiagnostics(reason: string = 'server crashed'): boolean {
+	let dumped = false;
+	for (const instance of instances.values()) {
+		if (instance.exitStatus !== null) {
+			dumpDiagnostics(instance, reason);
+			dumped = true;
+		}
+	}
+	return dumped;
 }

--- a/tests/runner.ts
+++ b/tests/runner.ts
@@ -341,9 +341,17 @@ async function runIntegration(target?: string): Promise<number> {
 			const result = await runIntegrationSpec(specFiles[0], 'inherit');
 			exitCode = result.code;
 		} else {
-			// Multiple specs - run in parallel, collect output
-			console.log(`Running ${specFiles.length} specs in parallel...\n`);
-			const results = await Promise.all(specFiles.map((f) => runIntegrationSpec(f, 'piped')));
+			// Multiple specs - run in chunked parallel, collect output.
+			// Cap concurrency so the CI runner (2 vCPU / 7 GB) can handle the
+			// per-spec server processes without OOM-killing them mid-test.
+			const CONCURRENCY = 8;
+			console.log(`Running ${specFiles.length} specs (up to ${CONCURRENCY} in parallel)...\n`);
+			const results: Array<{ code: number; stdout: string; stderr: string }> = [];
+			for (let i = 0; i < specFiles.length; i += CONCURRENCY) {
+				const batch = specFiles.slice(i, i + CONCURRENCY);
+				const batchResults = await Promise.all(batch.map((f) => runIntegrationSpec(f, 'piped')));
+				results.push(...batchResults);
+			}
 
 			exitCode = 0;
 			for (let i = 0; i < specFiles.length; i++) {

--- a/tests/runner.ts
+++ b/tests/runner.ts
@@ -341,9 +341,11 @@ async function runIntegration(target?: string): Promise<number> {
 			const result = await runIntegrationSpec(specFiles[0], 'inherit');
 			exitCode = result.code;
 		} else {
-			// Multiple specs - run in chunked parallel. Print a live one-liner
-			// per spec as it finishes, then a consolidated FAILURES section
-			// dumping full stdout+stderr only for failed specs.
+			// Multiple specs - run with rolling concurrency. Keep CONCURRENCY
+			// specs running at once; as soon as any finishes, the next queued
+			// spec takes its slot. Print a live one-liner per spec as it
+			// completes, then a consolidated FAILURES section dumping full
+			// stdout+stderr only for failed specs.
 			//
 			// Concurrency is capped because each spec spawns its own profilarr
 			// server; without a cap, parallel boots saturate memory on smaller
@@ -386,12 +388,17 @@ async function runIntegration(target?: string): Promise<number> {
 				};
 			};
 
+			const queue = [...specFiles];
 			const results: SpecResult[] = [];
-			for (let i = 0; i < specFiles.length; i += CONCURRENCY) {
-				const batch = specFiles.slice(i, i + CONCURRENCY);
-				const batchResults = await Promise.all(batch.map(runSpec));
-				results.push(...batchResults);
-			}
+			const workerCount = Math.min(CONCURRENCY, queue.length);
+			const workers = Array.from({ length: workerCount }, async () => {
+				while (queue.length > 0) {
+					const f = queue.shift();
+					if (f === undefined) break;
+					results.push(await runSpec(f));
+				}
+			});
+			await Promise.all(workers);
 
 			const failures = results.filter((r) => r.code !== 0);
 			exitCode = failures.length > 0 ? 1 : 0;

--- a/tests/runner.ts
+++ b/tests/runner.ts
@@ -275,11 +275,21 @@ async function runIntegration(target?: string): Promise<number> {
 		runningAuthSpecs && (!specName || !suite || INTEGRATION_NEEDS_DOCKER.has(specName));
 	let exitCode = 1;
 
+	// Docker is brought up in parallel with non-Docker specs. Specs that need
+	// Docker (see INTEGRATION_NEEDS_DOCKER) will await this promise before
+	// running; everything else proceeds immediately.
+	let dockerReady: Promise<void> | undefined;
+
 	try {
 		if (dockerRequired) {
-			console.log('Starting Docker infrastructure...');
-			await exec('docker', ['compose', '-f', INTEGRATION_COMPOSE, 'up', '-d', '--wait']);
-			console.log('Docker infrastructure ready.\n');
+			dockerReady = execQuiet('docker', [
+				'compose',
+				'-f',
+				INTEGRATION_COMPOSE,
+				'up',
+				'-d',
+				'--wait'
+			]);
 		}
 
 		// Collect spec files from all suites
@@ -365,6 +375,8 @@ async function runIntegration(target?: string): Promise<number> {
 
 			const formatSpecName = (f: string): string =>
 				f.replace('tests/integration/', '').replace('/specs/', '/').replace('.test.ts', '');
+			const specBasename = (f: string): string => f.split('/').pop()!.replace('.test.ts', '');
+			const needsDocker = (f: string): boolean => INTEGRATION_NEEDS_DOCKER.has(specBasename(f));
 
 			const RESET = '\x1b[0m';
 			const GREEN = '\x1b[32m';
@@ -373,6 +385,21 @@ async function runIntegration(target?: string): Promise<number> {
 
 			const runSpec = async (f: string): Promise<SpecResult> => {
 				const name = formatSpecName(f);
+				if (needsDocker(f) && dockerReady) {
+					try {
+						await dockerReady;
+					} catch (err) {
+						const msg = err instanceof Error ? err.message : String(err);
+						console.log(`  ${RED}✗${RESET} ${name.padEnd(NAME_WIDTH)}  (docker)`);
+						return {
+							name,
+							code: 1,
+							stdout: '',
+							stderr: `Docker infrastructure failed to start: ${msg}`,
+							durationMs: 0
+						};
+					}
+				}
 				const specStart = Date.now();
 				const result = await runIntegrationSpec(f, 'piped');
 				const durationMs = Date.now() - specStart;
@@ -388,7 +415,14 @@ async function runIntegration(target?: string): Promise<number> {
 				};
 			};
 
-			const queue = [...specFiles];
+			// Run non-Docker specs first so they fill the pool while Docker is
+			// still starting; Docker-needing specs await dockerReady inside runSpec.
+			const queue = [...specFiles].sort((a, b) => {
+				const ad = needsDocker(a);
+				const bd = needsDocker(b);
+				if (ad === bd) return 0;
+				return ad ? 1 : -1;
+			});
 			const results: SpecResult[] = [];
 			const workerCount = Math.min(CONCURRENCY, queue.length);
 			const workers = Array.from({ length: workerCount }, async () => {
@@ -771,6 +805,29 @@ async function exec(cmd: string, args: string[]): Promise<void> {
 	});
 	const { code } = await command.output();
 	if (code !== 0) {
+		throw new Error(`Command failed: ${cmd} ${args.join(' ')}`);
+	}
+}
+
+/**
+ * Run a command with stdout/stderr captured. On non-zero exit, the captured
+ * output is printed and an error is thrown. On success, output is silently
+ * discarded. Use for noisy commands whose output is only interesting on failure
+ * (e.g. docker compose up/down).
+ */
+async function execQuiet(cmd: string, args: string[]): Promise<void> {
+	const command = new Deno.Command(cmd, {
+		args,
+		stdout: 'piped',
+		stderr: 'piped'
+	});
+	const result = await command.output();
+	if (result.code !== 0) {
+		const decoder = new TextDecoder();
+		const stdout = decoder.decode(result.stdout);
+		const stderr = decoder.decode(result.stderr);
+		if (stdout) console.error(stdout);
+		if (stderr) console.error(stderr);
 		throw new Error(`Command failed: ${cmd} ${args.join(' ')}`);
 	}
 }

--- a/tests/runner.ts
+++ b/tests/runner.ts
@@ -341,33 +341,105 @@ async function runIntegration(target?: string): Promise<number> {
 			const result = await runIntegrationSpec(specFiles[0], 'inherit');
 			exitCode = result.code;
 		} else {
-			// Multiple specs - run in chunked parallel, collect output.
-			// Cap concurrency so the CI runner (2 vCPU / 7 GB) can handle the
-			// per-spec server processes without OOM-killing them mid-test.
-			const CONCURRENCY = 8;
+			// Multiple specs - run in chunked parallel. Print a live one-liner
+			// per spec as it finishes, then a consolidated FAILURES section
+			// dumping full stdout+stderr only for failed specs.
+			//
+			// Concurrency is capped because each spec spawns its own profilarr
+			// server; without a cap, parallel boots saturate memory on smaller
+			// runners (CI 2 vCPU / 7 GB, WSL allocations) and the OS OOM-kills
+			// the slowest-starting servers.
+			const CONCURRENCY = 10;
+			const startMs = Date.now();
 			console.log(`Running ${specFiles.length} specs (up to ${CONCURRENCY} in parallel)...\n`);
-			const results: Array<{ code: number; stdout: string; stderr: string }> = [];
+
+			type SpecResult = {
+				name: string;
+				code: number;
+				stdout: string;
+				stderr: string;
+				durationMs: number;
+			};
+
+			const formatSpecName = (f: string): string =>
+				f.replace('tests/integration/', '').replace('/specs/', '/').replace('.test.ts', '');
+
+			const RESET = '\x1b[0m';
+			const GREEN = '\x1b[32m';
+			const RED = '\x1b[31m';
+			const NAME_WIDTH = Math.max(...specFiles.map((f) => formatSpecName(f).length), 20);
+
+			const runSpec = async (f: string): Promise<SpecResult> => {
+				const name = formatSpecName(f);
+				const specStart = Date.now();
+				const result = await runIntegrationSpec(f, 'piped');
+				const durationMs = Date.now() - specStart;
+				const sym = result.code === 0 ? `${GREEN}✓${RESET}` : `${RED}✗${RESET}`;
+				const dur = `${(durationMs / 1000).toFixed(1)}s`;
+				console.log(`  ${sym} ${name.padEnd(NAME_WIDTH)}  ${dur.padStart(7)}`);
+				return {
+					name,
+					code: result.code,
+					stdout: result.stdout,
+					stderr: result.stderr,
+					durationMs
+				};
+			};
+
+			const results: SpecResult[] = [];
 			for (let i = 0; i < specFiles.length; i += CONCURRENCY) {
 				const batch = specFiles.slice(i, i + CONCURRENCY);
-				const batchResults = await Promise.all(batch.map((f) => runIntegrationSpec(f, 'piped')));
+				const batchResults = await Promise.all(batch.map(runSpec));
 				results.push(...batchResults);
 			}
 
-			exitCode = 0;
-			for (let i = 0; i < specFiles.length; i++) {
-				// Extract suite/spec name for display
-				const name = specFiles[i]
-					.replace('tests/integration/', '')
-					.replace('/specs/', '/')
-					.replace('.test.ts', '');
-				const result = results[i];
-				console.log(`\n${'='.repeat(60)}`);
-				console.log(` ${name}`);
-				console.log(`${'='.repeat(60)}`);
-				console.log(result.stdout);
-				if (result.stderr) console.error(result.stderr);
-				if (result.code !== 0) exitCode = 1;
+			const failures = results.filter((r) => r.code !== 0);
+			exitCode = failures.length > 0 ? 1 : 0;
+
+			if (failures.length > 0) {
+				console.log('');
+				console.log('='.repeat(60));
+				console.log(` FAILURES (${failures.length})`);
+				console.log('='.repeat(60));
+				for (const f of failures) {
+					console.log('');
+					console.log(`${RED}✗ ${f.name}${RESET}`);
+					console.log('');
+					// If the spec ran tests and produced a "Failures:" summary block,
+					// print only that block (the actual failures + final counts).
+					// Otherwise the spec died in setup; print stdout as-is — those
+					// dumps are already short (server start logs + diagnostic).
+					// Note: the spec's harness wraps "Failures:" in ANSI codes, so
+					// we search for the bare token then walk back to the line start.
+					const idx = f.stdout.lastIndexOf('Failures:');
+					if (idx >= 0) {
+						const lineStart = f.stdout.lastIndexOf('\n', idx) + 1;
+						console.log('  --- spec failures ---');
+						console.log(f.stdout.slice(lineStart));
+					} else {
+						console.log('  --- spec stdout ---');
+						console.log(f.stdout || '  (empty)');
+					}
+					if (f.stderr) {
+						console.log('  --- spec stderr ---');
+						console.log(f.stderr);
+					}
+				}
 			}
+
+			const totalSec = ((Date.now() - startMs) / 1000).toFixed(1);
+			console.log('');
+			console.log('='.repeat(60));
+			if (failures.length > 0) {
+				console.log(
+					` ${RED}${results.length} specs, ${failures.length} failed in ${totalSec}s${RESET}`
+				);
+				console.log(' Failed:');
+				for (const f of failures) console.log(`   ${f.name}`);
+			} else {
+				console.log(` ${GREEN}${results.length} specs passed in ${totalSec}s${RESET}`);
+			}
+			console.log('='.repeat(60));
 		}
 	} catch (error) {
 		console.error('Integration test error:', error);


### PR DESCRIPTION
- Drops redundant `develop` and tag-push CI triggers; PRs and `hotfix/*` still run full suite
- Reshapes integration test runner output: rolling pool of 10 specs, live one-liner per spec, FAILURES section with per-spec stdout/stderr and server diagnostics
- Parallelizes Docker startup with non-Docker specs; quiets Docker output unless it errors
- Drops Deno FFI cache clearing + warmup steps; caches Playwright browsers
- Sets SQLite `busy_timeout = 5000` so startup write contention waits instead of failing with `database is locked`