### PR TITLE
fix: apply busy_timeout to test harness DB connections

### DIFF
--- a/tests/integration/announcements/harness/setup.ts
+++ b/tests/integration/announcements/harness/setup.ts
@@ -5,7 +5,7 @@
  * constraints under test.
  */
 
-import { Database } from '@db/sqlite';
+import { openDb } from '$test-harness/db.ts';
 
 export interface CreateDbOpts {
 	uuid: string;
@@ -19,7 +19,7 @@ export interface CreateDbOpts {
  * the integration server's actual SQLite file.
  */
 export function createDatabaseInstance(dbPath: string, opts: CreateDbOpts): number {
-	const db = new Database(dbPath);
+	const db = openDb(dbPath);
 	try {
 		db.exec(
 			`INSERT INTO database_instances (
@@ -49,7 +49,7 @@ export interface InsertAnnouncementOpts {
 
 /** Insert one `database_announcements` row directly. */
 export function insertAnnouncement(dbPath: string, opts: InsertAnnouncementOpts): void {
-	const db = new Database(dbPath);
+	const db = openDb(dbPath);
 	try {
 		db.exec(
 			`INSERT INTO database_announcements (
@@ -72,7 +72,7 @@ export function insertAnnouncement(dbPath: string, opts: InsertAnnouncementOpts)
 
 /** Count announcements scoped to a single database id. */
 export function countAnnouncementsFor(dbPath: string, databaseId: number): number {
-	const db = new Database(dbPath);
+	const db = openDb(dbPath);
 	try {
 		const row = db
 			.prepare('SELECT COUNT(*) AS c FROM database_announcements WHERE database_id = ?')
@@ -85,7 +85,7 @@ export function countAnnouncementsFor(dbPath: string, databaseId: number): numbe
 
 /** Total count across all databases. */
 export function countAnnouncements(dbPath: string): number {
-	const db = new Database(dbPath);
+	const db = openDb(dbPath);
 	try {
 		const row = db.prepare('SELECT COUNT(*) AS c FROM database_announcements').get() as
 			| { c: number }
@@ -98,7 +98,7 @@ export function countAnnouncements(dbPath: string): number {
 
 /** Delete one parent row, exercising the ON DELETE CASCADE. */
 export function deleteDatabaseInstance(dbPath: string, id: number): void {
-	const db = new Database(dbPath);
+	const db = openDb(dbPath);
 	try {
 		db.exec('DELETE FROM database_instances WHERE id = ?', [id]);
 	} finally {
@@ -108,7 +108,7 @@ export function deleteDatabaseInstance(dbPath: string, id: number): void {
 
 /** Try to insert with a non-existent database_id. Returns true if rejected. */
 export function tryInsertOrphanAnnouncement(dbPath: string, missingId: number): boolean {
-	const db = new Database(dbPath);
+	const db = openDb(dbPath);
 	try {
 		try {
 			db.exec(

--- a/tests/integration/announcements/specs/first-sync.test.ts
+++ b/tests/integration/announcements/specs/first-sync.test.ts
@@ -12,7 +12,7 @@
 import { assertEquals, assert } from '@std/assert';
 import { run, setup, teardown, test } from '$test-harness/runner.ts';
 import { getDbPath, startServer, stopServer } from '$test-harness/server.ts';
-import { Database } from '@db/sqlite';
+import { openDb } from '$test-harness/db.ts';
 import { createDatabaseInstance } from '../harness/setup.ts';
 
 const PORT = 7171;
@@ -68,7 +68,7 @@ Body for ${id}.
 }
 
 function setLastSyncedAt(databaseId: number, value: string | null): void {
-	const db = new Database(dbPath);
+	const db = openDb(dbPath);
 	try {
 		db.exec('UPDATE database_instances SET last_synced_at = ? WHERE id = ?', [value, databaseId]);
 	} finally {
@@ -77,7 +77,7 @@ function setLastSyncedAt(databaseId: number, value: string | null): void {
 }
 
 function readReadAt(databaseId: number, announcementId: string): string | null {
-	const db = new Database(dbPath);
+	const db = openDb(dbPath);
 	try {
 		const row = db
 			.prepare('SELECT read_at FROM database_announcements WHERE database_id = ? AND id = ?')

--- a/tests/integration/api/specs/arr.test.ts
+++ b/tests/integration/api/specs/arr.test.ts
@@ -13,7 +13,7 @@ import { TestClient } from '$test-harness/client.ts';
 import { startServer, stopServer, getDbPath } from '$test-harness/server.ts';
 import { createUserDirect, setApiKey } from '$test-harness/setup.ts';
 import { setup, teardown, test, run } from '$test-harness/runner.ts';
-import { Database } from '@db/sqlite';
+import { openDb } from '$test-harness/db.ts';
 
 const PORT = 7021;
 const ORIGIN = `http://localhost:${PORT}`;
@@ -22,7 +22,7 @@ const API_KEY = 'arr-test-key-abc123';
 let client: TestClient;
 
 function seedArrInstance(dbPath: string): void {
-	const db = new Database(dbPath);
+	const db = openDb(dbPath);
 	try {
 		db.exec(
 			`INSERT INTO arr_instances (name, type, url, api_key, enabled)

--- a/tests/integration/api/specs/databases.test.ts
+++ b/tests/integration/api/specs/databases.test.ts
@@ -43,7 +43,7 @@ import { TestClient } from '$test-harness/client.ts';
 import { startServer, stopServer, getDbPath } from '$test-harness/server.ts';
 import { createUserDirect, setApiKey } from '$test-harness/setup.ts';
 import { setup, teardown, test, run } from '$test-harness/runner.ts';
-import { Database } from '@db/sqlite';
+import { openDb } from '$test-harness/db.ts';
 
 const PORT = 7020;
 const ORIGIN = `http://localhost:${PORT}`;
@@ -53,7 +53,7 @@ let client: TestClient;
 let linkedDbId: number;
 
 function seedDatabase(dbPath: string): void {
-	const db = new Database(dbPath);
+	const db = openDb(dbPath);
 	try {
 		db.exec(
 			`INSERT INTO database_instances (uuid, name, repository_url, local_path, personal_access_token, enabled)

--- a/tests/integration/api/specs/status.test.ts
+++ b/tests/integration/api/specs/status.test.ts
@@ -16,7 +16,7 @@ import { TestClient } from '$test-harness/client.ts';
 import { startServer, stopServer, getDbPath } from '$test-harness/server.ts';
 import { createUserDirect, setApiKey } from '$test-harness/setup.ts';
 import { setup, teardown, test, run } from '$test-harness/runner.ts';
-import { Database } from '@db/sqlite';
+import { openDb } from '$test-harness/db.ts';
 
 const PORT = 7035;
 const ORIGIN = `http://localhost:${PORT}`;
@@ -25,7 +25,7 @@ const API_KEY = 'status-test-key-abc123';
 let client: TestClient;
 
 function seedDatabase(dbPath: string): void {
-	const db = new Database(dbPath);
+	const db = openDb(dbPath);
 	try {
 		db.exec(
 			`INSERT INTO database_instances (uuid, name, repository_url, local_path, enabled, sync_strategy)
@@ -37,7 +37,7 @@ function seedDatabase(dbPath: string): void {
 }
 
 function seedArrInstance(dbPath: string): void {
-	const db = new Database(dbPath);
+	const db = openDb(dbPath);
 	try {
 		db.exec(
 			`INSERT INTO arr_instances (name, type, url, api_key, enabled)

--- a/tests/integration/auth/specs/pathTraversal.test.ts
+++ b/tests/integration/auth/specs/pathTraversal.test.ts
@@ -21,7 +21,7 @@ import { TestClient } from '$test-harness/client.ts';
 import { startServer, stopServer, getDbPath } from '$test-harness/server.ts';
 import { createUserDirect, login } from '$test-harness/setup.ts';
 import { setup, teardown, test, run } from '$test-harness/runner.ts';
-import { Database } from '@db/sqlite';
+import { openDb } from '$test-harness/db.ts';
 
 const PORT = 7018;
 const ORIGIN = `http://localhost:${PORT}`;
@@ -38,7 +38,7 @@ let sessionClient: TestClient;
 let outsideDir: string;
 
 function seedDatabase(dbPath: string): { id: number; uuid: string } {
-	const db = new Database(dbPath);
+	const db = openDb(dbPath);
 	try {
 		const uuid = crypto.randomUUID();
 		const localPath = `./dist/integration-${PORT}/data/databases/${uuid}`;

--- a/tests/integration/auth/specs/secretExposure.test.ts
+++ b/tests/integration/auth/specs/secretExposure.test.ts
@@ -48,7 +48,7 @@ import { TestClient } from '$test-harness/client.ts';
 import { startServer, stopServer, getDbPath } from '$test-harness/server.ts';
 import { createUserDirect, login } from '$test-harness/setup.ts';
 import { setup, teardown, test, run } from '$test-harness/runner.ts';
-import { Database } from '@db/sqlite';
+import { openDb } from '$test-harness/db.ts';
 import { hash } from '@felix/bcrypt';
 
 const PORT = 7016;
@@ -68,7 +68,7 @@ let pcdDatabaseId: number;
 let notificationServiceId: string;
 
 async function seedSecrets(dbPath: string) {
-	const db = new Database(dbPath);
+	const db = openDb(dbPath);
 	try {
 		// Arr instance with known API key
 		db.exec(

--- a/tests/integration/auth/specs/xForwardedFor.test.ts
+++ b/tests/integration/auth/specs/xForwardedFor.test.ts
@@ -24,7 +24,7 @@ import { TestClient } from '$test-harness/client.ts';
 import { startServer, stopServer, getDbPath } from '$test-harness/server.ts';
 import { createUserDirect, clearLoginAttempts, queryDb } from '$test-harness/setup.ts';
 import { setup, teardown, test, run } from '$test-harness/runner.ts';
-import { Database } from '@db/sqlite';
+import { openDb } from '$test-harness/db.ts';
 
 const PORT = 7015;
 const ORIGIN = `http://localhost:${PORT}`;
@@ -68,7 +68,7 @@ test('local bypass uses real TCP address, not proxy headers', async () => {
 	// test runs from localhost, the real TCP address IS local, so bypass
 	// works. A remote attacker spoofing X-Forwarded-For: 192.168.x.x
 	// would be rejected because their real TCP address is public.
-	const conn = new Database(getDbPath(PORT));
+	const conn = openDb(getDbPath(PORT));
 	try {
 		conn.exec('UPDATE auth_settings SET local_bypass_enabled = 1 WHERE id = 1');
 	} finally {

--- a/tests/integration/backups/specs/backupSecrets.test.ts
+++ b/tests/integration/backups/specs/backupSecrets.test.ts
@@ -37,7 +37,7 @@ import { TestClient } from '$test-harness/client.ts';
 import { startServer, stopServer, getDbPath } from '$test-harness/server.ts';
 import { createUserDirect, login } from '$test-harness/setup.ts';
 import { setup, teardown, test, run } from '$test-harness/runner.ts';
-import { Database } from '@db/sqlite';
+import { openDb } from '$test-harness/db.ts';
 import { hash } from '@felix/bcrypt';
 
 const PORT = 7017;
@@ -55,7 +55,7 @@ let backupDbPath: string;
 let extractDir: string;
 
 async function seedSecrets(dbPath: string) {
-	const db = new Database(dbPath);
+	const db = openDb(dbPath);
 	try {
 		// Arr instance
 		db.exec(
@@ -186,7 +186,7 @@ teardown(async () => {
 });
 
 test('backup DB does not contain arr API keys', () => {
-	const db = new Database(backupDbPath);
+	const db = openDb(backupDbPath);
 	try {
 		const rows = db.prepare('SELECT api_key FROM arr_instances').all() as { api_key: string }[];
 		for (const row of rows) {
@@ -198,7 +198,7 @@ test('backup DB does not contain arr API keys', () => {
 });
 
 test('backup DB does not contain database PATs', () => {
-	const db = new Database(backupDbPath);
+	const db = openDb(backupDbPath);
 	try {
 		const rows = db.prepare('SELECT personal_access_token FROM database_instances').all() as {
 			personal_access_token: string | null;
@@ -216,7 +216,7 @@ test('backup DB does not contain database PATs', () => {
 });
 
 test('backup DB does not contain Profilarr API key', () => {
-	const db = new Database(backupDbPath);
+	const db = openDb(backupDbPath);
 	try {
 		const row = db.prepare('SELECT api_key FROM auth_settings WHERE id = 1').get() as {
 			api_key: string | null;
@@ -228,7 +228,7 @@ test('backup DB does not contain Profilarr API key', () => {
 });
 
 test('backup DB does not contain AI API key', () => {
-	const db = new Database(backupDbPath);
+	const db = openDb(backupDbPath);
 	try {
 		const row = db.prepare('SELECT api_key FROM ai_settings WHERE id = 1').get() as
 			| {
@@ -244,7 +244,7 @@ test('backup DB does not contain AI API key', () => {
 });
 
 test('backup DB does not contain TMDB API key', () => {
-	const db = new Database(backupDbPath);
+	const db = openDb(backupDbPath);
 	try {
 		const row = db.prepare('SELECT api_key FROM tmdb_settings WHERE id = 1').get() as {
 			api_key: string;
@@ -256,7 +256,7 @@ test('backup DB does not contain TMDB API key', () => {
 });
 
 test('backup DB does not contain notification webhook URLs', () => {
-	const db = new Database(backupDbPath);
+	const db = openDb(backupDbPath);
 	try {
 		const rows = db.prepare('SELECT config FROM notification_services').all() as {
 			config: string;
@@ -274,7 +274,7 @@ test('backup DB does not contain notification webhook URLs', () => {
 });
 
 test('backup DB does not contain user password hashes', () => {
-	const db = new Database(backupDbPath);
+	const db = openDb(backupDbPath);
 	try {
 		const rows = db.prepare('SELECT * FROM users').all();
 		assertEquals(rows.length, 0, 'Backup DB still contains user records');
@@ -284,7 +284,7 @@ test('backup DB does not contain user password hashes', () => {
 });
 
 test('backup DB does not contain sessions', () => {
-	const db = new Database(backupDbPath);
+	const db = openDb(backupDbPath);
 	try {
 		const rows = db.prepare('SELECT * FROM sessions').all();
 		assertEquals(rows.length, 0, 'Backup DB still contains session records');
@@ -294,7 +294,7 @@ test('backup DB does not contain sessions', () => {
 });
 
 test('backup DB does not contain login attempts', () => {
-	const db = new Database(backupDbPath);
+	const db = openDb(backupDbPath);
 	try {
 		const rows = db.prepare('SELECT * FROM login_attempts').all();
 		assertEquals(rows.length, 0, 'Backup DB still contains login attempt records');

--- a/tests/integration/backups/specs/jobStatus.test.ts
+++ b/tests/integration/backups/specs/jobStatus.test.ts
@@ -10,7 +10,7 @@ import { setup, teardown, test, run } from '$test-harness/runner.ts';
 import { startServer, stopServer, getDbPath } from '$test-harness/server.ts';
 import { TestClient } from '$test-harness/client.ts';
 import { createUser, login, setApiKey, queryDb } from '$test-harness/setup.ts';
-import { Database } from 'jsr:@db/sqlite@0.12';
+import { openDb } from '$test-harness/db.ts';
 
 const PORT = 7030;
 const ORIGIN = `http://localhost:${PORT}`;
@@ -31,7 +31,7 @@ function insertJob(
 		finishedAt?: string | null;
 	}
 ): number {
-	const db = new Database(dbPath);
+	const db = openDb(dbPath);
 	try {
 		db.exec(
 			`INSERT INTO job_queue (job_type, status, run_at, payload, source, started_at, finished_at)
@@ -63,7 +63,7 @@ function insertRunHistory(
 		error?: string | null;
 	}
 ): void {
-	const db = new Database(dbPath);
+	const db = openDb(dbPath);
 	try {
 		db.exec(
 			`INSERT INTO job_run_history (queue_id, job_type, status, started_at, finished_at, duration_ms, output, error)

--- a/tests/integration/backups/specs/restore.test.ts
+++ b/tests/integration/backups/specs/restore.test.ts
@@ -24,7 +24,7 @@ import { setup, teardown, test, run } from '$test-harness/runner.ts';
 import { startServer, stopServer, getDbPath } from '$test-harness/server.ts';
 import { TestClient } from '$test-harness/client.ts';
 import { createUser, login, setApiKey } from '$test-harness/setup.ts';
-import { Database } from '@db/sqlite';
+import { openDb } from '$test-harness/db.ts';
 
 const PORT_A = 7035;
 const PORT_B = 7036;
@@ -39,7 +39,7 @@ let clientB: TestClient;
  * Seed known data into server A's database so we can verify it after restore.
  */
 function seedData(dbPath: string) {
-	const db = new Database(dbPath);
+	const db = openDb(dbPath);
 	try {
 		db.exec(
 			`INSERT INTO arr_instances (name, type, url, api_key, enabled)

--- a/tests/integration/conflicts/harness/setup.ts
+++ b/tests/integration/conflicts/harness/setup.ts
@@ -2,7 +2,7 @@
  * PCD conflict test helpers — create database instances, insert ops, query state.
  */
 
-import { Database } from '@db/sqlite';
+import { openDb } from '$test-harness/db.ts';
 import { log } from '$test-harness/log.ts';
 
 // ─── Database Instance ─────────────────────────────────────────────────────────
@@ -22,7 +22,7 @@ export interface CreateDatabaseInstanceOpts {
  */
 export function createDatabaseInstance(dbPath: string, opts: CreateDatabaseInstanceOpts): number {
 	log.setup(`Creating database instance "${opts.name ?? 'test-db'}"`);
-	const db = new Database(dbPath);
+	const db = openDb(dbPath);
 	try {
 		db.exec(
 			`INSERT INTO database_instances (
@@ -71,7 +71,7 @@ export interface InsertOpOpts {
  * Insert a pcd_ops row directly. Returns the inserted op id.
  */
 export function insertOp(dbPath: string, opts: InsertOpOpts): number {
-	const db = new Database(dbPath);
+	const db = openDb(dbPath);
 	try {
 		db.exec(
 			`INSERT INTO pcd_ops (
@@ -151,7 +151,7 @@ export interface HistoryRow {
  * Get a single pcd_ops row by id.
  */
 export function queryOp(dbPath: string, opId: number): OpRow | undefined {
-	const db = new Database(dbPath);
+	const db = openDb(dbPath);
 	try {
 		return db.prepare('SELECT * FROM pcd_ops WHERE id = ?').get(opId) as OpRow | undefined;
 	} finally {
@@ -167,7 +167,7 @@ export function queryOpsByDatabase(
 	databaseId: number,
 	filters?: { origin?: string; state?: string }
 ): OpRow[] {
-	const db = new Database(dbPath);
+	const db = openDb(dbPath);
 	try {
 		const clauses = ['database_id = ?'];
 		const params: (string | number)[] = [databaseId];
@@ -192,7 +192,7 @@ export function queryOpsByDatabase(
  * filtered to conflicted/conflicted_pending statuses.
  */
 export function queryLatestConflicts(dbPath: string, databaseId: number): HistoryRow[] {
-	const db = new Database(dbPath);
+	const db = openDb(dbPath);
 	try {
 		return db
 			.prepare(
@@ -216,7 +216,7 @@ export function queryLatestConflicts(dbPath: string, databaseId: number): Histor
  * Get all pcd_op_history entries for a specific op.
  */
 export function queryAllHistory(dbPath: string, opId: number): HistoryRow[] {
-	const db = new Database(dbPath);
+	const db = openDb(dbPath);
 	try {
 		return db
 			.prepare('SELECT * FROM pcd_op_history WHERE op_id = ? ORDER BY id DESC')
@@ -230,7 +230,7 @@ export function queryAllHistory(dbPath: string, opId: number): HistoryRow[] {
  * Get the latest pcd_op_history entry for each op in a database (all statuses).
  */
 export function queryLatestHistory(dbPath: string, databaseId: number): HistoryRow[] {
-	const db = new Database(dbPath);
+	const db = openDb(dbPath);
 	try {
 		return db
 			.prepare(

--- a/tests/integration/conflicts/specs/group-member-position.test.ts
+++ b/tests/integration/conflicts/specs/group-member-position.test.ts
@@ -18,7 +18,7 @@ import {
 	queryLatestConflicts,
 	queryLatestHistory
 } from '../harness/setup.ts';
-import { Database } from '@db/sqlite';
+import { openDb } from '$test-harness/db.ts';
 
 const PORT = 7026;
 const ORIGIN = `http://localhost:${PORT}`;
@@ -849,7 +849,7 @@ test('ask: user reorder op conflicts when upstream also reordered', () => {
 // ─── Scenario 4: Conflict — align strategy ──────────────────────────────────
 
 test('align: user reorder op is auto-dropped', () => {
-	const db = new Database(getDbPath(PORT));
+	const db = openDb(getDbPath(PORT));
 	try {
 		const op = db.prepare('SELECT state FROM pcd_ops WHERE id = ?').get(alignUserOpId) as {
 			state: string;

--- a/tests/integration/harness/db.ts
+++ b/tests/integration/harness/db.ts
@@ -1,0 +1,20 @@
+/**
+ * Open a SQLite connection from a test harness with the same pragma
+ * configuration the server uses (src/lib/server/db/db.ts).
+ *
+ * Critical: busy_timeout = 5000. Without it the @db/sqlite default is 0,
+ * so the test connection fails with SQLITE_BUSY the moment the server
+ * writer holds the lock (e.g. announcements.fetch firing on startup).
+ *
+ * journal_mode = WAL is persistent in the file header so we don't repeat it.
+ * synchronous is per-connection but only affects crash safety, not concurrency.
+ */
+
+import { Database } from '@db/sqlite';
+
+export function openDb(dbPath: string): Database {
+	const db = new Database(dbPath);
+	db.exec('PRAGMA busy_timeout = 5000');
+	db.exec('PRAGMA foreign_keys = ON');
+	return db;
+}

--- a/tests/integration/harness/setup.ts
+++ b/tests/integration/harness/setup.ts
@@ -3,7 +3,7 @@
  */
 
 import { TestClient } from '$test-harness/client.ts';
-import { Database } from '@db/sqlite';
+import { openDb } from '$test-harness/db.ts';
 import { hash } from '@felix/bcrypt';
 import { log } from '$test-harness/log.ts';
 
@@ -62,7 +62,7 @@ export async function createUserDirect(
 ): Promise<void> {
 	log.setup(`Creating user "${username}" directly in DB`);
 	const passwordHash = await hash(password);
-	const db = new Database(dbPath);
+	const db = openDb(dbPath);
 	try {
 		db.exec('INSERT INTO users (username, password_hash) VALUES (?, ?)', [username, passwordHash]);
 	} finally {
@@ -76,7 +76,7 @@ export async function createUserDirect(
 export async function setApiKey(dbPath: string, apiKey: string): Promise<void> {
 	log.setup('Setting API key in DB');
 	const hashed = await hash(apiKey);
-	const db = new Database(dbPath);
+	const db = openDb(dbPath);
 	try {
 		db.exec('UPDATE auth_settings SET api_key = ?, updated_at = CURRENT_TIMESTAMP WHERE id = 1', [
 			hashed
@@ -91,7 +91,7 @@ export async function setApiKey(dbPath: string, apiKey: string): Promise<void> {
  */
 export function expireSession(dbPath: string, sessionId: string): void {
 	log.setup(`Expiring session ${sessionId.slice(0, 8)}...`);
-	const db = new Database(dbPath);
+	const db = openDb(dbPath);
 	try {
 		db.exec("UPDATE sessions SET expires_at = datetime('now', '-1 hour') WHERE id = ?", [
 			sessionId
@@ -112,7 +112,7 @@ export function insertExpiredAttempts(
 	minutesAgo: number
 ): void {
 	log.setup(`Inserting ${count} expired "${category}" attempts (${minutesAgo}m ago)`);
-	const db = new Database(dbPath);
+	const db = openDb(dbPath);
 	try {
 		for (let i = 0; i < count; i++) {
 			db.exec(
@@ -132,7 +132,7 @@ export function insertExpiredAttempts(
  */
 export function setSessionExpiry(dbPath: string, sessionId: string, minutesFromNow: number): void {
 	log.setup(`Setting session ${sessionId.slice(0, 8)}... to expire in ${minutesFromNow}m`);
-	const db = new Database(dbPath);
+	const db = openDb(dbPath);
 	try {
 		db.exec("UPDATE sessions SET expires_at = datetime('now', ? || ' minutes') WHERE id = ?", [
 			String(minutesFromNow),
@@ -148,7 +148,7 @@ export function setSessionExpiry(dbPath: string, sessionId: string, minutesFromN
  */
 export function getSessionExpiry(dbPath: string, sessionId: string): string | null {
 	log.setup(`Reading session ${sessionId.slice(0, 8)}... expiry`);
-	const db = new Database(dbPath);
+	const db = openDb(dbPath);
 	try {
 		const stmt = db.prepare('SELECT expires_at FROM sessions WHERE id = ?');
 		const row = stmt.get(sessionId) as { expires_at: string } | undefined;
@@ -163,7 +163,7 @@ export function getSessionExpiry(dbPath: string, sessionId: string): string | nu
  */
 export function clearLoginAttempts(dbPath: string): void {
 	log.setup('Clearing all login attempts');
-	const db = new Database(dbPath);
+	const db = openDb(dbPath);
 	try {
 		db.exec('DELETE FROM login_attempts');
 	} finally {
@@ -175,7 +175,7 @@ export function clearLoginAttempts(dbPath: string): void {
  * Read a value from the database.
  */
 export function queryDb(dbPath: string, sql: string, params: unknown[] = []): unknown[] {
-	const db = new Database(dbPath);
+	const db = openDb(dbPath);
 	try {
 		const stmt = db.prepare(sql);
 		return stmt.all(...params);


### PR DESCRIPTION
Test-harness raw `new Database(dbPath)` connections were missing `busy_timeout`, so they failed immediately with `SQLITE_BUSY` whenever the server's writer (e.g. `announcements.fetch` on startup) held the lock. PR #519 fixed this for server-side transactions but never extended to the harness.

Adds `tests/integration/harness/db.ts` with an `openDb()` helper that mirrors the server's pragma config, and routes all 44 raw call sites through it.