### PR TITLE
feat: enable editing for delay profiles on linked databases

### DIFF
--- a/docs/backend/pcd-entities.md
+++ b/docs/backend/pcd-entities.md
@@ -246,10 +246,17 @@ The schema enforces protocol constraints via CHECK clauses:
 - `only_usenet` -- `torrent_delay` must be NULL
 - bypass disabled -- `minimum_custom_format_score` must be NULL
 
-All CRUD uses single atomic ops (no per-field splitting). Value guards
-cover all fields, with careful NULL handling (`IS NULL` vs `=`).
-Base-origin locking is planned
-([#421](https://github.com/Dictionarry-Hub/profilarr/issues/421)).
+Create and delete use single atomic ops. Update splits into per-field ops
+with value guards on each changed field. Pure rename writes one `name` op
+with `previousName`; if the same submit changes other fields, all emitted
+ops share a `groupId`.
+
+Some field pairs stay atomic to satisfy schema constraints:
+
+- protocol changes group with delay NULLing when moving into or out of
+  `only_torrent` / `only_usenet`
+- bypass-score changes group with `minimum_custom_format_score` when the
+  score must become NULL or non-NULL
 
 ## Media Management
 
@@ -288,10 +295,10 @@ consistency.
 
 ## Summary
 
-| Entity             | Op splitting             | Cascading on rename     | Cascading on delete              |
-| ------------------ | ------------------------ | ----------------------- | -------------------------------- |
-| Custom format      | per-field, per-condition | QP scoring refs         | explicit QP score removal + FK   |
-| Quality profile    | per-field, per-score     | --                      | explicit sub-entity removal + FK |
-| Regular expression | main + dependents        | condition_patterns refs | dependent conditions + FK        |
-| Delay profile      | none (atomic)            | --                      | FK cascade                       |
-| Media management   | none (atomic)            | --                      | FK cascade                       |
+| Entity             | Op splitting                 | Cascading on rename     | Cascading on delete              |
+| ------------------ | ---------------------------- | ----------------------- | -------------------------------- |
+| Custom format      | per-field, per-condition     | QP scoring refs         | explicit QP score removal + FK   |
+| Quality profile    | per-field, per-score         | --                      | explicit sub-entity removal + FK |
+| Regular expression | main + dependents            | condition_patterns refs | dependent conditions + FK        |
+| Delay profile      | per-field, constrained pairs | --                      | FK cascade                       |
+| Media management   | none (atomic)                | --                      | FK cascade                       |

--- a/docs/backend/pcd.md
+++ b/docs/backend/pcd.md
@@ -450,3 +450,11 @@ Run via `deno task generate:pcd-types` (default version) or
 - [**#422**](https://github.com/Dictionarry-Hub/profilarr/issues/422):
   The PCD conflict test suite (86 Playwright specs) needs to migrate to
   integration tests for speed and CI reliability.
+
+- **Override-delete re-deletion**: Only `delay_profile` regenerates a
+  fresh delete when overriding a conflicted delete whose target row still
+  exists upstream. For other entities (CF, QP, regex, naming, media
+  settings), override-delete logs a warning and falls back to dropping
+  the user op without re-deleting the upstream row. Each remaining entity
+  needs its own `overrideDelete` handler before it can match delay
+  profile behavior.

--- a/docs/backend/pcd.md
+++ b/docs/backend/pcd.md
@@ -276,8 +276,12 @@ independent ops. If upstream changes the description but not the tags, only
 the description op conflicts -- the tag op still applies cleanly.
 
 Op splitting is implemented for custom format general/conditions, quality
-profile general/qualities/scoring, and regular expressions. Delay profiles
-and media management use base-origin locking instead (entities from base
+profile general/qualities/scoring, regular expressions, and delay profile
+updates. Delay profiles keep schema-constrained field pairs in one op when
+needed: protocol changes with delay NULLing, and bypass-score changes with
+minimum custom format score NULLing.
+
+Media management still uses base-origin locking instead (entities from base
 are not editable at the user layer). See
 [#421](https://github.com/Dictionarry-Hub/profilarr/issues/421) for
 remaining work.
@@ -432,9 +436,9 @@ Run via `deno task generate:pcd-types` (default version) or
 ## Open Work
 
 - [**#421**](https://github.com/Dictionarry-Hub/profilarr/issues/421):
-  Op splitting is done for CF and QP entities but not yet for regular
-  expressions. Delay profiles and media management will use base-origin
-  locking instead of per-field splits.
+  Op splitting is done for CF, QP, regular expression, and delay profile
+  updates. Media management still needs its write enablement and conflict
+  strategy decided.
 
 - [**#367**](https://github.com/Dictionarry-Hub/profilarr/issues/367):
   Stable entity IDs. Currently, entities are identified by name, and

--- a/src/lib/server/pcd/conflicts/override.ts
+++ b/src/lib/server/pcd/conflicts/override.ts
@@ -1,8 +1,9 @@
 import { databaseInstancesQueries } from '$db/queries/databaseInstances.ts';
 import { pcdOpsQueries } from '$db/queries/pcdOps.ts';
-import { compile } from '$pcd/index.ts';
+import { compile, getCache } from '$pcd/index.ts';
 import type { WriteResult } from '$pcd/index.ts';
 import { logger } from '$logger/logger.ts';
+import { AUTO_ALIGN_ENTITIES } from '$pcd/entities/registry.ts';
 import {
 	dropOp,
 	parseJson,
@@ -25,6 +26,7 @@ import {
 } from '$pcd/entities/regularExpressions/override.ts';
 import {
 	overrideCreate as dpOverrideCreate,
+	overrideDelete as dpOverrideDelete,
 	overrideUpdate as dpOverrideUpdate
 } from '$pcd/entities/delayProfiles/override.ts';
 import {
@@ -67,9 +69,9 @@ async function overrideEntity(
 				? reOverrideCreate(databaseId, metadata, desiredState)
 				: reOverrideUpdate(databaseId, metadata, desiredState);
 		case 'delay_profile':
-			return operation === 'create'
-				? dpOverrideCreate(databaseId, metadata, desiredState)
-				: dpOverrideUpdate(databaseId, metadata, desiredState);
+			if (operation === 'create') return dpOverrideCreate(databaseId, metadata, desiredState);
+			if (operation === 'delete') return dpOverrideDelete(databaseId, metadata, desiredState);
+			return dpOverrideUpdate(databaseId, metadata, desiredState);
 		case 'radarr_naming':
 		case 'sonarr_naming':
 			return operation === 'create'
@@ -91,6 +93,39 @@ async function overrideEntity(
 				error: `Override not yet implemented for entity: ${entity}`
 			};
 	}
+}
+
+function canOverrideDelete(entity?: string): boolean {
+	return entity === 'delay_profile';
+}
+
+function deleteTargetExists(databaseId: number, metadata: StoredOpMetadata | null): boolean | null {
+	const entityName = metadata?.entity;
+	if (!entityName) return null;
+
+	const entity = AUTO_ALIGN_ENTITIES.get(entityName);
+	if (!entity) return null;
+
+	const cache = getCache(databaseId);
+	if (!cache) return null;
+
+	const typedMetadata = metadata as StoredOpMetadata & { stableKey?: { value?: string } };
+	const candidates = [
+		metadata.stable_key?.value,
+		typedMetadata.stableKey?.value,
+		metadata.name
+	].filter((value): value is string => typeof value === 'string' && value.length > 0);
+
+	for (const candidate of candidates) {
+		// nosemgrep: profilarr.sql.template-literal-interpolation - table/column from hardcoded registry
+		const row = cache.queryOne<{ found: number }>(
+			`SELECT 1 AS found FROM ${entity.table} WHERE ${entity.keyColumn} = ? LIMIT 1`,
+			candidate
+		);
+		if (row) return true;
+	}
+
+	return false;
 }
 
 export async function overrideConflict(input: {
@@ -118,6 +153,9 @@ export async function overrideConflict(input: {
 	const instance = databaseInstancesQueries.getById(databaseId);
 
 	if (operation === 'delete') {
+		const targetExists = deleteTargetExists(databaseId, metadata);
+		const canRegenerate = targetExists === true && canOverrideDelete(metadata?.entity);
+
 		const dropped = await dropOp(databaseId, opId);
 		if (!dropped) {
 			return {
@@ -127,6 +165,40 @@ export async function overrideConflict(input: {
 		}
 		if (instance?.enabled) {
 			await compile(instance.local_path, databaseId);
+		}
+
+		if (canRegenerate) {
+			const result: WriteResult = await overrideEntity(
+				databaseId,
+				metadata,
+				desiredState,
+				operation
+			);
+			if (!result.success) {
+				return {
+					success: false,
+					error: result.error || 'Failed to override conflict'
+				};
+			}
+
+			const newOpId = parseOpIdFromFilepath(result.filepath ?? null);
+			if (newOpId) {
+				await supersedeOp(databaseId, opId, newOpId);
+			}
+
+			await logger.info('Overrode conflict', {
+				source: 'PCDConflicts',
+				meta: { databaseId, opId, newOpId }
+			});
+
+			return { success: true };
+		}
+
+		if (targetExists === true) {
+			await logger.warn('Override delete fell back to drop; re-deletion not implemented', {
+				source: 'PCDConflicts',
+				meta: { databaseId, opId, entity: metadata?.entity }
+			});
 		}
 
 		await logger.info('Overrode conflict', {

--- a/src/lib/server/pcd/database/cache.ts
+++ b/src/lib/server/pcd/database/cache.ts
@@ -25,6 +25,7 @@ import {
 	parseOpMetadata
 } from '$pcd/conflicts/autoAlign/index.ts';
 import { checkFullListConflict } from '$pcd/conflicts/fullListCheck.ts';
+import { AUTO_ALIGN_ENTITIES } from '$pcd/entities/registry.ts';
 
 /**
  * PCDCache - Manages an in-memory compiled database for a single PCD
@@ -160,7 +161,7 @@ export class PCDCache {
 
 								if (status !== 'dropped') {
 									status = conflictStrategy === 'ask' ? 'conflicted_pending' : 'conflicted';
-									conflictReason = getConflictReason(metadata?.operation);
+									conflictReason = getConflictReason(this.db!, metadata);
 									const priorReason = priorConflicts.get(opId);
 									if (priorReason !== conflictReason) {
 										await logger.info('Recorded op conflict', {
@@ -247,9 +248,26 @@ export class PCDCache {
 					const shouldRecordConflict = trackHistory && (isDuplicateKey || isMissingTarget);
 
 					if (shouldRecordConflict) {
-						const status: PcdOpHistoryStatus =
+						let status: PcdOpHistoryStatus =
 							conflictStrategy === 'ask' ? 'conflicted_pending' : 'conflicted';
-						const conflictReason = isDuplicateKey ? 'duplicate_key' : 'missing_target';
+						let conflictReason = isDuplicateKey ? 'duplicate_key' : 'missing_target';
+						if (conflictStrategy === 'align') {
+							const updated = pcdOpsQueries.update(opId, { state: 'dropped' });
+							if (updated) {
+								status = 'dropped';
+								conflictReason = 'aligned';
+								stats.needsRebuild = true;
+								await logger.info('Forced align conflict', {
+									source: 'PCDCache',
+									meta: {
+										opId,
+										databaseInstanceId: this.databaseInstanceId,
+										conflictStrategy,
+										conflictReason
+									}
+								});
+							}
+						}
 						const priorReason = priorConflicts.get(opId);
 						if (priorReason !== conflictReason) {
 							await logger.info('Recorded op conflict', {
@@ -533,16 +551,51 @@ function parseOpId(filepath: string): number | null {
 	return Number.isFinite(opId) ? opId : null;
 }
 
-function getConflictReason(operation?: string): string {
-	switch (operation) {
+function getConflictReason(
+	db: Database,
+	metadata: ReturnType<typeof parseOpMetadata>
+): string {
+	switch (metadata?.operation) {
 		case 'create':
 			return 'duplicate_key';
 		case 'delete':
-			return 'missing_target';
+			return deleteTargetExists(db, metadata) ? 'guard_mismatch' : 'missing_target';
 		case 'update':
 		default:
 			return 'guard_mismatch';
 	}
+}
+
+function deleteTargetExists(db: Database, metadata: ReturnType<typeof parseOpMetadata>): boolean {
+	const entityName = metadata?.entity;
+	if (!entityName) return false;
+
+	const entity = AUTO_ALIGN_ENTITIES.get(entityName);
+	if (!entity) return false;
+
+	const typedMetadata = metadata as {
+		stable_key?: { value?: string };
+		stableKey?: { value?: string };
+	} | null;
+	const candidates = [
+		typedMetadata?.stable_key?.value,
+		typedMetadata?.stableKey?.value,
+		metadata?.name
+	].filter((value): value is string => typeof value === 'string' && value.length > 0);
+
+	for (const candidate of candidates) {
+		try {
+			// nosemgrep: profilarr.sql.template-literal-interpolation - table/column from hardcoded registry
+			const row = db
+				.prepare(`SELECT 1 FROM ${entity.table} WHERE ${entity.keyColumn} = ? LIMIT 1`)
+				.get(candidate);
+			if (row) return true;
+		} catch {
+			return false;
+		}
+	}
+
+	return false;
 }
 
 function isUniqueConstraintError(errorStr: string): boolean {

--- a/src/lib/server/pcd/database/cache.ts
+++ b/src/lib/server/pcd/database/cache.ts
@@ -551,10 +551,7 @@ function parseOpId(filepath: string): number | null {
 	return Number.isFinite(opId) ? opId : null;
 }
 
-function getConflictReason(
-	db: Database,
-	metadata: ReturnType<typeof parseOpMetadata>
-): string {
+function getConflictReason(db: Database, metadata: ReturnType<typeof parseOpMetadata>): string {
 	switch (metadata?.operation) {
 		case 'create':
 			return 'duplicate_key';

--- a/src/lib/server/pcd/entities/delayProfiles/override.ts
+++ b/src/lib/server/pcd/entities/delayProfiles/override.ts
@@ -3,6 +3,7 @@ import type { PCDCache, WriteResult } from '$pcd/index.ts';
 import type { PreferredProtocol } from '$shared/pcd/display.ts';
 import { get as getDelayProfile } from './read.ts';
 import { update } from './update.ts';
+import { remove } from './delete.ts';
 import type { StoredOpMetadata, StoredDesiredState } from '$pcd/conflicts/overrideUtils.ts';
 import { getDesiredTo, followRenameChain, valuesEqual } from '$pcd/conflicts/overrideUtils.ts';
 
@@ -157,4 +158,41 @@ async function overrideDelay(
 	});
 }
 
-export { overrideDelay as overrideCreate, overrideDelay as overrideUpdate };
+async function overrideDelete(
+	databaseId: number,
+	metadata: StoredOpMetadata | null,
+	desiredState: StoredDesiredState | null
+): Promise<WriteResult> {
+	const cache = getCache(databaseId);
+	if (!cache) {
+		return { success: false, error: 'Cache not available' };
+	}
+
+	const profileName = await resolveProfileName(cache, databaseId, metadata, desiredState);
+	if (!profileName) {
+		return { success: true };
+	}
+
+	const profileRow = await cache.kb
+		.selectFrom('delay_profiles')
+		.select('id')
+		.where('name', '=', profileName)
+		.executeTakeFirst();
+	if (!profileRow) {
+		return { success: true };
+	}
+
+	const current = await getDelayProfile(cache, profileRow.id);
+	if (!current) {
+		return { success: true };
+	}
+
+	return remove({
+		databaseId,
+		cache,
+		layer: 'user',
+		current
+	});
+}
+
+export { overrideDelay as overrideCreate, overrideDelay as overrideUpdate, overrideDelete };

--- a/src/lib/server/pcd/entities/delayProfiles/update.ts
+++ b/src/lib/server/pcd/entities/delayProfiles/update.ts
@@ -3,9 +3,11 @@
  */
 
 import type { PCDCache } from '$pcd/index.ts';
-import { writeOperation, type OperationLayer } from '$pcd/index.ts';
+import { writeOperation, type OperationLayer, type WriteResult } from '$pcd/index.ts';
 import type { DelayProfilesRow, PreferredProtocol } from '$shared/pcd/display.ts';
 import { logger } from '$logger/logger.ts';
+import { uuid } from '$shared/utils/uuid.ts';
+import type { CompiledQuery } from 'kysely';
 
 interface UpdateDelayProfileInput {
 	name: string;
@@ -25,6 +27,23 @@ interface UpdateDelayProfileOptions {
 	current: DelayProfilesRow;
 	/** The new values */
 	input: UpdateDelayProfileInput;
+}
+
+type DelayProfileField =
+	| 'name'
+	| 'preferred_protocol'
+	| 'usenet_delay'
+	| 'torrent_delay'
+	| 'bypass_if_highest_quality'
+	| 'bypass_if_above_custom_format_score'
+	| 'minimum_custom_format_score';
+
+interface FieldChange {
+	field: DelayProfileField;
+	from: unknown;
+	to: unknown;
+	setValue: unknown;
+	guardValue: unknown;
 }
 
 /**
@@ -60,114 +79,73 @@ export async function update(options: UpdateDelayProfileOptions) {
 	// minimum_custom_format_score must be NULL if bypass_if_above_custom_format_score is false
 	const minimumCfScore = input.bypassIfAboveCfScore ? input.minimumCfScore : null;
 
-	// Update the delay profile with value guards
-	const setValues: Record<string, unknown> = {};
+	const changes: FieldChange[] = [];
 
 	if (current.name !== input.name) {
-		setValues.name = input.name;
+		changes.push({
+			field: 'name',
+			from: current.name,
+			to: input.name,
+			setValue: input.name,
+			guardValue: current.name
+		});
 	}
 	if (current.preferred_protocol !== input.preferredProtocol) {
-		setValues.preferred_protocol = input.preferredProtocol;
+		changes.push({
+			field: 'preferred_protocol',
+			from: current.preferred_protocol,
+			to: input.preferredProtocol,
+			setValue: input.preferredProtocol,
+			guardValue: current.preferred_protocol
+		});
 	}
 	if (current.usenet_delay !== usenetDelay) {
-		setValues.usenet_delay = usenetDelay;
+		changes.push({
+			field: 'usenet_delay',
+			from: current.usenet_delay,
+			to: usenetDelay,
+			setValue: usenetDelay,
+			guardValue: current.usenet_delay
+		});
 	}
 	if (current.torrent_delay !== torrentDelay) {
-		setValues.torrent_delay = torrentDelay;
+		changes.push({
+			field: 'torrent_delay',
+			from: current.torrent_delay,
+			to: torrentDelay,
+			setValue: torrentDelay,
+			guardValue: current.torrent_delay
+		});
 	}
 	if (current.bypass_if_highest_quality !== input.bypassIfHighestQuality) {
-		setValues.bypass_if_highest_quality = input.bypassIfHighestQuality ? 1 : 0;
-	}
-	if (current.bypass_if_above_custom_format_score !== input.bypassIfAboveCfScore) {
-		setValues.bypass_if_above_custom_format_score = input.bypassIfAboveCfScore ? 1 : 0;
-	}
-	if (current.minimum_custom_format_score !== minimumCfScore) {
-		setValues.minimum_custom_format_score = minimumCfScore;
-	}
-
-	let updateProfile = db
-		.updateTable('delay_profiles')
-		.set(setValues)
-		// Value guard - ensure this is the profile we expect
-		.where('name', '=', current.name);
-
-	if (current.preferred_protocol !== input.preferredProtocol) {
-		updateProfile = updateProfile.where('preferred_protocol', '=', current.preferred_protocol);
-	}
-	if (current.usenet_delay !== usenetDelay) {
-		if (current.usenet_delay === null) {
-			updateProfile = updateProfile.where('usenet_delay', 'is', null);
-		} else {
-			updateProfile = updateProfile.where('usenet_delay', '=', current.usenet_delay);
-		}
-	}
-	if (current.torrent_delay !== torrentDelay) {
-		if (current.torrent_delay === null) {
-			updateProfile = updateProfile.where('torrent_delay', 'is', null);
-		} else {
-			updateProfile = updateProfile.where('torrent_delay', '=', current.torrent_delay);
-		}
-	}
-	if (current.bypass_if_highest_quality !== input.bypassIfHighestQuality) {
-		updateProfile = updateProfile.where(
-			'bypass_if_highest_quality',
-			'=',
-			current.bypass_if_highest_quality ? 1 : 0
-		);
-	}
-	if (current.bypass_if_above_custom_format_score !== input.bypassIfAboveCfScore) {
-		updateProfile = updateProfile.where(
-			'bypass_if_above_custom_format_score',
-			'=',
-			current.bypass_if_above_custom_format_score ? 1 : 0
-		);
-	}
-	if (current.minimum_custom_format_score !== minimumCfScore) {
-		if (current.minimum_custom_format_score === null) {
-			updateProfile = updateProfile.where('minimum_custom_format_score', 'is', null);
-		} else {
-			updateProfile = updateProfile.where(
-				'minimum_custom_format_score',
-				'=',
-				current.minimum_custom_format_score
-			);
-		}
-	}
-
-	const updateProfileQuery = Object.keys(setValues).length > 0 ? updateProfile.compile() : null;
-
-	// Log what's being changed
-	const changes: Record<string, { from: unknown; to: unknown }> = {};
-
-	if (current.name !== input.name) {
-		changes.name = { from: current.name, to: input.name };
-	}
-	if (current.preferred_protocol !== input.preferredProtocol) {
-		changes.preferredProtocol = { from: current.preferred_protocol, to: input.preferredProtocol };
-	}
-	if (current.usenet_delay !== usenetDelay) {
-		changes.usenetDelay = { from: current.usenet_delay, to: usenetDelay };
-	}
-	if (current.torrent_delay !== torrentDelay) {
-		changes.torrentDelay = { from: current.torrent_delay, to: torrentDelay };
-	}
-	if (current.bypass_if_highest_quality !== input.bypassIfHighestQuality) {
-		changes.bypassIfHighestQuality = {
+		changes.push({
+			field: 'bypass_if_highest_quality',
 			from: current.bypass_if_highest_quality,
-			to: input.bypassIfHighestQuality
-		};
+			to: input.bypassIfHighestQuality,
+			setValue: input.bypassIfHighestQuality ? 1 : 0,
+			guardValue: current.bypass_if_highest_quality ? 1 : 0
+		});
 	}
 	if (current.bypass_if_above_custom_format_score !== input.bypassIfAboveCfScore) {
-		changes.bypassIfAboveCfScore = {
+		changes.push({
+			field: 'bypass_if_above_custom_format_score',
 			from: current.bypass_if_above_custom_format_score,
-			to: input.bypassIfAboveCfScore
-		};
+			to: input.bypassIfAboveCfScore,
+			setValue: input.bypassIfAboveCfScore ? 1 : 0,
+			guardValue: current.bypass_if_above_custom_format_score ? 1 : 0
+		});
 	}
 	if (current.minimum_custom_format_score !== minimumCfScore) {
-		changes.minimumCfScore = { from: current.minimum_custom_format_score, to: minimumCfScore };
+		changes.push({
+			field: 'minimum_custom_format_score',
+			from: current.minimum_custom_format_score,
+			to: minimumCfScore,
+			setValue: minimumCfScore,
+			guardValue: current.minimum_custom_format_score
+		});
 	}
 
-	if (!updateProfileQuery) {
+	if (changes.length === 0) {
 		return { success: true };
 	}
 
@@ -179,61 +157,160 @@ export async function update(options: UpdateDelayProfileOptions) {
 		}
 	});
 
-	// Write the operation with metadata
-	const isRename = input.name !== current.name;
-	const changedFields = Object.keys(changes);
-	const desiredState: Record<string, unknown> = {};
-	if (changes.name) {
-		desiredState.name = { from: current.name, to: input.name };
-	}
-	if (changes.preferredProtocol) {
-		desiredState.preferred_protocol = {
-			from: current.preferred_protocol,
-			to: input.preferredProtocol
-		};
-	}
-	if (changes.usenetDelay) {
-		desiredState.usenet_delay = { from: current.usenet_delay, to: usenetDelay };
-	}
-	if (changes.torrentDelay) {
-		desiredState.torrent_delay = { from: current.torrent_delay, to: torrentDelay };
-	}
-	if (changes.bypassIfHighestQuality) {
-		desiredState.bypass_if_highest_quality = {
-			from: current.bypass_if_highest_quality,
-			to: input.bypassIfHighestQuality
-		};
-	}
-	if (changes.bypassIfAboveCfScore) {
-		desiredState.bypass_if_above_custom_format_score = {
-			from: current.bypass_if_above_custom_format_score,
-			to: input.bypassIfAboveCfScore
-		};
-	}
-	if (changes.minimumCfScore) {
-		desiredState.minimum_custom_format_score = {
-			from: current.minimum_custom_format_score,
-			to: minimumCfScore
-		};
-	}
+	const opGroups = groupChanges(changes, current, usenetDelay, torrentDelay, minimumCfScore);
+	const groupId = opGroups.length > 1 ? uuid() : undefined;
+	const operations = opGroups.map((opChanges) => {
+		const fields = opChanges.map((change) => change.field);
+		const isRename = fields.length === 1 && fields[0] === 'name';
 
-	const result = await writeOperation({
-		databaseId,
-		layer,
-		description: `update-delay-profile-${input.name}`,
-		queries: [updateProfileQuery],
-		desiredState,
-		metadata: {
-			operation: 'update',
-			entity: 'delay_profile',
-			name: input.name,
-			...(isRename && { previousName: current.name }),
-			stableKey: { key: 'delay_profile_name', value: current.name },
-			changedFields,
-			summary: 'Update delay profile',
-			title: `Update delay profile "${input.name}"`
-		}
+		return {
+			fields,
+			isRename,
+			queries: [buildUpdateQuery(cache, current, opChanges)],
+			desiredState: buildDesiredState(opChanges)
+		};
 	});
+	let lastResult: WriteResult | null = null;
 
-	return result;
+	for (const operation of operations) {
+		const result = await writeOperation({
+			databaseId,
+			layer,
+			description: `update-delay-profile-${operation.fields.join('-')}-${input.name}`,
+			queries: operation.queries,
+			desiredState: operation.desiredState,
+			metadata: {
+				operation: 'update',
+				entity: 'delay_profile',
+				name: input.name,
+				...(operation.isRename && { previousName: current.name }),
+				stableKey: { key: 'delay_profile_name', value: current.name },
+				...(groupId && { groupId }),
+				changedFields: operation.fields,
+				summary: operation.isRename ? 'Rename delay profile' : 'Update delay profile',
+				title: operation.isRename
+					? `Rename delay profile "${current.name}"`
+					: `Update delay profile "${input.name}"`
+			}
+		});
+
+		if (!result.success) {
+			return result;
+		}
+		lastResult = result;
+	}
+
+	return lastResult ?? { success: true };
+}
+
+function groupChanges(
+	changes: FieldChange[],
+	current: DelayProfilesRow,
+	usenetDelay: number | null,
+	torrentDelay: number | null,
+	minimumCfScore: number | null
+): FieldChange[][] {
+	const byField = new Map<DelayProfileField, FieldChange>();
+	for (const change of changes) {
+		byField.set(change.field, change);
+	}
+
+	const groups: FieldChange[][] = [];
+	const used = new Set<DelayProfileField>();
+	const protocolChange = byField.get('preferred_protocol');
+
+	if (protocolChange) {
+		const protocolFields: DelayProfileField[] = ['preferred_protocol'];
+		if (current.usenet_delay === null || usenetDelay === null) {
+			protocolFields.push('usenet_delay');
+		}
+		if (current.torrent_delay === null || torrentDelay === null) {
+			protocolFields.push('torrent_delay');
+		}
+		addGroup(groups, used, byField, protocolFields);
+	}
+
+	addSingle(groups, used, byField, 'usenet_delay');
+	addSingle(groups, used, byField, 'torrent_delay');
+	addSingle(groups, used, byField, 'bypass_if_highest_quality');
+
+	const bypassChange = byField.get('bypass_if_above_custom_format_score');
+	if (bypassChange) {
+		const bypassFields: DelayProfileField[] = ['bypass_if_above_custom_format_score'];
+		if (current.minimum_custom_format_score === null || minimumCfScore === null) {
+			bypassFields.push('minimum_custom_format_score');
+		}
+		addGroup(groups, used, byField, bypassFields);
+	}
+
+	addSingle(groups, used, byField, 'minimum_custom_format_score');
+	addSingle(groups, used, byField, 'name');
+
+	for (const change of changes) {
+		if (!used.has(change.field)) {
+			groups.push([change]);
+		}
+	}
+
+	return groups;
+}
+
+function addSingle(
+	groups: FieldChange[][],
+	used: Set<DelayProfileField>,
+	byField: Map<DelayProfileField, FieldChange>,
+	field: DelayProfileField
+) {
+	addGroup(groups, used, byField, [field]);
+}
+
+function addGroup(
+	groups: FieldChange[][],
+	used: Set<DelayProfileField>,
+	byField: Map<DelayProfileField, FieldChange>,
+	fields: DelayProfileField[]
+) {
+	const group = fields
+		.filter((field) => !used.has(field))
+		.map((field) => byField.get(field))
+		.filter((change): change is FieldChange => !!change);
+
+	if (group.length === 0) return;
+	for (const change of group) {
+		used.add(change.field);
+	}
+	groups.push(group);
+}
+
+function buildDesiredState(changes: FieldChange[]): Record<string, unknown> {
+	const desiredState: Record<string, unknown> = {};
+	for (const change of changes) {
+		desiredState[change.field] = { from: change.from, to: change.to };
+	}
+	return desiredState;
+}
+
+function buildUpdateQuery(
+	cache: PCDCache,
+	current: DelayProfilesRow,
+	changes: FieldChange[]
+): CompiledQuery {
+	const db = cache.kb;
+	const setValues: Record<string, unknown> = {};
+	for (const change of changes) {
+		setValues[change.field] = change.setValue;
+	}
+
+	let query = db.updateTable('delay_profiles').set(setValues).where('name', '=', current.name);
+
+	for (const change of changes) {
+		if (change.field === 'name') continue;
+		if (change.guardValue === null) {
+			query = query.where(change.field, 'is', null);
+		} else {
+			query = query.where(change.field, '=', change.guardValue as never);
+		}
+	}
+
+	return query.compile();
 }

--- a/src/routes/delay-profiles/[databaseId]/+page.svelte
+++ b/src/routes/delay-profiles/[databaseId]/+page.svelte
@@ -13,7 +13,6 @@
 	import { alertStore } from '$alerts/store';
 	import { Info, Plus } from 'lucide-svelte';
 	import type { PageData } from './$types';
-	import { delayProfileLockedMessage } from './lock';
 	import { copyToClipboard } from '$lib/client/utils/clipboard';
 
 	export let data: PageData;
@@ -22,24 +21,12 @@
 	let cloneModalOpen = false;
 	let cloneSourceName = '';
 
-	function notifyLocked() {
-		alertStore.add('info', delayProfileLockedMessage);
-	}
-
 	function handleClone(event: CustomEvent<{ name: string }>) {
-		if (!data.canWriteToBase) {
-			notifyLocked();
-			return;
-		}
 		cloneSourceName = event.detail.name;
 		cloneModalOpen = true;
 	}
 
 	function handleCreate() {
-		if (!data.canWriteToBase) {
-			notifyLocked();
-			return;
-		}
 		goto(`/delay-profiles/${data.currentDatabase.id}/new`);
 	}
 
@@ -118,19 +105,9 @@
 				<p class="text-neutral-600 dark:text-neutral-400">No delay profiles match your search</p>
 			</div>
 		{:else if $view === 'table'}
-			<TableView
-				profiles={$filtered}
-				canWriteToBase={data.canWriteToBase}
-				on:clone={handleClone}
-				on:export={handleExport}
-			/>
+			<TableView profiles={$filtered} on:clone={handleClone} on:export={handleExport} />
 		{:else}
-			<CardView
-				profiles={$filtered}
-				canWriteToBase={data.canWriteToBase}
-				on:clone={handleClone}
-				on:export={handleExport}
-			/>
+			<CardView profiles={$filtered} on:clone={handleClone} on:export={handleExport} />
 		{/if}
 	</div>
 </div>

--- a/src/routes/delay-profiles/[databaseId]/components/DelayProfileForm.svelte
+++ b/src/routes/delay-profiles/[databaseId]/components/DelayProfileForm.svelte
@@ -17,7 +17,6 @@
 	import type { PreferredProtocol } from '$shared/pcd/display.ts';
 	import { current, isDirty, initEdit, initCreate, update } from '$lib/client/stores/dirty';
 	import type { AffectedArr } from '$shared/sync/types.ts';
-	import { delayProfileLockedMessage } from '../lock';
 
 	// Form data shape
 	interface DelayProfileFormData {
@@ -69,7 +68,6 @@
 
 	// Layer selection
 	let selectedLayer: 'user' | 'base' = canWriteToBase ? 'base' : 'user';
-	$: readOnly = !canWriteToBase;
 
 	// Modal states
 	let showSyncModal = false;
@@ -85,9 +83,8 @@
 
 	// Display text based on mode
 	$: title = mode === 'create' ? 'New Delay Profile' : 'Edit Delay Profile';
-	$: description = readOnly
-		? 'Delay profiles from linked databases cannot be edited directly'
-		: mode === 'create'
+	$: description =
+		mode === 'create'
 			? `Create a new delay profile for ${databaseName}`
 			: `Update delay profile settings`;
 	$: submitButtonText = mode === 'create' ? 'Create Profile' : 'Save Changes';
@@ -115,41 +112,24 @@
 	$: protocolDescription =
 		protocolOptions.find((o) => o.value === formData.preferredProtocol)?.description ?? '';
 
-	function notifyLocked() {
-		alertStore.add('info', delayProfileLockedMessage);
-	}
-
 	function updateField<K extends keyof DelayProfileFormData>(
 		field: K,
 		value: DelayProfileFormData[K]
 	) {
-		if (readOnly) return;
 		update<DelayProfileFormData, K>(field, value);
 	}
 
 	async function handleSaveClick() {
-		if (readOnly) {
-			notifyLocked();
-			return;
-		}
 		selectedLayer = canWriteToBase ? 'base' : 'user';
 		await tick();
 		mainFormElement?.requestSubmit();
 	}
 
 	async function handleDeleteClick() {
-		if (readOnly) {
-			notifyLocked();
-			return;
-		}
 		showDeleteModal = true;
 	}
 
 	async function handleDeleteConfirm() {
-		if (readOnly) {
-			notifyLocked();
-			return;
-		}
 		deleteLayer = canWriteToBase ? 'base' : 'user';
 		showDeleteModal = false;
 		await tick();
@@ -171,7 +151,7 @@
 		</svelte:fragment>
 		<svelte:fragment slot="right">
 			<div class="flex items-center gap-2">
-				{#if mode === 'edit' && !readOnly}
+				{#if mode === 'edit'}
 					<Button
 						disabled={deleting}
 						icon={deleting ? Loader2 : Trash2}
@@ -182,8 +162,7 @@
 				{/if}
 				<Button text="Cancel" on:click={onCancel} />
 				<Button
-					disabled={!readOnly && (saving || !isValid || !$isDirty)}
-					softDisabled={readOnly}
+					disabled={saving || !isValid || !$isDirty}
 					icon={saving ? Loader2 : Save}
 					iconColor="text-blue-600 dark:text-blue-400"
 					text={saving ? (mode === 'create' ? 'Creating...' : 'Saving...') : submitButtonText}
@@ -256,7 +235,6 @@
 						placeholder="e.g., Standard Delay"
 						required
 						value={formData.name}
-						disabled={readOnly}
 						on:input={(e) => updateField('name', e.detail)}
 					/>
 				</div>
@@ -270,7 +248,6 @@
 						value={formData.preferredProtocol}
 						options={protocolOptions}
 						fullWidth
-						disabled={readOnly}
 						on:change={(e) => updateField('preferredProtocol', e.detail as PreferredProtocol)}
 					/>
 					{#if protocolDescription}
@@ -302,7 +279,7 @@
 									onchange={(v) => updateField('usenetDelay', v)}
 									min={0}
 									font="mono"
-									disabled={readOnly || !usenetEnabled}
+									disabled={!usenetEnabled}
 								/>
 							</div>
 						</div>
@@ -322,7 +299,7 @@
 									onchange={(v) => updateField('torrentDelay', v)}
 									min={0}
 									font="mono"
-									disabled={readOnly || !torrentEnabled}
+									disabled={!torrentEnabled}
 								/>
 							</div>
 						</div>
@@ -343,7 +320,6 @@
 								label="Bypass if Highest Quality"
 								checked={formData.bypassIfHighestQuality}
 								fullWidth
-								disabled={readOnly}
 								on:change={() =>
 									updateField('bypassIfHighestQuality', !formData.bypassIfHighestQuality)}
 							/>
@@ -358,7 +334,6 @@
 									label="Bypass if Above Custom Format Score"
 									checked={formData.bypassIfAboveCfScore}
 									fullWidth
-									disabled={readOnly}
 									on:change={() =>
 										updateField('bypassIfAboveCfScore', !formData.bypassIfAboveCfScore)}
 								/>
@@ -367,7 +342,7 @@
 									id="min-cf-score"
 									value={formData.minimumCfScore}
 									onchange={(v) => updateField('minimumCfScore', v)}
-									disabled={readOnly || !formData.bypassIfAboveCfScore}
+									disabled={!formData.bypassIfAboveCfScore}
 									font="mono"
 								/>
 							</div>
@@ -382,7 +357,7 @@
 	</form>
 
 	<!-- Hidden delete form -->
-	{#if mode === 'edit' && !readOnly}
+	{#if mode === 'edit'}
 		<form
 			bind:this={deleteFormElement}
 			method="POST"

--- a/src/routes/delay-profiles/[databaseId]/lock.ts
+++ b/src/routes/delay-profiles/[databaseId]/lock.ts
@@ -1,2 +1,0 @@
-export const delayProfileLockedMessage =
-	'This delay profile is read-only because it comes from a linked database. Use your own database, or edit it directly in Radarr/Sonarr.';

--- a/src/routes/delay-profiles/[databaseId]/views/CardView.svelte
+++ b/src/routes/delay-profiles/[databaseId]/views/CardView.svelte
@@ -2,18 +2,14 @@
 	import { createEventDispatcher } from 'svelte';
 	import type { DelayProfilesRow } from '$shared/pcd/display.ts';
 	import { page } from '$app/stores';
-	import { goto } from '$app/navigation';
 	import { Clock, Zap, Shield, Copy, Download } from 'lucide-svelte';
 	import CardGrid from '$ui/card/CardGrid.svelte';
 	import Card from '$ui/card/Card.svelte';
 	import Button from '$ui/button/Button.svelte';
-	import { alertStore } from '$alerts/store';
 	import { createProgressiveList } from '$lib/client/utils/progressiveList';
 	import { FEATURES } from '$shared/features.ts';
-	import { delayProfileLockedMessage } from '../lock';
 
 	export let profiles: DelayProfilesRow[];
-	export let canWriteToBase: boolean = false;
 
 	const dispatch = createEventDispatcher<{ clone: { name: string }; export: { name: string } }>();
 
@@ -51,20 +47,11 @@
 	function getProfileHref(profile: DelayProfilesRow): string {
 		return `/delay-profiles/${databaseId}/${encodeURIComponent(profile.name)}`;
 	}
-
-	function handleLockedOpen(profile: DelayProfilesRow) {
-		alertStore.add('info', delayProfileLockedMessage);
-		goto(getProfileHref(profile));
-	}
 </script>
 
 <CardGrid columns={5} flush>
 	{#each visibleProfiles as profile}
-		<Card
-			href={canWriteToBase ? getProfileHref(profile) : undefined}
-			onclick={canWriteToBase ? undefined : () => handleLockedOpen(profile)}
-			hoverable
-		>
+		<Card href={getProfileHref(profile)} hoverable>
 			<svelte:fragment slot="header">
 				<!-- svelte-ignore a11y-click-events-have-key-events a11y-no-static-element-interactions -->
 				<div class="flex items-center justify-between">

--- a/src/routes/delay-profiles/[databaseId]/views/TableView.svelte
+++ b/src/routes/delay-profiles/[databaseId]/views/TableView.svelte
@@ -7,13 +7,9 @@
 	import { Tag, Clock, Zap, Shield, Copy, Download } from 'lucide-svelte';
 	import { escapeHtml } from '$shared/utils/sanitize.ts';
 	import { page } from '$app/stores';
-	import { goto } from '$app/navigation';
-	import { alertStore } from '$alerts/store';
 	import { FEATURES } from '$shared/features.ts';
-	import { delayProfileLockedMessage } from '../lock';
 
 	export let profiles: DelayProfilesRow[];
-	export let canWriteToBase: boolean = false;
 
 	const dispatch = createEventDispatcher<{ clone: { name: string }; export: { name: string } }>();
 
@@ -21,11 +17,6 @@
 
 	function getRowHref(row: DelayProfilesRow): string {
 		return `/delay-profiles/${databaseId}/${encodeURIComponent(row.name)}`;
-	}
-
-	function handleLockedRowClick(row: DelayProfilesRow) {
-		alertStore.add('info', delayProfileLockedMessage);
-		goto(getRowHref(row));
 	}
 
 	function formatProtocol(protocol: string): string {
@@ -128,8 +119,7 @@
 	emptyMessage="No delay profiles found"
 	hoverable={true}
 	compact={false}
-	rowHref={canWriteToBase ? getRowHref : undefined}
-	onRowClick={canWriteToBase ? undefined : handleLockedRowClick}
+	rowHref={getRowHref}
 >
 	<!-- svelte-ignore a11y-click-events-have-key-events a11y-no-static-element-interactions -->
 	<svelte:fragment slot="actions" let:row>

--- a/tests/integration/pcd/conflicts/delay-profiles.test.ts
+++ b/tests/integration/pcd/conflicts/delay-profiles.test.ts
@@ -157,7 +157,10 @@ test('protocol constrained pair conflicts atomically', async () => {
 		assertStrategyOutcome(ctx, op, strategy, 'guard_mismatch');
 
 		const row = assertDelayProfile(ctx, 'Protocol Pair');
-		assertEquals(row.preferred_protocol, strategy === 'override' ? 'only_torrent' : 'prefer_usenet');
+		assertEquals(
+			row.preferred_protocol,
+			strategy === 'override' ? 'only_torrent' : 'prefer_usenet'
+		);
 		assertEquals(row.usenet_delay, strategy === 'override' ? null : 12);
 	}
 });
@@ -205,9 +208,12 @@ test('bypass score constrained pair conflicts atomically', async () => {
 			minimumCfScore: 80
 		});
 
-		seedUpstream(ctx, upstreamUpdate('Bypass Pair', {
-			minimum_custom_format_score: { from: 80, to: 90 }
-		}));
+		seedUpstream(
+			ctx,
+			upstreamUpdate('Bypass Pair', {
+				minimum_custom_format_score: { from: 80, to: 90 }
+			})
+		);
 		await compilePcd(ctx);
 
 		const op = firstOpForChangedFields(opsSince(ctx, checkpoint), [
@@ -389,10 +395,7 @@ test('delete missing target auto-aligns', async () => {
 	}
 });
 
-async function newScenario(
-	strategy: ConflictStrategy,
-	name: string
-): Promise<PcdTestContext> {
+async function newScenario(strategy: ConflictStrategy, name: string): Promise<PcdTestContext> {
 	counter++;
 	return setupPcd({
 		port: PORT,
@@ -440,8 +443,7 @@ function firstOpForChangedFields(ops: OpRow[], fields: string[]): OpRow {
 	const op = ops.find((candidate) => {
 		const actual = changedFields(candidate).sort();
 		return (
-			actual.length === expected.length &&
-			actual.every((field, index) => field === expected[index])
+			actual.length === expected.length && actual.every((field, index) => field === expected[index])
 		);
 	});
 	assertExists(op, `Expected a user op for ${fields.join(', ')}`);
@@ -579,7 +581,10 @@ function compiledDelayProfiles(ctx: PcdTestContext): DelayProfileRow[] {
 	}
 }
 
-function latestHistories(db: ReturnType<typeof openDb>, databaseId: number): Map<number, LatestHistory> {
+function latestHistories(
+	db: ReturnType<typeof openDb>,
+	databaseId: number
+): Map<number, LatestHistory> {
 	const rows = db
 		.prepare(
 			`SELECT op_id, status, conflict_reason

--- a/tests/integration/pcd/conflicts/delay-profiles.test.ts
+++ b/tests/integration/pcd/conflicts/delay-profiles.test.ts
@@ -1,0 +1,653 @@
+/**
+ * PCD conflict tests: delay profiles.
+ */
+
+import { assert, assertEquals, assertExists } from '@std/assert';
+import { startServer, stopServer } from '$test-harness/server.ts';
+import { openDb } from '$test-harness/db.ts';
+import { run, setup, teardown, test } from '$test-harness/runner.ts';
+import { base } from '../harness/fixtures.ts';
+import {
+	compilePcd,
+	insertOp,
+	opCheckpoint,
+	parseMetadata,
+	queryOpsSince,
+	seedBase,
+	setupPcd,
+	type ConflictStrategy,
+	type OpRow,
+	type PcdTestContext,
+	type SeedOperation
+} from '../harness/pcd.ts';
+import { write } from '../harness/write.ts';
+
+const PORT = 7044;
+const ORIGIN = `http://localhost:${PORT}`;
+const STRATEGIES: ConflictStrategy[] = ['ask', 'align', 'override'];
+
+type LatestHistory = {
+	status: string;
+	conflict_reason: string | null;
+};
+
+type DelayProfileRow = {
+	name: string;
+	preferred_protocol: string;
+	usenet_delay: number | null;
+	torrent_delay: number | null;
+	bypass_if_highest_quality: number;
+	bypass_if_above_custom_format_score: number;
+	minimum_custom_format_score: number | null;
+};
+
+let counter = 0;
+
+setup(async () => {
+	await startServer(PORT, { AUTH: 'off', ORIGIN }, 'preview');
+});
+
+teardown(async () => {
+	await stopServer(PORT);
+});
+
+/**
+ * Base
+ *   Delay profile:
+ *     name='Split Conflict', preferredProtocol='prefer_usenet',
+ *     usenetDelay=10, torrentDelay=20
+ *
+ * User
+ *   POST update changes:
+ *     usenetDelay  = 15
+ *     torrentDelay = 25
+ *
+ * Upstream
+ *   Published base op changes:
+ *     usenetDelay 10 -> 12
+ *
+ * Expect
+ *   - ask: usenet_delay is conflicted_pending, torrent_delay applies
+ *   - align: usenet_delay is dropped/aligned, torrent_delay applies
+ *   - override: usenet_delay is superseded by a replacement, torrent_delay applies
+ *   - final torrent_delay is 25 for every strategy
+ *   - final usenet_delay is 15 only for override, otherwise 12
+ */
+test('split scalar conflicts resolve per field by strategy', async () => {
+	for (const strategy of STRATEGIES) {
+		const ctx = await seededScenario(strategy, 'split-scalar', [
+			base.delayProfile({
+				name: 'Split Conflict',
+				preferredProtocol: 'prefer_usenet',
+				usenetDelay: 10,
+				torrentDelay: 20
+			})
+		]);
+		const checkpoint = opCheckpoint(ctx);
+
+		await write.delayProfile.update(ctx, 'Split Conflict', {
+			name: 'Split Conflict',
+			preferredProtocol: 'prefer_usenet',
+			usenetDelay: 15,
+			torrentDelay: 25
+		});
+
+		seedUpstream(ctx, upstreamUpdate('Split Conflict', { usenet_delay: { from: 10, to: 12 } }));
+		await compilePcd(ctx);
+
+		const ops = userOpsSince(ctx, checkpoint);
+		const usenetOp = firstOpForChangedFields(ops, ['usenet_delay']);
+		const torrentOp = firstOpForChangedFields(ops, ['torrent_delay']);
+
+		assertStrategyOutcome(ctx, usenetOp, strategy, 'guard_mismatch');
+		assertLatestHistory(ctx, torrentOp, 'applied');
+
+		const row = assertDelayProfile(ctx, 'Split Conflict');
+		assertEquals(row.usenet_delay, strategy === 'override' ? 15 : 12);
+		assertEquals(row.torrent_delay, 25);
+	}
+});
+
+/**
+ * Base
+ *   Delay profile:
+ *     name='Protocol Pair', preferredProtocol='prefer_usenet',
+ *     usenetDelay=10, torrentDelay=20
+ *
+ * User
+ *   POST update changes:
+ *     preferredProtocol = 'only_torrent'
+ *     usenetDelay       = null via writer normalization
+ *
+ * Upstream
+ *   Published base op changes:
+ *     usenetDelay 10 -> 12
+ *
+ * Expect
+ *   - grouped ['preferred_protocol', 'usenet_delay'] op conflicts as one unit
+ *   - preferred_protocol does not partially apply for ask or align
+ *   - override reapplies both fields against the upstream row
+ */
+test('protocol constrained pair conflicts atomically', async () => {
+	for (const strategy of STRATEGIES) {
+		const ctx = await seededScenario(strategy, 'protocol-pair', [
+			base.delayProfile({
+				name: 'Protocol Pair',
+				preferredProtocol: 'prefer_usenet',
+				usenetDelay: 10,
+				torrentDelay: 20
+			})
+		]);
+		const checkpoint = opCheckpoint(ctx);
+
+		await write.delayProfile.update(ctx, 'Protocol Pair', {
+			name: 'Protocol Pair',
+			preferredProtocol: 'only_torrent',
+			usenetDelay: 10,
+			torrentDelay: 20
+		});
+
+		seedUpstream(ctx, upstreamUpdate('Protocol Pair', { usenet_delay: { from: 10, to: 12 } }));
+		await compilePcd(ctx);
+
+		const op = firstOpForChangedFields(opsSince(ctx, checkpoint), [
+			'preferred_protocol',
+			'usenet_delay'
+		]);
+		assertStrategyOutcome(ctx, op, strategy, 'guard_mismatch');
+
+		const row = assertDelayProfile(ctx, 'Protocol Pair');
+		assertEquals(row.preferred_protocol, strategy === 'override' ? 'only_torrent' : 'prefer_usenet');
+		assertEquals(row.usenet_delay, strategy === 'override' ? null : 12);
+	}
+});
+
+/**
+ * Base
+ *   Delay profile:
+ *     name='Bypass Pair', bypassIfAboveCfScore=true,
+ *     minimumCfScore=80
+ *
+ * User
+ *   POST update changes:
+ *     bypassIfAboveCfScore = false
+ *     minimumCfScore       = null via writer normalization
+ *
+ * Upstream
+ *   Published base op changes:
+ *     minimumCfScore 80 -> 90
+ *
+ * Expect
+ *   - grouped [
+ *       'bypass_if_above_custom_format_score',
+ *       'minimum_custom_format_score'
+ *     ] op conflicts as one unit
+ *   - bypass flag does not partially apply for ask or align
+ *   - override reapplies both fields against the upstream row
+ */
+test('bypass score constrained pair conflicts atomically', async () => {
+	for (const strategy of STRATEGIES) {
+		const ctx = await seededScenario(strategy, 'bypass-pair', [
+			base.delayProfile({
+				name: 'Bypass Pair',
+				bypassIfAboveCfScore: true,
+				minimumCfScore: 80
+			})
+		]);
+		const checkpoint = opCheckpoint(ctx);
+
+		await write.delayProfile.update(ctx, 'Bypass Pair', {
+			name: 'Bypass Pair',
+			preferredProtocol: 'prefer_usenet',
+			usenetDelay: 0,
+			torrentDelay: 0,
+			bypassIfAboveCfScore: false,
+			minimumCfScore: 80
+		});
+
+		seedUpstream(ctx, upstreamUpdate('Bypass Pair', {
+			minimum_custom_format_score: { from: 80, to: 90 }
+		}));
+		await compilePcd(ctx);
+
+		const op = firstOpForChangedFields(opsSince(ctx, checkpoint), [
+			'bypass_if_above_custom_format_score',
+			'minimum_custom_format_score'
+		]);
+		assertStrategyOutcome(ctx, op, strategy, 'guard_mismatch');
+
+		const row = assertDelayProfile(ctx, 'Bypass Pair');
+		assertEquals(row.bypass_if_above_custom_format_score, strategy === 'override' ? 0 : 1);
+		assertEquals(row.minimum_custom_format_score, strategy === 'override' ? null : 90);
+	}
+});
+
+/**
+ * Base
+ *   Delay profile:
+ *     name='Old Delay'
+ *
+ * User
+ *   POST update changes:
+ *     name = 'User Delay'
+ *
+ * Upstream
+ *   Published base rename changes:
+ *     name 'Old Delay' -> 'Upstream Delay'
+ *
+ * Expect
+ *   - ask: rename op is conflicted_pending
+ *   - align: rename op is dropped/aligned
+ *   - override: rename op is superseded and final row is 'User Delay'
+ */
+test('rename conflict follows upstream rename by strategy', async () => {
+	for (const strategy of STRATEGIES) {
+		const ctx = await seededScenario(strategy, 'rename', [
+			base.delayProfile({ name: 'Old Delay' })
+		]);
+		const checkpoint = opCheckpoint(ctx);
+
+		await write.delayProfile.update(ctx, 'Old Delay', {
+			name: 'User Delay',
+			preferredProtocol: 'prefer_usenet',
+			usenetDelay: 0,
+			torrentDelay: 0
+		});
+
+		seedUpstream(ctx, upstreamRename('Old Delay', 'Upstream Delay'));
+		await compilePcd(ctx);
+
+		const op = firstOpForChangedFields(opsSince(ctx, checkpoint), ['name']);
+		assertStrategyOutcome(ctx, op, strategy, 'guard_mismatch');
+
+		if (strategy === 'override') {
+			assertDelayProfile(ctx, 'User Delay');
+			assertNoDelayProfile(ctx, 'Upstream Delay');
+		} else {
+			assertDelayProfile(ctx, 'Upstream Delay');
+			assertNoDelayProfile(ctx, 'User Delay');
+		}
+	}
+});
+
+/**
+ * Base
+ *   Empty PCD.
+ *
+ * User
+ *   POST create delay profile:
+ *     name='Create Conflict'
+ *     usenetDelay=10
+ *
+ * Upstream
+ *   Published base create:
+ *     name='Create Conflict'
+ *     usenetDelay=20
+ *
+ * Expect
+ *   - ask: user create op is conflicted_pending, reason='duplicate_key'
+ *   - align: user create op is dropped/aligned
+ *   - override: user create op is superseded by a replacement update op
+ *   - final usenet_delay is 10 only for override, otherwise 20
+ */
+test('create duplicate conflict resolves by strategy', async () => {
+	for (const strategy of STRATEGIES) {
+		const ctx = await newScenario(strategy, 'create-duplicate');
+		await compilePcd(ctx);
+		const checkpoint = opCheckpoint(ctx);
+
+		await write.delayProfile.create(ctx, {
+			name: 'Create Conflict',
+			usenetDelay: 10
+		});
+
+		seedUpstream(ctx, base.delayProfile({ name: 'Create Conflict', usenetDelay: 20 }));
+		await compilePcd(ctx);
+
+		const op = firstOpForOperation(opsSince(ctx, checkpoint), 'create');
+		assertStrategyOutcome(ctx, op, strategy, 'duplicate_key');
+
+		const row = assertDelayProfile(ctx, 'Create Conflict');
+		assertEquals(row.usenet_delay, strategy === 'override' ? 10 : 20);
+	}
+});
+
+/**
+ * Base
+ *   Delay profile:
+ *     name='Delete Conflict', usenetDelay=10
+ *
+ * User
+ *   POST delete delay profile.
+ *
+ * Upstream
+ *   Published base op changes:
+ *     usenetDelay 10 -> 20
+ *
+ * Expect
+ *   - ask: delete op is conflicted_pending, reason='guard_mismatch'
+ *   - align: delete op is dropped/aligned
+ *   - override: delete op is superseded by a replacement delete op
+ *   - final row is absent only for override, otherwise upstream row remains
+ */
+test('delete guard conflict resolves by strategy', async () => {
+	for (const strategy of STRATEGIES) {
+		const ctx = await seededScenario(strategy, 'delete-guard', [
+			base.delayProfile({ name: 'Delete Conflict', usenetDelay: 10 })
+		]);
+		const checkpoint = opCheckpoint(ctx);
+
+		await write.delayProfile.remove(ctx, 'Delete Conflict');
+
+		seedUpstream(ctx, upstreamUpdate('Delete Conflict', { usenet_delay: { from: 10, to: 20 } }));
+		await compilePcd(ctx);
+
+		const op = firstOpForOperation(opsSince(ctx, checkpoint), 'delete');
+		assertStrategyOutcome(ctx, op, strategy, 'guard_mismatch');
+
+		if (strategy === 'override') {
+			assertNoDelayProfile(ctx, 'Delete Conflict');
+		} else {
+			const row = assertDelayProfile(ctx, 'Delete Conflict');
+			assertEquals(row.usenet_delay, 20);
+		}
+	}
+});
+
+/**
+ * Base
+ *   Delay profile:
+ *     name='Already Deleted'
+ *
+ * User
+ *   POST delete delay profile.
+ *
+ * Upstream
+ *   Published base delete removes the same row.
+ *
+ * Expect
+ *   - all strategies: user delete auto-aligns/drops because the target is gone
+ *   - no pending conflict remains
+ *   - final row is absent
+ */
+test('delete missing target auto-aligns', async () => {
+	for (const strategy of STRATEGIES) {
+		const ctx = await seededScenario(strategy, 'delete-missing-target', [
+			base.delayProfile({ name: 'Already Deleted' })
+		]);
+		const checkpoint = opCheckpoint(ctx);
+
+		await write.delayProfile.remove(ctx, 'Already Deleted');
+
+		seedUpstream(ctx, upstreamDelete('Already Deleted'));
+		await compilePcd(ctx);
+
+		const op = firstOpForOperation(opsSince(ctx, checkpoint), 'delete');
+		assertEquals(op.state, 'dropped');
+		assertLatestHistory(ctx, op, 'dropped', 'aligned');
+		assertNoDelayProfile(ctx, 'Already Deleted');
+	}
+});
+
+async function newScenario(
+	strategy: ConflictStrategy,
+	name: string
+): Promise<PcdTestContext> {
+	counter++;
+	return setupPcd({
+		port: PORT,
+		name: `pcd-conflict-delay-profile-${counter}-${strategy}-${name}`,
+		conflictStrategy: strategy
+	});
+}
+
+async function seededScenario(
+	strategy: ConflictStrategy,
+	name: string,
+	operations: Array<string | SeedOperation>
+): Promise<PcdTestContext> {
+	const ctx = await newScenario(strategy, name);
+	seedBase(ctx, operations);
+	await compilePcd(ctx);
+	return ctx;
+}
+
+function seedUpstream(ctx: PcdTestContext, operation: SeedOperation): number {
+	return insertOp(ctx, {
+		...operation,
+		origin: 'base',
+		state: 'published',
+		source: 'repo'
+	});
+}
+
+function opsSince(ctx: PcdTestContext, checkpoint: number): OpRow[] {
+	return queryOpsSince(ctx, checkpoint, { origin: 'user' });
+}
+
+function userOpsSince(ctx: PcdTestContext, checkpoint: number): OpRow[] {
+	return opsSince(ctx, checkpoint);
+}
+
+function firstOpForOperation(ops: OpRow[], operation: string): OpRow {
+	const op = ops.find((candidate) => parseMetadata(candidate).operation === operation);
+	assertExists(op, `Expected a user ${operation} op`);
+	return op;
+}
+
+function firstOpForChangedFields(ops: OpRow[], fields: string[]): OpRow {
+	const expected = [...fields].sort();
+	const op = ops.find((candidate) => {
+		const actual = changedFields(candidate).sort();
+		return (
+			actual.length === expected.length &&
+			actual.every((field, index) => field === expected[index])
+		);
+	});
+	assertExists(op, `Expected a user op for ${fields.join(', ')}`);
+	return op;
+}
+
+function changedFields(op: OpRow): string[] {
+	const fields = parseMetadata(op).changed_fields;
+	if (!Array.isArray(fields)) return [];
+	return fields.filter((field): field is string => typeof field === 'string');
+}
+
+function assertStrategyOutcome(
+	ctx: PcdTestContext,
+	op: OpRow,
+	strategy: ConflictStrategy,
+	reason: string
+): void {
+	if (strategy === 'ask') {
+		assertEquals(op.state, 'published');
+		assertLatestHistory(ctx, op, 'conflicted_pending', reason);
+		return;
+	}
+
+	if (strategy === 'align') {
+		assertEquals(op.state, 'dropped');
+		assertLatestHistory(ctx, op, 'dropped', 'aligned');
+		return;
+	}
+
+	assertEquals(op.state, 'superseded');
+	assert(op.superseded_by_op_id !== null, 'Expected override to link a replacement op');
+	assertLatestHistory(ctx, op, 'superseded');
+}
+
+function assertLatestHistory(
+	ctx: PcdTestContext,
+	op: OpRow,
+	status: string,
+	reason?: string
+): void {
+	const history = latestHistory(ctx, op.id);
+	assertEquals(history.status, status);
+	if (reason !== undefined) {
+		assertEquals(history.conflict_reason, reason);
+	}
+}
+
+function latestHistory(ctx: PcdTestContext, opId: number): LatestHistory {
+	const db = openDb(ctx.dbPath);
+	try {
+		const row = db
+			.prepare(
+				`SELECT status, conflict_reason
+				 FROM pcd_op_history
+				 WHERE database_id = ?
+				   AND op_id = ?
+				 ORDER BY applied_at DESC, id DESC
+				 LIMIT 1`
+			)
+			.get(ctx.dbId, opId) as LatestHistory | undefined;
+		assertExists(row, `Expected latest history for op ${opId}`);
+		return row;
+	} finally {
+		db.close();
+	}
+}
+
+function assertDelayProfile(ctx: PcdTestContext, name: string): DelayProfileRow {
+	const row = compiledDelayProfiles(ctx).find((profile) => profile.name === name);
+	assertExists(row, `Expected delay profile ${name}`);
+	return row;
+}
+
+function assertNoDelayProfile(ctx: PcdTestContext, name: string): void {
+	const row = compiledDelayProfiles(ctx).find((profile) => profile.name === name);
+	assertEquals(row, undefined);
+}
+
+function compiledDelayProfiles(ctx: PcdTestContext): DelayProfileRow[] {
+	const source = openDb(ctx.dbPath);
+	const replay = openDb(':memory:');
+
+	try {
+		replay.exec('PRAGMA foreign_keys = ON');
+		replay.exec(Deno.readTextFileSync('docs/backend/0.schema.sql'));
+
+		const baseOps = source
+			.prepare(
+				`SELECT *
+				 FROM pcd_ops
+				 WHERE database_id = ?
+				   AND origin = 'base'
+				   AND state = 'published'
+				 ORDER BY COALESCE(sequence, id), id`
+			)
+			.all(ctx.dbId) as OpRow[];
+
+		const userOps = source
+			.prepare(
+				`SELECT *
+				 FROM pcd_ops
+				 WHERE database_id = ?
+				   AND origin = 'user'
+				   AND state = 'published'
+				 ORDER BY COALESCE(sequence, id), id`
+			)
+			.all(ctx.dbId) as OpRow[];
+		const histories = latestHistories(source, ctx.dbId);
+
+		for (const op of baseOps) {
+			replay.exec(op.sql);
+		}
+		for (const op of userOps) {
+			if (histories.get(op.id)?.status !== 'applied') continue;
+			replay.exec(op.sql);
+		}
+
+		return replay
+			.prepare(
+				`SELECT name,
+				        preferred_protocol,
+				        usenet_delay,
+				        torrent_delay,
+				        bypass_if_highest_quality,
+				        bypass_if_above_custom_format_score,
+				        minimum_custom_format_score
+				 FROM delay_profiles
+				 ORDER BY name`
+			)
+			.all() as DelayProfileRow[];
+	} finally {
+		replay.close();
+		source.close();
+	}
+}
+
+function latestHistories(db: ReturnType<typeof openDb>, databaseId: number): Map<number, LatestHistory> {
+	const rows = db
+		.prepare(
+			`SELECT op_id, status, conflict_reason
+			 FROM pcd_op_history
+			 WHERE database_id = ?
+			 ORDER BY applied_at ASC, id ASC`
+		)
+		.all(databaseId) as Array<LatestHistory & { op_id: number }>;
+	const latest = new Map<number, LatestHistory>();
+	for (const row of rows) {
+		latest.set(row.op_id, row);
+	}
+	return latest;
+}
+
+function upstreamUpdate(
+	name: string,
+	changes: Record<string, { from: unknown; to: unknown }>
+): SeedOperation {
+	const fields = Object.keys(changes);
+	const setSql = fields.map((field) => `${field} = ${sqlValue(changes[field].to)}`).join(', ');
+	return {
+		sql: `UPDATE delay_profiles SET ${setSql} WHERE name = ${sqlValue(name)};`,
+		metadata: JSON.stringify({
+			operation: 'update',
+			entity: 'delay_profile',
+			name,
+			stable_key: { key: 'delay_profile_name', value: name },
+			changed_fields: fields
+		}),
+		desiredState: JSON.stringify(changes)
+	};
+}
+
+function upstreamRename(from: string, to: string): SeedOperation {
+	return {
+		sql: `UPDATE delay_profiles SET name = ${sqlValue(to)} WHERE name = ${sqlValue(from)};`,
+		metadata: JSON.stringify({
+			operation: 'update',
+			entity: 'delay_profile',
+			name: to,
+			previousName: from,
+			stable_key: { key: 'delay_profile_name', value: from },
+			changed_fields: ['name']
+		}),
+		desiredState: JSON.stringify({ name: { from, to } })
+	};
+}
+
+function upstreamDelete(name: string): SeedOperation {
+	return {
+		sql: `DELETE FROM delay_profiles WHERE name = ${sqlValue(name)};`,
+		metadata: JSON.stringify({
+			operation: 'delete',
+			entity: 'delay_profile',
+			name,
+			stable_key: { key: 'delay_profile_name', value: name },
+			changed_fields: ['deleted']
+		}),
+		desiredState: JSON.stringify({ deleted: true, name })
+	};
+}
+
+function sqlValue(value: unknown): string {
+	if (value === null || value === undefined) return 'NULL';
+	if (typeof value === 'number') return String(value);
+	if (typeof value === 'boolean') return value ? '1' : '0';
+	return `'${String(value).replace(/'/g, "''")}'`;
+}
+
+await run();

--- a/tests/integration/pcd/harness/fixtures.ts
+++ b/tests/integration/pcd/harness/fixtures.ts
@@ -1,6 +1,45 @@
 import type { SeedOperation } from './pcd.ts';
 
 export const base = {
+	delayProfile(input: {
+		name: string;
+		preferredProtocol?: 'prefer_usenet' | 'prefer_torrent' | 'only_usenet' | 'only_torrent';
+		usenetDelay?: number | null;
+		torrentDelay?: number | null;
+		bypassIfHighestQuality?: boolean;
+		bypassIfAboveCfScore?: boolean;
+		minimumCfScore?: number | null;
+	}): SeedOperation {
+		const preferredProtocol = input.preferredProtocol ?? 'prefer_usenet';
+		const usenetDelay =
+			preferredProtocol === 'only_torrent' ? null : (input.usenetDelay ?? 0);
+		const torrentDelay =
+			preferredProtocol === 'only_usenet' ? null : (input.torrentDelay ?? 0);
+		const bypassIfAboveCfScore = input.bypassIfAboveCfScore ?? false;
+		const minimumCfScore = bypassIfAboveCfScore ? (input.minimumCfScore ?? 0) : null;
+
+		return {
+			sql: `INSERT INTO delay_profiles (
+				       name,
+				       preferred_protocol,
+				       usenet_delay,
+				       torrent_delay,
+				       bypass_if_highest_quality,
+				       bypass_if_above_custom_format_score,
+				       minimum_custom_format_score
+			      )
+			      VALUES (
+				       ${sqlValue(input.name)},
+				       ${sqlValue(preferredProtocol)},
+				       ${sqlNumber(usenetDelay)},
+				       ${sqlNumber(torrentDelay)},
+				       ${input.bypassIfHighestQuality ? 1 : 0},
+				       ${bypassIfAboveCfScore ? 1 : 0},
+				       ${sqlNumber(minimumCfScore)}
+			      );`
+		};
+	},
+
 	regex(input: {
 		name: string;
 		pattern: string;
@@ -60,4 +99,8 @@ export const base = {
 function sqlValue(value: string | null): string {
 	if (value === null) return 'NULL';
 	return `'${value.replace(/'/g, "''")}'`;
+}
+
+function sqlNumber(value: number | null): string {
+	return value === null ? 'NULL' : String(value);
 }

--- a/tests/integration/pcd/harness/fixtures.ts
+++ b/tests/integration/pcd/harness/fixtures.ts
@@ -11,10 +11,8 @@ export const base = {
 		minimumCfScore?: number | null;
 	}): SeedOperation {
 		const preferredProtocol = input.preferredProtocol ?? 'prefer_usenet';
-		const usenetDelay =
-			preferredProtocol === 'only_torrent' ? null : (input.usenetDelay ?? 0);
-		const torrentDelay =
-			preferredProtocol === 'only_usenet' ? null : (input.torrentDelay ?? 0);
+		const usenetDelay = preferredProtocol === 'only_torrent' ? null : (input.usenetDelay ?? 0);
+		const torrentDelay = preferredProtocol === 'only_usenet' ? null : (input.torrentDelay ?? 0);
 		const bypassIfAboveCfScore = input.bypassIfAboveCfScore ?? false;
 		const minimumCfScore = bypassIfAboveCfScore ? (input.minimumCfScore ?? 0) : null;
 

--- a/tests/integration/pcd/harness/write.ts
+++ b/tests/integration/pcd/harness/write.ts
@@ -73,11 +73,9 @@ export async function submitCreateDelayProfile(
 	ctx: PcdTestContext,
 	input: DelayProfileFormInput
 ): Promise<Response> {
-	return ctx.client.postForm(
-		`/delay-profiles/${ctx.dbId}/new`,
-		delayProfileFields(input),
-		{ headers: { Origin: ctx.origin } }
-	);
+	return ctx.client.postForm(`/delay-profiles/${ctx.dbId}/new`, delayProfileFields(input), {
+		headers: { Origin: ctx.origin }
+	});
 }
 
 export async function submitUpdateDelayProfile(

--- a/tests/integration/pcd/harness/write.ts
+++ b/tests/integration/pcd/harness/write.ts
@@ -23,8 +23,12 @@ export interface DelayProfileFormInput {
 
 export const write = {
 	delayProfile: {
+		create: createDelayProfile,
 		update: updateDelayProfile,
-		submitUpdate: submitUpdateDelayProfile
+		remove: removeDelayProfile,
+		submitCreate: submitCreateDelayProfile,
+		submitUpdate: submitUpdateDelayProfile,
+		submitRemove: submitRemoveDelayProfile
 	},
 	regex: {
 		create: createRegex,
@@ -35,6 +39,13 @@ export const write = {
 		submitRemove: submitRemoveRegex
 	}
 };
+
+export async function createDelayProfile(
+	ctx: PcdTestContext,
+	input: DelayProfileFormInput
+): Promise<Response> {
+	return assertSuccessfulAction(await submitCreateDelayProfile(ctx, input), 'create delay profile');
+}
 
 export async function updateDelayProfile(
 	ctx: PcdTestContext,
@@ -47,6 +58,28 @@ export async function updateDelayProfile(
 	);
 }
 
+export async function removeDelayProfile(
+	ctx: PcdTestContext,
+	currentName: string,
+	layer: OpOrigin = 'user'
+): Promise<Response> {
+	return assertSuccessfulAction(
+		await submitRemoveDelayProfile(ctx, currentName, layer),
+		'delete delay profile'
+	);
+}
+
+export async function submitCreateDelayProfile(
+	ctx: PcdTestContext,
+	input: DelayProfileFormInput
+): Promise<Response> {
+	return ctx.client.postForm(
+		`/delay-profiles/${ctx.dbId}/new`,
+		delayProfileFields(input),
+		{ headers: { Origin: ctx.origin } }
+	);
+}
+
 export async function submitUpdateDelayProfile(
 	ctx: PcdTestContext,
 	currentName: string,
@@ -55,6 +88,18 @@ export async function submitUpdateDelayProfile(
 	return ctx.client.postForm(
 		`/delay-profiles/${ctx.dbId}/${encodeURIComponent(currentName)}?/update`,
 		delayProfileFields(input),
+		{ headers: { Origin: ctx.origin } }
+	);
+}
+
+export async function submitRemoveDelayProfile(
+	ctx: PcdTestContext,
+	currentName: string,
+	layer: OpOrigin = 'user'
+): Promise<Response> {
+	return ctx.client.postForm(
+		`/delay-profiles/${ctx.dbId}/${encodeURIComponent(currentName)}?/delete`,
+		{ layer },
 		{ headers: { Origin: ctx.origin } }
 	);
 }

--- a/tests/integration/pcd/harness/write.ts
+++ b/tests/integration/pcd/harness/write.ts
@@ -10,7 +10,22 @@ export interface RegexFormInput {
 	layer?: OpOrigin;
 }
 
+export interface DelayProfileFormInput {
+	name: string;
+	preferredProtocol?: 'prefer_usenet' | 'prefer_torrent' | 'only_usenet' | 'only_torrent';
+	usenetDelay?: number;
+	torrentDelay?: number;
+	bypassIfHighestQuality?: boolean;
+	bypassIfAboveCfScore?: boolean;
+	minimumCfScore?: number;
+	layer?: OpOrigin;
+}
+
 export const write = {
+	delayProfile: {
+		update: updateDelayProfile,
+		submitUpdate: submitUpdateDelayProfile
+	},
 	regex: {
 		create: createRegex,
 		update: updateRegex,
@@ -20,6 +35,29 @@ export const write = {
 		submitRemove: submitRemoveRegex
 	}
 };
+
+export async function updateDelayProfile(
+	ctx: PcdTestContext,
+	currentName: string,
+	input: DelayProfileFormInput
+): Promise<Response> {
+	return assertSuccessfulAction(
+		await submitUpdateDelayProfile(ctx, currentName, input),
+		'update delay profile'
+	);
+}
+
+export async function submitUpdateDelayProfile(
+	ctx: PcdTestContext,
+	currentName: string,
+	input: DelayProfileFormInput
+): Promise<Response> {
+	return ctx.client.postForm(
+		`/delay-profiles/${ctx.dbId}/${encodeURIComponent(currentName)}?/update`,
+		delayProfileFields(input),
+		{ headers: { Origin: ctx.origin } }
+	);
+}
 
 export async function createRegex(ctx: PcdTestContext, input: RegexFormInput): Promise<Response> {
 	return assertSuccessfulAction(await submitCreateRegex(ctx, input), 'create regex');
@@ -79,6 +117,19 @@ function regexFields(input: RegexFormInput): Record<string, string> {
 		description: input.description ?? '',
 		tags: JSON.stringify(input.tags ?? []),
 		regex101Id: input.regex101Id ?? '',
+		layer: input.layer ?? 'user'
+	};
+}
+
+function delayProfileFields(input: DelayProfileFormInput): Record<string, string> {
+	return {
+		name: input.name,
+		preferredProtocol: input.preferredProtocol ?? 'prefer_usenet',
+		usenetDelay: String(input.usenetDelay ?? 0),
+		torrentDelay: String(input.torrentDelay ?? 0),
+		bypassIfHighestQuality: String(input.bypassIfHighestQuality ?? false),
+		bypassIfAboveCfScore: String(input.bypassIfAboveCfScore ?? false),
+		minimumCfScore: String(input.minimumCfScore ?? 0),
 		layer: input.layer ?? 'user'
 	};
 }

--- a/tests/integration/pcd/write/delay-profiles/create.test.ts
+++ b/tests/integration/pcd/write/delay-profiles/create.test.ts
@@ -1,0 +1,197 @@
+/**
+ * PCD write tests: delay profile create.
+ */
+
+import { assert, assertEquals } from '@std/assert';
+import { startServer, stopServer } from '$test-harness/server.ts';
+import { run, setup, teardown, test } from '$test-harness/runner.ts';
+import { base } from '../../harness/fixtures.ts';
+import {
+	compilePcd,
+	normalizeSql,
+	opCheckpoint,
+	parseDesiredState,
+	parseMetadata
+} from '../../harness/pcd.ts';
+import { write } from '../../harness/write.ts';
+import { assertActionFailed, createScenarioFactory, userOpsSince } from './helpers.ts';
+
+const PORT = 7042;
+const ORIGIN = `http://localhost:${PORT}`;
+
+const { newPcd, seededPcd } = createScenarioFactory(PORT, 'pcd-write-delay-profile-create');
+
+setup(async () => {
+	await startServer(PORT, { AUTH: 'off', ORIGIN }, 'preview');
+});
+
+teardown(async () => {
+	await stopServer(PORT);
+});
+
+/**
+ * Context
+ *   Empty PCD (only schema seeded), compiled once.
+ *
+ * Submit
+ *   POST /delay-profiles/{ctx.dbId}/new with form fields:
+ *     name                     = 'Created Delay'
+ *     preferredProtocol        = 'prefer_usenet'
+ *     usenetDelay              = '0'
+ *     torrentDelay             = '0'
+ *     bypassIfHighestQuality   = 'false'
+ *     bypassIfAboveCfScore     = 'false'
+ *     minimumCfScore           = '0'
+ *     layer                    = 'user'
+ *
+ * Expect
+ *   - userOpsSince(checkpoint).length === 1
+ *   - op.metadata.operation === 'create'
+ *   - op.metadata.entity    === 'delay_profile'
+ *   - op.metadata.name      === 'Created Delay'
+ *   - op.desired_state.name === 'Created Delay'
+ *   - op.desired_state.preferred_protocol === 'prefer_usenet'
+ *   - op.desired_state.usenet_delay       === 0
+ *   - op.desired_state.torrent_delay      === 0
+ *   - op.desired_state.minimum_custom_format_score === null
+ *   - op.sql matches /insert into "?delay_profiles"?/i
+ */
+test('minimal delay profile emits one create op', async () => {
+	const ctx = await newPcd('minimal');
+	await compilePcd(ctx);
+	const checkpoint = opCheckpoint(ctx);
+
+	await write.delayProfile.create(ctx, {
+		name: 'Created Delay'
+	});
+
+	const ops = userOpsSince(ctx, checkpoint);
+	assertEquals(ops.length, 1);
+	const op = ops[0];
+	const metadata = parseMetadata(op);
+	assertEquals(metadata.operation, 'create');
+	assertEquals(metadata.entity, 'delay_profile');
+	assertEquals(metadata.name, 'Created Delay');
+	const desired = parseDesiredState(op);
+	assertEquals(desired.name, 'Created Delay');
+	assertEquals(desired.preferred_protocol, 'prefer_usenet');
+	assertEquals(desired.usenet_delay, 0);
+	assertEquals(desired.torrent_delay, 0);
+	assertEquals(desired.bypass_if_highest_quality, false);
+	assertEquals(desired.bypass_if_above_custom_format_score, false);
+	assertEquals(desired.minimum_custom_format_score, null);
+	assert(/insert into "?delay_profiles"?/i.test(normalizeSql(op.sql)));
+});
+
+/**
+ * Context
+ *   Empty PCD (only schema seeded), compiled once.
+ *
+ * Submit
+ *   POST /delay-profiles/{ctx.dbId}/new with form fields:
+ *     name                     = 'Torrent Only Create'
+ *     preferredProtocol        = 'only_torrent'
+ *     usenetDelay              = '30'      // ignored by writer, stored as NULL
+ *     torrentDelay             = '10'
+ *     bypassIfHighestQuality   = 'false'
+ *     bypassIfAboveCfScore     = 'false'
+ *     minimumCfScore           = '0'
+ *     layer                    = 'user'
+ *
+ * Expect
+ *   - userOpsSince(checkpoint).length === 1
+ *   - op.desired_state.preferred_protocol === 'only_torrent'
+ *   - op.desired_state.usenet_delay       === null
+ *   - op.desired_state.torrent_delay      === 10
+ */
+test('protocol-constrained create stores ignored delay as null', async () => {
+	const ctx = await newPcd('protocol-constrained');
+	await compilePcd(ctx);
+	const checkpoint = opCheckpoint(ctx);
+
+	await write.delayProfile.create(ctx, {
+		name: 'Torrent Only Create',
+		preferredProtocol: 'only_torrent',
+		usenetDelay: 30,
+		torrentDelay: 10
+	});
+
+	const ops = userOpsSince(ctx, checkpoint);
+	assertEquals(ops.length, 1);
+	const desired = parseDesiredState(ops[0]);
+	assertEquals(desired.preferred_protocol, 'only_torrent');
+	assertEquals(desired.usenet_delay, null);
+	assertEquals(desired.torrent_delay, 10);
+});
+
+/**
+ * Context
+ *   Empty PCD (only schema seeded), compiled once.
+ *
+ * Submit
+ *   POST /delay-profiles/{ctx.dbId}/new with form fields:
+ *     name                     = 'Score Disabled Create'
+ *     preferredProtocol        = 'prefer_usenet'
+ *     usenetDelay              = '0'
+ *     torrentDelay             = '0'
+ *     bypassIfHighestQuality   = 'false'
+ *     bypassIfAboveCfScore     = 'false'
+ *     minimumCfScore           = '80'      // ignored by writer, stored as NULL
+ *     layer                    = 'user'
+ *
+ * Expect
+ *   - userOpsSince(checkpoint).length === 1
+ *   - op.desired_state.bypass_if_above_custom_format_score === false
+ *   - op.desired_state.minimum_custom_format_score          === null
+ */
+test('bypass-score-disabled create stores score as null', async () => {
+	const ctx = await newPcd('bypass-score-disabled');
+	await compilePcd(ctx);
+	const checkpoint = opCheckpoint(ctx);
+
+	await write.delayProfile.create(ctx, {
+		name: 'Score Disabled Create',
+		minimumCfScore: 80
+	});
+
+	const ops = userOpsSince(ctx, checkpoint);
+	assertEquals(ops.length, 1);
+	const desired = parseDesiredState(ops[0]);
+	assertEquals(desired.bypass_if_above_custom_format_score, false);
+	assertEquals(desired.minimum_custom_format_score, null);
+});
+
+/**
+ * Context
+ *   Base layer seeded with one delay profile via base.delayProfile():
+ *     name='Existing Delay'
+ *   Compiled so it is in the cache.
+ *
+ * Submit
+ *   POST /delay-profiles/{ctx.dbId}/new with form fields:
+ *     name                     = 'existing delay'   // lowercase variant of the seeded name
+ *     preferredProtocol        = 'prefer_usenet'
+ *     usenetDelay              = '0'
+ *     torrentDelay             = '0'
+ *     bypassIfHighestQuality   = 'false'
+ *     bypassIfAboveCfScore     = 'false'
+ *     minimumCfScore           = '0'
+ *     layer                    = 'user'
+ *
+ * Expect
+ *   - response.status >= 400 OR body contains '"type":"failure"'
+ *   - userOpsSince(checkpoint).length === 0
+ */
+test('duplicate name fails without writing ops', async () => {
+	const ctx = await seededPcd('duplicate', [base.delayProfile({ name: 'Existing Delay' })]);
+	const checkpoint = opCheckpoint(ctx);
+
+	const response = await write.delayProfile.submitCreate(ctx, {
+		name: 'existing delay'
+	});
+
+	await assertActionFailed(response);
+	assertEquals(userOpsSince(ctx, checkpoint).length, 0);
+});
+
+await run();

--- a/tests/integration/pcd/write/delay-profiles/delete.test.ts
+++ b/tests/integration/pcd/write/delay-profiles/delete.test.ts
@@ -6,12 +6,7 @@ import { assert, assertEquals } from '@std/assert';
 import { startServer, stopServer } from '$test-harness/server.ts';
 import { run, setup, teardown, test } from '$test-harness/runner.ts';
 import { base } from '../../harness/fixtures.ts';
-import {
-	normalizeSql,
-	opCheckpoint,
-	parseDesiredState,
-	parseMetadata
-} from '../../harness/pcd.ts';
+import { normalizeSql, opCheckpoint, parseDesiredState, parseMetadata } from '../../harness/pcd.ts';
 import { write } from '../../harness/write.ts';
 import { createScenarioFactory, userOpsSince } from './helpers.ts';
 

--- a/tests/integration/pcd/write/delay-profiles/delete.test.ts
+++ b/tests/integration/pcd/write/delay-profiles/delete.test.ts
@@ -1,0 +1,93 @@
+/**
+ * PCD write tests: delay profile delete.
+ */
+
+import { assert, assertEquals } from '@std/assert';
+import { startServer, stopServer } from '$test-harness/server.ts';
+import { run, setup, teardown, test } from '$test-harness/runner.ts';
+import { base } from '../../harness/fixtures.ts';
+import {
+	normalizeSql,
+	opCheckpoint,
+	parseDesiredState,
+	parseMetadata
+} from '../../harness/pcd.ts';
+import { write } from '../../harness/write.ts';
+import { createScenarioFactory, userOpsSince } from './helpers.ts';
+
+const PORT = 7043;
+const ORIGIN = `http://localhost:${PORT}`;
+
+const { seededPcd } = createScenarioFactory(PORT, 'pcd-write-delay-profile-delete');
+
+setup(async () => {
+	await startServer(PORT, { AUTH: 'off', ORIGIN }, 'preview');
+});
+
+teardown(async () => {
+	await stopServer(PORT);
+});
+
+/**
+ * Context
+ *   Base layer seeded with one delay profile via base.delayProfile():
+ *     name='Delete Delay', preferredProtocol='prefer_torrent',
+ *     usenetDelay=15, torrentDelay=5, bypassIfHighestQuality=true,
+ *     bypassIfAboveCfScore=true, minimumCfScore=80
+ *   Compiled.
+ *
+ * Submit
+ *   POST /delay-profiles/{ctx.dbId}/Delete%20Delay?/delete with form fields:
+ *     layer = 'user'
+ *
+ * Expect
+ *   - userOpsSince(checkpoint).length === 1
+ *   - op.metadata.operation      === 'delete'
+ *   - op.metadata.entity         === 'delay_profile'
+ *   - op.metadata.name           === 'Delete Delay'
+ *   - op.metadata.changed_fields === ['deleted']
+ *   - op.desired_state.deleted   === true
+ *   - op.desired_state.name      === 'Delete Delay'
+ *   - op.desired_state.preferred_protocol === 'prefer_torrent'
+ *   - op.desired_state.usenet_delay       === 15
+ *   - op.desired_state.torrent_delay      === 5
+ *   - op.desired_state.minimum_custom_format_score === 80
+ *   - op.sql matches /delete from "?delay_profiles"?/i
+ */
+test('delay profile emits one delete op', async () => {
+	const ctx = await seededPcd('simple', [
+		base.delayProfile({
+			name: 'Delete Delay',
+			preferredProtocol: 'prefer_torrent',
+			usenetDelay: 15,
+			torrentDelay: 5,
+			bypassIfHighestQuality: true,
+			bypassIfAboveCfScore: true,
+			minimumCfScore: 80
+		})
+	]);
+	const checkpoint = opCheckpoint(ctx);
+
+	await write.delayProfile.remove(ctx, 'Delete Delay');
+
+	const ops = userOpsSince(ctx, checkpoint);
+	assertEquals(ops.length, 1);
+	const op = ops[0];
+	const metadata = parseMetadata(op);
+	assertEquals(metadata.operation, 'delete');
+	assertEquals(metadata.entity, 'delay_profile');
+	assertEquals(metadata.name, 'Delete Delay');
+	assertEquals(metadata.changed_fields, ['deleted']);
+	const desired = parseDesiredState(op);
+	assertEquals(desired.deleted, true);
+	assertEquals(desired.name, 'Delete Delay');
+	assertEquals(desired.preferred_protocol, 'prefer_torrent');
+	assertEquals(desired.usenet_delay, 15);
+	assertEquals(desired.torrent_delay, 5);
+	assertEquals(desired.bypass_if_highest_quality, true);
+	assertEquals(desired.bypass_if_above_custom_format_score, true);
+	assertEquals(desired.minimum_custom_format_score, 80);
+	assert(/delete from "?delay_profiles"?/i.test(normalizeSql(op.sql)));
+});
+
+await run();

--- a/tests/integration/pcd/write/delay-profiles/helpers.ts
+++ b/tests/integration/pcd/write/delay-profiles/helpers.ts
@@ -69,8 +69,7 @@ export function opForChangedFields(ops: OpRow[], fields: string[]): OpRow {
 	const op = ops.find((candidate) => {
 		const actual = changedFields(candidate).sort();
 		return (
-			actual.length === expected.length &&
-			actual.every((field, index) => field === expected[index])
+			actual.length === expected.length && actual.every((field, index) => field === expected[index])
 		);
 	});
 	assertExists(op, `Expected a user op for ${fields.join(', ')}`);

--- a/tests/integration/pcd/write/delay-profiles/helpers.ts
+++ b/tests/integration/pcd/write/delay-profiles/helpers.ts
@@ -1,0 +1,97 @@
+/**
+ * Shared scenario factory and op assertions for delay profile write specs.
+ */
+
+import { assert, assertEquals, assertExists } from '@std/assert';
+import {
+	compilePcd,
+	normalizeSql,
+	parseMetadata,
+	queryOpsSince,
+	seedBase,
+	setupPcd,
+	type OpRow,
+	type PcdTestContext,
+	type SetupPcdOptions
+} from '../../harness/pcd.ts';
+
+export function createScenarioFactory(port: number, prefix: string) {
+	let counter = 0;
+
+	async function newPcd(
+		name: string,
+		options: Partial<SetupPcdOptions> = {}
+	): Promise<PcdTestContext> {
+		counter++;
+		return setupPcd({
+			port,
+			name: `${prefix}-${counter}-${name}`,
+			conflictStrategy: 'ask',
+			...options
+		});
+	}
+
+	async function seededPcd(
+		name: string,
+		operations: Parameters<typeof seedBase>[1],
+		options: Partial<SetupPcdOptions> = {}
+	): Promise<PcdTestContext> {
+		const ctx = await newPcd(name, options);
+		seedBase(ctx, operations);
+		await compilePcd(ctx);
+		return ctx;
+	}
+
+	return { newPcd, seededPcd };
+}
+
+export function userOpsSince(ctx: PcdTestContext, checkpoint: number): OpRow[] {
+	return queryOpsSince(ctx, checkpoint, { origin: 'user', state: 'published' });
+}
+
+export function changedFields(op: OpRow): string[] {
+	const fields = parseMetadata(op).changed_fields;
+	if (!Array.isArray(fields)) return [];
+	return fields.filter((field): field is string => typeof field === 'string');
+}
+
+export function opForChangedField(ops: OpRow[], field: string): OpRow {
+	const op = ops.find((candidate) => {
+		const fields = changedFields(candidate);
+		return fields.length === 1 && fields[0] === field;
+	});
+	assertExists(op, `Expected a user op for ${field}`);
+	return op;
+}
+
+export function opForChangedFields(ops: OpRow[], fields: string[]): OpRow {
+	const expected = [...fields].sort();
+	const op = ops.find((candidate) => {
+		const actual = changedFields(candidate).sort();
+		return (
+			actual.length === expected.length &&
+			actual.every((field, index) => field === expected[index])
+		);
+	});
+	assertExists(op, `Expected a user op for ${fields.join(', ')}`);
+	return op;
+}
+
+export function assertOnlyField(ops: OpRow[], field: string): void {
+	const op = opForChangedField(ops, field);
+	assertEquals(changedFields(op), [field]);
+	const sql = normalizeSql(op.sql).toLowerCase();
+	assert(
+		sql.includes(`"${field}"`) || sql.includes(field),
+		`Expected ${field} SQL to mention its field, got ${sql}`
+	);
+}
+
+export function assertSameGroup(ops: OpRow[]): void {
+	const groupIds = ops.map((op) => parseMetadata(op).group_id);
+	assert(groupIds.length > 0);
+	assertExists(groupIds[0]);
+	for (const groupId of groupIds) {
+		assertEquals(groupId, groupIds[0]);
+	}
+}

--- a/tests/integration/pcd/write/delay-profiles/helpers.ts
+++ b/tests/integration/pcd/write/delay-profiles/helpers.ts
@@ -95,3 +95,11 @@ export function assertSameGroup(ops: OpRow[]): void {
 		assertEquals(groupId, groupIds[0]);
 	}
 }
+
+export async function assertActionFailed(response: Response): Promise<void> {
+	const body = await response.text();
+	assert(
+		response.status >= 400 || body.includes('"type":"failure"'),
+		`Expected form action failure, got status=${response.status} body=${body}`
+	);
+}

--- a/tests/integration/pcd/write/delay-profiles/update.test.ts
+++ b/tests/integration/pcd/write/delay-profiles/update.test.ts
@@ -1,0 +1,326 @@
+/**
+ * PCD write tests: delay profile update.
+ */
+
+import { assertEquals } from '@std/assert';
+import { startServer, stopServer } from '$test-harness/server.ts';
+import { run, setup, teardown, test } from '$test-harness/runner.ts';
+import { base } from '../../harness/fixtures.ts';
+import { opCheckpoint, parseDesiredState, parseMetadata } from '../../harness/pcd.ts';
+import { write } from '../../harness/write.ts';
+import {
+	assertOnlyField,
+	assertSameGroup,
+	createScenarioFactory,
+	opForChangedField,
+	opForChangedFields,
+	userOpsSince
+} from './helpers.ts';
+
+const PORT = 7041;
+const ORIGIN = `http://localhost:${PORT}`;
+
+const { seededPcd } = createScenarioFactory(PORT, 'pcd-write-delay-profile-update');
+
+setup(async () => {
+	await startServer(PORT, { AUTH: 'off', ORIGIN }, 'preview');
+});
+
+teardown(async () => {
+	await stopServer(PORT);
+});
+
+/**
+ * Context
+ *   Base layer seeded with one delay profile via base.delayProfile():
+ *     name='Split Profile', preferredProtocol='prefer_usenet',
+ *     usenetDelay=10, torrentDelay=20, bypassIfHighestQuality=false,
+ *     bypassIfAboveCfScore=true, minimumCfScore=100
+ *   Compiled.
+ *
+ * Submit
+ *   POST /delay-profiles/{ctx.dbId}/Split%20Profile?/update with form fields:
+ *     name                     = 'Split Profile'      // unchanged
+ *     preferredProtocol        = 'prefer_torrent'     // changed, standalone-valid
+ *     usenetDelay              = '15'                 // changed
+ *     torrentDelay             = '25'                 // changed
+ *     bypassIfHighestQuality   = 'true'               // changed
+ *     bypassIfAboveCfScore     = 'true'               // unchanged
+ *     minimumCfScore           = '125'                // changed
+ *     layer                    = 'user'
+ *
+ * Expect
+ *   - userOpsSince(checkpoint).length === 5
+ *   - one op with metadata.changed_fields === ['preferred_protocol']
+ *   - one op with metadata.changed_fields === ['usenet_delay']
+ *   - one op with metadata.changed_fields === ['torrent_delay']
+ *   - one op with metadata.changed_fields === ['bypass_if_highest_quality']
+ *   - one op with metadata.changed_fields === ['minimum_custom_format_score']
+ *   - all five ops share the same metadata.group_id
+ */
+test('independent scalar fields split into grouped ops', async () => {
+	const ctx = await seededPcd('scalars', [
+		base.delayProfile({
+			name: 'Split Profile',
+			preferredProtocol: 'prefer_usenet',
+			usenetDelay: 10,
+			torrentDelay: 20,
+			bypassIfHighestQuality: false,
+			bypassIfAboveCfScore: true,
+			minimumCfScore: 100
+		})
+	]);
+	const checkpoint = opCheckpoint(ctx);
+
+	await write.delayProfile.update(ctx, 'Split Profile', {
+		name: 'Split Profile',
+		preferredProtocol: 'prefer_torrent',
+		usenetDelay: 15,
+		torrentDelay: 25,
+		bypassIfHighestQuality: true,
+		bypassIfAboveCfScore: true,
+		minimumCfScore: 125
+	});
+
+	const ops = userOpsSince(ctx, checkpoint);
+	assertEquals(ops.length, 5);
+	assertOnlyField(ops, 'preferred_protocol');
+	assertOnlyField(ops, 'usenet_delay');
+	assertOnlyField(ops, 'torrent_delay');
+	assertOnlyField(ops, 'bypass_if_highest_quality');
+	assertOnlyField(ops, 'minimum_custom_format_score');
+	assertSameGroup(ops);
+});
+
+/**
+ * Context
+ *   Base layer seeded with one delay profile via base.delayProfile():
+ *     name='Old Delay', preferredProtocol='prefer_usenet',
+ *     usenetDelay=0, torrentDelay=30
+ *   Compiled.
+ *
+ * Submit
+ *   POST /delay-profiles/{ctx.dbId}/Old%20Delay?/update with form fields:
+ *     name                     = 'New Delay'       // changed
+ *     preferredProtocol        = 'prefer_usenet'   // unchanged
+ *     usenetDelay              = '0'               // unchanged
+ *     torrentDelay             = '45'              // changed
+ *     bypassIfHighestQuality   = 'false'
+ *     bypassIfAboveCfScore     = 'false'
+ *     minimumCfScore           = '0'
+ *     layer                    = 'user'
+ *
+ * Expect
+ *   - userOpsSince(checkpoint).length === 2
+ *   - one op with metadata.changed_fields === ['torrent_delay']
+ *   - one op with metadata.changed_fields === ['name']
+ *   - both ops share the same metadata.group_id
+ *   - rename op.metadata.name         === 'New Delay'
+ *   - rename op.metadata.previousName === 'Old Delay'
+ *   - rename op.desired_state.name    === { from: 'Old Delay', to: 'New Delay' }
+ */
+test('rename plus scalar change emits grouped split ops', async () => {
+	const ctx = await seededPcd('rename-scalar', [
+		base.delayProfile({
+			name: 'Old Delay',
+			preferredProtocol: 'prefer_usenet',
+			usenetDelay: 0,
+			torrentDelay: 30
+		})
+	]);
+	const checkpoint = opCheckpoint(ctx);
+
+	await write.delayProfile.update(ctx, 'Old Delay', {
+		name: 'New Delay',
+		preferredProtocol: 'prefer_usenet',
+		usenetDelay: 0,
+		torrentDelay: 45,
+		bypassIfHighestQuality: false,
+		bypassIfAboveCfScore: false,
+		minimumCfScore: 0
+	});
+
+	const ops = userOpsSince(ctx, checkpoint);
+	assertEquals(ops.length, 2);
+	assertOnlyField(ops, 'torrent_delay');
+	assertOnlyField(ops, 'name');
+	assertSameGroup(ops);
+	const renameOp = opForChangedField(ops, 'name');
+	const metadata = parseMetadata(renameOp);
+	assertEquals(metadata.name, 'New Delay');
+	assertEquals(metadata.previousName, 'Old Delay');
+	assertEquals(parseDesiredState(renameOp).name, { from: 'Old Delay', to: 'New Delay' });
+});
+
+/**
+ * Context
+ *   Base layer seeded with one delay profile via base.delayProfile():
+ *     name='Torrent Only Profile', preferredProtocol='prefer_usenet',
+ *     usenetDelay=10, torrentDelay=20
+ *   Compiled.
+ *
+ * Submit
+ *   POST /delay-profiles/{ctx.dbId}/Torrent%20Only%20Profile?/update with form fields:
+ *     name                     = 'Torrent Only Profile'
+ *     preferredProtocol        = 'only_torrent'    // changed
+ *     usenetDelay              = '10'              // ignored by writer, stored as NULL
+ *     torrentDelay             = '20'
+ *     bypassIfHighestQuality   = 'false'
+ *     bypassIfAboveCfScore     = 'false'
+ *     minimumCfScore           = '0'
+ *     layer                    = 'user'
+ *
+ * Expect
+ *   - userOpsSince(checkpoint).length === 1
+ *   - op.metadata.changed_fields === ['preferred_protocol', 'usenet_delay']
+ *   - op.desired_state.preferred_protocol === { from: 'prefer_usenet', to: 'only_torrent' }
+ *   - op.desired_state.usenet_delay       === { from: 10, to: null }
+ *
+ * Note: preferred_protocol and usenet_delay must stay in one op because the
+ * schema check requires usenet_delay to be NULL for only_torrent.
+ */
+test('protocol nulling writes a constrained paired op', async () => {
+	const ctx = await seededPcd('protocol-nulling', [
+		base.delayProfile({
+			name: 'Torrent Only Profile',
+			preferredProtocol: 'prefer_usenet',
+			usenetDelay: 10,
+			torrentDelay: 20
+		})
+	]);
+	const checkpoint = opCheckpoint(ctx);
+
+	await write.delayProfile.update(ctx, 'Torrent Only Profile', {
+		name: 'Torrent Only Profile',
+		preferredProtocol: 'only_torrent',
+		usenetDelay: 10,
+		torrentDelay: 20,
+		bypassIfHighestQuality: false,
+		bypassIfAboveCfScore: false,
+		minimumCfScore: 0
+	});
+
+	const ops = userOpsSince(ctx, checkpoint);
+	assertEquals(ops.length, 1);
+	const op = opForChangedFields(ops, ['preferred_protocol', 'usenet_delay']);
+	const desired = parseDesiredState(op);
+	assertEquals(desired.preferred_protocol, {
+		from: 'prefer_usenet',
+		to: 'only_torrent'
+	});
+	assertEquals(desired.usenet_delay, { from: 10, to: null });
+});
+
+/**
+ * Context
+ *   Base layer seeded with one delay profile via base.delayProfile():
+ *     name='Bypass Score Profile', preferredProtocol='prefer_usenet',
+ *     usenetDelay=0, torrentDelay=0, bypassIfAboveCfScore=true,
+ *     minimumCfScore=80
+ *   Compiled.
+ *
+ * Submit
+ *   POST /delay-profiles/{ctx.dbId}/Bypass%20Score%20Profile?/update with form fields:
+ *     name                     = 'Bypass Score Profile'
+ *     preferredProtocol        = 'prefer_usenet'
+ *     usenetDelay              = '0'
+ *     torrentDelay             = '0'
+ *     bypassIfHighestQuality   = 'false'
+ *     bypassIfAboveCfScore     = 'false'    // changed
+ *     minimumCfScore           = '80'       // ignored by writer, stored as NULL
+ *     layer                    = 'user'
+ *
+ * Expect
+ *   - userOpsSince(checkpoint).length === 1
+ *   - op.metadata.changed_fields === [
+ *       'bypass_if_above_custom_format_score',
+ *       'minimum_custom_format_score'
+ *     ]
+ *   - op.desired_state.bypass_if_above_custom_format_score === { from: true, to: false }
+ *   - op.desired_state.minimum_custom_format_score          === { from: 80, to: null }
+ *
+ * Note: bypass_if_above_custom_format_score and minimum_custom_format_score
+ * must stay in one op because the schema check requires NULL score when
+ * bypass is disabled.
+ */
+test('disabling bypass score writes a constrained paired op', async () => {
+	const ctx = await seededPcd('bypass-nulling', [
+		base.delayProfile({
+			name: 'Bypass Score Profile',
+			preferredProtocol: 'prefer_usenet',
+			usenetDelay: 0,
+			torrentDelay: 0,
+			bypassIfHighestQuality: false,
+			bypassIfAboveCfScore: true,
+			minimumCfScore: 80
+		})
+	]);
+	const checkpoint = opCheckpoint(ctx);
+
+	await write.delayProfile.update(ctx, 'Bypass Score Profile', {
+		name: 'Bypass Score Profile',
+		preferredProtocol: 'prefer_usenet',
+		usenetDelay: 0,
+		torrentDelay: 0,
+		bypassIfHighestQuality: false,
+		bypassIfAboveCfScore: false,
+		minimumCfScore: 80
+	});
+
+	const ops = userOpsSince(ctx, checkpoint);
+	assertEquals(ops.length, 1);
+	const op = opForChangedFields(ops, [
+		'bypass_if_above_custom_format_score',
+		'minimum_custom_format_score'
+	]);
+	const desired = parseDesiredState(op);
+	assertEquals(desired.bypass_if_above_custom_format_score, { from: true, to: false });
+	assertEquals(desired.minimum_custom_format_score, { from: 80, to: null });
+});
+
+/**
+ * Context
+ *   Base layer seeded with one delay profile via base.delayProfile():
+ *     name='Noop Delay', preferredProtocol='prefer_usenet',
+ *     usenetDelay=0, torrentDelay=0
+ *   Compiled.
+ *
+ * Submit
+ *   POST /delay-profiles/{ctx.dbId}/Noop%20Delay?/update with form fields:
+ *     name                     = 'Noop Delay'
+ *     preferredProtocol        = 'prefer_usenet'
+ *     usenetDelay              = '0'
+ *     torrentDelay             = '0'
+ *     bypassIfHighestQuality   = 'false'
+ *     bypassIfAboveCfScore     = 'false'
+ *     minimumCfScore           = '0'
+ *     layer                    = 'user'
+ *
+ * Expect
+ *   - userOpsSince(checkpoint).length === 0
+ */
+test('unchanged submit writes no ops', async () => {
+	const ctx = await seededPcd('noop', [
+		base.delayProfile({
+			name: 'Noop Delay',
+			preferredProtocol: 'prefer_usenet',
+			usenetDelay: 0,
+			torrentDelay: 0
+		})
+	]);
+	const checkpoint = opCheckpoint(ctx);
+
+	await write.delayProfile.update(ctx, 'Noop Delay', {
+		name: 'Noop Delay',
+		preferredProtocol: 'prefer_usenet',
+		usenetDelay: 0,
+		torrentDelay: 0,
+		bypassIfHighestQuality: false,
+		bypassIfAboveCfScore: false,
+		minimumCfScore: 0
+	});
+
+	assertEquals(userOpsSince(ctx, checkpoint).length, 0);
+});
+
+await run();

--- a/tests/integration/pcd/write/delay-profiles/update.test.ts
+++ b/tests/integration/pcd/write/delay-profiles/update.test.ts
@@ -155,6 +155,66 @@ test('rename plus scalar change emits grouped split ops', async () => {
 /**
  * Context
  *   Base layer seeded with one delay profile via base.delayProfile():
+ *     name='Pure Rename Delay', preferredProtocol='prefer_usenet',
+ *     usenetDelay=0, torrentDelay=30
+ *   Compiled.
+ *
+ * Submit
+ *   POST /delay-profiles/{ctx.dbId}/Pure%20Rename%20Delay?/update with form fields:
+ *     name                     = 'Renamed Delay'   // changed
+ *     preferredProtocol        = 'prefer_usenet'
+ *     usenetDelay              = '0'
+ *     torrentDelay             = '30'
+ *     bypassIfHighestQuality   = 'false'
+ *     bypassIfAboveCfScore     = 'false'
+ *     minimumCfScore           = '0'
+ *     layer                    = 'user'
+ *
+ * Expect
+ *   - userOpsSince(checkpoint).length === 1
+ *   - op.metadata.changed_fields === ['name']
+ *   - op.metadata.group_id      === undefined
+ *   - op.metadata.name          === 'Renamed Delay'
+ *   - op.metadata.previousName  === 'Pure Rename Delay'
+ *   - op.desired_state.name     === { from: 'Pure Rename Delay', to: 'Renamed Delay' }
+ */
+test('pure rename emits one ungrouped rename op', async () => {
+	const ctx = await seededPcd('pure-rename', [
+		base.delayProfile({
+			name: 'Pure Rename Delay',
+			preferredProtocol: 'prefer_usenet',
+			usenetDelay: 0,
+			torrentDelay: 30
+		})
+	]);
+	const checkpoint = opCheckpoint(ctx);
+
+	await write.delayProfile.update(ctx, 'Pure Rename Delay', {
+		name: 'Renamed Delay',
+		preferredProtocol: 'prefer_usenet',
+		usenetDelay: 0,
+		torrentDelay: 30,
+		bypassIfHighestQuality: false,
+		bypassIfAboveCfScore: false,
+		minimumCfScore: 0
+	});
+
+	const ops = userOpsSince(ctx, checkpoint);
+	assertEquals(ops.length, 1);
+	const renameOp = opForChangedField(ops, 'name');
+	const metadata = parseMetadata(renameOp);
+	assertEquals(metadata.group_id, undefined);
+	assertEquals(metadata.name, 'Renamed Delay');
+	assertEquals(metadata.previousName, 'Pure Rename Delay');
+	assertEquals(parseDesiredState(renameOp).name, {
+		from: 'Pure Rename Delay',
+		to: 'Renamed Delay'
+	});
+});
+
+/**
+ * Context
+ *   Base layer seeded with one delay profile via base.delayProfile():
  *     name='Torrent Only Profile', preferredProtocol='prefer_usenet',
  *     usenetDelay=10, torrentDelay=20
  *   Compiled.


### PR DESCRIPTION
## Summary

- Splits delay profile updates into per-field ops, with constrained pairs (protocol + delay nulling, bypass + min CF score) kept atomic to satisfy schema checks.
- Adds delay profile write coverage: create, update, rename, delete, no-op, duplicate-name failure, and constrained nulling.
- Adds delay profile conflict coverage across all three strategies (ask, align, override) for split scalars, constrained pairs, rename, create duplicate, delete guard, and delete missing-target.
- Hardens PCD conflict handling: align now drops constraint conflicts (duplicate_key, missing_target) instead of leaving them pending; delete rowcount-zero reports `guard_mismatch` when the row still exists vs `missing_target` when truly gone; delay profile delete override regenerates a fresh delete against the upstream row instead of dropping the user op.
- Removes the `readOnly` gate on the delay profile UI. Linked-database profiles are now fully editable; edits write user-layer ops.
- Updates `docs/backend/pcd.md` and `pcd-entities.md` to reflect the new write/conflict behavior, and notes that override-delete re-deletion is currently delay-profile only.