### PR TITLE
feat: surface field-level info in conflict UI

### DIFF
--- a/src/routes/databases/[id]/conflicts/+page.server.ts
+++ b/src/routes/databases/[id]/conflicts/+page.server.ts
@@ -3,6 +3,15 @@ import type { Actions, PageServerLoad } from './$types';
 import { pcdOpHistoryQueries } from '$db/queries/pcdOpHistory.ts';
 import type { OperationMetadata } from '$pcd/core/types.ts';
 import { alignConflict, overrideConflict } from '$pcd/conflicts/index.ts';
+import { getCache } from '$pcd/index.ts';
+import { AUTO_ALIGN_ENTITIES } from '$pcd/entities/registry.ts';
+
+type FieldConflict = {
+	field: string;
+	was: unknown;
+	you: unknown;
+	upstreamNow: unknown;
+};
 
 type ConflictRow = {
 	opId: number;
@@ -17,15 +26,47 @@ type ConflictRow = {
 	origin: string;
 	/** Group identifier for visually clustering siblings from the same save. */
 	groupId: string | null;
+	/** Per-field conflict breakdown for simple update ops. Empty when complex. */
+	fields: FieldConflict[];
+	/**
+	 * True when desired_state isn't simple per-field {from,to} (creates,
+	 * deletes, CF conditions, QP qualities/scoring, etc). UI renders a
+	 * placeholder for these.
+	 */
+	complex: boolean;
 };
 
-function parseMetadata(raw: string | null): (OperationMetadata & { group_id?: string }) | null {
+type ParsedMetadata = (OperationMetadata & { group_id?: string }) | null;
+
+function parseMetadata(raw: string | null): ParsedMetadata {
 	if (!raw) return null;
 	try {
 		return JSON.parse(raw) as OperationMetadata & { group_id?: string };
 	} catch {
 		return null;
 	}
+}
+
+function parseDesiredState(raw: string | null): Record<string, unknown> | null {
+	if (!raw) return null;
+	try {
+		const parsed = JSON.parse(raw);
+		if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+			return parsed as Record<string, unknown>;
+		}
+	} catch {
+		// fall through
+	}
+	return null;
+}
+
+function isFromTo(value: unknown): value is { from: unknown; to: unknown } {
+	return (
+		value !== null &&
+		typeof value === 'object' &&
+		'from' in (value as Record<string, unknown>) &&
+		'to' in (value as Record<string, unknown>)
+	);
 }
 
 function formatEntity(entity?: string): string {
@@ -39,13 +80,84 @@ function formatTitle(metadata: OperationMetadata | null): string {
 	return `${operation} ${entity}${name}`;
 }
 
+type CurrentRowLookup = (entity: string, lookupName: string) => Record<string, unknown> | null;
+
+function makeCurrentRowLookup(databaseId: number): CurrentRowLookup {
+	const cache = getCache(databaseId);
+	const memo = new Map<string, Record<string, unknown> | null>();
+	return (entity, lookupName) => {
+		if (!cache) return null;
+		const config = AUTO_ALIGN_ENTITIES.get(entity);
+		if (!config) return null;
+
+		const cacheKey = `${entity}::${lookupName}`;
+		if (memo.has(cacheKey)) return memo.get(cacheKey) ?? null;
+
+		try {
+			// nosemgrep: profilarr.sql.template-literal-interpolation - table/column from hardcoded registry
+			const row = cache.queryOne<Record<string, unknown>>(
+				`SELECT * FROM ${config.table} WHERE ${config.keyColumn} = ? LIMIT 1`,
+				lookupName
+			);
+			memo.set(cacheKey, row ?? null);
+			return row ?? null;
+		} catch {
+			memo.set(cacheKey, null);
+			return null;
+		}
+	};
+}
+
+function buildFieldConflicts(
+	lookupRow: CurrentRowLookup,
+	entity: string,
+	metadata: ParsedMetadata,
+	desiredState: Record<string, unknown> | null
+): { fields: FieldConflict[]; complex: boolean } {
+	if (!desiredState) return { fields: [], complex: false };
+
+	const keys = Object.keys(desiredState);
+	if (keys.length === 0) return { fields: [], complex: false };
+
+	if (!keys.every((key) => isFromTo(desiredState[key]))) {
+		return { fields: [], complex: true };
+	}
+
+	const lookupName = lookupNameFromMetadata(metadata);
+	const currentRow = lookupName ? lookupRow(entity, lookupName) : null;
+
+	const fields: FieldConflict[] = keys.map((field) => {
+		const change = desiredState[field] as { from: unknown; to: unknown };
+		return {
+			field,
+			was: change.from,
+			you: change.to,
+			upstreamNow: currentRow ? (currentRow[field] ?? null) : null
+		};
+	});
+
+	return { fields, complex: false };
+}
+
+function lookupNameFromMetadata(metadata: ParsedMetadata): string | null {
+	if (!metadata) return null;
+	const stableKeyValue = metadata.stable_key?.value;
+	if (typeof stableKeyValue === 'string' && stableKeyValue.length > 0) return stableKeyValue;
+	if (typeof metadata.name === 'string' && metadata.name.length > 0) return metadata.name;
+	return null;
+}
+
 export const load: PageServerLoad = async ({ parent }) => {
 	const { database } = await parent();
 	const conflicts = pcdOpHistoryQueries.listLatestConflictsByDatabase(database.id);
+	const lookupRow = makeCurrentRowLookup(database.id);
 
 	const rows: ConflictRow[] = conflicts.map(({ history, op }) => {
 		const metadata = parseMetadata(op.metadata ?? null);
+		const desiredState = parseDesiredState(op.desired_state ?? null);
 		const title = metadata?.title ?? metadata?.summary ?? formatTitle(metadata);
+		const entity = metadata?.entity ?? 'operation';
+		const { fields, complex } = buildFieldConflicts(lookupRow, entity, metadata, desiredState);
 
 		return {
 			opId: op.id,
@@ -53,12 +165,14 @@ export const load: PageServerLoad = async ({ parent }) => {
 			conflictReason: history.conflict_reason,
 			appliedAt: history.applied_at,
 			operation: metadata?.operation ?? 'update',
-			entity: metadata?.entity ?? 'operation',
+			entity,
 			name: metadata?.name ?? '',
 			title,
 			summary: metadata?.summary ?? null,
 			origin: op.origin,
-			groupId: typeof metadata?.group_id === 'string' ? metadata.group_id : null
+			groupId: typeof metadata?.group_id === 'string' ? metadata.group_id : null,
+			fields,
+			complex
 		};
 	});
 

--- a/src/routes/databases/[id]/conflicts/+page.server.ts
+++ b/src/routes/databases/[id]/conflicts/+page.server.ts
@@ -141,7 +141,8 @@ function buildFieldConflicts(
 
 function lookupNameFromMetadata(metadata: ParsedMetadata): string | null {
 	if (!metadata) return null;
-	const stableKeyValue = metadata.stable_key?.value;
+	const stableKey = (metadata as unknown as { stable_key?: { value?: unknown } }).stable_key;
+	const stableKeyValue = stableKey?.value;
 	if (typeof stableKeyValue === 'string' && stableKeyValue.length > 0) return stableKeyValue;
 	if (typeof metadata.name === 'string' && metadata.name.length > 0) return metadata.name;
 	return null;

--- a/src/routes/databases/[id]/conflicts/+page.svelte
+++ b/src/routes/databases/[id]/conflicts/+page.svelte
@@ -7,15 +7,23 @@
 	import DropdownHeader from '$ui/dropdown/DropdownHeader.svelte';
 	import DropdownItem from '$ui/dropdown/DropdownItem.svelte';
 	import Button from '$ui/button/Button.svelte';
+	import ExpandableCard from '$ui/card/ExpandableCard.svelte';
+	import Label from '$ui/label/Label.svelte';
+	import ConflictField from './ConflictField.svelte';
 	import { enhance } from '$app/forms';
 	import { alertStore } from '$alerts/store';
 	import { Fingerprint, AlertTriangle, HeartHandshake, HandMetal } from 'lucide-svelte';
-	import Table from '$ui/table/Table.svelte';
-	import type { Column } from '$ui/table/types';
 	import { getPersistentSearchStore, type SearchStore } from '$lib/client/stores/search';
 	import type { PageData } from './$types';
 
 	export let data: PageData;
+
+	type FieldConflict = {
+		field: string;
+		was: unknown;
+		you: unknown;
+		upstreamNow: unknown;
+	};
 
 	type ConflictRow = {
 		opId: number;
@@ -29,6 +37,16 @@
 		summary: string | null;
 		origin: string;
 		groupId: string | null;
+		fields: FieldConflict[];
+		complex: boolean;
+	};
+
+	type ConflictGroup = {
+		key: string;
+		title: string;
+		entity: string;
+		name: string;
+		conflicts: ConflictRow[];
 	};
 
 	function groupKey(row: ConflictRow): string {
@@ -92,22 +110,25 @@
 		activeReasons = new Set(activeReasons);
 	}
 
+	type LabelVariant =
+		| 'default'
+		| 'secondary'
+		| 'destructive'
+		| 'outline'
+		| 'ghost'
+		| 'success'
+		| 'warning'
+		| 'danger'
+		| 'info'
+		| 'link';
+
 	const reasonLabels: Record<string, string> = {
 		guard_mismatch: 'Guard mismatch',
 		duplicate_key: 'Duplicate key',
 		missing_target: 'Missing target'
 	};
 
-	const badgeVariants: Record<string, string> = {
-		accent: 'bg-accent-100 text-accent-800 dark:bg-accent-900 dark:text-accent-200',
-		neutral: 'bg-neutral-100 text-neutral-700 dark:bg-neutral-800 dark:text-neutral-300',
-		success: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900 dark:text-emerald-200',
-		warning: 'bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200',
-		danger: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200',
-		info: 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200'
-	};
-
-	const reasonVariants: Record<string, string> = {
+	const reasonVariants: Record<string, LabelVariant> = {
 		guard_mismatch: 'warning',
 		duplicate_key: 'danger',
 		missing_target: 'warning'
@@ -128,29 +149,20 @@
 		test_release: 'Test Release'
 	};
 
-	const entityVariants: Record<string, string> = {
+	const entityVariants: Record<string, LabelVariant> = {
 		quality_profile: 'info',
-		custom_format: 'accent',
+		custom_format: 'default',
 		regular_expression: 'warning',
 		delay_profile: 'success',
-		radarr_naming: 'neutral',
-		sonarr_naming: 'neutral',
-		radarr_media_settings: 'neutral',
-		sonarr_media_settings: 'neutral',
-		radarr_quality_definitions: 'neutral',
-		sonarr_quality_definitions: 'neutral',
-		test_entity: 'neutral',
-		test_release: 'neutral'
+		radarr_naming: 'secondary',
+		sonarr_naming: 'secondary',
+		radarr_media_settings: 'secondary',
+		sonarr_media_settings: 'secondary',
+		radarr_quality_definitions: 'secondary',
+		sonarr_quality_definitions: 'secondary',
+		test_entity: 'secondary',
+		test_release: 'secondary'
 	};
-
-	function escapeHtml(value: string): string {
-		return value
-			.replace(/&/g, '&amp;')
-			.replace(/</g, '&lt;')
-			.replace(/>/g, '&gt;')
-			.replace(/"/g, '&quot;')
-			.replace(/'/g, '&#39;');
-	}
 
 	function titleCase(value: string): string {
 		return value
@@ -163,87 +175,93 @@
 		return titleCase(entity.replace(/_/g, ' '));
 	}
 
-	function badgeHtml(label: string, variant: string): string {
-		const classes = badgeVariants[variant] ?? badgeVariants.neutral;
-		return `<span class="inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-medium ${classes}">${escapeHtml(label)}</span>`;
+	function formatValue(value: unknown): string {
+		if (value === null || value === undefined) return '—';
+		if (typeof value === 'boolean') return value ? 'Yes' : 'No';
+		if (typeof value === 'string') {
+			if (value === '') return '(empty)';
+			return value;
+		}
+		if (typeof value === 'number') return String(value);
+		try {
+			return JSON.stringify(value);
+		} catch {
+			return String(value);
+		}
 	}
 
-	const columns: Column<ConflictRow>[] = [
-		{
-			key: 'opId',
-			header: 'Op #',
-			width: '90px',
-			cell: (row) => ({
-				// nosemgrep: profilarr.xss.table-cell-html-unescaped — internal numeric operation ID
-				html: `<span class="font-mono text-xs text-neutral-600 dark:text-neutral-400">${row.opId}</span>`
-			})
-		},
-		{
-			key: 'entity',
-			header: 'Entity',
-			width: '170px',
-			cell: (row) => {
-				const label = entityLabels[row.entity] ?? formatEntity(row.entity);
-				const variant = entityVariants[row.entity] ?? 'neutral';
-				return { html: badgeHtml(label, variant) };
-			}
-		},
-		{
-			key: 'name',
-			header: 'Name',
-			width: '220px',
-			cell: (row) => escapeHtml(row.name || '-')
-		},
-		{
-			key: 'conflictReason',
-			header: 'Reason',
-			width: '150px',
-			cell: (row) => {
-				const reasonKey = row.conflictReason ?? 'guard_mismatch';
-				const label = reasonLabels[reasonKey] ?? reasonKey;
-				const variant = reasonVariants[reasonKey] ?? 'neutral';
-				return { html: badgeHtml(label, variant) };
-			}
-		},
-		{
-			key: 'title',
-			header: 'Operation',
-			cell: (row) => {
-				return {
-					html: `<div class="font-normal text-neutral-900 dark:text-neutral-100">${escapeHtml(row.title)}</div>`
+	function reasonLabel(reason: string | null): string {
+		const key = reason ?? 'guard_mismatch';
+		return reasonLabels[key] ?? key;
+	}
+
+	function reasonVariant(reason: string | null): LabelVariant {
+		const key = reason ?? 'guard_mismatch';
+		return reasonVariants[key] ?? 'secondary';
+	}
+
+	function entityLabel(entity: string): string {
+		return entityLabels[entity] ?? formatEntity(entity);
+	}
+
+	function entityVariant(entity: string): LabelVariant {
+		return entityVariants[entity] ?? 'secondary';
+	}
+
+	function rowMatchesQuery(conflict: ConflictRow, query: string): boolean {
+		if (!query) return true;
+		const haystack = [
+			conflict.title,
+			conflict.entity,
+			conflict.name,
+			reasonLabels[conflict.conflictReason ?? 'guard_mismatch'] ?? conflict.conflictReason ?? '',
+			conflict.status,
+			...conflict.fields.flatMap((f) => [
+				f.field,
+				formatValue(f.was),
+				formatValue(f.you),
+				formatValue(f.upstreamNow)
+			])
+		]
+			.join(' ')
+			.toLowerCase();
+		return haystack.includes(query);
+	}
+
+	$: filteredConflicts = data.conflicts.filter((conflict) => {
+		const query = $searchStore.query?.trim().toLowerCase() ?? '';
+		const matchesQuery = rowMatchesQuery(conflict, query);
+		const matchesEntity = activeEntities.size === 0 ? true : activeEntities.has(conflict.entity);
+		const matchesReason =
+			activeReasons.size === 0 ? true : activeReasons.has(conflict.conflictReason ?? '');
+		return matchesQuery && matchesEntity && matchesReason;
+	});
+
+	$: filteredGroups = ((): ConflictGroup[] => {
+		const groups = new Map<string, ConflictGroup>();
+		for (const conflict of filteredConflicts) {
+			const key = groupKey(conflict);
+			let group = groups.get(key);
+			if (!group) {
+				group = {
+					key,
+					title: conflict.title,
+					entity: conflict.entity,
+					name: conflict.name,
+					conflicts: []
 				};
+				groups.set(key, group);
 			}
+			group.conflicts.push(conflict);
 		}
-	];
-
-	$: filteredConflicts = data.conflicts
-		.filter((conflict) => {
-			const query = $searchStore.query?.trim().toLowerCase();
-			const matchesQuery = !query
-				? true
-				: conflict.title.toLowerCase().includes(query) ||
-					conflict.entity.toLowerCase().includes(query) ||
-					conflict.name.toLowerCase().includes(query) ||
-					(
-						reasonLabels[conflict.conflictReason ?? 'guard_mismatch'] ??
-						conflict.conflictReason ??
-						''
-					)
-						.toLowerCase()
-						.includes(query) ||
-					conflict.status.toLowerCase().includes(query);
-
-			const matchesEntity = activeEntities.size === 0 ? true : activeEntities.has(conflict.entity);
-			const matchesReason =
-				activeReasons.size === 0 ? true : activeReasons.has(conflict.conflictReason ?? '');
-
-			return matchesQuery && matchesEntity && matchesReason;
-		})
-		// Cluster ops from the same save adjacently so it is obvious they came
-		// from one user action. Ungrouped conflicts each form their own
-		// single-element cluster keyed by opId, preserving their original order.
-		.slice()
-		.sort((a, b) => groupKey(a).localeCompare(groupKey(b)) || a.opId - b.opId);
+		// Stable order: groups in their natural appearance order; conflicts within
+		// a group ordered by opId so split-save siblings render in a predictable
+		// sequence.
+		for (const group of groups.values()) {
+			group.conflicts.sort((a, b) => a.opId - b.opId);
+		}
+		return Array.from(groups.values());
+	})();
 </script>
 
 <svelte:head>
@@ -307,48 +325,99 @@
 	</ActionButton>
 </ActionsBar>
 
-<div class="mt-6">
-	<Table
-		data={filteredConflicts}
-		{columns}
-		emptyMessage="No conflicts detected"
-		hoverable={true}
-		compact={true}
-		responsive
-	>
-		<svelte:fragment slot="actions" let:row>
-			<div class="flex items-center justify-end gap-1">
-				<form
-					method="POST"
-					action="?/align"
-					use:enhance={handleConflictAction('Conflict aligned', 'Align conflict failed')}
-				>
-					<input type="hidden" name="opId" value={row.opId} />
-					<Button
-						icon={HeartHandshake}
-						text="Align"
-						variant="secondary"
-						iconColor="text-emerald-600 dark:text-emerald-400"
-						size="xs"
-						type="submit"
-					/>
-				</form>
-				<form
-					method="POST"
-					action="?/override"
-					use:enhance={handleConflictAction('Conflict override queued', 'Override conflict failed')}
-				>
-					<input type="hidden" name="opId" value={row.opId} />
-					<Button
-						icon={HandMetal}
-						text="Override"
-						variant="secondary"
-						iconColor="text-accent-600 dark:text-accent-400"
-						size="xs"
-						type="submit"
-					/>
-				</form>
-			</div>
-		</svelte:fragment>
-	</Table>
+<div class="mt-6 space-y-4">
+	{#if filteredGroups.length === 0}
+		<div
+			class="rounded-lg border border-neutral-200 bg-white p-8 text-center text-sm text-neutral-600 dark:border-neutral-800 dark:bg-neutral-900 dark:text-neutral-400"
+		>
+			No conflicts detected
+		</div>
+	{:else}
+		{#each filteredGroups as group (group.key)}
+			<ExpandableCard
+				title={group.title}
+				description={group.conflicts.length > 1
+					? `${group.conflicts.length} fields conflicted`
+					: ''}
+				open
+			>
+				<svelte:fragment slot="header-right">
+					<Label variant={entityVariant(group.entity)} size="sm" rounded="md">
+						{entityLabel(group.entity)}
+					</Label>
+				</svelte:fragment>
+				<div class="divide-y divide-neutral-200 dark:divide-neutral-800">
+					{#each group.conflicts as row (row.opId)}
+						<div
+							class="flex flex-col gap-4 px-4 py-4 md:flex-row md:items-start md:justify-between"
+						>
+							<div class="flex-1 space-y-3">
+								<div class="flex flex-wrap items-center gap-2 text-xs">
+									<span class="font-mono text-neutral-500 dark:text-neutral-400">#{row.opId}</span>
+									<Label variant={reasonVariant(row.conflictReason)} size="sm" rounded="md">
+										{reasonLabel(row.conflictReason)}
+									</Label>
+								</div>
+								{#if row.complex}
+									<p class="text-xs text-neutral-500 dark:text-neutral-400">
+										Complex change &middot; {row.summary ?? row.title}
+									</p>
+								{:else if row.fields.length === 0}
+									<p class="text-xs text-neutral-500 dark:text-neutral-400">
+										{row.summary ?? row.title}
+									</p>
+								{:else}
+									<div class="space-y-4">
+										{#each row.fields as field (field.field)}
+											<ConflictField
+												field={field.field}
+												was={field.was}
+												you={field.you}
+												upstreamNow={field.upstreamNow}
+											/>
+										{/each}
+									</div>
+								{/if}
+							</div>
+							<div class="flex shrink-0 items-center gap-2">
+								<form
+									method="POST"
+									action="?/align"
+									use:enhance={handleConflictAction('Conflict aligned', 'Align conflict failed')}
+								>
+									<input type="hidden" name="opId" value={row.opId} />
+									<Button
+										icon={HeartHandshake}
+										text="Align"
+										variant="secondary"
+										iconColor="text-emerald-600 dark:text-emerald-400"
+										size="sm"
+										type="submit"
+									/>
+								</form>
+								<form
+									method="POST"
+									action="?/override"
+									use:enhance={handleConflictAction(
+										'Conflict override queued',
+										'Override conflict failed'
+									)}
+								>
+									<input type="hidden" name="opId" value={row.opId} />
+									<Button
+										icon={HandMetal}
+										text="Override"
+										variant="secondary"
+										iconColor="text-accent-600 dark:text-accent-400"
+										size="sm"
+										type="submit"
+									/>
+								</form>
+							</div>
+						</div>
+					{/each}
+				</div>
+			</ExpandableCard>
+		{/each}
+	{/if}
 </div>

--- a/src/routes/databases/[id]/conflicts/ConflictField.svelte
+++ b/src/routes/databases/[id]/conflicts/ConflictField.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+	export let field: string;
+	export let was: unknown;
+	export let you: unknown;
+	export let upstreamNow: unknown;
+
+	function titleCase(value: string): string {
+		return value
+			.split(/[\s_]+/)
+			.filter(Boolean)
+			.map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+			.join(' ');
+	}
+
+	function formatValue(value: unknown): string {
+		if (value === null || value === undefined) return '—';
+		if (typeof value === 'boolean') return value ? 'Yes' : 'No';
+		if (typeof value === 'string') {
+			if (value === '') return '(empty)';
+			return value;
+		}
+		if (typeof value === 'number') return String(value);
+		try {
+			return JSON.stringify(value);
+		} catch {
+			return String(value);
+		}
+	}
+</script>
+
+<div class="space-y-1.5">
+	<h4 class="text-sm font-semibold text-neutral-900 dark:text-neutral-100">
+		{titleCase(field)}
+	</h4>
+	<dl class="flex flex-wrap items-baseline gap-x-6 gap-y-1 text-xs">
+		<div class="flex items-baseline gap-1.5">
+			<dt class="text-neutral-500 dark:text-neutral-400">Original:</dt>
+			<dd class="font-mono text-neutral-900 dark:text-neutral-100">{formatValue(was)}</dd>
+		</div>
+		<div class="flex items-baseline gap-1.5">
+			<dt class="text-neutral-500 dark:text-neutral-400">You Set:</dt>
+			<dd class="font-mono text-neutral-900 dark:text-neutral-100">{formatValue(you)}</dd>
+		</div>
+		<div class="flex items-baseline gap-1.5">
+			<dt class="text-neutral-500 dark:text-neutral-400">Upstream Set:</dt>
+			<dd class="font-mono text-neutral-900 dark:text-neutral-100">{formatValue(upstreamNow)}</dd>
+		</div>
+	</dl>
+</div>


### PR DESCRIPTION
## Summary

- Conflict rows now show per-field detail (Original / You Set / Upstream Set) for simple update ops, with values pulled live from the cache via the AUTO_ALIGN_ENTITIES registry.
- Conflicts are grouped by `group_id` into ExpandableCard sections so siblings from one save render together with the save title and field count.
- New route-local `ConflictField.svelte` component handles the per-field stack (title-cased field name, mono values, `—` for null, `(empty)` for empty strings).
- Entity and reason badges use `Label` (deprecated `Badge` styling replaced) with `rounded="md"`.
- Complex desired-state shapes (CF conditions, QP qualities/scoring, quality definitions, creates, deletes) keep the existing "Complex change · {summary}" placeholder; richer renderers for those shapes are out of scope here.