### PR TITLE
refactor: centralize integration test port allocation

### DIFF
--- a/tests/e2e/auth/oidc.spec.ts
+++ b/tests/e2e/auth/oidc.spec.ts
@@ -11,7 +11,7 @@
  */
 import { test, expect } from '@playwright/test';
 
-const DIRECT_URL = process.env.OIDC_DIRECT_URL || 'http://localhost:7006';
+const DIRECT_URL = process.env.OIDC_DIRECT_URL || 'http://localhost:7007';
 const PROXY_URL = process.env.OIDC_PROXY_URL || 'https://localhost:7445';
 
 /**

--- a/tests/integration/announcements/specs/cascade.test.ts
+++ b/tests/integration/announcements/specs/cascade.test.ts
@@ -14,6 +14,7 @@
 
 import { assertEquals } from '@std/assert';
 import { run, setup, teardown, test } from '$test-harness/runner.ts';
+import { PORTS } from '$test-harness/ports.ts';
 import { getDbPath, startServer, stopServer } from '$test-harness/server.ts';
 import {
 	countAnnouncements,
@@ -24,7 +25,7 @@ import {
 	tryInsertOrphanAnnouncement
 } from '../harness/setup.ts';
 
-const PORT = 7170;
+const PORT = PORTS.announcements.cascade;
 
 let dbPath: string;
 

--- a/tests/integration/announcements/specs/first-sync.test.ts
+++ b/tests/integration/announcements/specs/first-sync.test.ts
@@ -11,11 +11,12 @@
 
 import { assertEquals, assert } from '@std/assert';
 import { run, setup, teardown, test } from '$test-harness/runner.ts';
+import { PORTS } from '$test-harness/ports.ts';
 import { getDbPath, startServer, stopServer } from '$test-harness/server.ts';
 import { openDb } from '$test-harness/db.ts';
 import { createDatabaseInstance } from '../harness/setup.ts';
 
-const PORT = 7171;
+const PORT = PORTS.announcements.firstSync;
 const BASE_PATH = `./dist/integration-${PORT}`;
 
 let dbPath: string;

--- a/tests/integration/api/specs/arr.test.ts
+++ b/tests/integration/api/specs/arr.test.ts
@@ -13,9 +13,10 @@ import { TestClient } from '$test-harness/client.ts';
 import { startServer, stopServer, getDbPath } from '$test-harness/server.ts';
 import { createUserDirect, setApiKey } from '$test-harness/setup.ts';
 import { setup, teardown, test, run } from '$test-harness/runner.ts';
+import { PORTS } from '$test-harness/ports.ts';
 import { openDb } from '$test-harness/db.ts';
 
-const PORT = 7021;
+const PORT = PORTS.api.arr;
 const ORIGIN = `http://localhost:${PORT}`;
 const API_KEY = 'arr-test-key-abc123';
 

--- a/tests/integration/api/specs/databases.test.ts
+++ b/tests/integration/api/specs/databases.test.ts
@@ -43,9 +43,10 @@ import { TestClient } from '$test-harness/client.ts';
 import { startServer, stopServer, getDbPath } from '$test-harness/server.ts';
 import { createUserDirect, setApiKey } from '$test-harness/setup.ts';
 import { setup, teardown, test, run } from '$test-harness/runner.ts';
+import { PORTS } from '$test-harness/ports.ts';
 import { openDb } from '$test-harness/db.ts';
 
-const PORT = 7020;
+const PORT = PORTS.api.databases;
 const ORIGIN = `http://localhost:${PORT}`;
 const API_KEY = 'databases-test-key-abc123';
 

--- a/tests/integration/api/specs/status.test.ts
+++ b/tests/integration/api/specs/status.test.ts
@@ -16,9 +16,10 @@ import { TestClient } from '$test-harness/client.ts';
 import { startServer, stopServer, getDbPath } from '$test-harness/server.ts';
 import { createUserDirect, setApiKey } from '$test-harness/setup.ts';
 import { setup, teardown, test, run } from '$test-harness/runner.ts';
+import { PORTS } from '$test-harness/ports.ts';
 import { openDb } from '$test-harness/db.ts';
 
-const PORT = 7011;
+const PORT = PORTS.api.status;
 const ORIGIN = `http://localhost:${PORT}`;
 const API_KEY = 'status-test-key-abc123';
 

--- a/tests/integration/auth/Caddyfile
+++ b/tests/integration/auth/Caddyfile
@@ -1,17 +1,17 @@
-# HTTPS termination for cookie security tests (server on port 7003)
+# HTTPS termination for cookie security tests (PORTS.auth.cookieHttps).
 localhost:7443 {
 	tls internal
-	reverse_proxy host.docker.internal:7003
+	reverse_proxy host.docker.internal:7001
 }
 
-# HTTPS termination for reverse proxy tests (server on port 7008)
+# HTTPS termination for reverse proxy tests (PORTS.auth.proxy).
 localhost:7444 {
 	tls internal
-	reverse_proxy host.docker.internal:7008
+	reverse_proxy host.docker.internal:7011
 }
 
-# HTTPS termination for OIDC proxy tests (server on port 7009)
+# HTTPS termination for OIDC proxy tests (PORTS.auth.oidcProxy).
 localhost:7445 {
 	tls internal
-	reverse_proxy host.docker.internal:7009
+	reverse_proxy host.docker.internal:7008
 }

--- a/tests/integration/auth/nginx-small-header.conf
+++ b/tests/integration/auth/nginx-small-header.conf
@@ -6,7 +6,8 @@ http {
 		server_name localhost;
 
 		location / {
-			proxy_pass http://host.docker.internal:7019;
+			# Targets PORTS.auth.reverseProxy502.
+			proxy_pass http://host.docker.internal:7013;
 			proxy_http_version 1.1;
 			proxy_set_header Host $host;
 			proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/tests/integration/auth/specs/apiKey.test.ts
+++ b/tests/integration/auth/specs/apiKey.test.ts
@@ -15,8 +15,9 @@ import { TestClient } from '$test-harness/client.ts';
 import { startServer, stopServer, getDbPath } from '$test-harness/server.ts';
 import { createUser, setApiKey } from '$test-harness/setup.ts';
 import { setup, teardown, test, run } from '$test-harness/runner.ts';
+import { PORTS } from '$test-harness/ports.ts';
 
-const PORT = 7004;
+const PORT = PORTS.auth.apiKey;
 const ORIGIN = `http://localhost:${PORT}`;
 const API_KEY = 'test-api-key-valid-12345';
 

--- a/tests/integration/auth/specs/cookie.test.ts
+++ b/tests/integration/auth/specs/cookie.test.ts
@@ -2,7 +2,7 @@
  * Integration tests: Cookie security flags
  *
  * Verifies Set-Cookie attributes on session cookies.
- * HTTPS test goes through Caddy (self-signed TLS on :7443 → server on :7003).
+ * HTTPS test goes through Caddy (self-signed TLS on :7443 → PORTS.auth.cookieHttps).
  * HTTP test uses a separate server with no proxy.
  *
  * Tests:
@@ -17,13 +17,14 @@ import { TestClient } from '$test-harness/client.ts';
 import { startServer, stopServer, getDbPath } from '$test-harness/server.ts';
 import { createUser, createUserDirect, login } from '$test-harness/setup.ts';
 import { setup, teardown, test, run } from '$test-harness/runner.ts';
+import { PORTS } from '$test-harness/ports.ts';
 
 // HTTPS: Caddy on :7443 → server on :7003
-const HTTPS_PORT = 7003;
+const HTTPS_PORT = PORTS.auth.cookieHttps;
 const HTTPS_ORIGIN = 'https://localhost:7443';
 
 // HTTP: direct, no proxy
-const HTTP_PORT = 7013;
+const HTTP_PORT = PORTS.auth.cookieHttp;
 const HTTP_ORIGIN = `http://localhost:${HTTP_PORT}`;
 
 setup(async () => {

--- a/tests/integration/auth/specs/csrf.test.ts
+++ b/tests/integration/auth/specs/csrf.test.ts
@@ -23,16 +23,17 @@ import { TestClient } from '$test-harness/client.ts';
 import { startServer, stopServer, getDbPath } from '$test-harness/server.ts';
 import { createUser, createUserDirect } from '$test-harness/setup.ts';
 import { setup, teardown, test, run } from '$test-harness/runner.ts';
+import { PORTS } from '$test-harness/ports.ts';
 
-const PORT = 7002;
+const PORT = PORTS.auth.csrf;
 const ORIGIN = `http://localhost:${PORT}`;
 
 // Tests 4-5: no ORIGIN env — SvelteKit falls back to request URL
-const NO_ORIGIN_PORT = 7012;
+const NO_ORIGIN_PORT = PORTS.auth.csrfNoOrigin;
 const NO_ORIGIN_URL = `http://localhost:${NO_ORIGIN_PORT}`;
 
 // Tests 6-7: ORIGIN differs from actual server URL (reverse proxy scenario)
-const PROXY_PORT = 7014;
+const PROXY_PORT = PORTS.auth.csrfProxy;
 const PROXY_ORIGIN = 'https://profilarr.mydomain.com';
 
 setup(async () => {

--- a/tests/integration/auth/specs/health.test.ts
+++ b/tests/integration/auth/specs/health.test.ts
@@ -10,8 +10,9 @@ import { TestClient } from '$test-harness/client.ts';
 import { startServer, stopServer, getDbPath } from '$test-harness/server.ts';
 import { createUserDirect } from '$test-harness/setup.ts';
 import { setup, teardown, test, run } from '$test-harness/runner.ts';
+import { PORTS } from '$test-harness/ports.ts';
 
-const PORT = 7001;
+const PORT = PORTS.auth.health;
 const ORIGIN = `http://localhost:${PORT}`;
 
 setup(async () => {

--- a/tests/integration/auth/specs/oidc.test.ts
+++ b/tests/integration/auth/specs/oidc.test.ts
@@ -21,16 +21,17 @@ import { TestClient } from '$test-harness/client.ts';
 import { startServer, stopServer, getDbPath } from '$test-harness/server.ts';
 import { queryDb, createUserDirect } from '$test-harness/setup.ts';
 import { setup, teardown, test, run } from '$test-harness/runner.ts';
+import { PORTS } from '$test-harness/ports.ts';
 
-const PORT = 7006;
+const PORT = PORTS.auth.oidc;
 const ORIGIN = `http://localhost:${PORT}`;
 const MOCK_OIDC_URL = 'http://localhost:9090/default/.well-known/openid-configuration';
 
-const PROXY_PORT = 7009;
+const PROXY_PORT = PORTS.auth.oidcProxy;
 const PROXY_ORIGIN = 'https://localhost:7445';
 
 // Separate AUTH=on server for testing OIDC-disabled behavior
-const AUTH_ON_PORT = 7010;
+const AUTH_ON_PORT = PORTS.auth.oidcAuthOn;
 const AUTH_ON_ORIGIN = `http://localhost:${AUTH_ON_PORT}`;
 
 const OIDC_ENV = {

--- a/tests/integration/auth/specs/pathTraversal.test.ts
+++ b/tests/integration/auth/specs/pathTraversal.test.ts
@@ -21,9 +21,10 @@ import { TestClient } from '$test-harness/client.ts';
 import { startServer, stopServer, getDbPath } from '$test-harness/server.ts';
 import { createUserDirect, login } from '$test-harness/setup.ts';
 import { setup, teardown, test, run } from '$test-harness/runner.ts';
+import { PORTS } from '$test-harness/ports.ts';
 import { openDb } from '$test-harness/db.ts';
 
-const PORT = 7018;
+const PORT = PORTS.auth.pathTraversal;
 const ORIGIN = `http://localhost:${PORT}`;
 const PAYLOADS = [
 	{ name: 'relative traversal', path: '../../etc/passwd' },

--- a/tests/integration/auth/specs/proxy.test.ts
+++ b/tests/integration/auth/specs/proxy.test.ts
@@ -1,8 +1,8 @@
 /**
  * Integration tests: Reverse proxy
  *
- * Server on port 7008 with ORIGIN=https://localhost:7444.
- * Caddy terminates TLS on :7444 and proxies to :7008.
+ * Server on PORTS.auth.proxy with ORIGIN=https://localhost:7444.
+ * Caddy terminates TLS on :7444 and proxies to PORTS.auth.proxy.
  * All requests go through Caddy (the real proxy path).
  *
  * Tests:
@@ -18,8 +18,9 @@ import { TestClient } from '$test-harness/client.ts';
 import { startServer, stopServer, getDbPath } from '$test-harness/server.ts';
 import { createUserDirect, queryDb } from '$test-harness/setup.ts';
 import { setup, teardown, test, run } from '$test-harness/runner.ts';
+import { PORTS } from '$test-harness/ports.ts';
 
-const PORT = 7008;
+const PORT = PORTS.auth.proxy;
 const PROXY_ORIGIN = 'https://localhost:7444';
 
 setup(async () => {

--- a/tests/integration/auth/specs/rateLimit.test.ts
+++ b/tests/integration/auth/specs/rateLimit.test.ts
@@ -30,8 +30,9 @@ import {
 	insertExpiredAttempts
 } from '$test-harness/setup.ts';
 import { setup, teardown, test, run } from '$test-harness/runner.ts';
+import { PORTS } from '$test-harness/ports.ts';
 
-const PORT = 7007;
+const PORT = PORTS.auth.rateLimit;
 const ORIGIN = `http://localhost:${PORT}`;
 
 /**

--- a/tests/integration/auth/specs/reverseProxy502-manual.test.ts
+++ b/tests/integration/auth/specs/reverseProxy502-manual.test.ts
@@ -7,7 +7,7 @@
  *   deno task test integration reverseProxy502-manual
  *
  * It starts:
- * - Profilarr preview on :7019
+ * - Profilarr preview on PORTS.auth.reverseProxy502Manual
  * - nginx proxy on :7446 (small proxy_buffer_size)
  *
  * Then it pauses so you can test in a browser and inspect nginx logs after:
@@ -23,8 +23,9 @@
 import { startServer, stopServer, getDbPath } from '$test-harness/server.ts';
 import { createUserDirect } from '$test-harness/setup.ts';
 import { setup, teardown, test, run } from '$test-harness/runner.ts';
+import { PORTS } from '$test-harness/ports.ts';
 
-const PORT = 7019;
+const PORT = PORTS.auth.reverseProxy502Manual;
 const PROXY_ORIGIN = 'http://localhost:7446';
 
 setup(async () => {

--- a/tests/integration/auth/specs/reverseProxy502.test.ts
+++ b/tests/integration/auth/specs/reverseProxy502.test.ts
@@ -1,8 +1,8 @@
 /**
  * Integration tests: Reverse proxy 502 reproduction
  *
- * Backend server on port 7019 with AUTH=on.
- * nginx on :7446 proxies to :7019 with proxy_buffer_size=4k.
+ * Backend server on PORTS.auth.reverseProxy502 with AUTH=on.
+ * nginx on :7446 proxies to that port with proxy_buffer_size=4k.
  *
  * Expected fixed behavior:
  * - /auth/login works through the proxy
@@ -17,8 +17,9 @@ import { TestClient } from '$test-harness/client.ts';
 import { startServer, stopServer, getDbPath } from '$test-harness/server.ts';
 import { createUserDirect, login } from '$test-harness/setup.ts';
 import { setup, teardown, test, run } from '$test-harness/runner.ts';
+import { PORTS } from '$test-harness/ports.ts';
 
-const PORT = 7019;
+const PORT = PORTS.auth.reverseProxy502;
 const PROXY_ORIGIN = 'http://localhost:7446';
 
 setup(async () => {

--- a/tests/integration/auth/specs/secretExposure.test.ts
+++ b/tests/integration/auth/specs/secretExposure.test.ts
@@ -48,10 +48,11 @@ import { TestClient } from '$test-harness/client.ts';
 import { startServer, stopServer, getDbPath } from '$test-harness/server.ts';
 import { createUserDirect, login } from '$test-harness/setup.ts';
 import { setup, teardown, test, run } from '$test-harness/runner.ts';
+import { PORTS } from '$test-harness/ports.ts';
 import { openDb } from '$test-harness/db.ts';
 import { hash } from '@felix/bcrypt';
 
-const PORT = 7016;
+const PORT = PORTS.auth.secretExposure;
 const ORIGIN = `http://localhost:${PORT}`;
 
 // Known secrets — we insert these and check they don't appear in responses

--- a/tests/integration/auth/specs/session.test.ts
+++ b/tests/integration/auth/specs/session.test.ts
@@ -25,8 +25,9 @@ import {
 	getSessionExpiry
 } from '$test-harness/setup.ts';
 import { setup, teardown, test, run } from '$test-harness/runner.ts';
+import { PORTS } from '$test-harness/ports.ts';
 
-const PORT = 7005;
+const PORT = PORTS.auth.session;
 const ORIGIN = `http://localhost:${PORT}`;
 
 setup(async () => {

--- a/tests/integration/auth/specs/xForwardedFor.test.ts
+++ b/tests/integration/auth/specs/xForwardedFor.test.ts
@@ -24,9 +24,10 @@ import { TestClient } from '$test-harness/client.ts';
 import { startServer, stopServer, getDbPath } from '$test-harness/server.ts';
 import { createUserDirect, clearLoginAttempts, queryDb } from '$test-harness/setup.ts';
 import { setup, teardown, test, run } from '$test-harness/runner.ts';
+import { PORTS } from '$test-harness/ports.ts';
 import { openDb } from '$test-harness/db.ts';
 
-const PORT = 7015;
+const PORT = PORTS.auth.xForwardedFor;
 const ORIGIN = `http://localhost:${PORT}`;
 
 setup(async () => {

--- a/tests/integration/backups/specs/backupSecrets.test.ts
+++ b/tests/integration/backups/specs/backupSecrets.test.ts
@@ -27,10 +27,11 @@ import { TestClient } from '$test-harness/client.ts';
 import { startServer, stopServer, getDbPath } from '$test-harness/server.ts';
 import { createUserDirect, login } from '$test-harness/setup.ts';
 import { setup, teardown, test, run } from '$test-harness/runner.ts';
+import { PORTS } from '$test-harness/ports.ts';
 import { openDb } from '$test-harness/db.ts';
 import { hash } from '@felix/bcrypt';
 
-const PORT = 7017;
+const PORT = PORTS.backups.backupSecrets;
 const ORIGIN = `http://localhost:${PORT}`;
 const BACKUPS_DIR = `./dist/integration-${PORT}/backups`;
 

--- a/tests/integration/backups/specs/createAndDelete.test.ts
+++ b/tests/integration/backups/specs/createAndDelete.test.ts
@@ -6,11 +6,12 @@
 
 import { assertEquals, assertExists } from '@std/assert';
 import { setup, teardown, test, run } from '$test-harness/runner.ts';
+import { PORTS } from '$test-harness/ports.ts';
 import { startServer, stopServer, getDbPath } from '$test-harness/server.ts';
 import { TestClient } from '$test-harness/client.ts';
 import { createUser, login, setApiKey } from '$test-harness/setup.ts';
 
-const PORT = 7032;
+const PORT = PORTS.backups.createAndDelete;
 const ORIGIN = `http://localhost:${PORT}`;
 const API_KEY = 'test-api-key-backups-crud-123';
 const BACKUPS_DIR = `./dist/integration-${PORT}/backups`;

--- a/tests/integration/backups/specs/jobStatus.test.ts
+++ b/tests/integration/backups/specs/jobStatus.test.ts
@@ -7,12 +7,13 @@
 
 import { assertEquals } from '@std/assert';
 import { setup, teardown, test, run } from '$test-harness/runner.ts';
+import { PORTS } from '$test-harness/ports.ts';
 import { startServer, stopServer, getDbPath } from '$test-harness/server.ts';
 import { TestClient } from '$test-harness/client.ts';
 import { createUser, login, setApiKey, queryDb } from '$test-harness/setup.ts';
 import { openDb } from '$test-harness/db.ts';
 
-const PORT = 7030;
+const PORT = PORTS.backups.jobStatus;
 const ORIGIN = `http://localhost:${PORT}`;
 const API_KEY = 'test-api-key-jobs-123';
 

--- a/tests/integration/backups/specs/listAndDownload.test.ts
+++ b/tests/integration/backups/specs/listAndDownload.test.ts
@@ -6,11 +6,12 @@
 
 import { assertEquals, assertExists } from '@std/assert';
 import { setup, teardown, test, run } from '$test-harness/runner.ts';
+import { PORTS } from '$test-harness/ports.ts';
 import { startServer, stopServer, getDbPath } from '$test-harness/server.ts';
 import { TestClient } from '$test-harness/client.ts';
 import { createUser, login, setApiKey } from '$test-harness/setup.ts';
 
-const PORT = 7031;
+const PORT = PORTS.backups.listAndDownload;
 const ORIGIN = `http://localhost:${PORT}`;
 const API_KEY = 'test-api-key-backups-list-123';
 const BACKUPS_DIR = `./dist/integration-${PORT}/backups`;

--- a/tests/integration/backups/specs/restore.test.ts
+++ b/tests/integration/backups/specs/restore.test.ts
@@ -21,13 +21,14 @@
 
 import { assertEquals, assertExists } from '@std/assert';
 import { setup, teardown, test, run } from '$test-harness/runner.ts';
+import { PORTS } from '$test-harness/ports.ts';
 import { startServer, stopServer, getDbPath } from '$test-harness/server.ts';
 import { TestClient } from '$test-harness/client.ts';
 import { createUser, login, setApiKey } from '$test-harness/setup.ts';
 import { openDb } from '$test-harness/db.ts';
 
-const PORT_A = 7035;
-const PORT_B = 7036;
+const PORT_A = PORTS.backups.restoreA;
+const PORT_B = PORTS.backups.restoreB;
 const ORIGIN_A = `http://localhost:${PORT_A}`;
 const ORIGIN_B = `http://localhost:${PORT_B}`;
 const API_KEY = 'test-api-key-restore-123';

--- a/tests/integration/backups/specs/restoreFormActions.test.ts
+++ b/tests/integration/backups/specs/restoreFormActions.test.ts
@@ -17,8 +17,9 @@ import { TestClient } from '$test-harness/client.ts';
 import { startServer, stopServer } from '$test-harness/server.ts';
 import { createUser, login } from '$test-harness/setup.ts';
 import { setup, teardown, test, run } from '$test-harness/runner.ts';
+import { PORTS } from '$test-harness/ports.ts';
 
-const PORT = 7040;
+const PORT = PORTS.backups.restoreFormActions;
 const ORIGIN = `http://localhost:${PORT}`;
 const BASE = `./dist/integration-${PORT}`;
 const BACKUPS_DIR = `${BASE}/backups`;

--- a/tests/integration/backups/specs/settings.test.ts
+++ b/tests/integration/backups/specs/settings.test.ts
@@ -6,11 +6,12 @@
 
 import { assertEquals } from '@std/assert';
 import { setup, teardown, test, run } from '$test-harness/runner.ts';
+import { PORTS } from '$test-harness/ports.ts';
 import { startServer, stopServer, getDbPath } from '$test-harness/server.ts';
 import { TestClient } from '$test-harness/client.ts';
 import { createUser, login, setApiKey } from '$test-harness/setup.ts';
 
-const PORT = 7037;
+const PORT = PORTS.backups.settings;
 const ORIGIN = `http://localhost:${PORT}`;
 const API_KEY = 'test-api-key-backups-settings-123';
 

--- a/tests/integration/backups/specs/upload.test.ts
+++ b/tests/integration/backups/specs/upload.test.ts
@@ -6,11 +6,12 @@
 
 import { assertEquals, assertExists } from '@std/assert';
 import { setup, teardown, test, run } from '$test-harness/runner.ts';
+import { PORTS } from '$test-harness/ports.ts';
 import { startServer, stopServer, getDbPath } from '$test-harness/server.ts';
 import { TestClient } from '$test-harness/client.ts';
 import { createUser, login, setApiKey } from '$test-harness/setup.ts';
 
-const PORT = 7033;
+const PORT = PORTS.backups.upload;
 const ORIGIN = `http://localhost:${PORT}`;
 const API_KEY = 'test-api-key-backups-upload-123';
 const BACKUPS_DIR = `./dist/integration-${PORT}/backups`;

--- a/tests/integration/conflicts/specs/group-member-position.test.ts
+++ b/tests/integration/conflicts/specs/group-member-position.test.ts
@@ -11,6 +11,7 @@ import { assertEquals, assertExists } from '@std/assert';
 import { TestClient } from '$test-harness/client.ts';
 import { getDbPath, startServer, stopServer } from '$test-harness/server.ts';
 import { run, setup, teardown, test } from '$test-harness/runner.ts';
+import { PORTS } from '$test-harness/ports.ts';
 import {
 	createDatabaseInstance,
 	createPcdRepo,
@@ -20,7 +21,7 @@ import {
 } from '../harness/setup.ts';
 import { openDb } from '$test-harness/db.ts';
 
-const PORT = 7026;
+const PORT = PORTS.conflicts.groupMemberPosition;
 const ORIGIN = `http://localhost:${PORT}`;
 
 let client: TestClient;

--- a/tests/integration/conflicts/specs/regex-delete-rename-generated-draft.test.ts
+++ b/tests/integration/conflicts/specs/regex-delete-rename-generated-draft.test.ts
@@ -7,6 +7,7 @@ import { assertEquals, assertExists, assert } from '@std/assert';
 import { TestClient } from '$test-harness/client.ts';
 import { startServer, stopServer, getDbPath } from '$test-harness/server.ts';
 import { setup, teardown, test, run } from '$test-harness/runner.ts';
+import { PORTS } from '$test-harness/ports.ts';
 import {
 	createPcdRepo,
 	createDatabaseInstance,
@@ -14,7 +15,7 @@ import {
 	queryOpsByDatabase
 } from '../harness/setup.ts';
 
-const PORT = 7034;
+const PORT = PORTS.conflicts.regexDeleteRenameGeneratedDraft;
 const ORIGIN = `http://localhost:${PORT}`;
 
 let client: TestClient;

--- a/tests/integration/conflicts/specs/regex-split-partial-conflict.test.ts
+++ b/tests/integration/conflicts/specs/regex-split-partial-conflict.test.ts
@@ -16,6 +16,7 @@ import { assertEquals, assertExists } from '@std/assert';
 import { TestClient } from '$test-harness/client.ts';
 import { startServer, stopServer, getDbPath } from '$test-harness/server.ts';
 import { setup, teardown, test, run } from '$test-harness/runner.ts';
+import { PORTS } from '$test-harness/ports.ts';
 import {
 	createPcdRepo,
 	createDatabaseInstance,
@@ -24,7 +25,7 @@ import {
 	queryLatestHistory
 } from '../harness/setup.ts';
 
-const PORT = 7028;
+const PORT = PORTS.conflicts.regexSplitPartialConflict;
 const ORIGIN = `http://localhost:${PORT}`;
 
 let client: TestClient;

--- a/tests/integration/conflicts/specs/regex-split-per-field.test.ts
+++ b/tests/integration/conflicts/specs/regex-split-per-field.test.ts
@@ -12,6 +12,7 @@ import { assertEquals, assertExists, assert } from '@std/assert';
 import { TestClient } from '$test-harness/client.ts';
 import { startServer, stopServer, getDbPath } from '$test-harness/server.ts';
 import { setup, teardown, test, run } from '$test-harness/runner.ts';
+import { PORTS } from '$test-harness/ports.ts';
 import {
 	createPcdRepo,
 	createDatabaseInstance,
@@ -19,7 +20,7 @@ import {
 	queryOpsByDatabase
 } from '../harness/setup.ts';
 
-const PORT = 7027;
+const PORT = PORTS.conflicts.regexSplitPerField;
 const ORIGIN = `http://localhost:${PORT}`;
 
 let client: TestClient;

--- a/tests/integration/conflicts/specs/regex-split-rename-cascade.test.ts
+++ b/tests/integration/conflicts/specs/regex-split-rename-cascade.test.ts
@@ -12,6 +12,7 @@ import { assertEquals, assertExists, assert } from '@std/assert';
 import { TestClient } from '$test-harness/client.ts';
 import { startServer, stopServer, getDbPath } from '$test-harness/server.ts';
 import { setup, teardown, test, run } from '$test-harness/runner.ts';
+import { PORTS } from '$test-harness/ports.ts';
 import {
 	createPcdRepo,
 	createDatabaseInstance,
@@ -20,7 +21,7 @@ import {
 	queryLatestHistory
 } from '../harness/setup.ts';
 
-const PORT = 7029;
+const PORT = PORTS.conflicts.regexSplitRenameCascade;
 const ORIGIN = `http://localhost:${PORT}`;
 
 let client: TestClient;

--- a/tests/integration/conflicts/specs/sequential-edits.test.ts
+++ b/tests/integration/conflicts/specs/sequential-edits.test.ts
@@ -12,6 +12,7 @@ import { assertEquals, assertExists } from '@std/assert';
 import { TestClient } from '$test-harness/client.ts';
 import { startServer, stopServer, getDbPath } from '$test-harness/server.ts';
 import { setup, teardown, test, run } from '$test-harness/runner.ts';
+import { PORTS } from '$test-harness/ports.ts';
 import {
 	createPcdRepo,
 	createDatabaseInstance,
@@ -20,7 +21,7 @@ import {
 	queryLatestHistory
 } from '../harness/setup.ts';
 
-const PORT = 7024;
+const PORT = PORTS.conflicts.sequentialEdits;
 const ORIGIN = `http://localhost:${PORT}`;
 
 let client: TestClient;

--- a/tests/integration/conflicts/specs/upstream-change.test.ts
+++ b/tests/integration/conflicts/specs/upstream-change.test.ts
@@ -15,6 +15,7 @@ import { assertEquals, assertExists, assert } from '@std/assert';
 import { TestClient } from '$test-harness/client.ts';
 import { startServer, stopServer, getDbPath } from '$test-harness/server.ts';
 import { setup, teardown, test, run } from '$test-harness/runner.ts';
+import { PORTS } from '$test-harness/ports.ts';
 import {
 	createPcdRepo,
 	createDatabaseInstance,
@@ -25,7 +26,7 @@ import {
 	queryOpsByDatabase
 } from '../harness/setup.ts';
 
-const PORT = 7025;
+const PORT = PORTS.conflicts.upstreamChange;
 const ORIGIN = `http://localhost:${PORT}`;
 
 let client: TestClient;

--- a/tests/integration/harness/ports.ts
+++ b/tests/integration/harness/ports.ts
@@ -1,0 +1,121 @@
+/**
+ * Integration test port registry.
+ *
+ * Single source of truth for port allocation across all integration specs.
+ * Specs import from here instead of declaring their own PORT constants, so
+ * collisions surface as a registry-time error at first import rather than as
+ * parallel-run flakes.
+ *
+ * Range strategy
+ *   7000-7099  auth
+ *   7100-7199  api
+ *   7200-7299  backups
+ *   7300-7399  conflicts
+ *   7400-7499  notifications (mock webhook targets)
+ *   7500-7599  announcements
+ *   7600-7699  pcd writes
+ *   7700-7799  pcd conflicts
+ *   7800-7899  pcd reserved (future write/conflict expansion)
+ *   7900-7999  reserved for future suites
+ *
+ * Each suite gets 100 ports of headroom. From a port number alone you can tell
+ * which suite it belongs to. New specs claim the next free slot in their
+ * suite's range.
+ */
+
+export const PORTS = {
+	auth: {
+		apiKey: 7000,
+		cookieHttps: 7001,
+		cookieHttp: 7002,
+		csrf: 7003,
+		csrfNoOrigin: 7004,
+		csrfProxy: 7005,
+		health: 7006,
+		oidc: 7007,
+		oidcProxy: 7008,
+		oidcAuthOn: 7009,
+		pathTraversal: 7010,
+		proxy: 7011,
+		rateLimit: 7012,
+		reverseProxy502: 7013,
+		reverseProxy502Manual: 7014,
+		secretExposure: 7015,
+		session: 7016,
+		xForwardedFor: 7017
+	},
+	api: {
+		arr: 7100,
+		databases: 7101,
+		status: 7102
+	},
+	backups: {
+		backupSecrets: 7200,
+		createAndDelete: 7201,
+		jobStatus: 7202,
+		listAndDownload: 7203,
+		restoreA: 7204,
+		restoreB: 7205,
+		restoreFormActions: 7206,
+		settings: 7207,
+		upload: 7208
+	},
+	conflicts: {
+		groupMemberPosition: 7300,
+		regexDeleteRenameGeneratedDraft: 7301,
+		regexSplitPartialConflict: 7302,
+		regexSplitPerField: 7303,
+		regexSplitRenameCascade: 7304,
+		sequentialEdits: 7305,
+		upstreamChange: 7306
+	},
+	notifications: {
+		announcement: 7400,
+		arrCleanup: 7401,
+		arrDrift: 7402,
+		arrSync: 7403,
+		backup: 7404,
+		pcdSync: 7405,
+		rename: 7406,
+		test: 7407,
+		upgrade: 7408
+	},
+	announcements: {
+		cascade: 7500,
+		firstSync: 7501
+	},
+	pcd: {
+		writeRegexCreate: 7600,
+		writeRegexDelete: 7601,
+		writeRegexRename: 7602,
+		writeRegexUpdate: 7603,
+		writeDelayProfilesCreate: 7610,
+		writeDelayProfilesDelete: 7611,
+		writeDelayProfilesUpdate: 7612,
+		conflictsDelayProfiles: 7700
+	}
+} as const;
+
+function assertNoDuplicates(): void {
+	const seen = new Map<number, string>();
+
+	function walk(node: unknown, path: string): void {
+		if (typeof node === 'number') {
+			const existing = seen.get(node);
+			if (existing) {
+				throw new Error(`Duplicate port ${node} in PORTS registry: ${existing} and ${path}`);
+			}
+			seen.set(node, path);
+			return;
+		}
+		if (node && typeof node === 'object') {
+			for (const [key, value] of Object.entries(node)) {
+				walk(value, path ? `${path}.${key}` : key);
+			}
+		}
+	}
+
+	walk(PORTS, '');
+}
+
+assertNoDuplicates();

--- a/tests/integration/notifications/specs/announcement.test.ts
+++ b/tests/integration/notifications/specs/announcement.test.ts
@@ -4,6 +4,7 @@
 
 import { assertEquals, assertExists } from '@std/assert';
 import { setup, teardown, test, run } from '$test-harness/runner.ts';
+import { PORTS } from '$test-harness/ports.ts';
 import { createMockServer, type CapturedRequest } from '../harness/mock-server.ts';
 import { DiscordNotifier } from '$notifications/notifiers/discord/DiscordNotifier.ts';
 import { NtfyNotifier } from '$notifications/notifiers/ntfy/NtfyNotifier.ts';
@@ -13,7 +14,7 @@ import { Colors } from '$notifications/notifiers/discord/embed.ts';
 import { announcementNew } from '$notifications/definitions/announcement.ts';
 import type { AnnouncementRecord } from '$announcements/profilarr/types.ts';
 
-const MOCK_PORT = 7141;
+const MOCK_PORT = PORTS.notifications.announcement;
 let captured: CapturedRequest[];
 let mockServer: Deno.HttpServer;
 

--- a/tests/integration/notifications/specs/arrCleanup.test.ts
+++ b/tests/integration/notifications/specs/arrCleanup.test.ts
@@ -4,6 +4,7 @@
 
 import { assertEquals, assertExists } from '@std/assert';
 import { setup, teardown, test, run } from '$test-harness/runner.ts';
+import { PORTS } from '$test-harness/ports.ts';
 import { createMockServer, type CapturedRequest } from '../harness/mock-server.ts';
 import { DiscordNotifier } from '$notifications/notifiers/discord/DiscordNotifier.ts';
 import { NtfyNotifier } from '$notifications/notifiers/ntfy/NtfyNotifier.ts';
@@ -13,7 +14,7 @@ import { Colors } from '$notifications/notifiers/discord/embed.ts';
 import { arrCleanup } from '$notifications/definitions/arrCleanup.ts';
 import type { ArrCleanupNotificationParams } from '$notifications/definitions/arrCleanup.ts';
 
-const MOCK_PORT = 7140;
+const MOCK_PORT = PORTS.notifications.arrCleanup;
 let captured: CapturedRequest[];
 let mockServer: Deno.HttpServer;
 

--- a/tests/integration/notifications/specs/arrDrift.test.ts
+++ b/tests/integration/notifications/specs/arrDrift.test.ts
@@ -4,6 +4,7 @@
 
 import { assertEquals, assertExists } from '@std/assert';
 import { setup, teardown, test, run } from '$test-harness/runner.ts';
+import { PORTS } from '$test-harness/ports.ts';
 import { createMockServer, type CapturedRequest } from '../harness/mock-server.ts';
 import { DiscordNotifier } from '$notifications/notifiers/discord/DiscordNotifier.ts';
 import { NtfyNotifier } from '$notifications/notifiers/ntfy/NtfyNotifier.ts';
@@ -18,7 +19,7 @@ import type {
 import type { DriftDisplayEntity, DriftDisplayState } from '$shared/drift.ts';
 import { notificationTypes } from '$shared/notifications/types.ts';
 
-const MOCK_PORT = 7142;
+const MOCK_PORT = PORTS.notifications.arrDrift;
 let captured: CapturedRequest[];
 let mockServer: Deno.HttpServer;
 

--- a/tests/integration/notifications/specs/arrSync.test.ts
+++ b/tests/integration/notifications/specs/arrSync.test.ts
@@ -4,6 +4,7 @@
 
 import { assertEquals, assertExists } from '@std/assert';
 import { setup, teardown, test, run } from '$test-harness/runner.ts';
+import { PORTS } from '$test-harness/ports.ts';
 import { createMockServer, type CapturedRequest } from '../harness/mock-server.ts';
 import { DiscordNotifier } from '$notifications/notifiers/discord/DiscordNotifier.ts';
 import { NtfyNotifier } from '$notifications/notifiers/ntfy/NtfyNotifier.ts';
@@ -13,7 +14,7 @@ import { Colors } from '$notifications/notifiers/discord/embed.ts';
 import { arrSync } from '$notifications/definitions/arrSync.ts';
 import type { ArrSyncNotificationParams } from '$notifications/definitions/arrSync.ts';
 
-const MOCK_PORT = 7137;
+const MOCK_PORT = PORTS.notifications.arrSync;
 let captured: CapturedRequest[];
 let mockServer: Deno.HttpServer;
 

--- a/tests/integration/notifications/specs/backup.test.ts
+++ b/tests/integration/notifications/specs/backup.test.ts
@@ -4,6 +4,7 @@
 
 import { assertEquals, assertExists } from '@std/assert';
 import { setup, teardown, test, run } from '$test-harness/runner.ts';
+import { PORTS } from '$test-harness/ports.ts';
 import { createMockServer, type CapturedRequest } from '../harness/mock-server.ts';
 import { DiscordNotifier } from '$notifications/notifiers/discord/DiscordNotifier.ts';
 import { NtfyNotifier } from '$notifications/notifiers/ntfy/NtfyNotifier.ts';
@@ -13,7 +14,7 @@ import { Colors } from '$notifications/notifiers/discord/embed.ts';
 import { backupSuccess, backupFailed } from '$notifications/definitions/backup.ts';
 import type { BackupSuccessParams, BackupFailedParams } from '$notifications/definitions/backup.ts';
 
-const MOCK_PORT = 7139;
+const MOCK_PORT = PORTS.notifications.backup;
 let captured: CapturedRequest[];
 let mockServer: Deno.HttpServer;
 

--- a/tests/integration/notifications/specs/pcdSync.test.ts
+++ b/tests/integration/notifications/specs/pcdSync.test.ts
@@ -4,6 +4,7 @@
 
 import { assertEquals, assertExists } from '@std/assert';
 import { setup, teardown, test, run } from '$test-harness/runner.ts';
+import { PORTS } from '$test-harness/ports.ts';
 import { createMockServer, type CapturedRequest } from '../harness/mock-server.ts';
 import { DiscordNotifier } from '$notifications/notifiers/discord/DiscordNotifier.ts';
 import { NtfyNotifier } from '$notifications/notifiers/ntfy/NtfyNotifier.ts';
@@ -21,7 +22,7 @@ import type {
 	PcdSyncFailedParams
 } from '$notifications/definitions/pcdSync.ts';
 
-const MOCK_PORT = 7138;
+const MOCK_PORT = PORTS.notifications.pcdSync;
 let captured: CapturedRequest[];
 let mockServer: Deno.HttpServer;
 

--- a/tests/integration/notifications/specs/rename.test.ts
+++ b/tests/integration/notifications/specs/rename.test.ts
@@ -4,6 +4,7 @@
 
 import { assertEquals, assertExists } from '@std/assert';
 import { setup, teardown, test, run } from '$test-harness/runner.ts';
+import { PORTS } from '$test-harness/ports.ts';
 import { createMockServer, type CapturedRequest } from '../harness/mock-server.ts';
 import { DiscordNotifier } from '$notifications/notifiers/discord/DiscordNotifier.ts';
 import { NtfyNotifier } from '$notifications/notifiers/ntfy/NtfyNotifier.ts';
@@ -13,7 +14,7 @@ import { Colors } from '$notifications/notifiers/discord/embed.ts';
 import { rename } from '$notifications/definitions/rename.ts';
 import type { RenameJobLog } from '$lib/server/rename/types.ts';
 
-const MOCK_PORT = 7134;
+const MOCK_PORT = PORTS.notifications.rename;
 let captured: CapturedRequest[];
 let mockServer: Deno.HttpServer;
 

--- a/tests/integration/notifications/specs/test.test.ts
+++ b/tests/integration/notifications/specs/test.test.ts
@@ -4,6 +4,7 @@
 
 import { assertEquals, assertExists } from '@std/assert';
 import { setup, teardown, test, run } from '$test-harness/runner.ts';
+import { PORTS } from '$test-harness/ports.ts';
 import { createMockServer, type CapturedRequest } from '../harness/mock-server.ts';
 import { DiscordNotifier } from '$notifications/notifiers/discord/DiscordNotifier.ts';
 import { NtfyNotifier } from '$notifications/notifiers/ntfy/NtfyNotifier.ts';
@@ -12,7 +13,7 @@ import { TelegramNotifier } from '$notifications/notifiers/telegram/TelegramNoti
 import { Colors } from '$notifications/notifiers/discord/embed.ts';
 import { test as testDef } from '$notifications/definitions/test.ts';
 
-const MOCK_PORT = 7132;
+const MOCK_PORT = PORTS.notifications.test;
 let captured: CapturedRequest[];
 let mockServer: Deno.HttpServer;
 

--- a/tests/integration/notifications/specs/upgrade.test.ts
+++ b/tests/integration/notifications/specs/upgrade.test.ts
@@ -4,6 +4,7 @@
 
 import { assertEquals, assertExists } from '@std/assert';
 import { setup, teardown, test, run } from '$test-harness/runner.ts';
+import { PORTS } from '$test-harness/ports.ts';
 import { createMockServer, type CapturedRequest } from '../harness/mock-server.ts';
 import { DiscordNotifier } from '$notifications/notifiers/discord/DiscordNotifier.ts';
 import { NtfyNotifier } from '$notifications/notifiers/ntfy/NtfyNotifier.ts';
@@ -13,7 +14,7 @@ import { Colors } from '$notifications/notifiers/discord/embed.ts';
 import { upgrade } from '$notifications/definitions/upgrade.ts';
 import type { UpgradeJobLog } from '$lib/server/upgrades/types.ts';
 
-const MOCK_PORT = 7133;
+const MOCK_PORT = PORTS.notifications.upgrade;
 let captured: CapturedRequest[];
 let mockServer: Deno.HttpServer;
 

--- a/tests/integration/pcd/conflicts/delay-profiles.test.ts
+++ b/tests/integration/pcd/conflicts/delay-profiles.test.ts
@@ -6,6 +6,7 @@ import { assert, assertEquals, assertExists } from '@std/assert';
 import { startServer, stopServer } from '$test-harness/server.ts';
 import { openDb } from '$test-harness/db.ts';
 import { run, setup, teardown, test } from '$test-harness/runner.ts';
+import { PORTS } from '$test-harness/ports.ts';
 import { base } from '../harness/fixtures.ts';
 import {
 	compilePcd,
@@ -22,7 +23,7 @@ import {
 } from '../harness/pcd.ts';
 import { write } from '../harness/write.ts';
 
-const PORT = 7044;
+const PORT = PORTS.pcd.conflictsDelayProfiles;
 const ORIGIN = `http://localhost:${PORT}`;
 const STRATEGIES: ConflictStrategy[] = ['ask', 'align', 'override'];
 

--- a/tests/integration/pcd/write/delay-profiles/create.test.ts
+++ b/tests/integration/pcd/write/delay-profiles/create.test.ts
@@ -5,6 +5,7 @@
 import { assert, assertEquals } from '@std/assert';
 import { startServer, stopServer } from '$test-harness/server.ts';
 import { run, setup, teardown, test } from '$test-harness/runner.ts';
+import { PORTS } from '$test-harness/ports.ts';
 import { base } from '../../harness/fixtures.ts';
 import {
 	compilePcd,
@@ -16,7 +17,7 @@ import {
 import { write } from '../../harness/write.ts';
 import { assertActionFailed, createScenarioFactory, userOpsSince } from './helpers.ts';
 
-const PORT = 7042;
+const PORT = PORTS.pcd.writeDelayProfilesCreate;
 const ORIGIN = `http://localhost:${PORT}`;
 
 const { newPcd, seededPcd } = createScenarioFactory(PORT, 'pcd-write-delay-profile-create');

--- a/tests/integration/pcd/write/delay-profiles/delete.test.ts
+++ b/tests/integration/pcd/write/delay-profiles/delete.test.ts
@@ -5,12 +5,13 @@
 import { assert, assertEquals } from '@std/assert';
 import { startServer, stopServer } from '$test-harness/server.ts';
 import { run, setup, teardown, test } from '$test-harness/runner.ts';
+import { PORTS } from '$test-harness/ports.ts';
 import { base } from '../../harness/fixtures.ts';
 import { normalizeSql, opCheckpoint, parseDesiredState, parseMetadata } from '../../harness/pcd.ts';
 import { write } from '../../harness/write.ts';
 import { createScenarioFactory, userOpsSince } from './helpers.ts';
 
-const PORT = 7043;
+const PORT = PORTS.pcd.writeDelayProfilesDelete;
 const ORIGIN = `http://localhost:${PORT}`;
 
 const { seededPcd } = createScenarioFactory(PORT, 'pcd-write-delay-profile-delete');

--- a/tests/integration/pcd/write/delay-profiles/update.test.ts
+++ b/tests/integration/pcd/write/delay-profiles/update.test.ts
@@ -5,6 +5,7 @@
 import { assertEquals } from '@std/assert';
 import { startServer, stopServer } from '$test-harness/server.ts';
 import { run, setup, teardown, test } from '$test-harness/runner.ts';
+import { PORTS } from '$test-harness/ports.ts';
 import { base } from '../../harness/fixtures.ts';
 import { opCheckpoint, parseDesiredState, parseMetadata } from '../../harness/pcd.ts';
 import { write } from '../../harness/write.ts';
@@ -17,7 +18,7 @@ import {
 	userOpsSince
 } from './helpers.ts';
 
-const PORT = 7041;
+const PORT = PORTS.pcd.writeDelayProfilesUpdate;
 const ORIGIN = `http://localhost:${PORT}`;
 
 const { seededPcd } = createScenarioFactory(PORT, 'pcd-write-delay-profile-update');

--- a/tests/integration/pcd/write/regex/create.test.ts
+++ b/tests/integration/pcd/write/regex/create.test.ts
@@ -5,6 +5,7 @@
 import { assert, assertEquals } from '@std/assert';
 import { startServer, stopServer } from '$test-harness/server.ts';
 import { run, setup, teardown, test } from '$test-harness/runner.ts';
+import { PORTS } from '$test-harness/ports.ts';
 import { base } from '../../harness/fixtures.ts';
 import {
 	compilePcd,
@@ -16,7 +17,7 @@ import {
 import { write } from '../../harness/write.ts';
 import { assertActionFailed, createScenarioFactory, userOpsSince } from './helpers.ts';
 
-const PORT = 7037;
+const PORT = PORTS.pcd.writeRegexCreate;
 const ORIGIN = `http://localhost:${PORT}`;
 
 const { newPcd, seededPcd } = createScenarioFactory(PORT, 'pcd-write-regex-create');

--- a/tests/integration/pcd/write/regex/delete.test.ts
+++ b/tests/integration/pcd/write/regex/delete.test.ts
@@ -5,6 +5,7 @@
 import { assert, assertEquals, assertExists } from '@std/assert';
 import { startServer, stopServer } from '$test-harness/server.ts';
 import { run, setup, teardown, test } from '$test-harness/runner.ts';
+import { PORTS } from '$test-harness/ports.ts';
 import { base } from '../../harness/fixtures.ts';
 import {
 	normalizeSql,
@@ -23,7 +24,7 @@ import {
 	userOpsSince
 } from './helpers.ts';
 
-const PORT = 7040;
+const PORT = PORTS.pcd.writeRegexDelete;
 const ORIGIN = `http://localhost:${PORT}`;
 
 const { seededPcd } = createScenarioFactory(PORT, 'pcd-write-regex-delete');

--- a/tests/integration/pcd/write/regex/rename.test.ts
+++ b/tests/integration/pcd/write/regex/rename.test.ts
@@ -5,6 +5,7 @@
 import { assert, assertEquals } from '@std/assert';
 import { startServer, stopServer } from '$test-harness/server.ts';
 import { run, setup, teardown, test } from '$test-harness/runner.ts';
+import { PORTS } from '$test-harness/ports.ts';
 import { base } from '../../harness/fixtures.ts';
 import { normalizeSql, opCheckpoint, parseDesiredState, parseMetadata } from '../../harness/pcd.ts';
 import { write } from '../../harness/write.ts';
@@ -18,7 +19,7 @@ import {
 	userOpsSince
 } from './helpers.ts';
 
-const PORT = 7039;
+const PORT = PORTS.pcd.writeRegexRename;
 const ORIGIN = `http://localhost:${PORT}`;
 
 const { seededPcd } = createScenarioFactory(PORT, 'pcd-write-regex-rename');

--- a/tests/integration/pcd/write/regex/update.test.ts
+++ b/tests/integration/pcd/write/regex/update.test.ts
@@ -5,6 +5,7 @@
 import { assert, assertEquals } from '@std/assert';
 import { startServer, stopServer } from '$test-harness/server.ts';
 import { run, setup, teardown, test } from '$test-harness/runner.ts';
+import { PORTS } from '$test-harness/ports.ts';
 import { base } from '../../harness/fixtures.ts';
 import { normalizeSql, opCheckpoint, parseDesiredState } from '../../harness/pcd.ts';
 import { write } from '../../harness/write.ts';
@@ -16,7 +17,7 @@ import {
 	userOpsSince
 } from './helpers.ts';
 
-const PORT = 7038;
+const PORT = PORTS.pcd.writeRegexUpdate;
 const ORIGIN = `http://localhost:${PORT}`;
 
 const { seededPcd } = createScenarioFactory(PORT, 'pcd-write-regex-update');

--- a/tests/runner.ts
+++ b/tests/runner.ts
@@ -68,6 +68,8 @@
  *   --help, -h      Show this help text.
  */
 
+import { PORTS } from './integration/harness/ports.ts';
+
 // ─── Constants ───────────────────────────────────────────────────────────────
 
 const INTEGRATION_COMPOSE = 'tests/integration/auth/docker-compose.yml';
@@ -682,8 +684,8 @@ async function runE2EPCD(selectors: string[], playwrightFlags: string[]): Promis
 
 async function runE2EAuth(playwrightFlags: string[]): Promise<number> {
 	const MOCK_OIDC_URL = 'http://localhost:9090/default/.well-known/openid-configuration';
-	const DIRECT_PORT = 7006;
-	const PROXY_PORT = 7009;
+	const DIRECT_PORT = PORTS.auth.oidc;
+	const PROXY_PORT = PORTS.auth.oidcProxy;
 	const PROXY_ORIGIN = 'https://localhost:7445';
 
 	const OIDC_ENV = {


### PR DESCRIPTION
## Summary

- New `tests/integration/harness/ports.ts` registry, single source of truth for port assignments.
- Self-validates at module load and throws on duplicates with a clear path.
- Migrates all 49 specs to import from the registry.
- Reorganizes into 100-slot suite ranges (auth 7000-7099, api 7100-7199, etc.) with reserved future bands.
- Resolves three latent collisions surfaced during the migration.