### PR TITLE
fix: align tabs with navbar and tighten arr/databases breakpoint

### DIFF
--- a/src/lib/client/ui/navigation/tabs/Tabs.svelte
+++ b/src/lib/client/ui/navigation/tabs/Tabs.svelte
@@ -32,7 +32,7 @@
 	export let responsive: boolean = false;
 	export let mobileBreakpoint: number = 768;
 	export let hideWhenSingle: boolean = true;
-	export let hiddenSpacerClass: string = 'h-1';
+	export let hiddenSpacerClass: string = 'h-16';
 
 	// Mobile detection
 	let isMobile = false;
@@ -73,8 +73,8 @@
 	<div class={hiddenSpacerClass}></div>
 {:else if useMobileMode}
 	<!-- Mobile: Custom dropdown with icons -->
-	<div class="border-b border-neutral-200 py-3 dark:border-neutral-800">
-		<div class="flex items-center gap-2">
+	<div class="flex h-16 items-center border-b border-neutral-200 dark:border-neutral-800">
+		<div class="flex flex-1 items-center gap-2">
 			<div
 				class="relative flex-1"
 				bind:this={triggerEl}
@@ -134,8 +134,8 @@
 	</div>
 {:else}
 	<!-- Desktop: Tab bar -->
-	<div class="border-b border-neutral-200 dark:border-neutral-800">
-		<nav class="-mb-px flex items-center justify-between gap-2" aria-label="Tabs">
+	<div class="flex h-16 items-end border-b border-neutral-200 dark:border-neutral-800">
+		<nav class="-mb-px flex flex-1 items-center justify-between gap-2" aria-label="Tabs">
 			<div class="flex gap-2">
 				{#each tabs as tab (tab.href)}
 					<button

--- a/src/lib/client/ui/navigation/tabs/Tabs.svelte
+++ b/src/lib/client/ui/navigation/tabs/Tabs.svelte
@@ -30,6 +30,7 @@
 	export let backButton: BackButton | undefined = undefined;
 	export let breadcrumb: Breadcrumb | undefined = undefined;
 	export let responsive: boolean = false;
+	export let mobileBreakpoint: number = 768;
 	export let hideWhenSingle: boolean = true;
 	export let hiddenSpacerClass: string = 'h-1';
 
@@ -41,7 +42,7 @@
 
 	onMount(() => {
 		if (responsive && typeof window !== 'undefined') {
-			mediaQuery = window.matchMedia('(max-width: 767px)');
+			mediaQuery = window.matchMedia(`(max-width: ${mobileBreakpoint - 1}px)`);
 			isMobile = mediaQuery.matches;
 			mediaQuery.addEventListener('change', handleMediaChange);
 		}

--- a/src/routes/arr/+page.svelte
+++ b/src/routes/arr/+page.svelte
@@ -55,7 +55,7 @@
 		onboarding="arr-add"
 	/>
 {:else}
-	<div class="space-y-6 p-4 sm:p-8">
+	<div class="space-y-6 px-4 pt-4 pb-8 md:px-8">
 		<!-- Actions Bar -->
 		<ActionsBar>
 			<SearchAction searchStore={search} placeholder="Search instances..." />

--- a/src/routes/arr/[id]/+layout.svelte
+++ b/src/routes/arr/[id]/+layout.svelte
@@ -83,7 +83,7 @@
 	};
 </script>
 
-<div class="overflow-x-clip p-4 md:p-8">
+<div class="overflow-x-clip px-4 pb-4 md:px-8 md:pb-8">
 	<Tabs {tabs} {breadcrumb} responsive mobileBreakpoint={1400} />
 	{#key data.instance.id}
 		<slot />

--- a/src/routes/arr/[id]/+layout.svelte
+++ b/src/routes/arr/[id]/+layout.svelte
@@ -84,7 +84,7 @@
 </script>
 
 <div class="overflow-x-clip p-4 md:p-8">
-	<Tabs {tabs} {breadcrumb} responsive />
+	<Tabs {tabs} {breadcrumb} responsive mobileBreakpoint={1400} />
 	{#key data.instance.id}
 		<slot />
 	{/key}

--- a/src/routes/arr/[id]/library/components/LibraryActionBar.svelte
+++ b/src/routes/arr/[id]/library/components/LibraryActionBar.svelte
@@ -81,7 +81,7 @@
 
 	onMount(() => {
 		if (typeof window !== 'undefined') {
-			mediaQuery = window.matchMedia('(max-width: 767px)');
+			mediaQuery = window.matchMedia('(max-width: 1399px)');
 			isMobile = mediaQuery.matches;
 			mediaQuery.addEventListener('change', handleMediaChange);
 		}

--- a/src/routes/custom-formats/[databaseId]/+page.svelte
+++ b/src/routes/custom-formats/[databaseId]/+page.svelte
@@ -193,7 +193,7 @@
 	<title>Custom Formats - {data.currentDatabase?.name} - Profilarr</title>
 </svelte:head>
 
-<div class="space-y-6 px-4 pt-4 pb-8 md:px-8">
+<div class="space-y-6 px-4 pb-8 md:px-8">
 	<!-- Tabs -->
 	<Tabs {tabs} responsive />
 

--- a/src/routes/custom-formats/[databaseId]/[id]/+layout.svelte
+++ b/src/routes/custom-formats/[databaseId]/[id]/+layout.svelte
@@ -42,7 +42,7 @@
 	};
 </script>
 
-<div class="p-4 md:p-8">
+<div class="px-4 pb-4 md:px-8 md:pb-8">
 	<Tabs {tabs} {breadcrumb} responsive />
 	<slot />
 </div>

--- a/src/routes/databases/+page.svelte
+++ b/src/routes/databases/+page.svelte
@@ -72,7 +72,7 @@
 		onboarding="db-add"
 	/>
 {:else}
-	<div class="space-y-6 p-4 sm:p-8">
+	<div class="space-y-6 px-4 pt-4 pb-8 md:px-8">
 		<!-- Actions Bar -->
 		<ActionsBar>
 			<SearchAction searchStore={search} placeholder="Search databases..." />

--- a/src/routes/databases/[id]/+layout.svelte
+++ b/src/routes/databases/[id]/+layout.svelte
@@ -81,7 +81,7 @@
 	};
 </script>
 
-<div class="p-4 md:p-8">
+<div class="px-4 pb-4 md:px-8 md:pb-8">
 	<Tabs {tabs} {breadcrumb} responsive mobileBreakpoint={1400} />
 	<slot />
 </div>

--- a/src/routes/databases/[id]/+layout.svelte
+++ b/src/routes/databases/[id]/+layout.svelte
@@ -82,6 +82,6 @@
 </script>
 
 <div class="p-4 md:p-8">
-	<Tabs {tabs} {breadcrumb} responsive />
+	<Tabs {tabs} {breadcrumb} responsive mobileBreakpoint={1400} />
 	<slot />
 </div>

--- a/src/routes/delay-profiles/[databaseId]/+page.svelte
+++ b/src/routes/delay-profiles/[databaseId]/+page.svelte
@@ -89,7 +89,7 @@
 	<title>Delay Profiles - {data.currentDatabase?.name} - Profilarr</title>
 </svelte:head>
 
-<div class="space-y-6 px-4 pt-4 pb-8 md:px-8">
+<div class="space-y-6 px-4 pb-8 md:px-8">
 	<!-- Tabs -->
 	<Tabs {tabs} responsive />
 

--- a/src/routes/media-management/[databaseId]/+layout.svelte
+++ b/src/routes/media-management/[databaseId]/+layout.svelte
@@ -31,7 +31,7 @@
 	<title>Media Management - {data.currentDatabase?.name} - Profilarr</title>
 </svelte:head>
 
-<div class="space-y-6 px-4 pt-4 pb-8 md:px-8">
+<div class="space-y-6 px-4 pb-8 md:px-8">
 	<!-- Database Tabs -->
 	{#if !isNestedPage}
 		<Tabs tabs={databaseTabs} />

--- a/src/routes/quality-profiles/[databaseId]/+page.svelte
+++ b/src/routes/quality-profiles/[databaseId]/+page.svelte
@@ -191,7 +191,7 @@
 	<title>Quality Profiles - {data.currentDatabase?.name} - Profilarr</title>
 </svelte:head>
 
-<div class="space-y-6 px-4 pt-4 pb-8 md:px-8">
+<div class="space-y-6 px-4 pb-8 md:px-8">
 	<!-- Tabs -->
 	<Tabs {tabs} responsive />
 

--- a/src/routes/quality-profiles/[databaseId]/[id]/+layout.svelte
+++ b/src/routes/quality-profiles/[databaseId]/[id]/+layout.svelte
@@ -38,7 +38,7 @@
 	};
 </script>
 
-<div class="p-4 md:p-8">
+<div class="px-4 pb-4 md:px-8 md:pb-8">
 	<Tabs {tabs} {breadcrumb} responsive />
 	<slot />
 </div>

--- a/src/routes/quality-profiles/entity-testing/[databaseId]/+page.svelte
+++ b/src/routes/quality-profiles/entity-testing/[databaseId]/+page.svelte
@@ -365,7 +365,7 @@
 	<title>Entity Testing - {data.currentDatabase?.name} - Profilarr</title>
 </svelte:head>
 
-<div class="space-y-6 px-4 pt-4 pb-8 md:px-8">
+<div class="space-y-6 px-4 pb-8 md:px-8">
 	<!-- Database Tabs -->
 	<Tabs {tabs} responsive />
 

--- a/src/routes/regular-expressions/[databaseId]/+page.svelte
+++ b/src/routes/regular-expressions/[databaseId]/+page.svelte
@@ -193,7 +193,7 @@
 	<title>Regular Expressions - {data.currentDatabase?.name} - Profilarr</title>
 </svelte:head>
 
-<div class="space-y-6 px-4 pt-4 pb-8 md:px-8">
+<div class="space-y-6 px-4 pb-8 md:px-8">
 	<!-- Tabs -->
 	<Tabs {tabs} responsive />
 


### PR DESCRIPTION
## Summary

- Tabs are now `h-16` and self-align so their bottom border lands at viewport `y=64`, matching the navbar's `border-b`. Page wrappers across all 10 tab-bearing routes had their top padding removed so the tabs sit flush.
- On `/arr/[id]` and `/databases/[id]`, the tabs now collapse to the dropdown variant below 1400px (was 768px). The library action bar's simple-mode threshold was bumped to match.
- `/arr` and `/databases` list pages updated to the canonical entity-list padding (`space-y-6 px-4 pt-4 pb-8 md:px-8`).