### PR TITLE
fix: make manual conflict align per-op instead of group-wide

### DIFF
--- a/src/lib/server/pcd/conflicts/align.ts
+++ b/src/lib/server/pcd/conflicts/align.ts
@@ -4,26 +4,11 @@ import { compile } from '$pcd/index.ts';
 import { databaseInstancesQueries } from '$db/queries/databaseInstances.ts';
 import { uuid } from '$shared/utils/uuid.ts';
 import { logger } from '$logger/logger.ts';
-import type { PcdOp } from '$db/queries/pcdOps.ts';
 
 export type AlignConflictResult = {
 	success: boolean;
 	error?: string;
 };
-
-type OpMetadata = {
-	group_id?: string;
-};
-
-function getGroupId(op: PcdOp): string | null {
-	if (!op.metadata) return null;
-	try {
-		const parsed = JSON.parse(op.metadata) as OpMetadata;
-		return typeof parsed.group_id === 'string' ? parsed.group_id : null;
-	} catch {
-		return null;
-	}
-}
 
 export async function alignConflict(input: {
 	databaseId: number;
@@ -40,34 +25,17 @@ export async function alignConflict(input: {
 		return { success: false, error: 'Only published user operations can be aligned' };
 	}
 
-	const groupId = getGroupId(op);
-	let opsToDrop: PcdOp[] = [op];
-
-	if (groupId) {
-		const candidates = pcdOpsQueries.listByDatabaseAndOrigin(databaseId, 'user', {
-			states: ['published']
-		});
-		const grouped = candidates.filter((candidate) => getGroupId(candidate) === groupId);
-		if (grouped.length > 0) {
-			opsToDrop = grouped;
-		}
+	const updated = pcdOpsQueries.update(opId, { state: 'dropped' });
+	if (!updated) {
+		return { success: false, error: 'Failed to drop conflicting operation' };
 	}
 
-	const batchId = uuid();
-
-	for (const dropOp of opsToDrop) {
-		const updated = pcdOpsQueries.update(dropOp.id, { state: 'dropped' });
-		if (!updated) {
-			return { success: false, error: 'Failed to drop conflicting operation' };
-		}
-
-		pcdOpHistoryQueries.create({
-			opId: dropOp.id,
-			databaseId,
-			batchId,
-			status: 'dropped'
-		});
-	}
+	pcdOpHistoryQueries.create({
+		opId,
+		databaseId,
+		batchId: uuid(),
+		status: 'dropped'
+	});
 
 	const instance = databaseInstancesQueries.getById(databaseId);
 	if (instance?.enabled) {
@@ -76,12 +44,7 @@ export async function alignConflict(input: {
 
 	await logger.info('Aligned conflict', {
 		source: 'PCDConflicts',
-		meta: {
-			databaseId,
-			opId,
-			groupId: groupId ?? undefined,
-			droppedOpIds: opsToDrop.map((dropOp) => dropOp.id)
-		}
+		meta: { databaseId, opId }
 	});
 
 	return { success: true };

--- a/src/routes/databases/[id]/conflicts/+page.server.ts
+++ b/src/routes/databases/[id]/conflicts/+page.server.ts
@@ -15,16 +15,14 @@ type ConflictRow = {
 	title: string;
 	summary: string | null;
 	origin: string;
-	/** All op IDs in this conflict group (for batch resolution) */
-	groupOpIds: number[];
-	/** Number of collapsed intermediate conflicts */
-	collapsedCount: number;
+	/** Group identifier for visually clustering siblings from the same save. */
+	groupId: string | null;
 };
 
-function parseMetadata(raw: string | null): OperationMetadata | null {
+function parseMetadata(raw: string | null): (OperationMetadata & { group_id?: string }) | null {
 	if (!raw) return null;
 	try {
-		return JSON.parse(raw) as OperationMetadata;
+		return JSON.parse(raw) as OperationMetadata & { group_id?: string };
 	} catch {
 		return null;
 	}
@@ -60,8 +58,7 @@ export const load: PageServerLoad = async ({ parent }) => {
 			title,
 			summary: metadata?.summary ?? null,
 			origin: op.origin,
-			groupOpIds: [op.id],
-			collapsedCount: 0
+			groupId: typeof metadata?.group_id === 'string' ? metadata.group_id : null
 		};
 	});
 
@@ -71,16 +68,10 @@ export const load: PageServerLoad = async ({ parent }) => {
 	};
 };
 
-function parseGroupOpIds(formData: FormData): number[] {
-	const raw = formData.get('groupOpIds');
-	if (!raw || typeof raw !== 'string') return [];
-	try {
-		const parsed = JSON.parse(raw) as unknown;
-		if (!Array.isArray(parsed)) return [];
-		return parsed.filter((id): id is number => typeof id === 'number' && Number.isFinite(id));
-	} catch {
-		return [];
-	}
+function parseOpId(formData: FormData): number | null {
+	const raw = formData.get('opId');
+	const opId = Number(raw);
+	return Number.isFinite(opId) ? opId : null;
 }
 
 export const actions: Actions = {
@@ -91,21 +82,14 @@ export const actions: Actions = {
 		}
 
 		const formData = await request.formData();
-		const groupOpIds = parseGroupOpIds(formData);
-		if (groupOpIds.length === 0) {
-			const opId = Number(formData.get('opId'));
-			if (!Number.isFinite(opId)) {
-				return fail(400, { error: 'Invalid operation id' });
-			}
-			groupOpIds.push(opId);
+		const opId = parseOpId(formData);
+		if (opId === null) {
+			return fail(400, { error: 'Invalid operation id' });
 		}
 
-		// Align all ops in the group
-		for (const opId of groupOpIds) {
-			const result = await alignConflict({ databaseId, opId });
-			if (!result.success) {
-				return fail(400, { error: result.error || 'Failed to align conflict' });
-			}
+		const result = await alignConflict({ databaseId, opId });
+		if (!result.success) {
+			return fail(400, { error: result.error || 'Failed to align conflict' });
 		}
 
 		return { success: true };
@@ -117,22 +101,14 @@ export const actions: Actions = {
 		}
 
 		const formData = await request.formData();
-		const groupOpIds = parseGroupOpIds(formData);
-		if (groupOpIds.length === 0) {
-			const opId = Number(formData.get('opId'));
-			if (!Number.isFinite(opId)) {
-				return fail(400, { error: 'Invalid operation id' });
-			}
-			groupOpIds.push(opId);
+		const opId = parseOpId(formData);
+		if (opId === null) {
+			return fail(400, { error: 'Invalid operation id' });
 		}
 
-		// Override sequentially, oldest first — each resolution may cascade-fix the next
-		for (const opId of groupOpIds) {
-			const result = await overrideConflict({ databaseId, opId });
-			if (!result.success) {
-				// Op may have auto-resolved from a prior override in this batch — skip
-				continue;
-			}
+		const result = await overrideConflict({ databaseId, opId });
+		if (!result.success) {
+			return fail(400, { error: result.error || 'Failed to override conflict' });
 		}
 
 		return { success: true };

--- a/src/routes/databases/[id]/conflicts/+page.svelte
+++ b/src/routes/databases/[id]/conflicts/+page.svelte
@@ -28,9 +28,12 @@
 		title: string;
 		summary: string | null;
 		origin: string;
-		groupOpIds: number[];
-		collapsedCount: number;
+		groupId: string | null;
 	};
+
+	function groupKey(row: ConflictRow): string {
+		return row.groupId ?? `op-${row.opId}`;
+	}
 
 	let searchStore: SearchStore;
 	$: searchStore = getPersistentSearchStore(`databaseConflictsSearch:${$page.params.id}`, {
@@ -213,24 +216,34 @@
 		}
 	];
 
-	$: filteredConflicts = data.conflicts.filter((conflict) => {
-		const query = $searchStore.query?.trim().toLowerCase();
-		const matchesQuery = !query
-			? true
-			: conflict.title.toLowerCase().includes(query) ||
-				conflict.entity.toLowerCase().includes(query) ||
-				conflict.name.toLowerCase().includes(query) ||
-				(reasonLabels[conflict.conflictReason ?? 'guard_mismatch'] ?? conflict.conflictReason ?? '')
-					.toLowerCase()
-					.includes(query) ||
-				conflict.status.toLowerCase().includes(query);
+	$: filteredConflicts = data.conflicts
+		.filter((conflict) => {
+			const query = $searchStore.query?.trim().toLowerCase();
+			const matchesQuery = !query
+				? true
+				: conflict.title.toLowerCase().includes(query) ||
+					conflict.entity.toLowerCase().includes(query) ||
+					conflict.name.toLowerCase().includes(query) ||
+					(
+						reasonLabels[conflict.conflictReason ?? 'guard_mismatch'] ??
+						conflict.conflictReason ??
+						''
+					)
+						.toLowerCase()
+						.includes(query) ||
+					conflict.status.toLowerCase().includes(query);
 
-		const matchesEntity = activeEntities.size === 0 ? true : activeEntities.has(conflict.entity);
-		const matchesReason =
-			activeReasons.size === 0 ? true : activeReasons.has(conflict.conflictReason ?? '');
+			const matchesEntity = activeEntities.size === 0 ? true : activeEntities.has(conflict.entity);
+			const matchesReason =
+				activeReasons.size === 0 ? true : activeReasons.has(conflict.conflictReason ?? '');
 
-		return matchesQuery && matchesEntity && matchesReason;
-	});
+			return matchesQuery && matchesEntity && matchesReason;
+		})
+		// Cluster ops from the same save adjacently so it is obvious they came
+		// from one user action. Ungrouped conflicts each form their own
+		// single-element cluster keyed by opId, preserving their original order.
+		.slice()
+		.sort((a, b) => groupKey(a).localeCompare(groupKey(b)) || a.opId - b.opId);
 </script>
 
 <svelte:head>
@@ -305,17 +318,12 @@
 	>
 		<svelte:fragment slot="actions" let:row>
 			<div class="flex items-center justify-end gap-1">
-				{#if row.collapsedCount > 0}
-					<span class="mr-1 text-[10px] font-medium text-neutral-500 dark:text-neutral-400">
-						+{row.collapsedCount} more
-					</span>
-				{/if}
 				<form
 					method="POST"
 					action="?/align"
 					use:enhance={handleConflictAction('Conflict aligned', 'Align conflict failed')}
 				>
-					<input type="hidden" name="groupOpIds" value={JSON.stringify(row.groupOpIds)} />
+					<input type="hidden" name="opId" value={row.opId} />
 					<Button
 						icon={HeartHandshake}
 						text="Align"
@@ -330,7 +338,7 @@
 					action="?/override"
 					use:enhance={handleConflictAction('Conflict override queued', 'Override conflict failed')}
 				>
-					<input type="hidden" name="groupOpIds" value={JSON.stringify(row.groupOpIds)} />
+					<input type="hidden" name="opId" value={row.opId} />
 					<Button
 						icon={HandMetal}
 						text="Override"


### PR DESCRIPTION
## Summary

- `align.ts`: drops only the op passed in. Removes the group-wide sibling expansion that silently dropped cleanly-applied user changes when the user only meant to yield one field.
- Manual align is now symmetric with manual override (both per-op).
- `+page.server.ts`: form actions take a single `opId` instead of a `groupOpIds` array.
- `+page.svelte`: rows sorted by `group_id` so siblings from the same save sit adjacent.
- Sectioned heading-per-group rendering deferred to a follow-up that also surfaces field-level conflict context.
- Auto-align during compile is unchanged (already per-op).