### PR TITLE
fix: converge delay profile delete to name-only guards

### DIFF
--- a/docs/backend/pcd-entities.md
+++ b/docs/backend/pcd-entities.md
@@ -246,10 +246,11 @@ The schema enforces protocol constraints via CHECK clauses:
 - `only_usenet` -- `torrent_delay` must be NULL
 - bypass disabled -- `minimum_custom_format_score` must be NULL
 
-Create and delete use single atomic ops. Update splits into per-field ops
-with value guards on each changed field. Pure rename writes one `name` op
-with `previousName`; if the same submit changes other fields, all emitted
-ops share a `groupId`.
+Create and delete use single atomic ops. Delete is name-only guarded
+(matches every other entity's delete contract). Update splits into per-field
+ops with value guards on each changed field. Pure rename writes one `name`
+op with `previousName`; if the same submit changes other fields, all
+emitted ops share a `groupId`.
 
 Some field pairs stay atomic to satisfy schema constraints:
 

--- a/docs/backend/pcd.md
+++ b/docs/backend/pcd.md
@@ -450,11 +450,3 @@ Run via `deno task generate:pcd-types` (default version) or
 - [**#422**](https://github.com/Dictionarry-Hub/profilarr/issues/422):
   The PCD conflict test suite (86 Playwright specs) needs to migrate to
   integration tests for speed and CI reliability.
-
-- **Override-delete re-deletion**: Only `delay_profile` regenerates a
-  fresh delete when overriding a conflicted delete whose target row still
-  exists upstream. For other entities (CF, QP, regex, naming, media
-  settings), override-delete logs a warning and falls back to dropping
-  the user op without re-deleting the upstream row. Each remaining entity
-  needs its own `overrideDelete` handler before it can match delay
-  profile behavior.

--- a/src/lib/server/pcd/conflicts/override.ts
+++ b/src/lib/server/pcd/conflicts/override.ts
@@ -1,9 +1,8 @@
 import { databaseInstancesQueries } from '$db/queries/databaseInstances.ts';
 import { pcdOpsQueries } from '$db/queries/pcdOps.ts';
-import { compile, getCache } from '$pcd/index.ts';
+import { compile } from '$pcd/index.ts';
 import type { WriteResult } from '$pcd/index.ts';
 import { logger } from '$logger/logger.ts';
-import { AUTO_ALIGN_ENTITIES } from '$pcd/entities/registry.ts';
 import {
 	dropOp,
 	parseJson,
@@ -26,7 +25,6 @@ import {
 } from '$pcd/entities/regularExpressions/override.ts';
 import {
 	overrideCreate as dpOverrideCreate,
-	overrideDelete as dpOverrideDelete,
 	overrideUpdate as dpOverrideUpdate
 } from '$pcd/entities/delayProfiles/override.ts';
 import {
@@ -69,9 +67,9 @@ async function overrideEntity(
 				? reOverrideCreate(databaseId, metadata, desiredState)
 				: reOverrideUpdate(databaseId, metadata, desiredState);
 		case 'delay_profile':
-			if (operation === 'create') return dpOverrideCreate(databaseId, metadata, desiredState);
-			if (operation === 'delete') return dpOverrideDelete(databaseId, metadata, desiredState);
-			return dpOverrideUpdate(databaseId, metadata, desiredState);
+			return operation === 'create'
+				? dpOverrideCreate(databaseId, metadata, desiredState)
+				: dpOverrideUpdate(databaseId, metadata, desiredState);
 		case 'radarr_naming':
 		case 'sonarr_naming':
 			return operation === 'create'
@@ -93,39 +91,6 @@ async function overrideEntity(
 				error: `Override not yet implemented for entity: ${entity}`
 			};
 	}
-}
-
-function canOverrideDelete(entity?: string): boolean {
-	return entity === 'delay_profile';
-}
-
-function deleteTargetExists(databaseId: number, metadata: StoredOpMetadata | null): boolean | null {
-	const entityName = metadata?.entity;
-	if (!entityName) return null;
-
-	const entity = AUTO_ALIGN_ENTITIES.get(entityName);
-	if (!entity) return null;
-
-	const cache = getCache(databaseId);
-	if (!cache) return null;
-
-	const typedMetadata = metadata as StoredOpMetadata & { stableKey?: { value?: string } };
-	const candidates = [
-		metadata.stable_key?.value,
-		typedMetadata.stableKey?.value,
-		metadata.name
-	].filter((value): value is string => typeof value === 'string' && value.length > 0);
-
-	for (const candidate of candidates) {
-		// nosemgrep: profilarr.sql.template-literal-interpolation - table/column from hardcoded registry
-		const row = cache.queryOne<{ found: number }>(
-			`SELECT 1 AS found FROM ${entity.table} WHERE ${entity.keyColumn} = ? LIMIT 1`,
-			candidate
-		);
-		if (row) return true;
-	}
-
-	return false;
 }
 
 export async function overrideConflict(input: {
@@ -153,9 +118,6 @@ export async function overrideConflict(input: {
 	const instance = databaseInstancesQueries.getById(databaseId);
 
 	if (operation === 'delete') {
-		const targetExists = deleteTargetExists(databaseId, metadata);
-		const canRegenerate = targetExists === true && canOverrideDelete(metadata?.entity);
-
 		const dropped = await dropOp(databaseId, opId);
 		if (!dropped) {
 			return {
@@ -165,40 +127,6 @@ export async function overrideConflict(input: {
 		}
 		if (instance?.enabled) {
 			await compile(instance.local_path, databaseId);
-		}
-
-		if (canRegenerate) {
-			const result: WriteResult = await overrideEntity(
-				databaseId,
-				metadata,
-				desiredState,
-				operation
-			);
-			if (!result.success) {
-				return {
-					success: false,
-					error: result.error || 'Failed to override conflict'
-				};
-			}
-
-			const newOpId = parseOpIdFromFilepath(result.filepath ?? null);
-			if (newOpId) {
-				await supersedeOp(databaseId, opId, newOpId);
-			}
-
-			await logger.info('Overrode conflict', {
-				source: 'PCDConflicts',
-				meta: { databaseId, opId, newOpId }
-			});
-
-			return { success: true };
-		}
-
-		if (targetExists === true) {
-			await logger.warn('Override delete fell back to drop; re-deletion not implemented', {
-				source: 'PCDConflicts',
-				meta: { databaseId, opId, entity: metadata?.entity }
-			});
 		}
 
 		await logger.info('Overrode conflict', {

--- a/src/lib/server/pcd/database/cache.ts
+++ b/src/lib/server/pcd/database/cache.ts
@@ -25,7 +25,6 @@ import {
 	parseOpMetadata
 } from '$pcd/conflicts/autoAlign/index.ts';
 import { checkFullListConflict } from '$pcd/conflicts/fullListCheck.ts';
-import { AUTO_ALIGN_ENTITIES } from '$pcd/entities/registry.ts';
 
 /**
  * PCDCache - Manages an in-memory compiled database for a single PCD
@@ -161,7 +160,7 @@ export class PCDCache {
 
 								if (status !== 'dropped') {
 									status = conflictStrategy === 'ask' ? 'conflicted_pending' : 'conflicted';
-									conflictReason = getConflictReason(this.db!, metadata);
+									conflictReason = getConflictReason(metadata);
 									const priorReason = priorConflicts.get(opId);
 									if (priorReason !== conflictReason) {
 										await logger.info('Recorded op conflict', {
@@ -551,48 +550,18 @@ function parseOpId(filepath: string): number | null {
 	return Number.isFinite(opId) ? opId : null;
 }
 
-function getConflictReason(db: Database, metadata: ReturnType<typeof parseOpMetadata>): string {
+function getConflictReason(metadata: ReturnType<typeof parseOpMetadata>): string {
 	switch (metadata?.operation) {
 		case 'create':
 			return 'duplicate_key';
 		case 'delete':
-			return deleteTargetExists(db, metadata) ? 'guard_mismatch' : 'missing_target';
+			// All entities use name-only delete guards. A delete that affects 0
+			// rows means the row is gone (renamed or deleted upstream).
+			return 'missing_target';
 		case 'update':
 		default:
 			return 'guard_mismatch';
 	}
-}
-
-function deleteTargetExists(db: Database, metadata: ReturnType<typeof parseOpMetadata>): boolean {
-	const entityName = metadata?.entity;
-	if (!entityName) return false;
-
-	const entity = AUTO_ALIGN_ENTITIES.get(entityName);
-	if (!entity) return false;
-
-	const typedMetadata = metadata as {
-		stable_key?: { value?: string };
-		stableKey?: { value?: string };
-	} | null;
-	const candidates = [
-		typedMetadata?.stable_key?.value,
-		typedMetadata?.stableKey?.value,
-		metadata?.name
-	].filter((value): value is string => typeof value === 'string' && value.length > 0);
-
-	for (const candidate of candidates) {
-		try {
-			// nosemgrep: profilarr.sql.template-literal-interpolation - table/column from hardcoded registry
-			const row = db
-				.prepare(`SELECT 1 FROM ${entity.table} WHERE ${entity.keyColumn} = ? LIMIT 1`)
-				.get(candidate);
-			if (row) return true;
-		} catch {
-			return false;
-		}
-	}
-
-	return false;
 }
 
 function isUniqueConstraintError(errorStr: string): boolean {

--- a/src/lib/server/pcd/entities/delayProfiles/delete.ts
+++ b/src/lib/server/pcd/entities/delayProfiles/delete.ts
@@ -16,46 +16,19 @@ interface DeleteDelayProfileOptions {
 
 /**
  * Delete a delay profile by writing an operation to the specified layer
- * Uses value guards to detect conflicts with upstream changes
+ *
+ * Value guard by name only. Once the user has decided to delete, the other
+ * field values don't matter — they're about to be gone. Matches the delete
+ * contract used by every other entity.
  */
 export async function remove(options: DeleteDelayProfileOptions) {
 	const { databaseId, cache, layer, current } = options;
 	const db = cache.kb;
 
-	// Delete the delay profile with value guards
-	let deleteProfile = db
+	const deleteProfileQuery = db
 		.deleteFrom('delay_profiles')
-		// Value guard - ensure this is the profile we expect
 		.where('name', '=', current.name)
-		.where('preferred_protocol', '=', current.preferred_protocol)
-		.where('bypass_if_highest_quality', '=', current.bypass_if_highest_quality ? 1 : 0)
-		.where(
-			'bypass_if_above_custom_format_score',
-			'=',
-			current.bypass_if_above_custom_format_score ? 1 : 0
-		);
-
-	if (current.usenet_delay === null) {
-		deleteProfile = deleteProfile.where('usenet_delay', 'is', null);
-	} else {
-		deleteProfile = deleteProfile.where('usenet_delay', '=', current.usenet_delay);
-	}
-	if (current.torrent_delay === null) {
-		deleteProfile = deleteProfile.where('torrent_delay', 'is', null);
-	} else {
-		deleteProfile = deleteProfile.where('torrent_delay', '=', current.torrent_delay);
-	}
-	if (current.minimum_custom_format_score === null) {
-		deleteProfile = deleteProfile.where('minimum_custom_format_score', 'is', null);
-	} else {
-		deleteProfile = deleteProfile.where(
-			'minimum_custom_format_score',
-			'=',
-			current.minimum_custom_format_score
-		);
-	}
-
-	const deleteProfileQuery = deleteProfile.compile();
+		.compile();
 
 	const result = await writeOperation({
 		databaseId,

--- a/src/lib/server/pcd/entities/delayProfiles/override.ts
+++ b/src/lib/server/pcd/entities/delayProfiles/override.ts
@@ -3,7 +3,6 @@ import type { PCDCache, WriteResult } from '$pcd/index.ts';
 import type { PreferredProtocol } from '$shared/pcd/display.ts';
 import { get as getDelayProfile } from './read.ts';
 import { update } from './update.ts';
-import { remove } from './delete.ts';
 import type { StoredOpMetadata, StoredDesiredState } from '$pcd/conflicts/overrideUtils.ts';
 import { getDesiredTo, followRenameChain, valuesEqual } from '$pcd/conflicts/overrideUtils.ts';
 
@@ -158,41 +157,4 @@ async function overrideDelay(
 	});
 }
 
-async function overrideDelete(
-	databaseId: number,
-	metadata: StoredOpMetadata | null,
-	desiredState: StoredDesiredState | null
-): Promise<WriteResult> {
-	const cache = getCache(databaseId);
-	if (!cache) {
-		return { success: false, error: 'Cache not available' };
-	}
-
-	const profileName = await resolveProfileName(cache, databaseId, metadata, desiredState);
-	if (!profileName) {
-		return { success: true };
-	}
-
-	const profileRow = await cache.kb
-		.selectFrom('delay_profiles')
-		.select('id')
-		.where('name', '=', profileName)
-		.executeTakeFirst();
-	if (!profileRow) {
-		return { success: true };
-	}
-
-	const current = await getDelayProfile(cache, profileRow.id);
-	if (!current) {
-		return { success: true };
-	}
-
-	return remove({
-		databaseId,
-		cache,
-		layer: 'user',
-		current
-	});
-}
-
-export { overrideDelay as overrideCreate, overrideDelay as overrideUpdate, overrideDelete };
+export { overrideDelay as overrideCreate, overrideDelay as overrideUpdate };

--- a/tests/integration/pcd/conflicts/delay-profiles.test.ts
+++ b/tests/integration/pcd/conflicts/delay-profiles.test.ts
@@ -331,15 +331,15 @@ test('create duplicate conflict resolves by strategy', async () => {
  *   Published base op changes:
  *     usenetDelay 10 -> 20
  *
- * Expect
- *   - ask: delete op is conflicted_pending, reason='guard_mismatch'
- *   - align: delete op is dropped/aligned
- *   - override: delete op is superseded by a replacement delete op
- *   - final row is absent only for override, otherwise upstream row remains
+ * Expect (verifies the name-only delete guard)
+ *   - user delete op stays state='published' and history.status='applied' for
+ *     every strategy. The delete only guards by name, which still matches
+ *     after upstream changed an unrelated field.
+ *   - final row is absent.
  */
-test('delete guard conflict resolves by strategy', async () => {
+test('delete applies cleanly after upstream non-name field change', async () => {
 	for (const strategy of STRATEGIES) {
-		const ctx = await seededScenario(strategy, 'delete-guard', [
+		const ctx = await seededScenario(strategy, 'delete-after-field-change', [
 			base.delayProfile({ name: 'Delete Conflict', usenetDelay: 10 })
 		]);
 		const checkpoint = opCheckpoint(ctx);
@@ -350,14 +350,9 @@ test('delete guard conflict resolves by strategy', async () => {
 		await compilePcd(ctx);
 
 		const op = firstOpForOperation(opsSince(ctx, checkpoint), 'delete');
-		assertStrategyOutcome(ctx, op, strategy, 'guard_mismatch');
-
-		if (strategy === 'override') {
-			assertNoDelayProfile(ctx, 'Delete Conflict');
-		} else {
-			const row = assertDelayProfile(ctx, 'Delete Conflict');
-			assertEquals(row.usenet_delay, 20);
-		}
+		assertEquals(op.state, 'published');
+		assertLatestHistory(ctx, op, 'applied');
+		assertNoDelayProfile(ctx, 'Delete Conflict');
 	}
 });
 


### PR DESCRIPTION
## Summary

- Delay profile delete now guards by name only, matching every other entity.
- Removes the bespoke `overrideDelete` handler, the `canOverrideDelete` gate, the `deleteTargetExists` cache lookup, and the soft-fallback warn path. All unreachable now.
- Updates the existing delay profile conflict test; previous "delete guard conflict" scenario applies cleanly after the change.
- Net 31 insertions / 211 deletions.