### PR TITLE
fix: use BEGIN IMMEDIATE for write transactions

### DIFF
--- a/docs/backend/database.md
+++ b/docs/backend/database.md
@@ -44,6 +44,13 @@ reinitializes the connection.
 that auto-commits on success and auto-rollbacks on error. Raw
 `beginTransaction()`, `commit()`, and `rollback()` methods are also exposed.
 
+The helper issues `BEGIN IMMEDIATE` rather than the default `BEGIN DEFERRED`,
+so write transactions acquire the write lock at `BEGIN` time. Two concurrent
+writers serialize cleanly via `busy_timeout` instead of one failing
+immediately with `SQLITE_BUSY` from a deferred read→write upgrade conflict
+(SQLite explicitly bypasses the busy handler in that case to avoid a
+permanent deadlock).
+
 ## Schema
 
 `src/lib/server/db/schema.sql` is a **reference snapshot** of the current

--- a/src/lib/server/db/db.ts
+++ b/src/lib/server/db/db.ts
@@ -159,10 +159,18 @@ class DatabaseManager {
 	}
 
 	/**
-	 * Begin a transaction
+	 * Begin a transaction.
+	 *
+	 * Uses `BEGIN IMMEDIATE` so the write lock is acquired at BEGIN time
+	 * rather than on the first write. This avoids the deferred read→write
+	 * upgrade case where SQLite returns SQLITE_BUSY without invoking the
+	 * busy handler (because retrying with a stale snapshot would just
+	 * deadlock). With `busy_timeout = 5000` already set on the connection,
+	 * two concurrent writers serialize cleanly through the busy handler
+	 * instead of one failing immediately.
 	 */
 	beginTransaction(): void {
-		this.exec('BEGIN TRANSACTION');
+		this.exec('BEGIN IMMEDIATE TRANSACTION');
 	}
 
 	/**


### PR DESCRIPTION
- The `db.transaction()` helper was issuing bare `BEGIN`, which defaults to `DEFERRED`. Two concurrent deferred transactions racing the read→write upgrade cause SQLite to return `SQLITE_BUSY` immediately, **without** invoking the busy handler — the `busy_timeout = 5000` we added earlier never gets a chance to run for this contention shape ([SQLite docs](https://www.sqlite.org/c3ref/busy_handler.html): "If SQLite determines that invoking the busy handler could result in a deadlock, it will go ahead and return SQLITE_BUSY to the application instead of invoking the busy handler.").
- This is the cause of the intermittent `Failed to reconcile announcements | error: database is locked` log + server-process exit we have been seeing in CI on `conflicts/upstream-change` and similar specs.
- Fix: switch to `BEGIN IMMEDIATE TRANSACTION`, which acquires the write lock at `BEGIN` time. Two concurrent writers now contend at the start, the busy handler is invoked, and `busy_timeout` properly serializes them.
- All four current callers of `db.transaction()` are write-only (migrations apply/rollback, announcements reconcile in two places), so no caller migration is needed and there is no behavioural regression.
- Database doc updated to note the IMMEDIATE behaviour.