### PR TITLE
feat: enable drift detection

### DIFF
--- a/docs/frontend/cutscene.md
+++ b/docs/frontend/cutscene.md
@@ -140,7 +140,7 @@ like Help where a "you're done" modal would be redundant.
 | `database-link`             | Link                | 7     |                                   | Connect a configuration database                               |
 | `database-manage`           | Overview            | 6     | `hasDatabase`                     | Tabs and features of a connected database                      |
 | `arr-link`                  | Link                | 5     |                                   | Connect a Radarr or Sonarr instance                            |
-| `arr-manage`                | Overview            | 7     | `hasArrInstance`                  | Tabs and features of a connected Arr instance                  |
+| `arr-manage`                | Overview            | 8     | `hasArrInstance`                  | Tabs and features of a connected Arr instance                  |
 | `arr-sync`                  | Sync                | 8     | `hasArrInstance`                  | Configure what gets synced and when                            |
 | `arr-upgrades`              | Upgrades            | 11    | `hasArrInstance`                  | Automated searching for better quality releases                |
 | `arr-renames`               | Rename              | 7     | `hasArrInstance`                  | Automated file and folder renaming                             |

--- a/src/lib/client/cutscene/definitions/stages/arrs/overview.ts
+++ b/src/lib/client/cutscene/definitions/stages/arrs/overview.ts
@@ -31,6 +31,15 @@ export const arrOverviewStage: Stage = {
 			completion: { type: 'manual' }
 		},
 		{
+			id: 'arr-nav-drift',
+			route: { resolve: 'firstArrDrift' },
+			target: 'arr-tab-drift',
+			title: 'Drift',
+			body: "The Drift tab catches changes made directly to this Arr that no longer match your Profilarr config. Each drifted item is listed with the exact differences, so you can review what's changed and re-sync when you're ready. It also drives the per-section progress chips on the Sync tab, so you can see at a glance how much of your config is still in sync.",
+			position: 'below',
+			completion: { type: 'manual' }
+		},
+		{
 			id: 'arr-nav-upgrades',
 			route: { resolve: 'firstArrUpgrades' },
 			target: 'arr-tab-upgrades',

--- a/src/lib/client/cutscene/routeResolvers.ts
+++ b/src/lib/client/cutscene/routeResolvers.ts
@@ -39,6 +39,11 @@ export const routeResolvers: Record<string, () => Promise<string>> = {
 		const arr = await res.json();
 		return `/arr/${arr[0].id}/sync`;
 	},
+	firstArrDrift: async () => {
+		const res = await fetch('/api/v1/arr');
+		const arr = await res.json();
+		return `/arr/${arr[0].id}/drift`;
+	},
 	firstArrUpgrades: async () => {
 		const res = await fetch('/api/v1/arr');
 		const arr = await res.json();

--- a/src/lib/shared/features.ts
+++ b/src/lib/shared/features.ts
@@ -13,5 +13,5 @@ export const FEATURES = {
 	/** Database tweaks UI */
 	tweaks: false,
 	/** Arr drift detection */
-	drift: false
+	drift: true
 } as const;


### PR DESCRIPTION
- Flips `FEATURES.drift` from `false` to `true`, releasing the work that has been built up behind the flag: custom format / quality profile / delay profile / media management drift comparison, the dedicated drift page, drift notifications, the post-sync drift refresh chain, and the per-section progress chips on the sync page.
- Adds a new step to the `arr-manage` ("Overview") cutscene introducing the Drift tab, plus a `firstArrDrift` route resolver and an updated step count in the cutscene doc.

Closes #307.