### PR TITLE
fix: shrink hidden tabs spacer back to h-1

### DIFF
--- a/src/lib/client/ui/navigation/tabs/Tabs.svelte
+++ b/src/lib/client/ui/navigation/tabs/Tabs.svelte
@@ -32,7 +32,7 @@
 	export let responsive: boolean = false;
 	export let mobileBreakpoint: number = 768;
 	export let hideWhenSingle: boolean = true;
-	export let hiddenSpacerClass: string = 'h-16';
+	export let hiddenSpacerClass: string = 'h-1';
 
 	// Mobile detection
 	let isMobile = false;


### PR DESCRIPTION
The `hiddenSpacerClass` default in `Tabs.svelte` was bumped to `h-16` in #522 to keep layout consistent with the visible tab bar. In practice this leaves a 64px dead band at the top of every entity list page when only a single database is linked. Reverting the default to `h-1` so single-DB pages don't show the gap; multi-tab pages still render the `h-16` tab bar.