### PR TITLE
feat: media management drift detection

### DIFF
--- a/docs/backend/drift.md
+++ b/docs/backend/drift.md
@@ -235,19 +235,23 @@ configuration, or triggers sync.
 
 Route: `/arr/[id]/sync`. Source: `src/routes/arr/[id]/sync/+page.server.ts`,
 `src/routes/arr/[id]/sync/components/QualityProfiles.svelte`,
-`src/routes/arr/[id]/sync/components/DelayProfiles.svelte`.
+`src/routes/arr/[id]/sync/components/DelayProfiles.svelte`,
+`src/routes/arr/[id]/sync/components/MediaManagement.svelte`.
 
 Per-section drift progress is rendered as `ProgressIndicator` chips in each
 sync section header (right-aligned on tablet+, stacked below the title on
 mobile). The Quality Profiles header carries two chips: one for QPs themselves
 and one for the custom formats referenced by those QPs. The Delay Profiles
-header carries one chip. The Media Management header has no chip yet.
+header carries one chip. The Media Management header carries up to three chips
+— one each for Naming, Quality Definitions, and Media Settings — corresponding
+to the three sub-configs the user selects in that section.
 
 Each chip shows `current / total` where:
 
 - `total`: managed items Profilarr would sync. Selected QP count for the QP
   chip, expected CF count from `buildExpectedCustomFormats` for the CF chip,
-  `0` or `1` for the delay profile chip.
+  `0` or `1` for the delay profile chip and each of the three Media Management
+  chips (Naming, Quality Definitions, Media Settings).
 - `current`: `total - drifted`. For the QP chip, `drifted` counts only QPs
   the drift comparison flagged directly. QPs that are only "transitively"
   affected (their scoring rows reference a CF that has been deleted from

--- a/docs/backend/drift.md
+++ b/docs/backend/drift.md
@@ -7,6 +7,7 @@
 `src/lib/server/drift/customFormats.ts`,
 `src/lib/server/drift/qualityProfiles.ts`,
 `src/lib/server/drift/delayProfiles.ts`,
+`src/lib/server/drift/mediaManagement.ts`,
 `src/lib/server/drift/display.ts`,
 `src/routes/arr/[id]/drift/+page.svelte`,
 `src/routes/arr/[id]/drift/+page.server.ts`,
@@ -19,10 +20,11 @@ Drift detection checks whether an Arr instance still matches the configuration
 Profilarr would sync now. It is observational: it does not write to Arr, repair
 config, delete stale items, or replace cleanup.
 
-Drift detection currently covers custom formats, quality profiles, and the
-default delay profile. Media management coverage (naming, media settings,
-quality definitions) is planned as a follow-up; until it lands, the sync page's
-Media Management section does not surface a drift chip.
+Drift detection currently covers custom formats, quality profiles, the default
+delay profile, and media management media settings. Media management naming and
+quality definitions are planned as follow-ups; until full media management
+coverage lands, the sync page's Media Management section does not surface a
+drift chip.
 
 ## Job
 
@@ -45,8 +47,8 @@ Current handler behavior:
 - missing instances fail
 - missing or disabled settings cancel the job
 - unsupported Arr types are skipped
-- enabled jobs compare custom formats, quality profiles, and delay profiles,
-  store the latest result, and return success
+- enabled jobs compare custom formats, quality profiles, delay profiles, and
+  media management media settings, store the latest result, and return success
 - drift-detected and failed runs notify subscribed services when the current
   drift or error hash has not already been notified
 - scheduled jobs calculate and store the next run before returning
@@ -79,11 +81,11 @@ Drift emits notification events through the shared notification manager:
 | `arr.drift.failed`   | Latest failure hash has not been sent | `error`   |
 
 Detected notifications emit one section block per drift category (Custom
-Format, Quality Profile, Delay Profile) listing up to 15 displayable drift
-entities total. If more entities exist, an additional `More` block summarises
-the remainder as `+N more`. Discord renders each section as a code-block field.
-Webhook receives the full payload. Summary-tier services such as Ntfy and
-Telegram show only the title because section blocks are omitted.
+Format, Quality Profile, Delay Profile, Media Management) listing up to 15
+displayable drift entities total. If more entities exist, an additional `More`
+block summarises the remainder as `+N more`. Discord renders each section as a
+code-block field. Webhook receives the full payload. Summary-tier services such
+as Ntfy and Telegram show only the title because section blocks are omitted.
 
 Failed notifications use the first error line as the message and include the
 full error text in an `Error` section.
@@ -140,6 +142,20 @@ Comparison rules:
 - compare id, derived protocol, delays, bypass fields, minimum custom format
   score, order, and tags
 
+## Media Management
+
+Media management drift compares the configured media settings selection against
+Arr's media management config. Naming and quality definitions are not compared
+yet.
+
+Comparison rules:
+
+- build expected media settings with the same transformer used by sync
+- no selected media settings config is clean
+- missing selected PCD cache or config fails the drift check
+- compare `downloadPropersAndRepacks` and `enableMediaInfo`
+- ignore unmanaged extra Arr media management fields
+
 ## Display Formatter
 
 `src/lib/server/drift/display.ts` maps the raw `diff_json` stored in
@@ -168,6 +184,9 @@ and unmanaged nonzero score rows.
 
 For delay profiles the formatter turns the derived protocol, delays, bypass
 flags, minimum score, order, and tags into friendly field rows.
+
+For media management media settings the formatter turns propers/repacks and
+media info parsing settings into friendly field rows.
 
 Display types live in `src/lib/shared/drift.ts`.
 
@@ -264,5 +283,5 @@ the post-completion idle window, so this does not hold a persistent connection.
 
 ## TODO
 
-- Media management drift comparison (naming, media settings, quality
-  definitions) plus display formatter and sync page chip.
+- Media management drift comparison for naming and quality definitions plus
+  sync page chip.

--- a/docs/backend/drift.md
+++ b/docs/backend/drift.md
@@ -21,10 +21,8 @@ Profilarr would sync now. It is observational: it does not write to Arr, repair
 config, delete stale items, or replace cleanup.
 
 Drift detection currently covers custom formats, quality profiles, the default
-delay profile, and media management media settings and naming. Media management
-quality definitions are planned as a follow-up; until full media management
-coverage lands, the sync page's Media Management section does not surface a
-drift chip.
+delay profile, and media management media settings, naming, and quality
+definitions.
 
 ## Job
 
@@ -48,8 +46,8 @@ Current handler behavior:
 - missing or disabled settings cancel the job
 - unsupported Arr types are skipped
 - enabled jobs compare custom formats, quality profiles, delay profiles, media
-  management media settings, and media management naming, store the latest
-  result, and return success
+  management media settings, media management naming, and media management
+  quality definitions, store the latest result, and return success
 - drift-detected and failed runs notify subscribed services when the current
   drift or error hash has not already been notified
 - scheduled jobs calculate and store the next run before returning
@@ -145,15 +143,15 @@ Comparison rules:
 
 ## Media Management
 
-Media management drift compares configured media settings and naming selections
-against Arr's media management and naming configs. Quality definitions are not
-compared yet.
+Media management drift compares configured media settings, naming, and quality
+definition selections against Arr's media management, naming, and quality
+definition configs.
 
 Comparison rules:
 
-- build expected media settings and naming with the same transformers used by
-  sync
-- no selected media settings or naming config is clean
+- build expected media settings, naming, and quality definitions with the same
+  transformers used by sync
+- no selected media settings, naming, or quality definitions config is clean
 - missing selected PCD cache or config fails the drift check
 - compare `downloadPropersAndRepacks` and `enableMediaInfo`
 - compare Radarr naming fields: rename, illegal-character replacement, colon
@@ -162,7 +160,11 @@ Comparison rules:
   replacement, custom colon replacement, multi-episode style, episode formats,
   series folder format, and season folder format
 - normalize Sonarr Arr enum integers back to semantic strings before comparing
-- ignore unmanaged extra Arr media management and naming fields
+- compare quality definition `minSize`, `maxSize`, and `preferredSize`
+- normalize PCD quality definition `0` size values to Arr `null` for unlimited
+  maximum and preferred sizes
+- ignore unmapped PCD quality definitions, mapped definitions missing in Arr,
+  extra Arr quality definitions, and unmanaged Arr fields
 
 ## Display Formatter
 
@@ -193,8 +195,8 @@ and unmanaged nonzero score rows.
 For delay profiles the formatter turns the derived protocol, delays, bypass
 flags, minimum score, order, and tags into friendly field rows.
 
-For media management the formatter turns media settings and naming changes into
-friendly field rows.
+For media management the formatter turns media settings, naming, and quality
+definition changes into friendly field rows.
 
 Display types live in `src/lib/shared/drift.ts`.
 
@@ -288,7 +290,3 @@ the state machine drops finished events for jobs it is not actively tracking,
 including a drift job chained right after a sync's completion holdoff window.
 SSE is opened on demand when the user triggers a sync and auto-closes after
 the post-completion idle window, so this does not hold a persistent connection.
-
-## TODO
-
-- Media management drift comparison for quality definitions plus sync page chip.

--- a/docs/backend/drift.md
+++ b/docs/backend/drift.md
@@ -21,8 +21,8 @@ Profilarr would sync now. It is observational: it does not write to Arr, repair
 config, delete stale items, or replace cleanup.
 
 Drift detection currently covers custom formats, quality profiles, the default
-delay profile, and media management media settings. Media management naming and
-quality definitions are planned as follow-ups; until full media management
+delay profile, and media management media settings and naming. Media management
+quality definitions are planned as a follow-up; until full media management
 coverage lands, the sync page's Media Management section does not surface a
 drift chip.
 
@@ -47,8 +47,9 @@ Current handler behavior:
 - missing instances fail
 - missing or disabled settings cancel the job
 - unsupported Arr types are skipped
-- enabled jobs compare custom formats, quality profiles, delay profiles, and
-  media management media settings, store the latest result, and return success
+- enabled jobs compare custom formats, quality profiles, delay profiles, media
+  management media settings, and media management naming, store the latest
+  result, and return success
 - drift-detected and failed runs notify subscribed services when the current
   drift or error hash has not already been notified
 - scheduled jobs calculate and store the next run before returning
@@ -144,17 +145,24 @@ Comparison rules:
 
 ## Media Management
 
-Media management drift compares the configured media settings selection against
-Arr's media management config. Naming and quality definitions are not compared
-yet.
+Media management drift compares configured media settings and naming selections
+against Arr's media management and naming configs. Quality definitions are not
+compared yet.
 
 Comparison rules:
 
-- build expected media settings with the same transformer used by sync
-- no selected media settings config is clean
+- build expected media settings and naming with the same transformers used by
+  sync
+- no selected media settings or naming config is clean
 - missing selected PCD cache or config fails the drift check
 - compare `downloadPropersAndRepacks` and `enableMediaInfo`
-- ignore unmanaged extra Arr media management fields
+- compare Radarr naming fields: rename, illegal-character replacement, colon
+  replacement, movie format, and movie folder format
+- compare Sonarr naming fields: rename, illegal-character replacement, colon
+  replacement, custom colon replacement, multi-episode style, episode formats,
+  series folder format, and season folder format
+- normalize Sonarr Arr enum integers back to semantic strings before comparing
+- ignore unmanaged extra Arr media management and naming fields
 
 ## Display Formatter
 
@@ -185,8 +193,8 @@ and unmanaged nonzero score rows.
 For delay profiles the formatter turns the derived protocol, delays, bypass
 flags, minimum score, order, and tags into friendly field rows.
 
-For media management media settings the formatter turns propers/repacks and
-media info parsing settings into friendly field rows.
+For media management the formatter turns media settings and naming changes into
+friendly field rows.
 
 Display types live in `src/lib/shared/drift.ts`.
 
@@ -283,5 +291,4 @@ the post-completion idle window, so this does not hold a persistent connection.
 
 ## TODO
 
-- Media management drift comparison for naming and quality definitions plus
-  sync page chip.
+- Media management drift comparison for quality definitions plus sync page chip.

--- a/src/lib/client/stores/jobStatus.ts
+++ b/src/lib/client/stores/jobStatus.ts
@@ -101,18 +101,23 @@ function createJobStatusStore() {
 	}
 
 	function handleStarted(data: StartedPayload) {
-		if (resetTimer) {
-			clearTimeout(resetTimer);
-			resetTimer = null;
-		}
-
 		const elapsed = Date.now() - completedAt;
 
 		if (completedAt > 0 && elapsed < COMPLETED_HOLDOFF_MS) {
+			// Buffer the start through the holdoff. Crucially we do NOT clear
+			// resetTimer here: if this buffered start later gets cancelled
+			// (its own finished event arrives during holdoff), the previous
+			// completion's display timer should keep ticking and transition
+			// to idle on schedule. The resetTimer only gets cleared when the
+			// buffered start is actually applied, in the holdoff callback.
 			pendingStartEvent = data;
 			if (holdoffTimer) clearTimeout(holdoffTimer);
 			holdoffTimer = setTimeout(() => {
 				if (pendingStartEvent) {
+					if (resetTimer) {
+						clearTimeout(resetTimer);
+						resetTimer = null;
+					}
 					currentJobId = pendingStartEvent.jobId;
 					set({
 						state: 'running',
@@ -127,6 +132,13 @@ function createJobStatusStore() {
 			return;
 		}
 
+		// Non-holdoff branch: transition straight to running. Cancel any
+		// outstanding completion-display timer so it doesn't fire later and
+		// flip us back to idle.
+		if (resetTimer) {
+			clearTimeout(resetTimer);
+			resetTimer = null;
+		}
 		completedAt = 0;
 		pendingStartEvent = null;
 		if (holdoffTimer) {
@@ -160,6 +172,16 @@ function createJobStatusStore() {
 			} catch {
 				// Swallow listener errors so one bad listener can't break others.
 			}
+		}
+
+		// If this finished event is for a job whose start was buffered during
+		// the post-completion holdoff (i.e. its entire lifecycle fit inside
+		// the holdoff window), drop the pending start. Otherwise the holdoff
+		// timer would later apply that start and put the store into a
+		// `running` state for a job that already finished, with no future
+		// finished event coming to clear it.
+		if (pendingStartEvent !== null && pendingStartEvent.jobId === data.jobId) {
+			pendingStartEvent = null;
 		}
 
 		// Ignore finished events for jobs we're not tracking (stale events

--- a/src/lib/server/drift/check.ts
+++ b/src/lib/server/drift/check.ts
@@ -17,7 +17,11 @@ export interface DriftCheckResult {
 export async function checkArrDrift(
 	client: Pick<
 		BaseArrClient,
-		'getCustomFormats' | 'getQualityProfiles' | 'getDelayProfiles' | 'getMediaManagementConfig'
+		| 'getCustomFormats'
+		| 'getQualityProfiles'
+		| 'getDelayProfiles'
+		| 'getMediaManagementConfig'
+		| 'getNamingConfig'
 	>,
 	instanceId: number,
 	arrType: SyncArrType

--- a/src/lib/server/drift/check.ts
+++ b/src/lib/server/drift/check.ts
@@ -4,6 +4,7 @@ import type { SyncArrType } from '$sync/mappings.ts';
 import { compareCustomFormatDrift, buildExpectedCustomFormats } from './customFormats.ts';
 import { checkDelayProfileDrift } from './delayProfiles.ts';
 import { hashDriftDiff } from './hash.ts';
+import { checkMediaManagementDrift } from './mediaManagement.ts';
 import { checkQualityProfileDrift } from './qualityProfiles.ts';
 
 export interface DriftCheckResult {
@@ -14,15 +15,20 @@ export interface DriftCheckResult {
 }
 
 export async function checkArrDrift(
-	client: Pick<BaseArrClient, 'getCustomFormats' | 'getQualityProfiles' | 'getDelayProfiles'>,
+	client: Pick<
+		BaseArrClient,
+		'getCustomFormats' | 'getQualityProfiles' | 'getDelayProfiles' | 'getMediaManagementConfig'
+	>,
 	instanceId: number,
 	arrType: SyncArrType
 ): Promise<DriftCheckResult> {
-	const [expectedCustomFormats, actualCustomFormats, delayProfiles] = await Promise.all([
-		buildExpectedCustomFormats(instanceId, arrType),
-		client.getCustomFormats(),
-		checkDelayProfileDrift(client, instanceId)
-	]);
+	const [expectedCustomFormats, actualCustomFormats, delayProfiles, mediaManagement] =
+		await Promise.all([
+			buildExpectedCustomFormats(instanceId, arrType),
+			client.getCustomFormats(),
+			checkDelayProfileDrift(client, instanceId),
+			checkMediaManagementDrift(client, instanceId, arrType)
+		]);
 	const customFormats = compareCustomFormatDrift(expectedCustomFormats, actualCustomFormats);
 	const qualityProfiles = await checkQualityProfileDrift(
 		client,
@@ -33,12 +39,14 @@ export async function checkArrDrift(
 	const counts: DriftCounts = {
 		custom_formats: customFormats.count,
 		quality_profiles: qualityProfiles.count,
-		delay_profiles: delayProfiles.count
+		delay_profiles: delayProfiles.count,
+		media_management: mediaManagement.count
 	};
 	const diff: DriftDiff = {
 		custom_formats: customFormats.diff,
 		quality_profiles: qualityProfiles.diff,
-		delay_profiles: delayProfiles.diff
+		delay_profiles: delayProfiles.diff,
+		media_management: mediaManagement.diff
 	};
 	const total = Object.values(counts).reduce((sum, count) => sum + (count ?? 0), 0);
 

--- a/src/lib/server/drift/check.ts
+++ b/src/lib/server/drift/check.ts
@@ -22,6 +22,7 @@ export async function checkArrDrift(
 		| 'getDelayProfiles'
 		| 'getMediaManagementConfig'
 		| 'getNamingConfig'
+		| 'getQualityDefinitions'
 	>,
 	instanceId: number,
 	arrType: SyncArrType

--- a/src/lib/server/drift/display.ts
+++ b/src/lib/server/drift/display.ts
@@ -31,6 +31,13 @@ interface DelayProfileDiff {
 	modified?: unknown[];
 }
 
+interface MediaManagementDiff {
+	media_settings: {
+		missing?: unknown[];
+		modified?: unknown[];
+	};
+}
+
 interface DriftFieldDiff {
 	path: string;
 	expected: unknown;
@@ -48,6 +55,11 @@ interface QualityProfileModifiedDiff {
 }
 
 interface DelayProfileModifiedDiff {
+	name: string;
+	fields: DriftFieldDiff[];
+}
+
+interface MediaSettingsModifiedDiff {
 	name: string;
 	fields: DriftFieldDiff[];
 }
@@ -89,7 +101,8 @@ export function buildDriftDisplayEntities(
 	return [
 		...buildCustomFormatEntities(diff.custom_formats, syncArrType),
 		...buildQualityProfileEntities(diff.quality_profiles, syncArrType),
-		...buildDelayProfileEntities(diff.delay_profiles)
+		...buildDelayProfileEntities(diff.delay_profiles),
+		...buildMediaManagementEntities(diff.media_management)
 	];
 }
 
@@ -269,6 +282,61 @@ function buildDelayProfileEntities(raw: unknown): DriftDisplayEntity[] {
 	return entities;
 }
 
+function buildMediaManagementEntities(raw: unknown): DriftDisplayEntity[] {
+	const diff = asMediaManagementDiff(raw);
+	if (!diff) return [];
+
+	const entities: DriftDisplayEntity[] = [];
+
+	for (const item of diff.media_settings.missing ?? []) {
+		const name = recordString(item, 'name');
+		if (!name) continue;
+
+		entities.push({
+			id: `media_management:media_settings:missing:${name}`,
+			section: 'media_management',
+			sectionLabel: 'Media Management',
+			title: `Media Settings: ${name}`,
+			state: 'missing',
+			stateLabel: 'Missing',
+			tone: 'danger',
+			summary: 'Profilarr expects this media settings config, but Arr does not have it.',
+			changes: [
+				{
+					id: `media-management-media-settings-missing:${name}:config`,
+					label: 'Media Settings',
+					detail: 'Missing from Arr',
+					expected: value('Present'),
+					actual: value('Missing', { tone: 'danger' }),
+					tone: 'danger'
+				}
+			]
+		});
+	}
+
+	for (const item of diff.media_settings.modified ?? []) {
+		const modified = asModifiedMediaSettings(item);
+		if (!modified) continue;
+		if (modified.fields.length === 0) continue;
+
+		const changes = modified.fields.map(formatMediaSettingsFieldDiff);
+
+		entities.push({
+			id: `media_management:media_settings:modified:${modified.name}`,
+			section: 'media_management',
+			sectionLabel: 'Media Management',
+			title: `Media Settings: ${modified.name}`,
+			state: 'modified',
+			stateLabel: 'Modified',
+			tone: 'warning',
+			summary: `${changes.length} ${changes.length === 1 ? 'change' : 'changes'} detected`,
+			changes
+		});
+	}
+
+	return entities;
+}
+
 function formatQualityProfileFieldDiff(
 	field: DriftFieldDiff,
 	index: number,
@@ -402,6 +470,39 @@ function formatDelayProfileFieldDiff(field: DriftFieldDiff, index: number): Drif
 		id: `delay-profile-field:${index}`,
 		label: delayProfileFieldLabel(field.path),
 		detail: 'Delay profile setting changed',
+		expected: formatGenericValue(field.expected),
+		actual: formatGenericValue(field.actual),
+		tone: field.actual === null || field.actual === undefined ? 'danger' : 'warning'
+	};
+}
+
+function formatMediaSettingsFieldDiff(field: DriftFieldDiff, index: number): DriftDisplayChange {
+	if (field.path === 'downloadPropersAndRepacks') {
+		return {
+			id: `media-settings-propers-repacks:${index}`,
+			label: 'Propers and Repacks',
+			detail: 'Propers and repacks preference changed',
+			expected: formatPropersRepacksValue(field.expected),
+			actual: formatPropersRepacksValue(field.actual),
+			tone: 'warning'
+		};
+	}
+
+	if (field.path === 'enableMediaInfo') {
+		return {
+			id: `media-settings-enable-media-info:${index}`,
+			label: 'Enable Media Info',
+			detail: 'Media info parsing changed',
+			expected: formatBooleanValue(field.expected),
+			actual: formatBooleanValue(field.actual),
+			tone: 'warning'
+		};
+	}
+
+	return {
+		id: `media-settings-field:${index}`,
+		label: titleize(field.path),
+		detail: 'Media setting changed',
 		expected: formatGenericValue(field.expected),
 		actual: formatGenericValue(field.actual),
 		tone: field.actual === null || field.actual === undefined ? 'danger' : 'warning'
@@ -604,6 +705,17 @@ function asDelayProfileDiff(raw: unknown): DelayProfileDiff | null {
 	};
 }
 
+function asMediaManagementDiff(raw: unknown): MediaManagementDiff | null {
+	if (!isRecord(raw)) return null;
+	const mediaSettings = isRecord(raw.media_settings) ? raw.media_settings : {};
+	return {
+		media_settings: {
+			missing: Array.isArray(mediaSettings.missing) ? mediaSettings.missing : [],
+			modified: Array.isArray(mediaSettings.modified) ? mediaSettings.modified : []
+		}
+	};
+}
+
 function asModifiedCustomFormat(raw: unknown): CustomFormatModifiedDiff | null {
 	if (!isRecord(raw)) return null;
 	const name = recordString(raw, 'name');
@@ -623,6 +735,15 @@ function asModifiedQualityProfile(raw: unknown): QualityProfileModifiedDiff | nu
 }
 
 function asModifiedDelayProfile(raw: unknown): DelayProfileModifiedDiff | null {
+	if (!isRecord(raw)) return null;
+	const name = recordString(raw, 'name');
+	if (!name || !Array.isArray(raw.fields)) return null;
+
+	const fields = raw.fields.filter(isFieldDiff);
+	return { name, fields };
+}
+
+function asModifiedMediaSettings(raw: unknown): MediaSettingsModifiedDiff | null {
 	if (!isRecord(raw)) return null;
 	const name = recordString(raw, 'name');
 	if (!name || !Array.isArray(raw.fields)) return null;
@@ -773,6 +894,17 @@ function formatDelayProtocolValue(raw: unknown): DriftDisplayValue {
 		only_usenet: 'Only Usenet',
 		only_torrent: 'Only Torrent',
 		unknown: 'Unknown'
+	};
+	if (raw === null || raw === undefined) return value('Missing', { tone: 'danger' });
+	if (typeof raw === 'string') return value(labels[raw] ?? titleize(raw));
+	return formatGenericValue(raw);
+}
+
+function formatPropersRepacksValue(raw: unknown): DriftDisplayValue {
+	const labels: Record<string, string> = {
+		doNotPrefer: 'Do Not Prefer',
+		preferAndUpgrade: 'Prefer and Upgrade',
+		doNotUpgrade: 'Do Not Upgrade Automatically'
 	};
 	if (raw === null || raw === undefined) return value('Missing', { tone: 'danger' });
 	if (typeof raw === 'string') return value(labels[raw] ?? titleize(raw));

--- a/src/lib/server/drift/display.ts
+++ b/src/lib/server/drift/display.ts
@@ -635,10 +635,15 @@ function formatNamingFieldDiff(field: DriftFieldDiff, index: number): DriftDispl
 	};
 }
 
-function formatQualityDefinitionFieldDiff(field: DriftFieldDiff, index: number): DriftDisplayChange {
+function formatQualityDefinitionFieldDiff(
+	field: DriftFieldDiff,
+	index: number
+): DriftDisplayChange {
 	const parsed = parseQualityDefinitionPath(field.path);
 	const qualityName = parsed?.qualityName ?? 'Quality definition';
-	const label = parsed ? qualityDefinitionFieldLabel(parsed.field) : qualityDefinitionFieldLabel(field.path);
+	const label = parsed
+		? qualityDefinitionFieldLabel(parsed.field)
+		: qualityDefinitionFieldLabel(field.path);
 
 	return {
 		id: `quality-definition-field:${index}`,
@@ -922,11 +927,7 @@ function asModifiedQualityDefinitions(raw: unknown): QualityDefinitionsModifiedD
 }
 
 function isQualityDefinitionFieldDiff(raw: unknown): raw is DriftFieldDiff {
-	return (
-		isRecord(raw) &&
-		typeof raw.path === 'string' &&
-		Object.hasOwn(raw, 'expected')
-	);
+	return isRecord(raw) && typeof raw.path === 'string' && Object.hasOwn(raw, 'expected');
 }
 
 function isFieldDiff(raw: unknown): raw is DriftFieldDiff {
@@ -1089,7 +1090,10 @@ function formatPropersRepacksValue(raw: unknown): DriftDisplayValue {
 }
 
 function formatNamingValue(field: string, raw: unknown): DriftDisplayValue {
-	if (field === 'customColonReplacementFormat' && (raw === null || raw === undefined || raw === '')) {
+	if (
+		field === 'customColonReplacementFormat' &&
+		(raw === null || raw === undefined || raw === '')
+	) {
 		return value('None');
 	}
 	if (raw === null || raw === undefined) return value('Missing', { tone: 'danger' });

--- a/src/lib/server/drift/display.ts
+++ b/src/lib/server/drift/display.ts
@@ -36,6 +36,10 @@ interface MediaManagementDiff {
 		missing?: unknown[];
 		modified?: unknown[];
 	};
+	naming: {
+		missing?: unknown[];
+		modified?: unknown[];
+	};
 }
 
 interface DriftFieldDiff {
@@ -60,6 +64,11 @@ interface DelayProfileModifiedDiff {
 }
 
 interface MediaSettingsModifiedDiff {
+	name: string;
+	fields: DriftFieldDiff[];
+}
+
+interface NamingModifiedDiff {
 	name: string;
 	fields: DriftFieldDiff[];
 }
@@ -334,6 +343,52 @@ function buildMediaManagementEntities(raw: unknown): DriftDisplayEntity[] {
 		});
 	}
 
+	for (const item of diff.naming.missing ?? []) {
+		const name = recordString(item, 'name');
+		if (!name) continue;
+
+		entities.push({
+			id: `media_management:naming:missing:${name}`,
+			section: 'media_management',
+			sectionLabel: 'Media Management',
+			title: `Naming: ${name}`,
+			state: 'missing',
+			stateLabel: 'Missing',
+			tone: 'danger',
+			summary: 'Profilarr expects this naming config, but Arr does not have it.',
+			changes: [
+				{
+					id: `media-management-naming-missing:${name}:config`,
+					label: 'Naming',
+					detail: 'Missing from Arr',
+					expected: value('Present'),
+					actual: value('Missing', { tone: 'danger' }),
+					tone: 'danger'
+				}
+			]
+		});
+	}
+
+	for (const item of diff.naming.modified ?? []) {
+		const modified = asModifiedNaming(item);
+		if (!modified) continue;
+		if (modified.fields.length === 0) continue;
+
+		const changes = modified.fields.map(formatNamingFieldDiff);
+
+		entities.push({
+			id: `media_management:naming:modified:${modified.name}`,
+			section: 'media_management',
+			sectionLabel: 'Media Management',
+			title: `Naming: ${modified.name}`,
+			state: 'modified',
+			stateLabel: 'Modified',
+			tone: 'warning',
+			summary: `${changes.length} ${changes.length === 1 ? 'change' : 'changes'} detected`,
+			changes
+		});
+	}
+
 	return entities;
 }
 
@@ -505,6 +560,17 @@ function formatMediaSettingsFieldDiff(field: DriftFieldDiff, index: number): Dri
 		detail: 'Media setting changed',
 		expected: formatGenericValue(field.expected),
 		actual: formatGenericValue(field.actual),
+		tone: field.actual === null || field.actual === undefined ? 'danger' : 'warning'
+	};
+}
+
+function formatNamingFieldDiff(field: DriftFieldDiff, index: number): DriftDisplayChange {
+	return {
+		id: `naming-field:${index}`,
+		label: namingFieldLabel(field.path),
+		detail: 'Naming setting changed',
+		expected: formatNamingValue(field.path, field.expected),
+		actual: formatNamingValue(field.path, field.actual),
 		tone: field.actual === null || field.actual === undefined ? 'danger' : 'warning'
 	};
 }
@@ -708,10 +774,15 @@ function asDelayProfileDiff(raw: unknown): DelayProfileDiff | null {
 function asMediaManagementDiff(raw: unknown): MediaManagementDiff | null {
 	if (!isRecord(raw)) return null;
 	const mediaSettings = isRecord(raw.media_settings) ? raw.media_settings : {};
+	const naming = isRecord(raw.naming) ? raw.naming : {};
 	return {
 		media_settings: {
 			missing: Array.isArray(mediaSettings.missing) ? mediaSettings.missing : [],
 			modified: Array.isArray(mediaSettings.modified) ? mediaSettings.modified : []
+		},
+		naming: {
+			missing: Array.isArray(naming.missing) ? naming.missing : [],
+			modified: Array.isArray(naming.modified) ? naming.modified : []
 		}
 	};
 }
@@ -744,6 +815,15 @@ function asModifiedDelayProfile(raw: unknown): DelayProfileModifiedDiff | null {
 }
 
 function asModifiedMediaSettings(raw: unknown): MediaSettingsModifiedDiff | null {
+	if (!isRecord(raw)) return null;
+	const name = recordString(raw, 'name');
+	if (!name || !Array.isArray(raw.fields)) return null;
+
+	const fields = raw.fields.filter(isFieldDiff);
+	return { name, fields };
+}
+
+function asModifiedNaming(raw: unknown): NamingModifiedDiff | null {
 	if (!isRecord(raw)) return null;
 	const name = recordString(raw, 'name');
 	if (!name || !Array.isArray(raw.fields)) return null;
@@ -911,6 +991,21 @@ function formatPropersRepacksValue(raw: unknown): DriftDisplayValue {
 	return formatGenericValue(raw);
 }
 
+function formatNamingValue(field: string, raw: unknown): DriftDisplayValue {
+	if (field === 'customColonReplacementFormat' && (raw === null || raw === undefined || raw === '')) {
+		return value('None');
+	}
+	if (raw === null || raw === undefined) return value('Missing', { tone: 'danger' });
+	if (typeof raw === 'boolean') return formatBooleanValue(raw);
+	if (typeof raw === 'string') {
+		if (field === 'colonReplacementFormat' || field === 'multiEpisodeStyle') {
+			return value(titleize(raw));
+		}
+		return value(raw, { mono: looksTechnical(raw) });
+	}
+	return formatGenericValue(raw);
+}
+
 function formatMinutesValue(raw: unknown): DriftDisplayValue {
 	if (raw === null || raw === undefined) return value('Missing', { tone: 'danger' });
 	if (typeof raw !== 'number') return formatGenericValue(raw);
@@ -988,6 +1083,26 @@ function delayProfileFieldLabel(path: string): string {
 		tags: 'Tags',
 		torrentDelay: 'Torrent Delay',
 		usenetDelay: 'Usenet Delay'
+	};
+
+	return labels[path] ?? titleize(path);
+}
+
+function namingFieldLabel(path: string): string {
+	const labels: Record<string, string> = {
+		animeEpisodeFormat: 'Anime Episode Format',
+		colonReplacementFormat: 'Colon Replacement',
+		customColonReplacementFormat: 'Custom Colon Replacement',
+		dailyEpisodeFormat: 'Daily Episode Format',
+		movieFolderFormat: 'Movie Folder Format',
+		multiEpisodeStyle: 'Multi Episode Style',
+		renameEpisodes: 'Rename Episodes',
+		renameMovies: 'Rename Movies',
+		replaceIllegalCharacters: 'Replace Illegal Characters',
+		seasonFolderFormat: 'Season Folder Format',
+		seriesFolderFormat: 'Series Folder Format',
+		standardEpisodeFormat: 'Standard Episode Format',
+		standardMovieFormat: 'Movie Format'
 	};
 
 	return labels[path] ?? titleize(path);

--- a/src/lib/server/drift/display.ts
+++ b/src/lib/server/drift/display.ts
@@ -40,6 +40,10 @@ interface MediaManagementDiff {
 		missing?: unknown[];
 		modified?: unknown[];
 	};
+	quality_definitions: {
+		missing?: unknown[];
+		modified?: unknown[];
+	};
 }
 
 interface DriftFieldDiff {
@@ -71,6 +75,16 @@ interface MediaSettingsModifiedDiff {
 interface NamingModifiedDiff {
 	name: string;
 	fields: DriftFieldDiff[];
+}
+
+interface QualityDefinitionsModifiedDiff {
+	name: string;
+	fields: DriftFieldDiff[];
+}
+
+interface ParsedQualityDefinitionPath {
+	qualityName: string;
+	field: string;
 }
 
 interface SpecificationValue {
@@ -389,6 +403,52 @@ function buildMediaManagementEntities(raw: unknown): DriftDisplayEntity[] {
 		});
 	}
 
+	for (const item of diff.quality_definitions.missing ?? []) {
+		const name = recordString(item, 'name');
+		if (!name) continue;
+
+		entities.push({
+			id: `media_management:quality_definitions:missing:${name}`,
+			section: 'media_management',
+			sectionLabel: 'Media Management',
+			title: `Quality Definitions: ${name}`,
+			state: 'missing',
+			stateLabel: 'Missing',
+			tone: 'danger',
+			summary: 'Profilarr expects this quality definitions config, but Arr does not have it.',
+			changes: [
+				{
+					id: `media-management-quality-definitions-missing:${name}:config`,
+					label: 'Quality definitions',
+					detail: 'Missing from Arr',
+					expected: value('Present'),
+					actual: value('Missing', { tone: 'danger' }),
+					tone: 'danger'
+				}
+			]
+		});
+	}
+
+	for (const item of diff.quality_definitions.modified ?? []) {
+		const modified = asModifiedQualityDefinitions(item);
+		if (!modified) continue;
+		if (modified.fields.length === 0) continue;
+
+		const changes = modified.fields.map(formatQualityDefinitionFieldDiff);
+
+		entities.push({
+			id: `media_management:quality_definitions:modified:${modified.name}`,
+			section: 'media_management',
+			sectionLabel: 'Media Management',
+			title: `Quality Definitions: ${modified.name}`,
+			state: 'modified',
+			stateLabel: 'Modified',
+			tone: 'warning',
+			summary: `${changes.length} ${changes.length === 1 ? 'change' : 'changes'} detected`,
+			changes
+		});
+	}
+
 	return entities;
 }
 
@@ -572,6 +632,21 @@ function formatNamingFieldDiff(field: DriftFieldDiff, index: number): DriftDispl
 		expected: formatNamingValue(field.path, field.expected),
 		actual: formatNamingValue(field.path, field.actual),
 		tone: field.actual === null || field.actual === undefined ? 'danger' : 'warning'
+	};
+}
+
+function formatQualityDefinitionFieldDiff(field: DriftFieldDiff, index: number): DriftDisplayChange {
+	const parsed = parseQualityDefinitionPath(field.path);
+	const qualityName = parsed?.qualityName ?? 'Quality definition';
+	const label = parsed ? qualityDefinitionFieldLabel(parsed.field) : qualityDefinitionFieldLabel(field.path);
+
+	return {
+		id: `quality-definition-field:${index}`,
+		label: qualityName,
+		detail: `${label} changed`,
+		expected: formatQualityDefinitionValue(parsed?.field ?? field.path, field.expected),
+		actual: formatQualityDefinitionValue(parsed?.field ?? field.path, field.actual),
+		tone: 'warning'
 	};
 }
 
@@ -775,6 +850,7 @@ function asMediaManagementDiff(raw: unknown): MediaManagementDiff | null {
 	if (!isRecord(raw)) return null;
 	const mediaSettings = isRecord(raw.media_settings) ? raw.media_settings : {};
 	const naming = isRecord(raw.naming) ? raw.naming : {};
+	const qualityDefinitions = isRecord(raw.quality_definitions) ? raw.quality_definitions : {};
 	return {
 		media_settings: {
 			missing: Array.isArray(mediaSettings.missing) ? mediaSettings.missing : [],
@@ -783,6 +859,10 @@ function asMediaManagementDiff(raw: unknown): MediaManagementDiff | null {
 		naming: {
 			missing: Array.isArray(naming.missing) ? naming.missing : [],
 			modified: Array.isArray(naming.modified) ? naming.modified : []
+		},
+		quality_definitions: {
+			missing: Array.isArray(qualityDefinitions.missing) ? qualityDefinitions.missing : [],
+			modified: Array.isArray(qualityDefinitions.modified) ? qualityDefinitions.modified : []
 		}
 	};
 }
@@ -830,6 +910,23 @@ function asModifiedNaming(raw: unknown): NamingModifiedDiff | null {
 
 	const fields = raw.fields.filter(isFieldDiff);
 	return { name, fields };
+}
+
+function asModifiedQualityDefinitions(raw: unknown): QualityDefinitionsModifiedDiff | null {
+	if (!isRecord(raw)) return null;
+	const name = recordString(raw, 'name');
+	if (!name || !Array.isArray(raw.fields)) return null;
+
+	const fields = raw.fields.filter(isQualityDefinitionFieldDiff);
+	return { name, fields };
+}
+
+function isQualityDefinitionFieldDiff(raw: unknown): raw is DriftFieldDiff {
+	return (
+		isRecord(raw) &&
+		typeof raw.path === 'string' &&
+		Object.hasOwn(raw, 'expected')
+	);
 }
 
 function isFieldDiff(raw: unknown): raw is DriftFieldDiff {
@@ -1006,6 +1103,18 @@ function formatNamingValue(field: string, raw: unknown): DriftDisplayValue {
 	return formatGenericValue(raw);
 }
 
+function formatQualityDefinitionValue(field: string, raw: unknown): DriftDisplayValue {
+	if (
+		(field === 'maxSize' || field === 'preferredSize') &&
+		(raw === null || raw === undefined || raw === 0)
+	) {
+		return value('Unlimited');
+	}
+	if (raw === null || raw === undefined) return value('Missing', { tone: 'danger' });
+	if (typeof raw === 'number') return value(String(raw), { mono: true });
+	return formatGenericValue(raw);
+}
+
 function formatMinutesValue(raw: unknown): DriftDisplayValue {
 	if (raw === null || raw === undefined) return value('Missing', { tone: 'danger' });
 	if (typeof raw !== 'number') return formatGenericValue(raw);
@@ -1106,6 +1215,25 @@ function namingFieldLabel(path: string): string {
 	};
 
 	return labels[path] ?? titleize(path);
+}
+
+function qualityDefinitionFieldLabel(path: string): string {
+	const labels: Record<string, string> = {
+		maxSize: 'Maximum Size',
+		minSize: 'Minimum Size',
+		preferredSize: 'Preferred Size'
+	};
+
+	return labels[path] ?? titleize(path);
+}
+
+function parseQualityDefinitionPath(path: string): ParsedQualityDefinitionPath | null {
+	const match = /^qualityDefinitions\[(.+)\]\.(.+)$/.exec(path);
+	if (!match) return null;
+	return {
+		qualityName: match[1],
+		field: match[2]
+	};
 }
 
 function implementationLabel(implementation: string): string {

--- a/src/lib/server/drift/mediaManagement.ts
+++ b/src/lib/server/drift/mediaManagement.ts
@@ -1,6 +1,10 @@
 import { arrSyncQueries } from '$db/queries/arrSync.ts';
 import type { BaseArrClient } from '$arr/base.ts';
-import type { ArrMediaManagementConfig, ArrNamingConfig, ArrQualityDefinition } from '$arr/types.ts';
+import type {
+	ArrMediaManagementConfig,
+	ArrNamingConfig,
+	ArrQualityDefinition
+} from '$arr/types.ts';
 import type { SyncArrType } from '$sync/mappings.ts';
 import { getCache } from '$pcd/index.ts';
 import {
@@ -338,7 +342,10 @@ export async function buildExpectedQualityDefinitions(
 	}
 
 	const apiMappings = await getQualityApiMappings(cache, arrType);
-	const { definitions } = transformQualityDefinitionsForArr(qualityDefinitions.entries, apiMappings);
+	const { definitions } = transformQualityDefinitionsForArr(
+		qualityDefinitions.entries,
+		apiMappings
+	);
 	return {
 		name: syncConfig.qualityDefinitionsConfigName,
 		definitions

--- a/src/lib/server/drift/mediaManagement.ts
+++ b/src/lib/server/drift/mediaManagement.ts
@@ -1,0 +1,132 @@
+import { arrSyncQueries } from '$db/queries/arrSync.ts';
+import type { BaseArrClient } from '$arr/base.ts';
+import type { ArrMediaManagementConfig } from '$arr/types.ts';
+import type { SyncArrType } from '$sync/mappings.ts';
+import { getCache } from '$pcd/index.ts';
+import {
+	getRadarrByName as getRadarrMediaSettings,
+	getSonarrByName as getSonarrMediaSettings
+} from '$pcd/entities/mediaManagement/media-settings/read.ts';
+import {
+	transformMediaSettings,
+	type ArrMediaSettingsManagedFields
+} from '$sync/mediaManagement/transformer.ts';
+import type { DriftFieldDiff } from './customFormats.ts';
+import { stringifyCanonical } from './hash.ts';
+
+export interface MediaSettingsMissingDiff {
+	name: string;
+}
+
+export interface MediaSettingsModifiedDiff {
+	name: string;
+	fields: DriftFieldDiff[];
+}
+
+export interface MediaSettingsDriftDiff {
+	missing: MediaSettingsMissingDiff[];
+	modified: MediaSettingsModifiedDiff[];
+}
+
+export interface MediaManagementDriftDiff {
+	media_settings: MediaSettingsDriftDiff;
+}
+
+export interface MediaManagementDriftResult {
+	count: number;
+	diff: MediaManagementDriftDiff;
+}
+
+export interface MediaSettingsDriftExpected extends ArrMediaSettingsManagedFields {
+	name: string;
+}
+
+const FIELD_ORDER = ['downloadPropersAndRepacks', 'enableMediaInfo'] as const;
+
+function emptyDiff(): MediaManagementDriftDiff {
+	return { media_settings: { missing: [], modified: [] } };
+}
+
+function valuesEqual(expected: unknown, actual: unknown): boolean {
+	return stringifyCanonical(expected) === stringifyCanonical(actual);
+}
+
+function compareMediaSettings(
+	expected: MediaSettingsDriftExpected,
+	actual: ArrMediaManagementConfig | null
+): DriftFieldDiff[] | null {
+	if (!actual) return null;
+
+	const diffs: DriftFieldDiff[] = [];
+	for (const field of FIELD_ORDER) {
+		if (!valuesEqual(expected[field], actual[field])) {
+			diffs.push({
+				path: field,
+				expected: expected[field],
+				actual: actual[field]
+			});
+		}
+	}
+	return diffs;
+}
+
+export function compareMediaManagementDrift(
+	expected: MediaSettingsDriftExpected | null,
+	actual: ArrMediaManagementConfig | null
+): MediaManagementDriftResult {
+	const diff = emptyDiff();
+	if (!expected) return { count: 0, diff };
+
+	const fields = compareMediaSettings(expected, actual);
+	if (!fields) {
+		diff.media_settings.missing.push({ name: expected.name });
+		return { count: 1, diff };
+	}
+
+	if (fields.length > 0) {
+		diff.media_settings.modified.push({ name: expected.name, fields });
+	}
+
+	return {
+		count: diff.media_settings.missing.length + diff.media_settings.modified.length,
+		diff
+	};
+}
+
+export async function buildExpectedMediaSettings(
+	instanceId: number,
+	arrType: SyncArrType
+): Promise<MediaSettingsDriftExpected | null> {
+	const syncConfig = arrSyncQueries.getMediaManagementSync(instanceId);
+	if (!syncConfig.mediaSettingsDatabaseId || !syncConfig.mediaSettingsConfigName) return null;
+
+	const cache = getCache(syncConfig.mediaSettingsDatabaseId);
+	if (!cache) {
+		throw new Error(`PCD cache not found for database ${syncConfig.mediaSettingsDatabaseId}`);
+	}
+
+	const getByName = arrType === 'radarr' ? getRadarrMediaSettings : getSonarrMediaSettings;
+	const mediaSettings = await getByName(cache, syncConfig.mediaSettingsConfigName);
+	if (!mediaSettings) {
+		throw new Error(
+			`Media settings "${syncConfig.mediaSettingsConfigName}" not found in database ${syncConfig.mediaSettingsDatabaseId}`
+		);
+	}
+
+	return {
+		name: syncConfig.mediaSettingsConfigName,
+		...transformMediaSettings(mediaSettings)
+	};
+}
+
+export async function checkMediaManagementDrift(
+	client: Pick<BaseArrClient, 'getMediaManagementConfig'>,
+	instanceId: number,
+	arrType: SyncArrType
+): Promise<MediaManagementDriftResult> {
+	const expected = await buildExpectedMediaSettings(instanceId, arrType);
+	if (!expected) return compareMediaManagementDrift(null, null);
+
+	const actual = await client.getMediaManagementConfig();
+	return compareMediaManagementDrift(expected, actual);
+}

--- a/src/lib/server/drift/mediaManagement.ts
+++ b/src/lib/server/drift/mediaManagement.ts
@@ -1,6 +1,6 @@
 import { arrSyncQueries } from '$db/queries/arrSync.ts';
 import type { BaseArrClient } from '$arr/base.ts';
-import type { ArrMediaManagementConfig } from '$arr/types.ts';
+import type { ArrMediaManagementConfig, ArrNamingConfig } from '$arr/types.ts';
 import type { SyncArrType } from '$sync/mappings.ts';
 import { getCache } from '$pcd/index.ts';
 import {
@@ -8,8 +8,15 @@ import {
 	getSonarrByName as getSonarrMediaSettings
 } from '$pcd/entities/mediaManagement/media-settings/read.ts';
 import {
+	getRadarrByName as getRadarrNaming,
+	getSonarrByName as getSonarrNaming
+} from '$pcd/entities/mediaManagement/naming/read.ts';
+import {
+	normalizeNamingConfig,
 	transformMediaSettings,
-	type ArrMediaSettingsManagedFields
+	transformNamingForDrift,
+	type ArrMediaSettingsManagedFields,
+	type NormalizedNamingManagedFields
 } from '$sync/mediaManagement/transformer.ts';
 import type { DriftFieldDiff } from './customFormats.ts';
 import { stringifyCanonical } from './hash.ts';
@@ -28,8 +35,23 @@ export interface MediaSettingsDriftDiff {
 	modified: MediaSettingsModifiedDiff[];
 }
 
+export interface NamingMissingDiff {
+	name: string;
+}
+
+export interface NamingModifiedDiff {
+	name: string;
+	fields: DriftFieldDiff[];
+}
+
+export interface NamingDriftDiff {
+	missing: NamingMissingDiff[];
+	modified: NamingModifiedDiff[];
+}
+
 export interface MediaManagementDriftDiff {
 	media_settings: MediaSettingsDriftDiff;
+	naming: NamingDriftDiff;
 }
 
 export interface MediaManagementDriftResult {
@@ -41,10 +63,40 @@ export interface MediaSettingsDriftExpected extends ArrMediaSettingsManagedField
 	name: string;
 }
 
-const FIELD_ORDER = ['downloadPropersAndRepacks', 'enableMediaInfo'] as const;
+export interface NamingDriftExpected {
+	name: string;
+	arrType: SyncArrType;
+	fields: NormalizedNamingManagedFields;
+}
+
+const MEDIA_SETTINGS_FIELD_ORDER = ['downloadPropersAndRepacks', 'enableMediaInfo'] as const;
+const NAMING_FIELD_ORDER: Record<SyncArrType, string[]> = {
+	radarr: [
+		'renameMovies',
+		'replaceIllegalCharacters',
+		'colonReplacementFormat',
+		'standardMovieFormat',
+		'movieFolderFormat'
+	],
+	sonarr: [
+		'renameEpisodes',
+		'replaceIllegalCharacters',
+		'colonReplacementFormat',
+		'customColonReplacementFormat',
+		'multiEpisodeStyle',
+		'standardEpisodeFormat',
+		'dailyEpisodeFormat',
+		'animeEpisodeFormat',
+		'seriesFolderFormat',
+		'seasonFolderFormat'
+	]
+};
 
 function emptyDiff(): MediaManagementDriftDiff {
-	return { media_settings: { missing: [], modified: [] } };
+	return {
+		media_settings: { missing: [], modified: [] },
+		naming: { missing: [], modified: [] }
+	};
 }
 
 function valuesEqual(expected: unknown, actual: unknown): boolean {
@@ -58,7 +110,7 @@ function compareMediaSettings(
 	if (!actual) return null;
 
 	const diffs: DriftFieldDiff[] = [];
-	for (const field of FIELD_ORDER) {
+	for (const field of MEDIA_SETTINGS_FIELD_ORDER) {
 		if (!valuesEqual(expected[field], actual[field])) {
 			diffs.push({
 				path: field,
@@ -70,25 +122,64 @@ function compareMediaSettings(
 	return diffs;
 }
 
+function fieldValue(fields: NormalizedNamingManagedFields, field: string): unknown {
+	return (fields as unknown as Record<string, unknown>)[field];
+}
+
+function compareNaming(
+	expected: NamingDriftExpected,
+	actual: ArrNamingConfig | null
+): DriftFieldDiff[] | null {
+	if (!actual) return null;
+
+	const actualFields = normalizeNamingConfig(actual, expected.arrType);
+	const diffs: DriftFieldDiff[] = [];
+	for (const field of NAMING_FIELD_ORDER[expected.arrType]) {
+		const expectedValue = fieldValue(expected.fields, field);
+		const actualValue = fieldValue(actualFields, field);
+		if (!valuesEqual(expectedValue, actualValue)) {
+			diffs.push({
+				path: field,
+				expected: expectedValue,
+				actual: actualValue
+			});
+		}
+	}
+	return diffs;
+}
+
 export function compareMediaManagementDrift(
 	expected: MediaSettingsDriftExpected | null,
-	actual: ArrMediaManagementConfig | null
+	actual: ArrMediaManagementConfig | null,
+	expectedNaming: NamingDriftExpected | null = null,
+	actualNaming: ArrNamingConfig | null = null
 ): MediaManagementDriftResult {
 	const diff = emptyDiff();
-	if (!expected) return { count: 0, diff };
 
-	const fields = compareMediaSettings(expected, actual);
-	if (!fields) {
-		diff.media_settings.missing.push({ name: expected.name });
-		return { count: 1, diff };
+	if (expected) {
+		const fields = compareMediaSettings(expected, actual);
+		if (!fields) {
+			diff.media_settings.missing.push({ name: expected.name });
+		} else if (fields.length > 0) {
+			diff.media_settings.modified.push({ name: expected.name, fields });
+		}
 	}
 
-	if (fields.length > 0) {
-		diff.media_settings.modified.push({ name: expected.name, fields });
+	if (expectedNaming) {
+		const fields = compareNaming(expectedNaming, actualNaming);
+		if (!fields) {
+			diff.naming.missing.push({ name: expectedNaming.name });
+		} else if (fields.length > 0) {
+			diff.naming.modified.push({ name: expectedNaming.name, fields });
+		}
 	}
 
 	return {
-		count: diff.media_settings.missing.length + diff.media_settings.modified.length,
+		count:
+			diff.media_settings.missing.length +
+			diff.media_settings.modified.length +
+			diff.naming.missing.length +
+			diff.naming.modified.length,
 		diff
 	};
 }
@@ -119,14 +210,54 @@ export async function buildExpectedMediaSettings(
 	};
 }
 
+export async function buildExpectedNaming(
+	instanceId: number,
+	arrType: SyncArrType
+): Promise<NamingDriftExpected | null> {
+	const syncConfig = arrSyncQueries.getMediaManagementSync(instanceId);
+	if (!syncConfig.namingDatabaseId || !syncConfig.namingConfigName) return null;
+
+	const cache = getCache(syncConfig.namingDatabaseId);
+	if (!cache) {
+		throw new Error(`PCD cache not found for database ${syncConfig.namingDatabaseId}`);
+	}
+
+	const getByName = arrType === 'radarr' ? getRadarrNaming : getSonarrNaming;
+	const naming = await getByName(cache, syncConfig.namingConfigName);
+	if (!naming) {
+		throw new Error(
+			`Naming config "${syncConfig.namingConfigName}" not found in database ${syncConfig.namingDatabaseId}`
+		);
+	}
+
+	return {
+		name: syncConfig.namingConfigName,
+		arrType,
+		fields: transformNamingForDrift(naming, arrType)
+	};
+}
+
 export async function checkMediaManagementDrift(
-	client: Pick<BaseArrClient, 'getMediaManagementConfig'>,
+	client: Pick<BaseArrClient, 'getMediaManagementConfig' | 'getNamingConfig'>,
 	instanceId: number,
 	arrType: SyncArrType
 ): Promise<MediaManagementDriftResult> {
-	const expected = await buildExpectedMediaSettings(instanceId, arrType);
-	if (!expected) return compareMediaManagementDrift(null, null);
+	const [expectedMediaSettings, expectedNaming] = await Promise.all([
+		buildExpectedMediaSettings(instanceId, arrType),
+		buildExpectedNaming(instanceId, arrType)
+	]);
+	if (!expectedMediaSettings && !expectedNaming) {
+		return compareMediaManagementDrift(null, null);
+	}
 
-	const actual = await client.getMediaManagementConfig();
-	return compareMediaManagementDrift(expected, actual);
+	const [actualMediaSettings, actualNaming] = await Promise.all([
+		expectedMediaSettings ? client.getMediaManagementConfig() : Promise.resolve(null),
+		expectedNaming ? client.getNamingConfig() : Promise.resolve(null)
+	]);
+	return compareMediaManagementDrift(
+		expectedMediaSettings,
+		actualMediaSettings,
+		expectedNaming,
+		actualNaming
+	);
 }

--- a/src/lib/server/drift/mediaManagement.ts
+++ b/src/lib/server/drift/mediaManagement.ts
@@ -1,6 +1,6 @@
 import { arrSyncQueries } from '$db/queries/arrSync.ts';
 import type { BaseArrClient } from '$arr/base.ts';
-import type { ArrMediaManagementConfig, ArrNamingConfig } from '$arr/types.ts';
+import type { ArrMediaManagementConfig, ArrNamingConfig, ArrQualityDefinition } from '$arr/types.ts';
 import type { SyncArrType } from '$sync/mappings.ts';
 import { getCache } from '$pcd/index.ts';
 import {
@@ -12,12 +12,20 @@ import {
 	getSonarrByName as getSonarrNaming
 } from '$pcd/entities/mediaManagement/naming/read.ts';
 import {
+	getRadarrByName as getRadarrQualityDefs,
+	getSonarrByName as getSonarrQualityDefs
+} from '$pcd/entities/mediaManagement/quality-definitions/read.ts';
+import {
+	normalizeArrQualityDefinition,
 	normalizeNamingConfig,
 	transformMediaSettings,
 	transformNamingForDrift,
+	transformQualityDefinitionsForArr,
 	type ArrMediaSettingsManagedFields,
+	type MappedQualityDefinition,
 	type NormalizedNamingManagedFields
 } from '$sync/mediaManagement/transformer.ts';
+import { getQualityApiMappings } from '$sync/qualityProfiles/transformer.ts';
 import type { DriftFieldDiff } from './customFormats.ts';
 import { stringifyCanonical } from './hash.ts';
 
@@ -49,9 +57,24 @@ export interface NamingDriftDiff {
 	modified: NamingModifiedDiff[];
 }
 
+export interface QualityDefinitionsMissingDiff {
+	name: string;
+}
+
+export interface QualityDefinitionsModifiedDiff {
+	name: string;
+	fields: DriftFieldDiff[];
+}
+
+export interface QualityDefinitionsDriftDiff {
+	missing: QualityDefinitionsMissingDiff[];
+	modified: QualityDefinitionsModifiedDiff[];
+}
+
 export interface MediaManagementDriftDiff {
 	media_settings: MediaSettingsDriftDiff;
 	naming: NamingDriftDiff;
+	quality_definitions: QualityDefinitionsDriftDiff;
 }
 
 export interface MediaManagementDriftResult {
@@ -67,6 +90,11 @@ export interface NamingDriftExpected {
 	name: string;
 	arrType: SyncArrType;
 	fields: NormalizedNamingManagedFields;
+}
+
+export interface QualityDefinitionsDriftExpected {
+	name: string;
+	definitions: MappedQualityDefinition[];
 }
 
 const MEDIA_SETTINGS_FIELD_ORDER = ['downloadPropersAndRepacks', 'enableMediaInfo'] as const;
@@ -91,11 +119,13 @@ const NAMING_FIELD_ORDER: Record<SyncArrType, string[]> = {
 		'seasonFolderFormat'
 	]
 };
+const QUALITY_DEFINITION_FIELD_ORDER = ['minSize', 'maxSize', 'preferredSize'] as const;
 
 function emptyDiff(): MediaManagementDriftDiff {
 	return {
 		media_settings: { missing: [], modified: [] },
-		naming: { missing: [], modified: [] }
+		naming: { missing: [], modified: [] },
+		quality_definitions: { missing: [], modified: [] }
 	};
 }
 
@@ -148,11 +178,48 @@ function compareNaming(
 	return diffs;
 }
 
+function compareQualityDefinitions(
+	expected: QualityDefinitionsDriftExpected,
+	actual: ArrQualityDefinition[] | null
+): DriftFieldDiff[] | null {
+	if (!actual) return null;
+
+	const actualMap = new Map<string, ArrQualityDefinition>();
+	for (const definition of actual) {
+		if (definition.quality.name) {
+			actualMap.set(definition.quality.name.toLowerCase(), definition);
+		}
+	}
+
+	const diffs: DriftFieldDiff[] = [];
+	for (const definition of expected.definitions) {
+		const actualDefinition = actualMap.get(definition.qualityName.toLowerCase());
+		if (!actualDefinition) continue;
+
+		const actualFields = normalizeArrQualityDefinition(actualDefinition);
+		for (const field of QUALITY_DEFINITION_FIELD_ORDER) {
+			const expectedValue = definition.fields[field];
+			const actualValue = actualFields[field];
+			if (!valuesEqual(expectedValue, actualValue)) {
+				diffs.push({
+					path: `qualityDefinitions[${definition.qualityName}].${field}`,
+					expected: expectedValue,
+					actual: actualValue
+				});
+			}
+		}
+	}
+
+	return diffs;
+}
+
 export function compareMediaManagementDrift(
 	expected: MediaSettingsDriftExpected | null,
 	actual: ArrMediaManagementConfig | null,
 	expectedNaming: NamingDriftExpected | null = null,
-	actualNaming: ArrNamingConfig | null = null
+	actualNaming: ArrNamingConfig | null = null,
+	expectedQualityDefinitions: QualityDefinitionsDriftExpected | null = null,
+	actualQualityDefinitions: ArrQualityDefinition[] | null = null
 ): MediaManagementDriftResult {
 	const diff = emptyDiff();
 
@@ -174,12 +241,23 @@ export function compareMediaManagementDrift(
 		}
 	}
 
+	if (expectedQualityDefinitions) {
+		const fields = compareQualityDefinitions(expectedQualityDefinitions, actualQualityDefinitions);
+		if (!fields) {
+			diff.quality_definitions.missing.push({ name: expectedQualityDefinitions.name });
+		} else if (fields.length > 0) {
+			diff.quality_definitions.modified.push({ name: expectedQualityDefinitions.name, fields });
+		}
+	}
+
 	return {
 		count:
 			diff.media_settings.missing.length +
 			diff.media_settings.modified.length +
 			diff.naming.missing.length +
-			diff.naming.modified.length,
+			diff.naming.modified.length +
+			diff.quality_definitions.missing.length +
+			diff.quality_definitions.modified.length,
 		diff
 	};
 }
@@ -237,27 +315,64 @@ export async function buildExpectedNaming(
 	};
 }
 
+export async function buildExpectedQualityDefinitions(
+	instanceId: number,
+	arrType: SyncArrType
+): Promise<QualityDefinitionsDriftExpected | null> {
+	const syncConfig = arrSyncQueries.getMediaManagementSync(instanceId);
+	if (!syncConfig.qualityDefinitionsDatabaseId || !syncConfig.qualityDefinitionsConfigName) {
+		return null;
+	}
+
+	const cache = getCache(syncConfig.qualityDefinitionsDatabaseId);
+	if (!cache) {
+		throw new Error(`PCD cache not found for database ${syncConfig.qualityDefinitionsDatabaseId}`);
+	}
+
+	const getByName = arrType === 'radarr' ? getRadarrQualityDefs : getSonarrQualityDefs;
+	const qualityDefinitions = await getByName(cache, syncConfig.qualityDefinitionsConfigName);
+	if (!qualityDefinitions) {
+		throw new Error(
+			`Quality definitions "${syncConfig.qualityDefinitionsConfigName}" not found in database ${syncConfig.qualityDefinitionsDatabaseId}`
+		);
+	}
+
+	const apiMappings = await getQualityApiMappings(cache, arrType);
+	const { definitions } = transformQualityDefinitionsForArr(qualityDefinitions.entries, apiMappings);
+	return {
+		name: syncConfig.qualityDefinitionsConfigName,
+		definitions
+	};
+}
+
 export async function checkMediaManagementDrift(
-	client: Pick<BaseArrClient, 'getMediaManagementConfig' | 'getNamingConfig'>,
+	client: Pick<
+		BaseArrClient,
+		'getMediaManagementConfig' | 'getNamingConfig' | 'getQualityDefinitions'
+	>,
 	instanceId: number,
 	arrType: SyncArrType
 ): Promise<MediaManagementDriftResult> {
-	const [expectedMediaSettings, expectedNaming] = await Promise.all([
+	const [expectedMediaSettings, expectedNaming, expectedQualityDefinitions] = await Promise.all([
 		buildExpectedMediaSettings(instanceId, arrType),
-		buildExpectedNaming(instanceId, arrType)
+		buildExpectedNaming(instanceId, arrType),
+		buildExpectedQualityDefinitions(instanceId, arrType)
 	]);
-	if (!expectedMediaSettings && !expectedNaming) {
+	if (!expectedMediaSettings && !expectedNaming && !expectedQualityDefinitions) {
 		return compareMediaManagementDrift(null, null);
 	}
 
-	const [actualMediaSettings, actualNaming] = await Promise.all([
+	const [actualMediaSettings, actualNaming, actualQualityDefinitions] = await Promise.all([
 		expectedMediaSettings ? client.getMediaManagementConfig() : Promise.resolve(null),
-		expectedNaming ? client.getNamingConfig() : Promise.resolve(null)
+		expectedNaming ? client.getNamingConfig() : Promise.resolve(null),
+		expectedQualityDefinitions ? client.getQualityDefinitions() : Promise.resolve(null)
 	]);
 	return compareMediaManagementDrift(
 		expectedMediaSettings,
 		actualMediaSettings,
 		expectedNaming,
-		actualNaming
+		actualNaming,
+		expectedQualityDefinitions,
+		actualQualityDefinitions
 	);
 }

--- a/src/lib/server/sync/entitySync.ts
+++ b/src/lib/server/sync/entitySync.ts
@@ -40,9 +40,11 @@ import {
 import type { RadarrNamingConfig, SonarrNamingConfig } from '$arr/types.ts';
 import { transformDelayProfile } from './delayProfiles/transformer.ts';
 import {
+	applyQualityDefinitionsToArr,
 	mergeMediaSettingsConfig,
 	mergeRadarrNamingConfig,
-	mergeSonarrNamingConfig
+	mergeSonarrNamingConfig,
+	transformQualityDefinitionsForArr
 } from './mediaManagement/transformer.ts';
 
 interface SyncResult {
@@ -408,29 +410,8 @@ export async function syncQualityDefinitions(
 		// GET existing quality definitions from arr
 		const arrDefinitions = await client.getQualityDefinitions();
 
-		// Build map of arr quality name (lowercase) -> definition
-		const arrDefMap = new Map<string, (typeof arrDefinitions)[0]>();
-		for (const def of arrDefinitions) {
-			if (def.quality.name) {
-				arrDefMap.set(def.quality.name.toLowerCase(), def);
-			}
-		}
-
-		// Update arr definitions with PCD values
-		let updatedCount = 0;
-		for (const entry of qualityDefsConfig.entries) {
-			const apiName = apiMappings.get(entry.quality_name.toLowerCase());
-			if (!apiName) continue;
-
-			const arrDef = arrDefMap.get(apiName.toLowerCase());
-			if (!arrDef) continue;
-
-			// PCD stores 0 for "unlimited", arr API expects null
-			arrDef.minSize = entry.min_size;
-			arrDef.maxSize = entry.max_size === 0 ? null : entry.max_size;
-			arrDef.preferredSize = entry.preferred_size === 0 ? null : entry.preferred_size;
-			updatedCount++;
-		}
+		const transformed = transformQualityDefinitionsForArr(qualityDefsConfig.entries, apiMappings);
+		const { updatedCount } = applyQualityDefinitionsToArr(arrDefinitions, transformed.definitions);
 
 		if (updatedCount === 0) {
 			return { success: false, error: 'No quality definitions matched for update' };

--- a/src/lib/server/sync/entitySync.ts
+++ b/src/lib/server/sync/entitySync.ts
@@ -37,10 +37,10 @@ import {
 	getRadarrByName as getRadarrMediaSettings,
 	getSonarrByName as getSonarrMediaSettings
 } from '$pcd/entities/mediaManagement/media-settings/read.ts';
-import type { ArrPropersAndRepacks } from '$arr/types.ts';
 import { colonReplacementToDb, multiEpisodeStyleToDb } from '$shared/pcd/mediaManagement.ts';
 import type { RadarrNamingConfig, SonarrNamingConfig } from '$arr/types.ts';
 import { transformDelayProfile } from './delayProfiles/transformer.ts';
+import { mergeMediaSettingsConfig } from './mediaManagement/transformer.ts';
 
 interface SyncResult {
 	success: boolean;
@@ -504,11 +504,7 @@ export async function syncMediaSettings(
 		}
 
 		const existing = await client.getMediaManagementConfig();
-		const updated = {
-			...existing,
-			downloadPropersAndRepacks: mapPropersRepacks(mediaSettings.propers_repacks),
-			enableMediaInfo: mediaSettings.enable_media_info
-		};
+		const updated = mergeMediaSettingsConfig(existing, mediaSettings);
 		await client.updateMediaManagementConfig(updated);
 
 		await logger.info(`Entity sync: updated media settings "${configName}"`, {
@@ -529,13 +525,4 @@ export async function syncMediaSettings(
 	} finally {
 		client.close();
 	}
-}
-
-function mapPropersRepacks(pcdValue: string): ArrPropersAndRepacks {
-	const mapping: Record<string, ArrPropersAndRepacks> = {
-		doNotPrefer: 'doNotPrefer',
-		preferAndUpgrade: 'preferAndUpgrade',
-		doNotUpgradeAutomatically: 'doNotUpgrade'
-	};
-	return mapping[pcdValue] ?? 'doNotPrefer';
 }

--- a/src/lib/server/sync/entitySync.ts
+++ b/src/lib/server/sync/entitySync.ts
@@ -37,10 +37,13 @@ import {
 	getRadarrByName as getRadarrMediaSettings,
 	getSonarrByName as getSonarrMediaSettings
 } from '$pcd/entities/mediaManagement/media-settings/read.ts';
-import { colonReplacementToDb, multiEpisodeStyleToDb } from '$shared/pcd/mediaManagement.ts';
 import type { RadarrNamingConfig, SonarrNamingConfig } from '$arr/types.ts';
 import { transformDelayProfile } from './delayProfiles/transformer.ts';
-import { mergeMediaSettingsConfig } from './mediaManagement/transformer.ts';
+import {
+	mergeMediaSettingsConfig,
+	mergeRadarrNamingConfig,
+	mergeSonarrNamingConfig
+} from './mediaManagement/transformer.ts';
 
 interface SyncResult {
 	success: boolean;
@@ -331,14 +334,7 @@ export async function syncNaming(
 			}
 
 			const existing = (await client.getNamingConfig()) as RadarrNamingConfig;
-			const updated: RadarrNamingConfig = {
-				...existing,
-				renameMovies: naming.rename,
-				replaceIllegalCharacters: naming.replace_illegal_characters,
-				colonReplacementFormat: naming.colon_replacement_format,
-				standardMovieFormat: naming.movie_format,
-				movieFolderFormat: naming.movie_folder_format
-			};
+			const updated = mergeRadarrNamingConfig(existing, naming);
 			await client.updateNamingConfig(updated);
 		} else if (instance.type === 'sonarr') {
 			const naming = await getSonarrNaming(cache, configName);
@@ -347,19 +343,7 @@ export async function syncNaming(
 			}
 
 			const existing = (await client.getNamingConfig()) as SonarrNamingConfig;
-			const updated: SonarrNamingConfig = {
-				...existing,
-				renameEpisodes: naming.rename,
-				replaceIllegalCharacters: naming.replace_illegal_characters,
-				colonReplacementFormat: colonReplacementToDb(naming.colon_replacement_format),
-				customColonReplacementFormat: naming.custom_colon_replacement_format,
-				multiEpisodeStyle: multiEpisodeStyleToDb(naming.multi_episode_style),
-				standardEpisodeFormat: naming.standard_episode_format,
-				dailyEpisodeFormat: naming.daily_episode_format,
-				animeEpisodeFormat: naming.anime_episode_format,
-				seriesFolderFormat: naming.series_folder_format,
-				seasonFolderFormat: naming.season_folder_format
-			};
+			const updated = mergeSonarrNamingConfig(existing, naming);
 			await client.updateNamingConfig(updated);
 		} else {
 			return { success: false, error: `Unsupported instance type: ${instance.type}` };

--- a/src/lib/server/sync/mediaManagement/syncer.ts
+++ b/src/lib/server/sync/mediaManagement/syncer.ts
@@ -34,10 +34,10 @@ import type { RadarrMediaSettingsRow, SonarrMediaSettingsRow } from '$shared/pcd
 import { colonReplacementToDb, multiEpisodeStyleToDb } from '$shared/pcd/mediaManagement.ts';
 import type {
 	ArrType,
-	ArrPropersAndRepacks,
 	RadarrNamingConfig,
 	SonarrNamingConfig
 } from '$arr/types.ts';
+import { mergeMediaSettingsConfig } from './transformer.ts';
 import { logger } from '$logger/logger.ts';
 
 export class MediaManagementSyncer extends BaseSyncer {
@@ -179,11 +179,7 @@ export class MediaManagementSyncer extends BaseSyncer {
 		const existingConfig = await this.client.getMediaManagementConfig();
 
 		// Transform and update
-		const updatedConfig = {
-			...existingConfig,
-			downloadPropersAndRepacks: this.mapPropersRepacks(mediaSettings.propers_repacks),
-			enableMediaInfo: mediaSettings.enable_media_info
-		};
+		const updatedConfig = mergeMediaSettingsConfig(existingConfig, mediaSettings);
 
 		await logger.debug('Updating media settings', {
 			source: 'Sync:MediaSettings',
@@ -197,15 +193,6 @@ export class MediaManagementSyncer extends BaseSyncer {
 
 		await this.client.updateMediaManagementConfig(updatedConfig);
 		return true;
-	}
-
-	private mapPropersRepacks(pcdValue: string): ArrPropersAndRepacks {
-		const mapping: Record<string, ArrPropersAndRepacks> = {
-			doNotPrefer: 'doNotPrefer',
-			preferAndUpgrade: 'preferAndUpgrade',
-			doNotUpgradeAutomatically: 'doNotUpgrade'
-		};
-		return mapping[pcdValue] ?? 'doNotPrefer';
 	}
 
 	// =========================================================================

--- a/src/lib/server/sync/mediaManagement/syncer.ts
+++ b/src/lib/server/sync/mediaManagement/syncer.ts
@@ -31,13 +31,12 @@ import {
 	getSonarrByName as getSonarrQualityDefs
 } from '$pcd/entities/mediaManagement/quality-definitions/read.ts';
 import type { RadarrMediaSettingsRow, SonarrMediaSettingsRow } from '$shared/pcd/display.ts';
-import { colonReplacementToDb, multiEpisodeStyleToDb } from '$shared/pcd/mediaManagement.ts';
-import type {
-	ArrType,
-	RadarrNamingConfig,
-	SonarrNamingConfig
-} from '$arr/types.ts';
-import { mergeMediaSettingsConfig } from './transformer.ts';
+import type { ArrType, RadarrNamingConfig, SonarrNamingConfig } from '$arr/types.ts';
+import {
+	mergeMediaSettingsConfig,
+	mergeRadarrNamingConfig,
+	mergeSonarrNamingConfig
+} from './transformer.ts';
 import { logger } from '$logger/logger.ts';
 
 export class MediaManagementSyncer extends BaseSyncer {
@@ -236,14 +235,7 @@ export class MediaManagementSyncer extends BaseSyncer {
 		const existingConfig = (await this.client.getNamingConfig()) as RadarrNamingConfig;
 
 		// Transform and update
-		const updatedConfig: RadarrNamingConfig = {
-			...existingConfig,
-			renameMovies: naming.rename,
-			replaceIllegalCharacters: naming.replace_illegal_characters,
-			colonReplacementFormat: naming.colon_replacement_format,
-			standardMovieFormat: naming.movie_format,
-			movieFolderFormat: naming.movie_folder_format
-		};
+		const updatedConfig = mergeRadarrNamingConfig(existingConfig, naming);
 
 		await logger.debug('Updating Radarr naming', {
 			source: 'Sync:Naming',
@@ -272,20 +264,8 @@ export class MediaManagementSyncer extends BaseSyncer {
 		// GET existing config
 		const existingConfig = (await this.client.getNamingConfig()) as SonarrNamingConfig;
 
-		// Transform and update - Sonarr uses integers for enums
-		const updatedConfig: SonarrNamingConfig = {
-			...existingConfig,
-			renameEpisodes: naming.rename,
-			replaceIllegalCharacters: naming.replace_illegal_characters,
-			colonReplacementFormat: colonReplacementToDb(naming.colon_replacement_format),
-			customColonReplacementFormat: naming.custom_colon_replacement_format,
-			multiEpisodeStyle: multiEpisodeStyleToDb(naming.multi_episode_style),
-			standardEpisodeFormat: naming.standard_episode_format,
-			dailyEpisodeFormat: naming.daily_episode_format,
-			animeEpisodeFormat: naming.anime_episode_format,
-			seriesFolderFormat: naming.series_folder_format,
-			seasonFolderFormat: naming.season_folder_format
-		};
+		// Transform and update
+		const updatedConfig = mergeSonarrNamingConfig(existingConfig, naming);
 
 		await logger.debug('Updating Sonarr naming', {
 			source: 'Sync:Naming',

--- a/src/lib/server/sync/mediaManagement/syncer.ts
+++ b/src/lib/server/sync/mediaManagement/syncer.ts
@@ -5,7 +5,7 @@
  * Handles three types of configs:
  * 1. Media Settings (downloadPropersAndRepacks, enableMediaInfo)
  * 2. Naming (movie/episode naming formats, folder formats)
- * 3. Quality Definitions (TODO)
+ * 3. Quality Definitions
  *
  * Flow for each:
  * 1. GET existing config from arr
@@ -33,9 +33,11 @@ import {
 import type { RadarrMediaSettingsRow, SonarrMediaSettingsRow } from '$shared/pcd/display.ts';
 import type { ArrType, RadarrNamingConfig, SonarrNamingConfig } from '$arr/types.ts';
 import {
+	applyQualityDefinitionsToArr,
 	mergeMediaSettingsConfig,
 	mergeRadarrNamingConfig,
-	mergeSonarrNamingConfig
+	mergeSonarrNamingConfig,
+	transformQualityDefinitionsForArr
 } from './transformer.ts';
 import { logger } from '$logger/logger.ts';
 
@@ -322,43 +324,23 @@ export class MediaManagementSyncer extends BaseSyncer {
 		// GET existing quality definitions from ARR
 		const arrDefinitions = await this.client.getQualityDefinitions();
 
-		// Build map of ARR quality name (lowercase) -> definition
-		const arrDefMap = new Map<string, (typeof arrDefinitions)[0]>();
-		for (const def of arrDefinitions) {
-			if (def.quality.name) {
-				arrDefMap.set(def.quality.name.toLowerCase(), def);
-			}
+		const transformed = transformQualityDefinitionsForArr(qualityDefsConfig.entries, apiMappings);
+		for (const qualityName of transformed.unmapped) {
+			await logger.debug(`No API mapping found for quality "${qualityName}"`, {
+				source: 'Sync:QualityDefinitions',
+				meta: { instanceId: this.instanceId, qualityName }
+			});
 		}
 
-		// Update ARR definitions with PCD values
-		let updatedCount = 0;
-		for (const entry of qualityDefsConfig.entries) {
-			// Get the API name for this quality
-			const apiName = apiMappings.get(entry.quality_name.toLowerCase());
-			if (!apiName) {
-				await logger.debug(`No API mapping found for quality "${entry.quality_name}"`, {
-					source: 'Sync:QualityDefinitions',
-					meta: { instanceId: this.instanceId, qualityName: entry.quality_name }
-				});
-				continue;
-			}
-
-			// Find matching ARR definition
-			const arrDef = arrDefMap.get(apiName.toLowerCase());
-			if (!arrDef) {
-				await logger.debug(`No ARR definition found for quality "${apiName}"`, {
-					source: 'Sync:QualityDefinitions',
-					meta: { instanceId: this.instanceId, apiName }
-				});
-				continue;
-			}
-
-			// Update the definition
-			// PCD stores 0 for "unlimited", arr API expects null
-			arrDef.minSize = entry.min_size;
-			arrDef.maxSize = entry.max_size === 0 ? null : entry.max_size;
-			arrDef.preferredSize = entry.preferred_size === 0 ? null : entry.preferred_size;
-			updatedCount++;
+		const { updatedCount, missing } = applyQualityDefinitionsToArr(
+			arrDefinitions,
+			transformed.definitions
+		);
+		for (const apiName of missing) {
+			await logger.debug(`No ARR definition found for quality "${apiName}"`, {
+				source: 'Sync:QualityDefinitions',
+				meta: { instanceId: this.instanceId, apiName }
+			});
 		}
 
 		if (updatedCount === 0) {

--- a/src/lib/server/sync/mediaManagement/transformer.ts
+++ b/src/lib/server/sync/mediaManagement/transformer.ts
@@ -288,7 +288,9 @@ export function normalizeSonarrNamingConfig(
 		renameEpisodes: config.renameEpisodes,
 		replaceIllegalCharacters: config.replaceIllegalCharacters,
 		colonReplacementFormat: colonReplacementFromDb(config.colonReplacementFormat),
-		customColonReplacementFormat: normalizeOptionalNamingString(config.customColonReplacementFormat),
+		customColonReplacementFormat: normalizeOptionalNamingString(
+			config.customColonReplacementFormat
+		),
 		multiEpisodeStyle: multiEpisodeStyleFromDb(config.multiEpisodeStyle),
 		standardEpisodeFormat: config.standardEpisodeFormat,
 		dailyEpisodeFormat: config.dailyEpisodeFormat,

--- a/src/lib/server/sync/mediaManagement/transformer.ts
+++ b/src/lib/server/sync/mediaManagement/transformer.ts
@@ -1,0 +1,40 @@
+import type { ArrMediaManagementConfig, ArrPropersAndRepacks } from '$arr/types.ts';
+import type { RadarrMediaSettingsRow, SonarrMediaSettingsRow } from '$shared/pcd/display.ts';
+
+export interface ArrMediaSettingsManagedFields {
+	downloadPropersAndRepacks: ArrPropersAndRepacks;
+	enableMediaInfo: boolean;
+}
+
+type PcdMediaSettings = Pick<
+	RadarrMediaSettingsRow | SonarrMediaSettingsRow,
+	'propers_repacks' | 'enable_media_info'
+>;
+
+export function transformMediaSettings(
+	mediaSettings: PcdMediaSettings
+): ArrMediaSettingsManagedFields {
+	return {
+		downloadPropersAndRepacks: mapPropersRepacks(mediaSettings.propers_repacks),
+		enableMediaInfo: mediaSettings.enable_media_info
+	};
+}
+
+export function mergeMediaSettingsConfig(
+	existing: ArrMediaManagementConfig,
+	mediaSettings: PcdMediaSettings
+): ArrMediaManagementConfig {
+	return {
+		...existing,
+		...transformMediaSettings(mediaSettings)
+	};
+}
+
+function mapPropersRepacks(pcdValue: string): ArrPropersAndRepacks {
+	const mapping: Record<string, ArrPropersAndRepacks> = {
+		doNotPrefer: 'doNotPrefer',
+		preferAndUpgrade: 'preferAndUpgrade',
+		doNotUpgradeAutomatically: 'doNotUpgrade'
+	};
+	return mapping[pcdValue] ?? 'doNotPrefer';
+}

--- a/src/lib/server/sync/mediaManagement/transformer.ts
+++ b/src/lib/server/sync/mediaManagement/transformer.ts
@@ -2,10 +2,12 @@ import type {
 	ArrMediaManagementConfig,
 	ArrNamingConfig,
 	ArrPropersAndRepacks,
+	ArrQualityDefinition,
 	RadarrNamingConfig,
 	SonarrNamingConfig
 } from '$arr/types.ts';
 import type {
+	QualityDefinitionEntry,
 	RadarrMediaSettingsRow,
 	RadarrNamingRow,
 	SonarrMediaSettingsRow,
@@ -86,6 +88,27 @@ type SonarrNamingApiManagedFields = Omit<
 
 export type NormalizedNamingManagedFields = RadarrNamingManagedFields | SonarrNamingManagedFields;
 
+export interface QualityDefinitionManagedFields {
+	minSize: number | null;
+	maxSize: number | null;
+	preferredSize: number | null;
+}
+
+export interface MappedQualityDefinition {
+	qualityName: string;
+	fields: QualityDefinitionManagedFields;
+}
+
+export interface QualityDefinitionTransformResult {
+	definitions: MappedQualityDefinition[];
+	unmapped: string[];
+}
+
+export interface QualityDefinitionApplyResult {
+	updatedCount: number;
+	missing: string[];
+}
+
 export function transformMediaSettings(
 	mediaSettings: PcdMediaSettings
 ): ArrMediaSettingsManagedFields {
@@ -128,6 +151,63 @@ export function transformNamingForDrift(
 		return transformRadarrNaming(naming as PcdRadarrNaming);
 	}
 	return normalizeSonarrNamingConfig(transformSonarrNaming(naming as PcdSonarrNaming));
+}
+
+export function transformQualityDefinitionsForArr(
+	entries: QualityDefinitionEntry[],
+	apiMappings: Map<string, string>
+): QualityDefinitionTransformResult {
+	const definitions: MappedQualityDefinition[] = [];
+	const unmapped: string[] = [];
+
+	for (const entry of entries) {
+		const apiName = apiMappings.get(entry.quality_name.toLowerCase());
+		if (!apiName) {
+			unmapped.push(entry.quality_name);
+			continue;
+		}
+
+		definitions.push({
+			qualityName: apiName,
+			fields: transformQualityDefinition(entry)
+		});
+	}
+
+	return { definitions, unmapped };
+}
+
+export function applyQualityDefinitionsToArr(
+	arrDefinitions: ArrQualityDefinition[],
+	definitions: MappedQualityDefinition[]
+): QualityDefinitionApplyResult {
+	const arrDefMap = buildArrQualityDefinitionMap(arrDefinitions);
+	const missing: string[] = [];
+	let updatedCount = 0;
+
+	for (const definition of definitions) {
+		const arrDef = arrDefMap.get(definition.qualityName.toLowerCase());
+		if (!arrDef) {
+			missing.push(definition.qualityName);
+			continue;
+		}
+
+		arrDef.minSize = definition.fields.minSize;
+		arrDef.maxSize = definition.fields.maxSize;
+		arrDef.preferredSize = definition.fields.preferredSize;
+		updatedCount++;
+	}
+
+	return { updatedCount, missing };
+}
+
+export function normalizeArrQualityDefinition(
+	definition: Pick<ArrQualityDefinition, 'minSize' | 'maxSize' | 'preferredSize'>
+): QualityDefinitionManagedFields {
+	return {
+		minSize: definition.minSize ?? null,
+		maxSize: definition.maxSize ?? null,
+		preferredSize: definition.preferredSize ?? null
+	};
 }
 
 export function mergeMediaSettingsConfig(
@@ -221,6 +301,26 @@ export function normalizeSonarrNamingConfig(
 function normalizeOptionalNamingString(value: string | null | undefined): string | null {
 	if (value === null || value === undefined) return null;
 	return value.trim() === '' ? null : value;
+}
+
+function transformQualityDefinition(entry: QualityDefinitionEntry): QualityDefinitionManagedFields {
+	return {
+		minSize: entry.min_size,
+		maxSize: entry.max_size === 0 ? null : entry.max_size,
+		preferredSize: entry.preferred_size === 0 ? null : entry.preferred_size
+	};
+}
+
+function buildArrQualityDefinitionMap(
+	arrDefinitions: ArrQualityDefinition[]
+): Map<string, ArrQualityDefinition> {
+	const arrDefMap = new Map<string, ArrQualityDefinition>();
+	for (const definition of arrDefinitions) {
+		if (definition.quality.name) {
+			arrDefMap.set(definition.quality.name.toLowerCase(), definition);
+		}
+	}
+	return arrDefMap;
 }
 
 function mapPropersRepacks(pcdValue: string): ArrPropersAndRepacks {

--- a/src/lib/server/sync/mediaManagement/transformer.ts
+++ b/src/lib/server/sync/mediaManagement/transformer.ts
@@ -1,5 +1,26 @@
-import type { ArrMediaManagementConfig, ArrPropersAndRepacks } from '$arr/types.ts';
-import type { RadarrMediaSettingsRow, SonarrMediaSettingsRow } from '$shared/pcd/display.ts';
+import type {
+	ArrMediaManagementConfig,
+	ArrNamingConfig,
+	ArrPropersAndRepacks,
+	RadarrNamingConfig,
+	SonarrNamingConfig
+} from '$arr/types.ts';
+import type {
+	RadarrMediaSettingsRow,
+	RadarrNamingRow,
+	SonarrMediaSettingsRow,
+	SonarrNamingRow
+} from '$shared/pcd/display.ts';
+import {
+	colonReplacementFromDb,
+	colonReplacementToDb,
+	multiEpisodeStyleFromDb,
+	multiEpisodeStyleToDb,
+	type MultiEpisodeStyle,
+	type RadarrColonReplacementFormat,
+	type SonarrColonReplacementFormat
+} from '$shared/pcd/mediaManagement.ts';
+import type { SyncArrType } from '$sync/mappings.ts';
 
 export interface ArrMediaSettingsManagedFields {
 	downloadPropersAndRepacks: ArrPropersAndRepacks;
@@ -11,6 +32,60 @@ type PcdMediaSettings = Pick<
 	'propers_repacks' | 'enable_media_info'
 >;
 
+type PcdRadarrNaming = Pick<
+	RadarrNamingRow,
+	| 'rename'
+	| 'replace_illegal_characters'
+	| 'colon_replacement_format'
+	| 'movie_format'
+	| 'movie_folder_format'
+>;
+
+type PcdSonarrNaming = Pick<
+	SonarrNamingRow,
+	| 'rename'
+	| 'replace_illegal_characters'
+	| 'colon_replacement_format'
+	| 'custom_colon_replacement_format'
+	| 'multi_episode_style'
+	| 'standard_episode_format'
+	| 'daily_episode_format'
+	| 'anime_episode_format'
+	| 'series_folder_format'
+	| 'season_folder_format'
+>;
+
+export interface RadarrNamingManagedFields {
+	renameMovies: boolean;
+	replaceIllegalCharacters: boolean;
+	colonReplacementFormat: RadarrColonReplacementFormat;
+	standardMovieFormat: string | null;
+	movieFolderFormat: string | null;
+}
+
+export interface SonarrNamingManagedFields {
+	renameEpisodes: boolean;
+	replaceIllegalCharacters: boolean;
+	colonReplacementFormat: SonarrColonReplacementFormat;
+	customColonReplacementFormat: string | null;
+	multiEpisodeStyle: MultiEpisodeStyle;
+	standardEpisodeFormat: string | null;
+	dailyEpisodeFormat: string | null;
+	animeEpisodeFormat: string | null;
+	seriesFolderFormat: string | null;
+	seasonFolderFormat: string | null;
+}
+
+type SonarrNamingApiManagedFields = Omit<
+	SonarrNamingManagedFields,
+	'colonReplacementFormat' | 'multiEpisodeStyle'
+> & {
+	colonReplacementFormat: number;
+	multiEpisodeStyle: number;
+};
+
+export type NormalizedNamingManagedFields = RadarrNamingManagedFields | SonarrNamingManagedFields;
+
 export function transformMediaSettings(
 	mediaSettings: PcdMediaSettings
 ): ArrMediaSettingsManagedFields {
@@ -18,6 +93,41 @@ export function transformMediaSettings(
 		downloadPropersAndRepacks: mapPropersRepacks(mediaSettings.propers_repacks),
 		enableMediaInfo: mediaSettings.enable_media_info
 	};
+}
+
+export function transformRadarrNaming(naming: PcdRadarrNaming): RadarrNamingManagedFields {
+	return {
+		renameMovies: naming.rename,
+		replaceIllegalCharacters: naming.replace_illegal_characters,
+		colonReplacementFormat: naming.colon_replacement_format,
+		standardMovieFormat: naming.movie_format,
+		movieFolderFormat: naming.movie_folder_format
+	};
+}
+
+export function transformSonarrNaming(naming: PcdSonarrNaming): SonarrNamingApiManagedFields {
+	return {
+		renameEpisodes: naming.rename,
+		replaceIllegalCharacters: naming.replace_illegal_characters,
+		colonReplacementFormat: colonReplacementToDb(naming.colon_replacement_format),
+		customColonReplacementFormat: naming.custom_colon_replacement_format,
+		multiEpisodeStyle: multiEpisodeStyleToDb(naming.multi_episode_style),
+		standardEpisodeFormat: naming.standard_episode_format,
+		dailyEpisodeFormat: naming.daily_episode_format,
+		animeEpisodeFormat: naming.anime_episode_format,
+		seriesFolderFormat: naming.series_folder_format,
+		seasonFolderFormat: naming.season_folder_format
+	};
+}
+
+export function transformNamingForDrift(
+	naming: PcdRadarrNaming | PcdSonarrNaming,
+	arrType: SyncArrType
+): NormalizedNamingManagedFields {
+	if (arrType === 'radarr') {
+		return transformRadarrNaming(naming as PcdRadarrNaming);
+	}
+	return normalizeSonarrNamingConfig(transformSonarrNaming(naming as PcdSonarrNaming));
 }
 
 export function mergeMediaSettingsConfig(
@@ -28,6 +138,89 @@ export function mergeMediaSettingsConfig(
 		...existing,
 		...transformMediaSettings(mediaSettings)
 	};
+}
+
+export function mergeRadarrNamingConfig(
+	existing: RadarrNamingConfig,
+	naming: PcdRadarrNaming
+): RadarrNamingConfig {
+	return {
+		...existing,
+		...transformRadarrNaming(naming)
+	};
+}
+
+export function mergeSonarrNamingConfig(
+	existing: SonarrNamingConfig,
+	naming: PcdSonarrNaming
+): SonarrNamingConfig {
+	return {
+		...existing,
+		...transformSonarrNaming(naming)
+	};
+}
+
+export function normalizeNamingConfig(
+	config: ArrNamingConfig,
+	arrType: SyncArrType
+): NormalizedNamingManagedFields {
+	if (arrType === 'radarr') {
+		return normalizeRadarrNamingConfig(config as RadarrNamingConfig);
+	}
+	return normalizeSonarrNamingConfig(config as SonarrNamingConfig);
+}
+
+export function normalizeRadarrNamingConfig(
+	config: Pick<
+		RadarrNamingConfig,
+		| 'renameMovies'
+		| 'replaceIllegalCharacters'
+		| 'colonReplacementFormat'
+		| 'standardMovieFormat'
+		| 'movieFolderFormat'
+	>
+): RadarrNamingManagedFields {
+	return {
+		renameMovies: config.renameMovies,
+		replaceIllegalCharacters: config.replaceIllegalCharacters,
+		colonReplacementFormat: config.colonReplacementFormat,
+		standardMovieFormat: config.standardMovieFormat,
+		movieFolderFormat: config.movieFolderFormat
+	};
+}
+
+export function normalizeSonarrNamingConfig(
+	config: Pick<
+		SonarrNamingConfig | SonarrNamingApiManagedFields,
+		| 'renameEpisodes'
+		| 'replaceIllegalCharacters'
+		| 'colonReplacementFormat'
+		| 'customColonReplacementFormat'
+		| 'multiEpisodeStyle'
+		| 'standardEpisodeFormat'
+		| 'dailyEpisodeFormat'
+		| 'animeEpisodeFormat'
+		| 'seriesFolderFormat'
+		| 'seasonFolderFormat'
+	>
+): SonarrNamingManagedFields {
+	return {
+		renameEpisodes: config.renameEpisodes,
+		replaceIllegalCharacters: config.replaceIllegalCharacters,
+		colonReplacementFormat: colonReplacementFromDb(config.colonReplacementFormat),
+		customColonReplacementFormat: normalizeOptionalNamingString(config.customColonReplacementFormat),
+		multiEpisodeStyle: multiEpisodeStyleFromDb(config.multiEpisodeStyle),
+		standardEpisodeFormat: config.standardEpisodeFormat,
+		dailyEpisodeFormat: config.dailyEpisodeFormat,
+		animeEpisodeFormat: config.animeEpisodeFormat,
+		seriesFolderFormat: config.seriesFolderFormat,
+		seasonFolderFormat: config.seasonFolderFormat
+	};
+}
+
+function normalizeOptionalNamingString(value: string | null | undefined): string | null {
+	if (value === null || value === undefined) return null;
+	return value.trim() === '' ? null : value;
 }
 
 function mapPropersRepacks(pcdValue: string): ArrPropersAndRepacks {

--- a/src/routes/arr/[id]/drift/+page.svelte
+++ b/src/routes/arr/[id]/drift/+page.svelte
@@ -295,11 +295,16 @@
 						</svelte:fragment>
 					</ExpandableTable>
 				{:else}
-					<div
-						class="rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm text-amber-700 dark:border-amber-900 dark:bg-amber-950/40 dark:text-amber-300"
-					>
-						Drift was detected, but no displayable items were stored.
-					</div>
+					<ExpandableTable
+						columns={driftColumns}
+						data={emptyDriftEntities}
+						getRowId={(row) => row.id}
+						responsive
+						chevronPosition="right"
+						primaryColumnKey="title"
+						flushExpanded
+						emptyMessage="Drift was detected, but no displayable items were stored."
+					/>
 				{/if}
 			</section>
 		{/if}

--- a/src/routes/arr/[id]/drift/+page.svelte
+++ b/src/routes/arr/[id]/drift/+page.svelte
@@ -35,7 +35,7 @@
 
 	const driftColumns: Column<DriftDisplayEntity>[] = [
 		{ key: 'title', header: 'Name' },
-		{ key: 'section', header: 'Entity', width: 'w-44' },
+		{ key: 'section', header: 'Entity', width: 'w-56' },
 		{ key: 'state', header: 'State', width: 'w-32' }
 	];
 

--- a/src/routes/arr/[id]/sync/+page.server.ts
+++ b/src/routes/arr/[id]/sync/+page.server.ts
@@ -21,6 +21,7 @@ import type {
 	QualityProfileDriftDiff,
 	QualityProfileModifiedDiff
 } from '$drift/qualityProfiles.ts';
+import type { MediaManagementDriftDiff } from '$drift/mediaManagement.ts';
 import { FEATURES } from '$shared/features.ts';
 import type { SyncArrType } from '$sync/mappings.ts';
 
@@ -34,6 +35,20 @@ interface DriftProgress {
 	customFormats?: SectionProgress;
 	qualityProfiles?: SectionProgress;
 	delayProfiles?: SectionProgress;
+	naming?: SectionProgress;
+	qualityDefinitions?: SectionProgress;
+	mediaSettings?: SectionProgress;
+}
+
+/**
+ * For each MM sub-config (naming, quality definitions, media settings) the
+ * "drift count" we surface in the chip is binary: 0 if there's no drift in
+ * that sub-config, 1 if there is. The denominator is also 0 or 1 — whether
+ * the sub-config is configured at all. So the chip ends up as 0/0 (hidden),
+ * 1/1 (clean), or 0/1 (drifted), mirroring the delay-profile chip pattern.
+ */
+function subConfigDrifted(sub: { missing: unknown[]; modified: unknown[] }): boolean {
+	return sub.missing.length > 0 || sub.modified.length > 0;
 }
 
 /**
@@ -130,17 +145,28 @@ async function loadDriftProgress(
 
 	const qpSync = arrSyncQueries.getQualityProfilesSync(instanceId);
 	const dpSync = arrSyncQueries.getDelayProfilesSync(instanceId);
+	const mmSync = arrSyncQueries.getMediaManagementSync(instanceId);
 
 	const qpTotal = qpSync.selections.length;
 	const dpTotal = dpSync.databaseId && dpSync.profileName ? 1 : 0;
 	const cfTotal = qpTotal > 0 ? (await buildExpectedCustomFormats(instanceId, arrType)).length : 0;
+	const namingTotal = mmSync.namingDatabaseId !== null && mmSync.namingConfigName ? 1 : 0;
+	const qualityDefinitionsTotal =
+		mmSync.qualityDefinitionsDatabaseId !== null && mmSync.qualityDefinitionsConfigName ? 1 : 0;
+	const mediaSettingsTotal =
+		mmSync.mediaSettingsDatabaseId !== null && mmSync.mediaSettingsConfigName ? 1 : 0;
 
 	const counts = status.counts ?? {};
 	const diff = status.diff as
-		| { quality_profiles?: QualityProfileDriftDiff; custom_formats?: CustomFormatDriftDiff }
+		| {
+				quality_profiles?: QualityProfileDriftDiff;
+				custom_formats?: CustomFormatDriftDiff;
+				media_management?: MediaManagementDriftDiff;
+		  }
 		| undefined;
 	const qpClass = classifyQpDrift(diff?.quality_profiles);
 	const cfNames = collectCfNames(diff?.custom_formats);
+	const mm = diff?.media_management;
 
 	const progress: DriftProgress = {};
 	if (qpTotal > 0) {
@@ -167,8 +193,39 @@ async function loadDriftProgress(
 			message: dpDrifted > 0 ? `${dpName} drifted.` : undefined
 		};
 	}
+	if (namingTotal > 0) {
+		const drifted = mm?.naming && subConfigDrifted(mm.naming) ? 1 : 0;
+		progress.naming = {
+			total: namingTotal,
+			drifted,
+			message: drifted > 0 ? `${mmSync.namingConfigName} drifted.` : undefined
+		};
+	}
+	if (qualityDefinitionsTotal > 0) {
+		const drifted = mm?.quality_definitions && subConfigDrifted(mm.quality_definitions) ? 1 : 0;
+		progress.qualityDefinitions = {
+			total: qualityDefinitionsTotal,
+			drifted,
+			message: drifted > 0 ? `${mmSync.qualityDefinitionsConfigName} drifted.` : undefined
+		};
+	}
+	if (mediaSettingsTotal > 0) {
+		const drifted = mm?.media_settings && subConfigDrifted(mm.media_settings) ? 1 : 0;
+		progress.mediaSettings = {
+			total: mediaSettingsTotal,
+			drifted,
+			message: drifted > 0 ? `${mmSync.mediaSettingsConfigName} drifted.` : undefined
+		};
+	}
 
-	if (!progress.qualityProfiles && !progress.delayProfiles && !progress.customFormats) {
+	if (
+		!progress.qualityProfiles &&
+		!progress.delayProfiles &&
+		!progress.customFormats &&
+		!progress.naming &&
+		!progress.qualityDefinitions &&
+		!progress.mediaSettings
+	) {
 		return null;
 	}
 

--- a/src/routes/arr/[id]/sync/+page.svelte
+++ b/src/routes/arr/[id]/sync/+page.svelte
@@ -155,6 +155,9 @@
 			bind:syncTrigger={mediaManagementTrigger}
 			bind:cronExpression={mediaManagementCron}
 			bind:isDirty={mediaManagementDirty}
+			namingProgress={data.driftProgress?.naming}
+			qualityDefinitionsProgress={data.driftProgress?.qualityDefinitions}
+			mediaSettingsProgress={data.driftProgress?.mediaSettings}
 		/>
 		<DelayProfiles
 			databases={data.databases}

--- a/src/routes/arr/[id]/sync/components/MediaManagement.svelte
+++ b/src/routes/arr/[id]/sync/components/MediaManagement.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import DropdownCombobox from '$ui/dropdown/DropdownCombobox.svelte';
 	import SyncFooter from './SyncFooter.svelte';
+	import ProgressIndicator from '$ui/arr/ProgressIndicator.svelte';
 	import { alertStore } from '$lib/client/alerts/store.ts';
 	import { deserialize } from '$app/forms';
 	import { jobStatus } from '$stores/jobStatus';
@@ -15,6 +16,12 @@
 		namingConfigs: ConfigOption[];
 		qualityDefinitionsConfigs: ConfigOption[];
 		mediaSettingsConfigs: ConfigOption[];
+	}
+
+	interface SectionProgress {
+		total: number;
+		drifted: number;
+		message?: string;
 	}
 
 	export let databases: Database[];
@@ -33,6 +40,9 @@
 		mediaSettingsDatabaseId: null,
 		mediaSettingsConfigName: null
 	};
+	export let namingProgress: SectionProgress | undefined = undefined;
+	export let qualityDefinitionsProgress: SectionProgress | undefined = undefined;
+	export let mediaSettingsProgress: SectionProgress | undefined = undefined;
 
 	type SelectionOption = {
 		value: string;
@@ -215,11 +225,70 @@
 	class="rounded-lg border border-neutral-200 bg-white dark:border-neutral-800 dark:bg-neutral-900"
 >
 	<!-- Header -->
-	<div class="border-b border-neutral-200 px-6 py-4 dark:border-neutral-800">
-		<h2 class="text-xl font-semibold text-neutral-900 dark:text-neutral-50">Media Management</h2>
-		<p class="mt-1 text-sm text-neutral-600 dark:text-neutral-400">
-			Select which database config to use for each media management setting
-		</p>
+	<div
+		class="flex flex-col gap-4 border-b border-neutral-200 px-6 py-4 md:flex-row md:items-start md:justify-between md:gap-6 dark:border-neutral-800"
+	>
+		<div class="min-w-0 md:flex-1">
+			<h2 class="text-xl font-semibold text-neutral-900 dark:text-neutral-50">Media Management</h2>
+			<p class="mt-1 text-sm text-neutral-600 dark:text-neutral-400">
+				Select which database config to use for each media management setting
+			</p>
+		</div>
+		{#if namingProgress || qualityDefinitionsProgress || mediaSettingsProgress}
+			<div class="flex flex-col gap-3 md:flex-shrink-0 md:flex-row md:flex-wrap md:gap-5 md:pt-1">
+				{#if namingProgress}
+					<div class="min-w-[9rem]">
+						<div class="mb-1 text-xs font-medium text-neutral-500 dark:text-neutral-400">
+							Naming
+						</div>
+						<ProgressIndicator
+							current={namingProgress.total - namingProgress.drifted}
+							target={namingProgress.total}
+							met={namingProgress.drifted === 0}
+							mode="compact"
+							colorMode="completion"
+							tooltip={namingProgress.message ?? ''}
+							tooltipPosition="bottom"
+							tooltipAlign="middle"
+						/>
+					</div>
+				{/if}
+				{#if qualityDefinitionsProgress}
+					<div class="min-w-[9rem]">
+						<div class="mb-1 text-xs font-medium text-neutral-500 dark:text-neutral-400">
+							Quality Definitions
+						</div>
+						<ProgressIndicator
+							current={qualityDefinitionsProgress.total - qualityDefinitionsProgress.drifted}
+							target={qualityDefinitionsProgress.total}
+							met={qualityDefinitionsProgress.drifted === 0}
+							mode="compact"
+							colorMode="completion"
+							tooltip={qualityDefinitionsProgress.message ?? ''}
+							tooltipPosition="bottom"
+							tooltipAlign="middle"
+						/>
+					</div>
+				{/if}
+				{#if mediaSettingsProgress}
+					<div class="min-w-[9rem]">
+						<div class="mb-1 text-xs font-medium text-neutral-500 dark:text-neutral-400">
+							Media Settings
+						</div>
+						<ProgressIndicator
+							current={mediaSettingsProgress.total - mediaSettingsProgress.drifted}
+							target={mediaSettingsProgress.total}
+							met={mediaSettingsProgress.drifted === 0}
+							mode="compact"
+							colorMode="completion"
+							tooltip={mediaSettingsProgress.message ?? ''}
+							tooltipPosition="bottom"
+							tooltipAlign="middle"
+						/>
+					</div>
+				{/if}
+			</div>
+		{/if}
 	</div>
 
 	<!-- Content -->

--- a/tests/unit/drift/mediaManagement.test.ts
+++ b/tests/unit/drift/mediaManagement.test.ts
@@ -1,0 +1,130 @@
+import { assertEquals } from '@std/assert';
+import { BaseTest } from '../base/BaseTest.ts';
+import {
+	compareMediaManagementDrift,
+	type MediaManagementDriftDiff,
+	type MediaSettingsDriftExpected
+} from '$drift/mediaManagement.ts';
+import { hashDriftDiff } from '$drift/hash.ts';
+import type { ArrMediaManagementConfig } from '$arr/types.ts';
+import { transformMediaSettings } from '$sync/mediaManagement/transformer.ts';
+
+function expectedMediaSettings(
+	input: Partial<MediaSettingsDriftExpected> = {}
+): MediaSettingsDriftExpected {
+	return {
+		name: input.name ?? 'Standard Media Settings',
+		downloadPropersAndRepacks: input.downloadPropersAndRepacks ?? 'preferAndUpgrade',
+		enableMediaInfo: input.enableMediaInfo ?? true
+	};
+}
+
+function actualMediaSettings(
+	input: Partial<ArrMediaManagementConfig> = {}
+): ArrMediaManagementConfig {
+	return {
+		id: input.id ?? 1,
+		downloadPropersAndRepacks: input.downloadPropersAndRepacks ?? 'preferAndUpgrade',
+		enableMediaInfo: input.enableMediaInfo ?? true,
+		...input
+	};
+}
+
+class MediaManagementDriftTest extends BaseTest {
+	runTests(): void {
+		this.test('clean when no media settings are configured', () => {
+			const result = compareMediaManagementDrift(null, actualMediaSettings());
+
+			assertEquals(result.count, 0);
+			assertEquals(result.diff, { media_settings: { missing: [], modified: [] } });
+		});
+
+		this.test('clean when expected and actual media settings match', () => {
+			const result = compareMediaManagementDrift(
+				expectedMediaSettings(),
+				actualMediaSettings({ untouchedArrField: 'preserved' })
+			);
+
+			assertEquals(result.count, 0);
+			assertEquals(result.diff, { media_settings: { missing: [], modified: [] } });
+		});
+
+		this.test('normalizes doNotUpgradeAutomatically to Arr doNotUpgrade', () => {
+			const result = transformMediaSettings({
+				propers_repacks: 'doNotUpgradeAutomatically',
+				enable_media_info: true
+			});
+
+			assertEquals(result.downloadPropersAndRepacks, 'doNotUpgrade');
+		});
+
+		this.test('reports propers and repacks mismatch', () => {
+			const result = compareMediaManagementDrift(
+				expectedMediaSettings({ downloadPropersAndRepacks: 'doNotUpgrade' }),
+				actualMediaSettings({ downloadPropersAndRepacks: 'doNotPrefer' })
+			);
+
+			assertEquals(result.count, 1);
+			assertEquals(result.diff.media_settings.modified, [
+				{
+					name: 'Standard Media Settings',
+					fields: [
+						{
+							path: 'downloadPropersAndRepacks',
+							expected: 'doNotUpgrade',
+							actual: 'doNotPrefer'
+						}
+					]
+				}
+			]);
+		});
+
+		this.test('reports enable media info mismatch', () => {
+			const result = compareMediaManagementDrift(
+				expectedMediaSettings({ enableMediaInfo: false }),
+				actualMediaSettings({ enableMediaInfo: true })
+			);
+
+			assertEquals(result.count, 1);
+			assertEquals(result.diff.media_settings.modified, [
+				{
+					name: 'Standard Media Settings',
+					fields: [{ path: 'enableMediaInfo', expected: false, actual: true }]
+				}
+			]);
+		});
+
+		this.test('hash is stable for equivalent object key order', async () => {
+			const first: MediaManagementDriftDiff = {
+				media_settings: {
+					missing: [],
+					modified: [
+						{
+							name: 'Standard Media Settings',
+							fields: [{ path: 'enableMediaInfo', expected: false, actual: true }]
+						}
+					]
+				}
+			};
+			const second = {
+				media_settings: {
+					modified: [
+						{
+							fields: [{ actual: true, expected: false, path: 'enableMediaInfo' }],
+							name: 'Standard Media Settings'
+						}
+					],
+					missing: []
+				}
+			};
+
+			assertEquals(
+				await hashDriftDiff({ media_management: first }),
+				await hashDriftDiff({ media_management: second })
+			);
+		});
+	}
+}
+
+const mediaManagementDriftTest = new MediaManagementDriftTest();
+mediaManagementDriftTest.runTests();

--- a/tests/unit/drift/mediaManagement.test.ts
+++ b/tests/unit/drift/mediaManagement.test.ts
@@ -4,15 +4,21 @@ import {
 	compareMediaManagementDrift,
 	type MediaManagementDriftDiff,
 	type MediaSettingsDriftExpected,
-	type NamingDriftExpected
+	type NamingDriftExpected,
+	type QualityDefinitionsDriftExpected
 } from '$drift/mediaManagement.ts';
+import { buildDriftDisplayEntities } from '$drift/display.ts';
 import { hashDriftDiff } from '$drift/hash.ts';
 import type {
 	ArrMediaManagementConfig,
+	ArrQualityDefinition,
 	RadarrNamingConfig,
 	SonarrNamingConfig
 } from '$arr/types.ts';
-import { transformMediaSettings } from '$sync/mediaManagement/transformer.ts';
+import {
+	transformMediaSettings,
+	transformQualityDefinitionsForArr
+} from '$sync/mediaManagement/transformer.ts';
 
 function expectedMediaSettings(
 	input: Partial<MediaSettingsDriftExpected> = {}
@@ -101,6 +107,45 @@ function actualSonarrNaming(input: Partial<SonarrNamingConfig> = {}): SonarrNami
 	};
 }
 
+function expectedQualityDefinitions(
+	input: Partial<QualityDefinitionsDriftExpected> = {}
+): QualityDefinitionsDriftExpected {
+	return {
+		name: input.name ?? 'Standard Quality Definitions',
+		definitions: input.definitions ?? [
+			{
+				qualityName: 'WEBDL-1080p',
+				fields: {
+					minSize: 10,
+					maxSize: null,
+					preferredSize: 20
+				}
+			}
+		]
+	};
+}
+
+function actualQualityDefinition(
+	qualityName: string,
+	input: Partial<ArrQualityDefinition> = {}
+): ArrQualityDefinition {
+	return {
+		id: input.id ?? 1,
+		quality: input.quality ?? {
+			id: 3,
+			name: qualityName,
+			source: 'webdl',
+			resolution: 1080
+		},
+		title: input.title ?? null,
+		weight: input.weight ?? 1,
+		minSize: Object.hasOwn(input, 'minSize') ? (input.minSize ?? null) : 10,
+		maxSize: Object.hasOwn(input, 'maxSize') ? (input.maxSize ?? null) : null,
+		preferredSize: Object.hasOwn(input, 'preferredSize') ? (input.preferredSize ?? null) : 20,
+		...input
+	};
+}
+
 class MediaManagementDriftTest extends BaseTest {
 	runTests(): void {
 		this.test('clean when no media settings are configured', () => {
@@ -109,7 +154,8 @@ class MediaManagementDriftTest extends BaseTest {
 			assertEquals(result.count, 0);
 			assertEquals(result.diff, {
 				media_settings: { missing: [], modified: [] },
-				naming: { missing: [], modified: [] }
+				naming: { missing: [], modified: [] },
+				quality_definitions: { missing: [], modified: [] }
 			});
 		});
 
@@ -122,7 +168,8 @@ class MediaManagementDriftTest extends BaseTest {
 			assertEquals(result.count, 0);
 			assertEquals(result.diff, {
 				media_settings: { missing: [], modified: [] },
-				naming: { missing: [], modified: [] }
+				naming: { missing: [], modified: [] },
+				quality_definitions: { missing: [], modified: [] }
 			});
 		});
 
@@ -276,6 +323,192 @@ class MediaManagementDriftTest extends BaseTest {
 			]);
 		});
 
+		this.test('clean when expected and actual quality definitions match', () => {
+			const result = compareMediaManagementDrift(
+				null,
+				null,
+				null,
+				null,
+				expectedQualityDefinitions(),
+				[actualQualityDefinition('WEBDL-1080p', { title: 'Preserved' })]
+			);
+
+			assertEquals(result.count, 0);
+			assertEquals(result.diff.quality_definitions, { missing: [], modified: [] });
+		});
+
+		this.test('normalizes unlimited quality definition sizes to Arr null', () => {
+			const transformed = transformQualityDefinitionsForArr(
+				[
+					{
+						quality_name: 'WEBDL-1080p',
+						min_size: 10,
+						max_size: 0,
+						preferred_size: 0
+					}
+				],
+				new Map([['webdl-1080p', 'WEBDL-1080p']])
+			);
+			const result = compareMediaManagementDrift(
+				null,
+				null,
+				null,
+				null,
+				expectedQualityDefinitions({ definitions: transformed.definitions }),
+				[actualQualityDefinition('WEBDL-1080p', { preferredSize: null })]
+			);
+
+			assertEquals(transformed.definitions[0].fields, {
+				minSize: 10,
+				maxSize: null,
+				preferredSize: null
+			});
+			assertEquals(result.count, 0);
+			assertEquals(result.diff.quality_definitions, { missing: [], modified: [] });
+		});
+
+		this.test('treats missing Arr quality definition size fields as unlimited', () => {
+			const actual = actualQualityDefinition('WEBDL-1080p');
+			delete (actual as unknown as Record<string, unknown>).maxSize;
+
+			const result = compareMediaManagementDrift(
+				null,
+				null,
+				null,
+				null,
+				expectedQualityDefinitions(),
+				[actual]
+			);
+
+			assertEquals(result.count, 0);
+			assertEquals(result.diff.quality_definitions, { missing: [], modified: [] });
+		});
+
+		this.test('reports quality definition size mismatch', () => {
+			const result = compareMediaManagementDrift(
+				null,
+				null,
+				null,
+				null,
+				expectedQualityDefinitions(),
+				[actualQualityDefinition('WEBDL-1080p', { maxSize: 100 })]
+			);
+
+			assertEquals(result.count, 1);
+			assertEquals(result.diff.quality_definitions.modified, [
+				{
+					name: 'Standard Quality Definitions',
+					fields: [
+						{
+							path: 'qualityDefinitions[WEBDL-1080p].maxSize',
+							expected: null,
+							actual: 100
+						}
+					]
+				}
+			]);
+		});
+
+		this.test('ignores unmapped PCD quality definition entries', () => {
+			const transformed = transformQualityDefinitionsForArr(
+				[
+					{
+						quality_name: 'Unmapped',
+						min_size: 10,
+						max_size: 20,
+						preferred_size: 30
+					}
+				],
+				new Map()
+			);
+			const result = compareMediaManagementDrift(
+				null,
+				null,
+				null,
+				null,
+				expectedQualityDefinitions({ definitions: transformed.definitions }),
+				[]
+			);
+
+			assertEquals(transformed.unmapped, ['Unmapped']);
+			assertEquals(result.count, 0);
+			assertEquals(result.diff.quality_definitions, { missing: [], modified: [] });
+		});
+
+		this.test('ignores mapped quality definition entries missing in Arr', () => {
+			const result = compareMediaManagementDrift(
+				null,
+				null,
+				null,
+				null,
+				expectedQualityDefinitions({
+					definitions: [
+						...expectedQualityDefinitions().definitions,
+						{
+							qualityName: 'Bluray-1080p',
+							fields: { minSize: 10, maxSize: null, preferredSize: 20 }
+						}
+					]
+				}),
+				[actualQualityDefinition('WEBDL-1080p')]
+			);
+
+			assertEquals(result.count, 0);
+			assertEquals(result.diff.quality_definitions, { missing: [], modified: [] });
+		});
+
+		this.test('ignores extra Arr quality definitions and unmanaged fields', () => {
+			const result = compareMediaManagementDrift(
+				null,
+				null,
+				null,
+				null,
+				expectedQualityDefinitions(),
+				[
+					actualQualityDefinition('WEBDL-1080p', {
+						id: 99,
+						title: 'Different',
+						weight: 500,
+						quality: { id: 3, name: 'WEBDL-1080p', source: 'different', resolution: 720 }
+					}),
+					actualQualityDefinition('Bluray-1080p', { minSize: 1, maxSize: 2, preferredSize: 3 })
+				]
+			);
+
+			assertEquals(result.count, 0);
+			assertEquals(result.diff.quality_definitions, { missing: [], modified: [] });
+		});
+
+		this.test('displays stored quality definition diffs with omitted actual values', () => {
+			const entities = buildDriftDisplayEntities(
+				{
+					media_management: {
+						media_settings: { missing: [], modified: [] },
+						naming: { missing: [], modified: [] },
+						quality_definitions: {
+							missing: [],
+							modified: [
+								{
+									name: 'Standard Quality Definitions',
+									fields: [
+										{
+											path: 'qualityDefinitions[WEBDL-1080p].maxSize',
+											expected: null
+										}
+									]
+								}
+							]
+						}
+					}
+				},
+				'radarr'
+			);
+
+			assertEquals(entities.length, 1);
+			assertEquals(entities[0].changes[0].label, 'WEBDL-1080p');
+			assertEquals(entities[0].changes[0].actual?.text, 'Unlimited');
+		});
+
 		this.test('hash is stable for equivalent object key order', async () => {
 			const first: MediaManagementDriftDiff = {
 				media_settings: {
@@ -297,6 +530,21 @@ class MediaManagementDriftTest extends BaseTest {
 									path: 'movieFolderFormat',
 									expected: '{Movie}',
 									actual: '{Movie CleanTitle}'
+								}
+							]
+						}
+					]
+				},
+				quality_definitions: {
+					missing: [],
+					modified: [
+						{
+							name: 'Standard Quality Definitions',
+							fields: [
+								{
+									path: 'qualityDefinitions[WEBDL-1080p].maxSize',
+									expected: null,
+									actual: 100
 								}
 							]
 						}
@@ -324,6 +572,21 @@ class MediaManagementDriftTest extends BaseTest {
 								}
 							],
 							name: 'Standard Naming'
+						}
+					],
+					missing: []
+				},
+				quality_definitions: {
+					modified: [
+						{
+							fields: [
+								{
+									actual: 100,
+									expected: null,
+									path: 'qualityDefinitions[WEBDL-1080p].maxSize'
+								}
+							],
+							name: 'Standard Quality Definitions'
 						}
 					],
 					missing: []

--- a/tests/unit/drift/mediaManagement.test.ts
+++ b/tests/unit/drift/mediaManagement.test.ts
@@ -3,10 +3,15 @@ import { BaseTest } from '../base/BaseTest.ts';
 import {
 	compareMediaManagementDrift,
 	type MediaManagementDriftDiff,
-	type MediaSettingsDriftExpected
+	type MediaSettingsDriftExpected,
+	type NamingDriftExpected
 } from '$drift/mediaManagement.ts';
 import { hashDriftDiff } from '$drift/hash.ts';
-import type { ArrMediaManagementConfig } from '$arr/types.ts';
+import type {
+	ArrMediaManagementConfig,
+	RadarrNamingConfig,
+	SonarrNamingConfig
+} from '$arr/types.ts';
 import { transformMediaSettings } from '$sync/mediaManagement/transformer.ts';
 
 function expectedMediaSettings(
@@ -30,13 +35,82 @@ function actualMediaSettings(
 	};
 }
 
+function expectedRadarrNaming(input: Partial<NamingDriftExpected> = {}): NamingDriftExpected {
+	return {
+		name: input.name ?? 'Standard Naming',
+		arrType: 'radarr',
+		fields: {
+			renameMovies: true,
+			replaceIllegalCharacters: true,
+			colonReplacementFormat: 'smart',
+			standardMovieFormat: '{Movie CleanTitle} ({Release Year})',
+			movieFolderFormat: '{Movie CleanTitle} ({Release Year})',
+			...input.fields
+		}
+	};
+}
+
+function actualRadarrNaming(input: Partial<RadarrNamingConfig> = {}): RadarrNamingConfig {
+	return {
+		id: input.id ?? 1,
+		renameMovies: input.renameMovies ?? true,
+		replaceIllegalCharacters: input.replaceIllegalCharacters ?? true,
+		colonReplacementFormat: input.colonReplacementFormat ?? 'smart',
+		standardMovieFormat: input.standardMovieFormat ?? '{Movie CleanTitle} ({Release Year})',
+		movieFolderFormat: input.movieFolderFormat ?? '{Movie CleanTitle} ({Release Year})',
+		...input
+	};
+}
+
+function expectedSonarrNaming(input: Partial<NamingDriftExpected> = {}): NamingDriftExpected {
+	return {
+		name: input.name ?? 'Standard Naming',
+		arrType: 'sonarr',
+		fields: {
+			renameEpisodes: true,
+			replaceIllegalCharacters: true,
+			colonReplacementFormat: 'spaceDash',
+			customColonReplacementFormat: null,
+			multiEpisodeStyle: 'scene',
+			standardEpisodeFormat: '{Series Title} - S{season:00}E{episode:00}',
+			dailyEpisodeFormat: '{Series Title} - {Air-Date}',
+			animeEpisodeFormat: '{Series Title} - S{season:00}E{episode:00}',
+			seriesFolderFormat: '{Series Title}',
+			seasonFolderFormat: 'Season {season:00}',
+			...input.fields
+		}
+	};
+}
+
+function actualSonarrNaming(input: Partial<SonarrNamingConfig> = {}): SonarrNamingConfig {
+	return {
+		id: input.id ?? 1,
+		renameEpisodes: input.renameEpisodes ?? true,
+		replaceIllegalCharacters: input.replaceIllegalCharacters ?? true,
+		colonReplacementFormat: input.colonReplacementFormat ?? 2,
+		customColonReplacementFormat: input.customColonReplacementFormat ?? null,
+		multiEpisodeStyle: input.multiEpisodeStyle ?? 3,
+		standardEpisodeFormat:
+			input.standardEpisodeFormat ?? '{Series Title} - S{season:00}E{episode:00}',
+		dailyEpisodeFormat: input.dailyEpisodeFormat ?? '{Series Title} - {Air-Date}',
+		animeEpisodeFormat: input.animeEpisodeFormat ?? '{Series Title} - S{season:00}E{episode:00}',
+		seriesFolderFormat: input.seriesFolderFormat ?? '{Series Title}',
+		seasonFolderFormat: input.seasonFolderFormat ?? 'Season {season:00}',
+		specialsFolderFormat: input.specialsFolderFormat ?? 'Specials',
+		...input
+	};
+}
+
 class MediaManagementDriftTest extends BaseTest {
 	runTests(): void {
 		this.test('clean when no media settings are configured', () => {
 			const result = compareMediaManagementDrift(null, actualMediaSettings());
 
 			assertEquals(result.count, 0);
-			assertEquals(result.diff, { media_settings: { missing: [], modified: [] } });
+			assertEquals(result.diff, {
+				media_settings: { missing: [], modified: [] },
+				naming: { missing: [], modified: [] }
+			});
 		});
 
 		this.test('clean when expected and actual media settings match', () => {
@@ -46,7 +120,10 @@ class MediaManagementDriftTest extends BaseTest {
 			);
 
 			assertEquals(result.count, 0);
-			assertEquals(result.diff, { media_settings: { missing: [], modified: [] } });
+			assertEquals(result.diff, {
+				media_settings: { missing: [], modified: [] },
+				naming: { missing: [], modified: [] }
+			});
 		});
 
 		this.test('normalizes doNotUpgradeAutomatically to Arr doNotUpgrade', () => {
@@ -94,6 +171,111 @@ class MediaManagementDriftTest extends BaseTest {
 			]);
 		});
 
+		this.test('clean when expected and actual Radarr naming match', () => {
+			const result = compareMediaManagementDrift(
+				null,
+				null,
+				expectedRadarrNaming(),
+				actualRadarrNaming({ untouchedArrField: 'preserved' })
+			);
+
+			assertEquals(result.count, 0);
+			assertEquals(result.diff.naming, { missing: [], modified: [] });
+		});
+
+		this.test('reports Radarr naming managed field mismatch', () => {
+			const result = compareMediaManagementDrift(
+				null,
+				null,
+				expectedRadarrNaming(),
+				actualRadarrNaming({ movieFolderFormat: '{Movie CleanTitle}' })
+			);
+
+			assertEquals(result.count, 1);
+			assertEquals(result.diff.naming.modified, [
+				{
+					name: 'Standard Naming',
+					fields: [
+						{
+							path: 'movieFolderFormat',
+							expected: '{Movie CleanTitle} ({Release Year})',
+							actual: '{Movie CleanTitle}'
+						}
+					]
+				}
+			]);
+		});
+
+		this.test('clean when Sonarr naming API enum values normalize to semantic values', () => {
+			const result = compareMediaManagementDrift(
+				null,
+				null,
+				expectedSonarrNaming(),
+				actualSonarrNaming({ untouchedArrField: 'preserved' })
+			);
+
+			assertEquals(result.count, 0);
+			assertEquals(result.diff.naming, { missing: [], modified: [] });
+		});
+
+		this.test('treats blank Sonarr custom colon replacement as empty', () => {
+			const result = compareMediaManagementDrift(
+				null,
+				null,
+				expectedSonarrNaming(),
+				actualSonarrNaming({ customColonReplacementFormat: '' })
+			);
+
+			assertEquals(result.count, 0);
+			assertEquals(result.diff.naming, { missing: [], modified: [] });
+		});
+
+		this.test('reports Sonarr colon replacement mismatch with semantic values', () => {
+			const result = compareMediaManagementDrift(
+				null,
+				null,
+				expectedSonarrNaming(),
+				actualSonarrNaming({ colonReplacementFormat: 4 })
+			);
+
+			assertEquals(result.count, 1);
+			assertEquals(result.diff.naming.modified, [
+				{
+					name: 'Standard Naming',
+					fields: [
+						{
+							path: 'colonReplacementFormat',
+							expected: 'spaceDash',
+							actual: 'smart'
+						}
+					]
+				}
+			]);
+		});
+
+		this.test('reports Sonarr multi episode style mismatch with semantic values', () => {
+			const result = compareMediaManagementDrift(
+				null,
+				null,
+				expectedSonarrNaming(),
+				actualSonarrNaming({ multiEpisodeStyle: 5 })
+			);
+
+			assertEquals(result.count, 1);
+			assertEquals(result.diff.naming.modified, [
+				{
+					name: 'Standard Naming',
+					fields: [
+						{
+							path: 'multiEpisodeStyle',
+							expected: 'scene',
+							actual: 'prefixedRange'
+						}
+					]
+				}
+			]);
+		});
+
 		this.test('hash is stable for equivalent object key order', async () => {
 			const first: MediaManagementDriftDiff = {
 				media_settings: {
@@ -104,6 +286,21 @@ class MediaManagementDriftTest extends BaseTest {
 							fields: [{ path: 'enableMediaInfo', expected: false, actual: true }]
 						}
 					]
+				},
+				naming: {
+					missing: [],
+					modified: [
+						{
+							name: 'Standard Naming',
+							fields: [
+								{
+									path: 'movieFolderFormat',
+									expected: '{Movie}',
+									actual: '{Movie CleanTitle}'
+								}
+							]
+						}
+					]
 				}
 			};
 			const second = {
@@ -112,6 +309,21 @@ class MediaManagementDriftTest extends BaseTest {
 						{
 							fields: [{ actual: true, expected: false, path: 'enableMediaInfo' }],
 							name: 'Standard Media Settings'
+						}
+					],
+					missing: []
+				},
+				naming: {
+					modified: [
+						{
+							fields: [
+								{
+									actual: '{Movie CleanTitle}',
+									expected: '{Movie}',
+									path: 'movieFolderFormat'
+								}
+							],
+							name: 'Standard Naming'
 						}
 					],
 					missing: []


### PR DESCRIPTION
- Adds drift comparison for the three media management sub-configs: media settings (`downloadPropersAndRepacks`, `enableMediaInfo`), naming (Radarr and Sonarr field sets), and quality definitions (`minSize`, `maxSize`, `preferredSize`).
- New shared transformer at `src/lib/server/sync/mediaManagement/transformer.ts` so drift can build expected state through the same code sync uses.
- Drift display formatter handles the new MM section (friendly field labels, byte sizes, naming format strings).
- Sync page Media Management header now shows up to three drift progress chips (Naming, Quality Definitions, Media Settings), each `0/1` or `1/1` like the delay profile chip.
- Two job-status fixes for the post-sync drift refresh: drift no longer gets stuck on "checking..." when its full lifecycle fits inside the 5s holdoff, and the previous jobs "completed" display no longer hangs indefinitely when the buffered start cancels itself.
- Drift docs updated to remove the "MM has no chip yet" line and document the three new chips.

Part of #307.