### PR TITLE
feat: surface per-section drift progress on sync page

### DIFF
--- a/docs/backend/drift.md
+++ b/docs/backend/drift.md
@@ -1,6 +1,7 @@
 # Drift Detection
 
 **Source:** `src/lib/server/jobs/handlers/arrDrift.ts`,
+`src/lib/server/jobs/handlers/arrSync.ts`,
 `src/lib/server/db/queries/arrDriftSettings.ts`,
 `src/lib/server/db/queries/arrDriftStatus.ts`,
 `src/lib/server/drift/customFormats.ts`,
@@ -9,18 +10,19 @@
 `src/lib/server/drift/display.ts`,
 `src/routes/arr/[id]/drift/+page.svelte`,
 `src/routes/arr/[id]/drift/+page.server.ts`,
-`src/routes/arr/[id]/drift/components/DriftFieldDiffTable.svelte`
+`src/routes/arr/[id]/drift/components/DriftFieldDiffTable.svelte`,
+`src/routes/arr/[id]/sync/+page.server.ts`,
+`src/routes/arr/[id]/sync/components/QualityProfiles.svelte`,
+`src/routes/arr/[id]/sync/components/DelayProfiles.svelte`
 
 Drift detection checks whether an Arr instance still matches the configuration
 Profilarr would sync now. It is observational: it does not write to Arr, repair
 config, delete stale items, or replace cleanup.
 
-Drift detection intentionally focuses on actively managed sync behavior:
-custom formats, quality profiles, and the default delay profile. Media
-management is treated as bootstrap configuration and is not checked for drift.
-Users often make local Arr-side edits to naming, media settings, and quality
-definitions after initial sync, so surfacing those edits as drift would be noisy
-and low value.
+Drift detection currently covers custom formats, quality profiles, and the
+default delay profile. Media management coverage (naming, media settings,
+quality definitions) is planned as a follow-up; until it lands, the sync page's
+Media Management section does not surface a drift chip.
 
 ## Job
 
@@ -200,6 +202,67 @@ State rendering inside the entities section:
 The page is read-only for drift results. It never writes to Arr, repairs
 configuration, or triggers sync.
 
+## Sync Page Progress
+
+Route: `/arr/[id]/sync`. Source: `src/routes/arr/[id]/sync/+page.server.ts`,
+`src/routes/arr/[id]/sync/components/QualityProfiles.svelte`,
+`src/routes/arr/[id]/sync/components/DelayProfiles.svelte`.
+
+Per-section drift progress is rendered as `ProgressIndicator` chips in each
+sync section header (right-aligned on tablet+, stacked below the title on
+mobile). The Quality Profiles header carries two chips: one for QPs themselves
+and one for the custom formats referenced by those QPs. The Delay Profiles
+header carries one chip. The Media Management header has no chip yet.
+
+Each chip shows `current / total` where:
+
+- `total`: managed items Profilarr would sync. Selected QP count for the QP
+  chip, expected CF count from `buildExpectedCustomFormats` for the CF chip,
+  `0` or `1` for the delay profile chip.
+- `current`: `total - drifted`. For the QP chip, `drifted` counts only QPs
+  the drift comparison flagged directly. QPs that are only "transitively"
+  affected (their scoring rows reference a CF that has been deleted from
+  Arr) are not subtracted from the QP chip; the user-visible impact is
+  surfaced via the CF chip's tooltip instead.
+
+Chips render with `colorMode="completion"`: green check when `met`, yellow
+bar otherwise. Anything below 100% is yellow regardless of how close to
+completion, because for drift "almost in sync" is still actionable.
+
+Each chip has a tooltip listing up to three affected entity names with a
+`+N more` suffix when the list overflows. Examples:
+
+- `"HD Movies, 4K Movies drifted."`
+- `"HD Movies affected by drifted custom formats."`
+- `"Streaming Tier drifted, used in HD Movies, TV."`
+- `"Standard Delay drifted."`
+
+Chips are hidden entirely when any of these conditions hold:
+
+- `FEATURES.drift` is off
+- per-instance `arr_drift_settings.enabled` is false
+- drift status is `never_checked` or `failed` (or no row exists)
+- the section's denominator is zero (e.g. no selected QPs)
+
+Failures (`status === 'failed'`) surface only on the dedicated drift page.
+
+### Post-sync drift refresh
+
+The arr sync handler (`src/lib/server/jobs/handlers/arrSync.ts`) enqueues an
+`arr.drift` job after a successful sync that touched Arr (any section ran).
+This keeps the sync page chips fresh after the user fixes drift by syncing,
+instead of waiting for the next scheduled drift run. The chain is gated on
+`FEATURES.drift` and per-instance `arr_drift_settings.enabled`.
+
+The sync page subscribes to job-finished events via
+`jobStatus.onJobFinished` and calls `invalidateAll()` whenever an `arr.drift`
+job completes. The raw hook is used (not the store's state machine) because
+the state machine drops finished events for jobs it is not actively tracking,
+including a drift job chained right after a sync's completion holdoff window.
+SSE is opened on demand when the user triggers a sync and auto-closes after
+the post-completion idle window, so this does not hold a persistent connection.
+
 ## TODO
 
-- Brief drift status on the sync page linking to the dedicated drift page.
+- Media management drift comparison (naming, media settings, quality
+  definitions) plus display formatter and sync page chip.

--- a/docs/backend/sync.md
+++ b/docs/backend/sync.md
@@ -262,9 +262,15 @@ Drift detection checks whether Arr still matches what Profilarr would sync now.
 It may reuse sync transformers to build expected state, but it does not sync,
 repair, or cleanup.
 
-Drift does not check media management. Naming, media settings, and quality
-definitions are treated as bootstrap configuration because users commonly tune
-them directly in Arr after initial sync.
+Drift currently covers custom formats, quality profiles, and the default delay
+profile. Media management coverage (naming, media settings, quality
+definitions) is planned as a follow-up.
+
+After a successful sync that touched Arr, the sync handler enqueues an
+`arr.drift` job for the same instance so the drift status (and the per-section
+progress chips on the sync page) reflect the new state without waiting for the
+next scheduled drift run. Gated on `FEATURES.drift` and per-instance drift
+settings.
 
 ## Impact Analysis
 

--- a/src/lib/client/stores/jobStatus.ts
+++ b/src/lib/client/stores/jobStatus.ts
@@ -68,6 +68,26 @@ function createJobStatusStore() {
 
 	let eventSource: EventSource | null = null;
 
+	const finishedListeners = new Set<(data: FinishedPayload) => void>();
+
+	/**
+	 * Subscribe to every job.finished SSE event, independent of the store's
+	 * state machine. The state machine drops finished events for jobs it
+	 * isn't actively tracking (notably chained jobs that fire during the
+	 * post-completion holdoff window). Page-level consumers that need to
+	 * react to every finished event (e.g. invalidate page data after a
+	 * drift refresh) should use this hook instead of subscribing to the
+	 * store's state.
+	 *
+	 * Returns an unsubscribe function.
+	 */
+	function onJobFinished(listener: (data: FinishedPayload) => void): () => void {
+		finishedListeners.add(listener);
+		return () => {
+			finishedListeners.delete(listener);
+		};
+	}
+
 	function clearTimers() {
 		if (resetTimer) {
 			clearTimeout(resetTimer);
@@ -129,6 +149,19 @@ function createJobStatusStore() {
 	}
 
 	function handleFinished(data: FinishedPayload) {
+		// Fire raw listeners independent of the state-machine. The state
+		// machine drops finished events for jobs it isn't actively tracking
+		// (e.g. a chained job that arrived during the completion holdoff),
+		// but consumers like page-level invalidators want to react to every
+		// finished event regardless.
+		for (const listener of finishedListeners) {
+			try {
+				listener(data);
+			} catch {
+				// Swallow listener errors so one bad listener can't break others.
+			}
+		}
+
 		// Ignore finished events for jobs we're not tracking (stale events
 		// from prior optimistic state mismatches).
 		if (currentJobId !== null && currentJobId !== data.jobId) return;
@@ -211,7 +244,7 @@ function createJobStatusStore() {
 		});
 	}
 
-	return { subscribe, connect, disconnect, setRunning, cancelOptimistic };
+	return { subscribe, connect, disconnect, setRunning, cancelOptimistic, onJobFinished };
 }
 
 export const jobStatus = createJobStatusStore();

--- a/src/lib/client/ui/arr/ProgressIndicator.svelte
+++ b/src/lib/client/ui/arr/ProgressIndicator.svelte
@@ -5,18 +5,28 @@
 	export let target: number = 0;
 	export let met: boolean = false;
 	export let mode: 'compact' | 'inline' = 'compact';
+	/**
+	 * How the bar's color is derived.
+	 * - `threshold` (default): red <50%, yellow 50-74%, green 75%+. Suited
+	 *   for "good enough" semantics like CF score.
+	 * - `completion`: green when met, yellow otherwise (regardless of how
+	 *   close to met). Suited for "anything less than 100% is a problem"
+	 *   semantics like drift.
+	 */
+	export let colorMode: 'threshold' | 'completion' = 'threshold';
 
 	$: progress = target > 0 ? Math.max(0, Math.min(current / target, 1)) : 0;
 	$: progressPercent = Math.round(progress * 100);
 
-	function getBarColor(p: number, done: boolean): string {
+	function getBarColor(p: number, done: boolean, mode: 'threshold' | 'completion'): string {
 		if (done) return 'bg-green-500 dark:bg-green-400';
+		if (mode === 'completion') return 'bg-yellow-500 dark:bg-yellow-400';
 		if (p >= 0.75) return 'bg-green-500 dark:bg-green-400';
 		if (p >= 0.5) return 'bg-yellow-500 dark:bg-yellow-400';
 		return 'bg-red-500 dark:bg-red-400';
 	}
 
-	$: barColor = getBarColor(progress, met);
+	$: barColor = getBarColor(progress, met, colorMode);
 </script>
 
 {#if mode === 'compact'}

--- a/src/lib/client/ui/arr/ProgressIndicator.svelte
+++ b/src/lib/client/ui/arr/ProgressIndicator.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { Check } from 'lucide-svelte';
+	import Tooltip from '$ui/tooltip/Tooltip.svelte';
 
 	export let current: number = 0;
 	export let target: number = 0;
@@ -14,6 +15,13 @@
 	 *   semantics like drift.
 	 */
 	export let colorMode: 'threshold' | 'completion' = 'threshold';
+	/**
+	 * Optional tooltip text shown on hover. When set, the indicator is
+	 * wrapped in a Tooltip; when empty/undefined, no tooltip is rendered.
+	 */
+	export let tooltip: string = '';
+	export let tooltipPosition: 'top' | 'bottom' | 'left' | 'right' = 'bottom';
+	export let tooltipAlign: 'left' | 'middle' | 'right' = 'middle';
 
 	$: progress = target > 0 ? Math.max(0, Math.min(current / target, 1)) : 0;
 	$: progressPercent = Math.round(progress * 100);
@@ -29,7 +37,59 @@
 	$: barColor = getBarColor(progress, met, colorMode);
 </script>
 
-{#if mode === 'compact'}
+{#if tooltip}
+	<Tooltip
+		text={tooltip}
+		position={tooltipPosition}
+		align={tooltipAlign}
+		fullWidth={mode === 'compact'}
+	>
+		{#if mode === 'compact'}
+			<!-- Card view: vertical stack -->
+			<div class="flex w-full flex-col gap-1">
+				<div class="flex items-center justify-between gap-2">
+					<span class="font-mono text-xs text-neutral-700 dark:text-neutral-300">
+						{current.toLocaleString()}
+						<span class="text-neutral-400 dark:text-neutral-500">
+							/ {target.toLocaleString()}
+						</span>
+					</span>
+					{#if met}
+						<Check size={14} class="flex-shrink-0 text-green-600 dark:text-green-400" />
+					{:else}
+						<span class="font-mono text-xs text-neutral-400 dark:text-neutral-500">
+							{progressPercent}%
+						</span>
+					{/if}
+				</div>
+				<div class="h-1.5 w-full overflow-hidden rounded-full bg-neutral-200 dark:bg-neutral-700">
+					<div
+						class="h-full rounded-full transition-all {barColor}"
+						style="width: {progressPercent}%"
+					></div>
+				</div>
+			</div>
+		{:else}
+			<!-- Table view: horizontal inline -->
+			<div class="flex items-center gap-2 whitespace-nowrap">
+				<div
+					class="h-1.5 w-12 flex-shrink-0 overflow-hidden rounded-full bg-neutral-200 dark:bg-neutral-700"
+				>
+					<div
+						class="h-full rounded-full transition-all {barColor}"
+						style="width: {progressPercent}%"
+					></div>
+				</div>
+				<span class="font-mono text-xs text-neutral-500 dark:text-neutral-400">
+					{current.toLocaleString()} / {target.toLocaleString()}
+				</span>
+				{#if met}
+					<Check size={12} class="flex-shrink-0 text-green-600 dark:text-green-400" />
+				{/if}
+			</div>
+		{/if}
+	</Tooltip>
+{:else if mode === 'compact'}
 	<!-- Card view: vertical stack -->
 	<div class="flex flex-col gap-1">
 		<div class="flex items-center justify-between gap-2">

--- a/src/lib/server/jobs/handlers/arrSync.ts
+++ b/src/lib/server/jobs/handlers/arrSync.ts
@@ -2,15 +2,18 @@ import { jobQueueRegistry } from '../queueRegistry.ts';
 import type { JobHandler, JobType } from '../queueTypes.ts';
 import { arrInstancesQueries } from '$db/queries/arrInstances.ts';
 import { arrSyncQueries } from '$db/queries/arrSync.ts';
+import { arrDriftSettingsQueries } from '$db/queries/arrDriftSettings.ts';
 import { createArrClient } from '$arr/factory.ts';
 import type { ArrType } from '$arr/types.ts';
 import { calculateNextRun } from '$lib/server/sync/utils.ts';
 import type { SectionType } from '$lib/server/sync/types.ts';
 import { getSection } from '$lib/server/sync/registry.ts';
+import { enqueueJob } from '$lib/server/jobs/queueService.ts';
 import { logger } from '$logger/logger.ts';
 import { notifications } from '$notifications/definitions/index.ts';
 import { notificationManager } from '$notifications/NotificationManager.ts';
 import type { ArrSyncSectionResult } from '$notifications/definitions/arrSync.ts';
+import { FEATURES } from '$shared/features.ts';
 
 // Register sync handlers
 import '$lib/server/sync/qualityProfiles/handler.ts';
@@ -146,6 +149,26 @@ const arrSyncHandler: JobHandler = async (job) => {
 				source: 'ArrSyncJob',
 				meta: { instanceId, error: err instanceof Error ? err.message : 'Unknown error' }
 			});
+		}
+
+		// Chain a drift refresh after any sync that touched Arr, so the
+		// drift status reflects the new state without waiting for the next
+		// scheduled drift run. Only fires when drift is enabled (feature
+		// flag + per-instance settings).
+		if (FEATURES.drift && arrDriftSettingsQueries.getByInstanceId(instanceId)?.enabled) {
+			try {
+				enqueueJob({
+					jobType: 'arr.drift',
+					runAt: new Date().toISOString(),
+					payload: { instanceId },
+					source: 'manual'
+				});
+			} catch (err) {
+				await logger.error('Failed to enqueue post-sync drift refresh', {
+					source: 'ArrSyncJob',
+					meta: { instanceId, error: err instanceof Error ? err.message : 'Unknown error' }
+				});
+			}
 		}
 	}
 

--- a/src/routes/arr/[id]/sync/+page.server.ts
+++ b/src/routes/arr/[id]/sync/+page.server.ts
@@ -3,6 +3,7 @@ import type { ServerLoad, Actions } from '@sveltejs/kit';
 import { arrInstancesQueries } from '$db/queries/arrInstances.ts';
 import { arrSyncQueries, type SyncTrigger, type ProfileSelection } from '$db/queries/arrSync.ts';
 import { arrDriftStatusQueries } from '$db/queries/arrDriftStatus.ts';
+import { arrDriftSettingsQueries } from '$db/queries/arrDriftSettings.ts';
 import { pcdManager } from '$pcd/core/manager.ts';
 import { logger } from '$logger/logger.ts';
 import * as qualityProfileQueries from '$pcd/entities/qualityProfiles/index.ts';
@@ -121,6 +122,7 @@ async function loadDriftProgress(
 	arrType: SyncArrType
 ): Promise<DriftProgress | null> {
 	if (!FEATURES.drift) return null;
+	if (!arrDriftSettingsQueries.getByInstanceId(instanceId)?.enabled) return null;
 
 	const status = arrDriftStatusQueries.getByInstanceId(instanceId);
 	if (!status) return null;

--- a/src/routes/arr/[id]/sync/+page.server.ts
+++ b/src/routes/arr/[id]/sync/+page.server.ts
@@ -2,6 +2,7 @@ import { error, fail } from '@sveltejs/kit';
 import type { ServerLoad, Actions } from '@sveltejs/kit';
 import { arrInstancesQueries } from '$db/queries/arrInstances.ts';
 import { arrSyncQueries, type SyncTrigger, type ProfileSelection } from '$db/queries/arrSync.ts';
+import { arrDriftStatusQueries } from '$db/queries/arrDriftStatus.ts';
 import { pcdManager } from '$pcd/core/manager.ts';
 import { logger } from '$logger/logger.ts';
 import * as qualityProfileQueries from '$pcd/entities/qualityProfiles/index.ts';
@@ -13,6 +14,56 @@ import { calculateNextRun } from '$lib/server/sync/utils.ts';
 import { scheduleArrSyncForInstance } from '$lib/server/jobs/init.ts';
 import { enqueueJob } from '$lib/server/jobs/queueService.ts';
 import { buildJobDisplayName } from '$lib/server/jobs/display.ts';
+import { buildExpectedCustomFormats } from '$drift/customFormats.ts';
+import { FEATURES } from '$shared/features.ts';
+import type { SyncArrType } from '$sync/mappings.ts';
+
+interface SectionProgress {
+	total: number;
+	drifted: number;
+}
+
+interface DriftProgress {
+	customFormats?: SectionProgress;
+	qualityProfiles?: SectionProgress;
+	delayProfiles?: SectionProgress;
+}
+
+async function loadDriftProgress(
+	instanceId: number,
+	arrType: SyncArrType
+): Promise<DriftProgress | null> {
+	if (!FEATURES.drift) return null;
+
+	const status = arrDriftStatusQueries.getByInstanceId(instanceId);
+	if (!status) return null;
+	if (status.status !== 'clean' && status.status !== 'drift_detected') return null;
+
+	const qpSync = arrSyncQueries.getQualityProfilesSync(instanceId);
+	const dpSync = arrSyncQueries.getDelayProfilesSync(instanceId);
+
+	const qpTotal = qpSync.selections.length;
+	const dpTotal = dpSync.databaseId && dpSync.profileName ? 1 : 0;
+	const cfTotal = qpTotal > 0 ? (await buildExpectedCustomFormats(instanceId, arrType)).length : 0;
+
+	const counts = status.counts ?? {};
+	const progress: DriftProgress = {};
+	if (qpTotal > 0) {
+		progress.qualityProfiles = { total: qpTotal, drifted: counts.quality_profiles ?? 0 };
+	}
+	if (dpTotal > 0) {
+		progress.delayProfiles = { total: dpTotal, drifted: counts.delay_profiles ?? 0 };
+	}
+	if (cfTotal > 0) {
+		progress.customFormats = { total: cfTotal, drifted: counts.custom_formats ?? 0 };
+	}
+
+	if (!progress.qualityProfiles && !progress.delayProfiles && !progress.customFormats) {
+		return null;
+	}
+
+	return progress;
+}
 
 export const load: ServerLoad = async ({ params }) => {
 	const id = parseInt(params.id || '', 10);
@@ -86,13 +137,15 @@ export const load: ServerLoad = async ({ params }) => {
 
 	// Load existing sync data
 	const syncData = arrSyncQueries.getFullSyncData(id);
+	const driftProgress = await loadDriftProgress(id, arrType);
 
 	const { api_key: _, ...safeInstance } = instance;
 
 	return {
 		instance: safeInstance,
 		databases: databasesWithProfiles,
-		syncData
+		syncData,
+		driftProgress
 	};
 };
 

--- a/src/routes/arr/[id]/sync/+page.server.ts
+++ b/src/routes/arr/[id]/sync/+page.server.ts
@@ -15,18 +15,105 @@ import { scheduleArrSyncForInstance } from '$lib/server/jobs/init.ts';
 import { enqueueJob } from '$lib/server/jobs/queueService.ts';
 import { buildJobDisplayName } from '$lib/server/jobs/display.ts';
 import { buildExpectedCustomFormats } from '$drift/customFormats.ts';
+import type { CustomFormatDriftDiff } from '$drift/customFormats.ts';
+import type {
+	QualityProfileDriftDiff,
+	QualityProfileModifiedDiff
+} from '$drift/qualityProfiles.ts';
 import { FEATURES } from '$shared/features.ts';
 import type { SyncArrType } from '$sync/mappings.ts';
 
 interface SectionProgress {
 	total: number;
 	drifted: number;
+	message?: string;
 }
 
 interface DriftProgress {
 	customFormats?: SectionProgress;
 	qualityProfiles?: SectionProgress;
 	delayProfiles?: SectionProgress;
+}
+
+/**
+ * A field on a modified QP is "transitive" iff it represents a CF score row
+ * that is now missing from Arr (i.e. the CF was deleted). The QP itself is
+ * structurally fine; it's just pointing at something that no longer exists.
+ */
+function fieldIsMissingCustomFormat(field: { path: string; actual: unknown }): boolean {
+	if (!field.path.startsWith('formatItems[')) return false;
+	const actual = field.actual;
+	return (
+		actual !== null &&
+		typeof actual === 'object' &&
+		'state' in actual &&
+		(actual as { state: unknown }).state === 'missing_custom_format'
+	);
+}
+
+function isTransitiveOnlyQp(modified: QualityProfileModifiedDiff): boolean {
+	if (modified.fields.length === 0) return false;
+	return modified.fields.every(fieldIsMissingCustomFormat);
+}
+
+function classifyQpDrift(qpDiff: QualityProfileDriftDiff | undefined) {
+	const result = {
+		directNames: [] as string[],
+		transitiveNames: [] as string[],
+		affectedQpNames: new Set<string>()
+	};
+	if (!qpDiff) return result;
+
+	// Missing QPs (selected but not in Arr) are always direct.
+	for (const m of qpDiff.missing) {
+		result.directNames.push(m.name);
+	}
+
+	for (const m of qpDiff.modified) {
+		if (isTransitiveOnlyQp(m)) {
+			result.transitiveNames.push(m.name);
+			result.affectedQpNames.add(m.name);
+		} else {
+			result.directNames.push(m.name);
+			// A direct drift can also reference missing CFs; track that too.
+			if (m.fields.some(fieldIsMissingCustomFormat)) {
+				result.affectedQpNames.add(m.name);
+			}
+		}
+	}
+	return result;
+}
+
+function collectCfNames(cfDiff: CustomFormatDriftDiff | undefined): string[] {
+	if (!cfDiff) return [];
+	const names: string[] = [];
+	for (const m of cfDiff.missing) names.push(m.name);
+	for (const m of cfDiff.modified) names.push(m.name);
+	return names;
+}
+
+const NAME_LIST_CAP = 3;
+
+function joinNames(names: string[]): string {
+	if (names.length <= NAME_LIST_CAP) return names.join(', ');
+	return `${names.slice(0, NAME_LIST_CAP).join(', ')} +${names.length - NAME_LIST_CAP} more`;
+}
+
+function buildQpMessage(directNames: string[], transitiveNames: string[]): string | undefined {
+	if (directNames.length === 0 && transitiveNames.length === 0) return undefined;
+	if (transitiveNames.length === 0) {
+		return `${joinNames(directNames)} drifted.`;
+	}
+	if (directNames.length === 0) {
+		return `${joinNames(transitiveNames)} affected by drifted custom formats.`;
+	}
+	return `${joinNames(directNames)} drifted; ${joinNames(transitiveNames)} also affected by drifted custom formats.`;
+}
+
+function buildCfMessage(cfNames: string[], affectedQpNames: string[]): string | undefined {
+	if (cfNames.length === 0) return undefined;
+	if (affectedQpNames.length === 0) return `${joinNames(cfNames)} drifted.`;
+	return `${joinNames(cfNames)} drifted, used in ${joinNames(affectedQpNames)}.`;
 }
 
 async function loadDriftProgress(
@@ -47,15 +134,36 @@ async function loadDriftProgress(
 	const cfTotal = qpTotal > 0 ? (await buildExpectedCustomFormats(instanceId, arrType)).length : 0;
 
 	const counts = status.counts ?? {};
+	const diff = status.diff as
+		| { quality_profiles?: QualityProfileDriftDiff; custom_formats?: CustomFormatDriftDiff }
+		| undefined;
+	const qpClass = classifyQpDrift(diff?.quality_profiles);
+	const cfNames = collectCfNames(diff?.custom_formats);
+
 	const progress: DriftProgress = {};
 	if (qpTotal > 0) {
-		progress.qualityProfiles = { total: qpTotal, drifted: counts.quality_profiles ?? 0 };
-	}
-	if (dpTotal > 0) {
-		progress.delayProfiles = { total: dpTotal, drifted: counts.delay_profiles ?? 0 };
+		progress.qualityProfiles = {
+			total: qpTotal,
+			drifted: qpClass.directNames.length,
+			message: buildQpMessage(qpClass.directNames, qpClass.transitiveNames)
+		};
 	}
 	if (cfTotal > 0) {
-		progress.customFormats = { total: cfTotal, drifted: counts.custom_formats ?? 0 };
+		const cfDrifted = counts.custom_formats ?? 0;
+		progress.customFormats = {
+			total: cfTotal,
+			drifted: cfDrifted,
+			message: buildCfMessage(cfNames, [...qpClass.affectedQpNames])
+		};
+	}
+	if (dpTotal > 0) {
+		const dpDrifted = counts.delay_profiles ?? 0;
+		const dpName = dpSync.profileName ?? 'Default delay profile';
+		progress.delayProfiles = {
+			total: dpTotal,
+			drifted: dpDrifted,
+			message: dpDrifted > 0 ? `${dpName} drifted.` : undefined
+		};
 	}
 
 	if (!progress.qualityProfiles && !progress.delayProfiles && !progress.customFormats) {

--- a/src/routes/arr/[id]/sync/+page.svelte
+++ b/src/routes/arr/[id]/sync/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import type { PageData } from './$types';
-	import { onMount } from 'svelte';
+	import { onDestroy, onMount } from 'svelte';
+	import { invalidateAll } from '$app/navigation';
 	import { Info } from 'lucide-svelte';
 	import InfoModal from '$ui/modal/InfoModal.svelte';
 	import DirtyModal from '$ui/modal/DirtyModal.svelte';
@@ -11,6 +12,7 @@
 	import MediaManagement from './components/MediaManagement.svelte';
 	import type { SyncTrigger } from '$db/queries/arrSync.ts';
 	import { initEdit, update, clear } from '$lib/client/stores/dirty';
+	import { jobStatus } from '$stores/jobStatus';
 
 	export let data: PageData;
 
@@ -66,6 +68,18 @@
 		initEdit({ anyDirty: false });
 		return () => clear();
 	});
+
+	// When a chained drift refresh finishes, reload page data so the
+	// progress chips reflect the new drift state immediately. Use the raw
+	// onJobFinished hook (not the store's state machine) because the state
+	// machine drops finished events for jobs it isn't actively tracking,
+	// including the drift job chained right after a sync.
+	const unsubscribeDriftFinished = jobStatus.onJobFinished((data) => {
+		if (data.jobType === 'arr.drift') {
+			invalidateAll();
+		}
+	});
+	onDestroy(unsubscribeDriftFinished);
 
 	// Sync combined dirty state to global dirty store for DirtyModal
 	$: anyDirty = qualityProfilesDirty || delayProfilesDirty || mediaManagementDirty;

--- a/src/routes/arr/[id]/sync/+page.svelte
+++ b/src/routes/arr/[id]/sync/+page.svelte
@@ -148,6 +148,7 @@
 			bind:syncTrigger={delayProfileTrigger}
 			bind:cronExpression={delayProfileCron}
 			bind:isDirty={delayProfilesDirty}
+			progress={data.driftProgress?.delayProfiles}
 		/>
 		<QualityProfiles
 			databases={data.databases}
@@ -157,6 +158,8 @@
 			bind:isDirty={qualityProfilesDirty}
 			canSave={qualityProfilesCanSave}
 			warning={qualityProfilesWarning}
+			qpProgress={data.driftProgress?.qualityProfiles}
+			cfProgress={data.driftProgress?.customFormats}
 		/>
 	</div>
 

--- a/src/routes/arr/[id]/sync/components/DelayProfiles.svelte
+++ b/src/routes/arr/[id]/sync/components/DelayProfiles.svelte
@@ -117,16 +117,16 @@
 >
 	<!-- Header -->
 	<div
-		class="flex items-start justify-between gap-6 border-b border-neutral-200 px-6 py-4 dark:border-neutral-800"
+		class="flex flex-col gap-4 border-b border-neutral-200 px-6 py-4 md:flex-row md:items-start md:justify-between md:gap-6 dark:border-neutral-800"
 	>
-		<div class="min-w-0 flex-1">
+		<div class="min-w-0 md:flex-1">
 			<h2 class="text-xl font-semibold text-neutral-900 dark:text-neutral-50">Delay Profiles</h2>
 			<p class="mt-1 text-sm text-neutral-600 dark:text-neutral-400">
 				Select delay profiles to sync to this instance
 			</p>
 		</div>
 		{#if progress}
-			<div class="min-w-[9rem] flex-shrink-0 pt-1">
+			<div class="min-w-[9rem] md:flex-shrink-0 md:pt-1">
 				<div class="mb-1 text-xs font-medium text-neutral-500 dark:text-neutral-400">
 					Delay Profiles
 				</div>

--- a/src/routes/arr/[id]/sync/components/DelayProfiles.svelte
+++ b/src/routes/arr/[id]/sync/components/DelayProfiles.svelte
@@ -2,6 +2,7 @@
 	import type { DelayProfilesRow } from '$shared/pcd/display.ts';
 	import Toggle from '$ui/toggle/Toggle.svelte';
 	import SyncFooter from './SyncFooter.svelte';
+	import ProgressIndicator from '$ui/arr/ProgressIndicator.svelte';
 	import { alertStore } from '$lib/client/alerts/store.ts';
 	import { deserialize } from '$app/forms';
 	import { jobStatus } from '$stores/jobStatus';
@@ -10,6 +11,11 @@
 		id: number;
 		name: string;
 		delayProfiles: DelayProfilesRow[];
+	}
+
+	interface SectionProgress {
+		total: number;
+		drifted: number;
 	}
 
 	export let databases: DatabaseWithProfiles[];
@@ -22,6 +28,7 @@
 	};
 	export let syncTrigger: 'manual' | 'on_pull' | 'schedule' = 'manual';
 	export let cronExpression: string = '0 * * * *';
+	export let progress: SectionProgress | undefined = undefined;
 
 	let saving = false;
 	let syncing = false;
@@ -108,11 +115,29 @@
 	class="rounded-lg border border-neutral-200 bg-white dark:border-neutral-800 dark:bg-neutral-900"
 >
 	<!-- Header -->
-	<div class="border-b border-neutral-200 px-6 py-4 dark:border-neutral-800">
-		<h2 class="text-xl font-semibold text-neutral-900 dark:text-neutral-50">Delay Profiles</h2>
-		<p class="mt-1 text-sm text-neutral-600 dark:text-neutral-400">
-			Select delay profiles to sync to this instance
-		</p>
+	<div
+		class="flex items-start justify-between gap-6 border-b border-neutral-200 px-6 py-4 dark:border-neutral-800"
+	>
+		<div class="min-w-0 flex-1">
+			<h2 class="text-xl font-semibold text-neutral-900 dark:text-neutral-50">Delay Profiles</h2>
+			<p class="mt-1 text-sm text-neutral-600 dark:text-neutral-400">
+				Select delay profiles to sync to this instance
+			</p>
+		</div>
+		{#if progress}
+			<div class="min-w-[9rem] flex-shrink-0 pt-1">
+				<div class="mb-1 text-xs font-medium text-neutral-500 dark:text-neutral-400">
+					Delay Profiles
+				</div>
+				<ProgressIndicator
+					current={progress.total - progress.drifted}
+					target={progress.total}
+					met={progress.drifted === 0}
+					mode="compact"
+					colorMode="completion"
+				/>
+			</div>
+		{/if}
 	</div>
 
 	<!-- Content -->

--- a/src/routes/arr/[id]/sync/components/DelayProfiles.svelte
+++ b/src/routes/arr/[id]/sync/components/DelayProfiles.svelte
@@ -16,6 +16,7 @@
 	interface SectionProgress {
 		total: number;
 		drifted: number;
+		message?: string;
 	}
 
 	export let databases: DatabaseWithProfiles[];
@@ -135,6 +136,9 @@
 					met={progress.drifted === 0}
 					mode="compact"
 					colorMode="completion"
+					tooltip={progress.message ?? ''}
+					tooltipPosition="bottom"
+					tooltipAlign="middle"
 				/>
 			</div>
 		{/if}

--- a/src/routes/arr/[id]/sync/components/QualityProfiles.svelte
+++ b/src/routes/arr/[id]/sync/components/QualityProfiles.svelte
@@ -17,6 +17,7 @@
 	interface SectionProgress {
 		total: number;
 		drifted: number;
+		message?: string;
 	}
 
 	export let databases: DatabaseWithProfiles[];
@@ -180,6 +181,9 @@
 							met={qpProgress.drifted === 0}
 							mode="compact"
 							colorMode="completion"
+							tooltip={qpProgress.message ?? ''}
+							tooltipPosition="bottom"
+							tooltipAlign="middle"
 						/>
 					</div>
 				{/if}
@@ -194,6 +198,9 @@
 							met={cfProgress.drifted === 0}
 							mode="compact"
 							colorMode="completion"
+							tooltip={cfProgress.message ?? ''}
+							tooltipPosition="bottom"
+							tooltipAlign="middle"
 						/>
 					</div>
 				{/if}

--- a/src/routes/arr/[id]/sync/components/QualityProfiles.svelte
+++ b/src/routes/arr/[id]/sync/components/QualityProfiles.svelte
@@ -2,6 +2,7 @@
 	import type { QualityProfileTableRow } from '$shared/pcd/display.ts';
 	import Toggle from '$ui/toggle/Toggle.svelte';
 	import SyncFooter from './SyncFooter.svelte';
+	import ProgressIndicator from '$ui/arr/ProgressIndicator.svelte';
 	import { alertStore } from '$lib/client/alerts/store.ts';
 	import { deserialize } from '$app/forms';
 	import { jobStatus } from '$stores/jobStatus';
@@ -12,12 +13,19 @@
 		qualityProfiles: QualityProfileTableRow[];
 	}
 
+	interface SectionProgress {
+		total: number;
+		drifted: number;
+	}
+
 	export let databases: DatabaseWithProfiles[];
 	export let state: Record<number, Record<string, boolean>> = {};
 	export let syncTrigger: 'manual' | 'on_pull' | 'schedule' = 'manual';
 	export let cronExpression: string = '0 * * * *';
 	export let canSave: boolean = true;
 	export let warning: string | null = null;
+	export let qpProgress: SectionProgress | undefined = undefined;
+	export let cfProgress: SectionProgress | undefined = undefined;
 
 	let saving = false;
 	let syncing = false;
@@ -149,12 +157,48 @@
 	class="rounded-lg border border-neutral-200 bg-white dark:border-neutral-800 dark:bg-neutral-900"
 >
 	<!-- Header -->
-	<div class="border-b border-neutral-200 px-6 py-4 dark:border-neutral-800">
-		<h2 class="text-xl font-semibold text-neutral-900 dark:text-neutral-50">Quality Profiles</h2>
-		<p class="mt-1 text-sm text-neutral-600 dark:text-neutral-400">
-			Select quality profiles to sync to this instance. Only one database can be used per instance
-			&mdash; to use a different database, sync it to a separate Arr instance.
-		</p>
+	<div
+		class="flex items-start justify-between gap-6 border-b border-neutral-200 px-6 py-4 dark:border-neutral-800"
+	>
+		<div class="min-w-0 flex-1">
+			<h2 class="text-xl font-semibold text-neutral-900 dark:text-neutral-50">Quality Profiles</h2>
+			<p class="mt-1 text-sm text-neutral-600 dark:text-neutral-400">
+				Select quality profiles to sync to this instance. Only one database can be used per instance
+				&mdash; to use a different database, sync it to a separate Arr instance.
+			</p>
+		</div>
+		{#if qpProgress || cfProgress}
+			<div class="flex flex-shrink-0 gap-5 pt-1">
+				{#if qpProgress}
+					<div class="min-w-[9rem]">
+						<div class="mb-1 text-xs font-medium text-neutral-500 dark:text-neutral-400">
+							Quality Profiles
+						</div>
+						<ProgressIndicator
+							current={qpProgress.total - qpProgress.drifted}
+							target={qpProgress.total}
+							met={qpProgress.drifted === 0}
+							mode="compact"
+							colorMode="completion"
+						/>
+					</div>
+				{/if}
+				{#if cfProgress}
+					<div class="min-w-[9rem]">
+						<div class="mb-1 text-xs font-medium text-neutral-500 dark:text-neutral-400">
+							Custom Formats
+						</div>
+						<ProgressIndicator
+							current={cfProgress.total - cfProgress.drifted}
+							target={cfProgress.total}
+							met={cfProgress.drifted === 0}
+							mode="compact"
+							colorMode="completion"
+						/>
+					</div>
+				{/if}
+			</div>
+		{/if}
 	</div>
 
 	<!-- Content -->

--- a/src/routes/arr/[id]/sync/components/QualityProfiles.svelte
+++ b/src/routes/arr/[id]/sync/components/QualityProfiles.svelte
@@ -160,16 +160,16 @@
 >
 	<!-- Header -->
 	<div
-		class="flex items-start justify-between gap-6 border-b border-neutral-200 px-6 py-4 dark:border-neutral-800"
+		class="flex flex-col gap-4 border-b border-neutral-200 px-6 py-4 md:flex-row md:items-start md:justify-between md:gap-6 dark:border-neutral-800"
 	>
-		<div class="min-w-0 flex-1">
+		<div class="min-w-0 md:flex-1">
 			<h2 class="text-xl font-semibold text-neutral-900 dark:text-neutral-50">Quality Profiles</h2>
 			<p class="mt-1 text-sm text-neutral-600 dark:text-neutral-400">
 				Select quality profiles to sync to this instance.
 			</p>
 		</div>
 		{#if qpProgress || cfProgress}
-			<div class="flex flex-shrink-0 gap-5 pt-1">
+			<div class="flex flex-col gap-3 md:flex-shrink-0 md:flex-row md:flex-wrap md:gap-5 md:pt-1">
 				{#if qpProgress}
 					<div class="min-w-[9rem]">
 						<div class="mb-1 text-xs font-medium text-neutral-500 dark:text-neutral-400">

--- a/src/routes/arr/[id]/sync/components/QualityProfiles.svelte
+++ b/src/routes/arr/[id]/sync/components/QualityProfiles.svelte
@@ -3,6 +3,7 @@
 	import Toggle from '$ui/toggle/Toggle.svelte';
 	import SyncFooter from './SyncFooter.svelte';
 	import ProgressIndicator from '$ui/arr/ProgressIndicator.svelte';
+	import Tooltip from '$ui/tooltip/Tooltip.svelte';
 	import { alertStore } from '$lib/client/alerts/store.ts';
 	import { deserialize } from '$app/forms';
 	import { jobStatus } from '$stores/jobStatus';
@@ -163,8 +164,7 @@
 		<div class="min-w-0 flex-1">
 			<h2 class="text-xl font-semibold text-neutral-900 dark:text-neutral-50">Quality Profiles</h2>
 			<p class="mt-1 text-sm text-neutral-600 dark:text-neutral-400">
-				Select quality profiles to sync to this instance. Only one database can be used per instance
-				&mdash; to use a different database, sync it to a separate Arr instance.
+				Select quality profiles to sync to this instance.
 			</p>
 		</div>
 		{#if qpProgress || cfProgress}
@@ -222,14 +222,20 @@
 						{:else}
 							<div class="grid grid-cols-1 gap-2 sm:grid-cols-3 md:grid-cols-5">
 								{#each database.qualityProfiles as profile}
-									<Toggle
-										checked={isSelected(database.id, profile.name)}
-										disabled={isInactive}
-										label={profile.name}
+									<Tooltip
+										text={isInactive ? 'Only one database can be used per instance.' : ''}
+										position="bottom"
 										fullWidth
-										ariaLabel={`Toggle quality profile ${profile.name} from ${database.name}`}
-										on:change={(e) => setProfile(database.id, profile.name, e.detail)}
-									/>
+									>
+										<Toggle
+											checked={isSelected(database.id, profile.name)}
+											disabled={isInactive}
+											label={profile.name}
+											fullWidth
+											ariaLabel={`Toggle quality profile ${profile.name} from ${database.name}`}
+											on:change={(e) => setProfile(database.id, profile.name, e.detail)}
+										/>
+									</Tooltip>
 								{/each}
 							</div>
 						{/if}


### PR DESCRIPTION
- Adds per-section drift progress chips to the sync page. Quality Profiles header carries two chips (QPs and CFs); Delay Profiles carries one. MM has no chip yet (waiting on MM drift comparison).
- Direct/transitive split on the QP chip so a CF deletion does not multiply across all QPs that score it; the user-visible impact is surfaced through the CF chip tooltip instead.
- Tooltips list up to three affected entity names with a `+N more` overflow suffix.
- Chains an `arr.drift` job after a successful arr sync and invalidates the sync page when it completes, so chips refresh without a manual reload.
- Hides chips when drift is disabled by the feature flag, by per-instance settings, or when status is `never_checked` / `failed`.
- Adds `colorMode` and `tooltip` props to `ProgressIndicator` so the same component handles both "score" (existing) and "drift completion" semantics.
- Mobile layout: chips stack below the section title; QP and CF chips each take their own row.

Part of #307.