### PR TITLE
feat: enable editing for media settings on linked databases

### DIFF
--- a/docs/backend/pcd-entities.md
+++ b/docs/backend/pcd-entities.md
@@ -264,8 +264,9 @@ Some field pairs stay atomic to satisfy schema constraints:
 **Source:** `entities/mediaManagement/`
 
 Media management covers three sub-entity types, each with Radarr and Sonarr
-variants. All use single atomic ops (no per-field splitting) and
-base-origin locking is planned
+variants. Media settings are editable on linked databases through user-layer
+ops. Naming and quality definitions still use atomic writes and base-origin
+locking while their conflict strategy is pending
 ([#421](https://github.com/Dictionarry-Hub/profilarr/issues/421)).
 
 ### Naming
@@ -283,7 +284,13 @@ settings.
 **Tables:** radarr_media_settings, sonarr_media_settings
 
 Global settings for propers/repacks handling and media info. Both variants
-have the same fields. Updates guard on all changed fields.
+have the same fields: name, propers_repacks, and enable_media_info.
+
+Create uses one insert op. Delete is name-only guarded, so upstream changes
+to propers_repacks or enable_media_info do not block a delete. Update splits
+into per-field ops with value guards on each changed field. Pure rename writes
+one `name` op with `previousName`; if the same submit changes scalar fields,
+all emitted ops share a `groupId`.
 
 ### Quality Definitions
 
@@ -296,10 +303,12 @@ consistency.
 
 ## Summary
 
-| Entity             | Op splitting                 | Cascading on rename     | Cascading on delete              |
-| ------------------ | ---------------------------- | ----------------------- | -------------------------------- |
-| Custom format      | per-field, per-condition     | QP scoring refs         | explicit QP score removal + FK   |
-| Quality profile    | per-field, per-score         | --                      | explicit sub-entity removal + FK |
-| Regular expression | main + dependents            | condition_patterns refs | dependent conditions + FK        |
-| Delay profile      | per-field, constrained pairs | --                      | FK cascade                       |
-| Media management   | none (atomic)                | --                      | FK cascade                       |
+| Entity              | Op splitting                 | Cascading on rename     | Cascading on delete              |
+| ------------------- | ---------------------------- | ----------------------- | -------------------------------- |
+| Custom format       | per-field, per-condition     | QP scoring refs         | explicit QP score removal + FK   |
+| Quality profile     | per-field, per-score         | --                      | explicit sub-entity removal + FK |
+| Regular expression  | main + dependents            | condition_patterns refs | dependent conditions + FK        |
+| Delay profile       | per-field, constrained pairs | --                      | FK cascade                       |
+| Media naming        | none (atomic)                | --                      | --                               |
+| Media settings      | per-field                    | --                      | --                               |
+| Quality definitions | full-list replace            | --                      | --                               |

--- a/docs/backend/pcd.md
+++ b/docs/backend/pcd.md
@@ -276,15 +276,15 @@ independent ops. If upstream changes the description but not the tags, only
 the description op conflicts -- the tag op still applies cleanly.
 
 Op splitting is implemented for custom format general/conditions, quality
-profile general/qualities/scoring, regular expressions, and delay profile
-updates. Delay profiles keep schema-constrained field pairs in one op when
-needed: protocol changes with delay NULLing, and bypass-score changes with
-minimum custom format score NULLing.
+profile general/qualities/scoring, regular expressions, delay profile
+updates, and media settings updates. Delay profiles keep schema-constrained
+field pairs in one op when needed: protocol changes with delay NULLing, and
+bypass-score changes with minimum custom format score NULLing.
 
-Media management still uses base-origin locking instead (entities from base
-are not editable at the user layer). See
-[#421](https://github.com/Dictionarry-Hub/profilarr/issues/421) for
-remaining work.
+Media settings split `name`, `propers_repacks`, and `enable_media_info`
+changes into independent ops. A rename plus scalar changes share a `groupId`
+so the conflict UI can present them as one user action while still resolving
+each field independently.
 
 ## Conflicts
 
@@ -436,17 +436,6 @@ Run via `deno task generate:pcd-types` (default version) or
 ## Open Work
 
 - [**#421**](https://github.com/Dictionarry-Hub/profilarr/issues/421):
-  Op splitting is done for CF, QP, regular expression, and delay profile
-  updates. Media management still needs its write enablement and conflict
-  strategy decided.
-
-- [**#367**](https://github.com/Dictionarry-Hub/profilarr/issues/367):
-  Stable entity IDs. Currently, entities are identified by name, and
-  renames cascade across all foreign key references. This makes revert
-  fragile. The plan is to assign stable, immutable IDs at op creation
-  time and switch cross-table references from name-based to ID-based FKs.
-  This unblocks user op history and safe revert.
-
-- [**#422**](https://github.com/Dictionarry-Hub/profilarr/issues/422):
-  The PCD conflict test suite (86 Playwright specs) needs to migrate to
-  integration tests for speed and CI reliability.
+  Op splitting is done for CF, QP, regular expression, delay profile, and
+  media settings updates. Media management naming and quality definitions
+  still need their write enablement and conflict strategy decided.

--- a/src/lib/server/pcd/entities/mediaManagement/media-settings/delete.ts
+++ b/src/lib/server/pcd/entities/mediaManagement/media-settings/delete.ts
@@ -20,8 +20,6 @@ export async function removeRadarrMediaSettings(options: RemoveMediaSettingsOpti
 	const deleteQuery = db
 		.deleteFrom('radarr_media_settings')
 		.where('name', '=', current.name)
-		.where('propers_repacks', '=', current.propers_repacks)
-		.where('enable_media_info', '=', current.enable_media_info ? 1 : 0)
 		.compile();
 
 	return writeOperation({
@@ -61,8 +59,6 @@ export async function removeSonarrMediaSettings(options: RemoveSonarrMediaSettin
 	const deleteQuery = db
 		.deleteFrom('sonarr_media_settings')
 		.where('name', '=', current.name)
-		.where('propers_repacks', '=', current.propers_repacks)
-		.where('enable_media_info', '=', current.enable_media_info ? 1 : 0)
 		.compile();
 
 	return writeOperation({

--- a/src/lib/server/pcd/entities/mediaManagement/media-settings/update.ts
+++ b/src/lib/server/pcd/entities/mediaManagement/media-settings/update.ts
@@ -2,15 +2,56 @@
  * Update media settings config operations
  */
 
-import type { PCDCache } from '$pcd/index.ts';
+import type { PCDCache, WriteResult } from '$pcd/index.ts';
 import { writeOperation, type OperationLayer } from '$pcd/index.ts';
 import type { RadarrMediaSettingsRow, SonarrMediaSettingsRow } from '$shared/pcd/display.ts';
+import { uuid } from '$shared/utils/uuid.ts';
+import type { CompiledQuery } from 'kysely';
 
 export interface UpdateMediaSettingsInput {
 	name: string;
 	propersRepacks: RadarrMediaSettingsRow['propers_repacks'];
 	enableMediaInfo: boolean;
 }
+
+type MediaSettingsTable = 'radarr_media_settings' | 'sonarr_media_settings';
+type MediaSettingsField = 'name' | 'propers_repacks' | 'enable_media_info';
+type MediaSettingsRow = Pick<
+	RadarrMediaSettingsRow,
+	'name' | 'propers_repacks' | 'enable_media_info'
+>;
+
+interface MediaSettingsConfig {
+	table: MediaSettingsTable;
+	entity: MediaSettingsTable;
+	stableKey: string;
+	arrType: 'radarr' | 'sonarr';
+	label: 'Radarr' | 'Sonarr';
+}
+
+interface FieldChange {
+	field: MediaSettingsField;
+	from: unknown;
+	to: unknown;
+	setValue: unknown;
+	guardValue: unknown;
+}
+
+const RADARR_CONFIG: MediaSettingsConfig = {
+	table: 'radarr_media_settings',
+	entity: 'radarr_media_settings',
+	stableKey: 'radarr_media_settings_name',
+	arrType: 'radarr',
+	label: 'Radarr'
+};
+
+const SONARR_CONFIG: MediaSettingsConfig = {
+	table: 'sonarr_media_settings',
+	entity: 'sonarr_media_settings',
+	stableKey: 'sonarr_media_settings_name',
+	arrType: 'sonarr',
+	label: 'Sonarr'
+};
 
 export interface UpdateMediaSettingsOptions {
 	databaseId: number;
@@ -21,91 +62,7 @@ export interface UpdateMediaSettingsOptions {
 }
 
 export async function updateRadarrMediaSettings(options: UpdateMediaSettingsOptions) {
-	const { databaseId, cache, layer, current, input } = options;
-	const db = cache.kb;
-
-	// If renaming, check if new name already exists
-	if (input.name !== current.name) {
-		const existing = await db
-			.selectFrom('radarr_media_settings')
-			.where((eb) => eb(eb.fn('lower', [eb.ref('name')]), '=', input.name.toLowerCase()))
-			.select('name')
-			.executeTakeFirst();
-
-		if (existing) {
-			throw new Error(`A radarr media settings config with name "${input.name}" already exists`);
-		}
-	}
-
-	const setValues: Record<string, unknown> = {};
-	if (current.name !== input.name) setValues.name = input.name;
-	if (current.propers_repacks !== input.propersRepacks) {
-		setValues.propers_repacks = input.propersRepacks;
-	}
-	if (current.enable_media_info !== input.enableMediaInfo) {
-		setValues.enable_media_info = input.enableMediaInfo ? 1 : 0;
-	}
-
-	let updateQuery = db
-		.updateTable('radarr_media_settings')
-		.set(setValues)
-		.where('name', '=', current.name);
-
-	if (current.propers_repacks !== input.propersRepacks) {
-		updateQuery = updateQuery.where('propers_repacks', '=', current.propers_repacks);
-	}
-	if (current.enable_media_info !== input.enableMediaInfo) {
-		updateQuery = updateQuery.where('enable_media_info', '=', current.enable_media_info ? 1 : 0);
-	}
-
-	if (Object.keys(setValues).length === 0) {
-		return { success: true };
-	}
-
-	const updateQueryCompiled = updateQuery.compile();
-
-	const changes: Record<string, { from: unknown; to: unknown }> = {};
-	if (current.name !== input.name) changes.name = { from: current.name, to: input.name };
-	if (current.propers_repacks !== input.propersRepacks) {
-		changes.propersRepacks = { from: current.propers_repacks, to: input.propersRepacks };
-	}
-	if (current.enable_media_info !== input.enableMediaInfo) {
-		changes.enableMediaInfo = { from: current.enable_media_info, to: input.enableMediaInfo };
-	}
-
-	const changedFields = Object.keys(changes);
-	const desiredState: Record<string, unknown> = {};
-	if (changes.name) desiredState.name = { from: current.name, to: input.name };
-	if (changes.propersRepacks) {
-		desiredState.propers_repacks = {
-			from: current.propers_repacks,
-			to: input.propersRepacks
-		};
-	}
-	if (changes.enableMediaInfo) {
-		desiredState.enable_media_info = {
-			from: current.enable_media_info,
-			to: input.enableMediaInfo
-		};
-	}
-
-	return writeOperation({
-		databaseId,
-		layer,
-		description: `update-radarr-media-settings-${input.name}`,
-		queries: [updateQueryCompiled],
-		desiredState,
-		metadata: {
-			operation: 'update',
-			entity: 'radarr_media_settings',
-			name: input.name,
-			...(current.name !== input.name && { previousName: current.name }),
-			stableKey: { key: 'radarr_media_settings_name', value: current.name },
-			changedFields,
-			summary: 'Update Radarr media settings',
-			title: `Update Radarr media settings "${input.name}"`
-		}
-	});
+	return updateMediaSettings({ ...options, config: RADARR_CONFIG });
 }
 
 export interface UpdateSonarrMediaSettingsOptions {
@@ -117,89 +74,136 @@ export interface UpdateSonarrMediaSettingsOptions {
 }
 
 export async function updateSonarrMediaSettings(options: UpdateSonarrMediaSettingsOptions) {
-	const { databaseId, cache, layer, current, input } = options;
+	return updateMediaSettings({ ...options, config: SONARR_CONFIG });
+}
+
+async function updateMediaSettings(options: {
+	databaseId: number;
+	cache: PCDCache;
+	layer: OperationLayer;
+	current: MediaSettingsRow;
+	input: UpdateMediaSettingsInput;
+	config: MediaSettingsConfig;
+}): Promise<WriteResult> {
+	const { databaseId, cache, layer, current, input, config } = options;
 	const db = cache.kb;
 
-	// If renaming, check if new name already exists
 	if (input.name !== current.name) {
 		const existing = await db
-			.selectFrom('sonarr_media_settings')
+			.selectFrom(config.table)
 			.where((eb) => eb(eb.fn('lower', [eb.ref('name')]), '=', input.name.toLowerCase()))
 			.select('name')
 			.executeTakeFirst();
 
 		if (existing) {
-			throw new Error(`A sonarr media settings config with name "${input.name}" already exists`);
+			throw new Error(`A ${config.arrType} media settings config with name "${input.name}" already exists`);
 		}
 	}
 
-	const setValues: Record<string, unknown> = {};
-	if (current.name !== input.name) setValues.name = input.name;
+	const changes: FieldChange[] = [];
+
 	if (current.propers_repacks !== input.propersRepacks) {
-		setValues.propers_repacks = input.propersRepacks;
+		changes.push({
+			field: 'propers_repacks',
+			from: current.propers_repacks,
+			to: input.propersRepacks,
+			setValue: input.propersRepacks,
+			guardValue: current.propers_repacks
+		});
 	}
 	if (current.enable_media_info !== input.enableMediaInfo) {
-		setValues.enable_media_info = input.enableMediaInfo ? 1 : 0;
+		changes.push({
+			field: 'enable_media_info',
+			from: current.enable_media_info,
+			to: input.enableMediaInfo,
+			setValue: input.enableMediaInfo ? 1 : 0,
+			guardValue: current.enable_media_info ? 1 : 0
+		});
+	}
+	if (current.name !== input.name) {
+		changes.push({
+			field: 'name',
+			from: current.name,
+			to: input.name,
+			setValue: input.name,
+			guardValue: current.name
+		});
 	}
 
-	let updateQuery = db
+	if (changes.length === 0) {
+		return { success: true };
+	}
+
+	const groupId = changes.length > 1 ? uuid() : undefined;
+	let lastResult: WriteResult | null = null;
+
+	for (let index = 0; index < changes.length; index++) {
+		const change = changes[index];
+		const isRename = change.field === 'name';
+		const result = await writeOperation({
+			databaseId,
+			layer,
+			description: `update-${config.arrType}-media-settings-${change.field}-${input.name}`,
+			queries: [buildUpdateQuery(cache, config.table, current, change)],
+			desiredState: {
+				[change.field]: { from: change.from, to: change.to }
+			},
+			metadata: {
+				operation: 'update',
+				entity: config.entity,
+				name: input.name,
+				...(isRename && { previousName: current.name }),
+				stableKey: { key: config.stableKey, value: current.name },
+				...(groupId && { groupId }),
+				changedFields: [change.field],
+				summary: isRename
+					? `Rename ${config.label} media settings`
+					: `Update ${config.label} media settings`,
+				title: isRename
+					? `Rename ${config.label} media settings "${current.name}"`
+					: `Update ${config.label} media settings "${input.name}"`
+			},
+			skipRecompile: index < changes.length - 1
+		});
+
+		if (!result.success) {
+			return result;
+		}
+		lastResult = result;
+	}
+
+	return lastResult ?? { success: true };
+}
+
+function buildUpdateQuery(
+	cache: PCDCache,
+	table: MediaSettingsTable,
+	current: MediaSettingsRow,
+	change: FieldChange
+): CompiledQuery {
+	if (table === 'radarr_media_settings') {
+		const setValues: Record<string, unknown> = { [change.field]: change.setValue };
+		let query = cache.kb
+			.updateTable('radarr_media_settings')
+			.set(setValues)
+			.where('name', '=', current.name);
+
+		if (change.field !== 'name') {
+			query = query.where(change.field, '=', change.guardValue as never);
+		}
+
+		return query.compile();
+	}
+
+	const setValues: Record<string, unknown> = { [change.field]: change.setValue };
+	let query = cache.kb
 		.updateTable('sonarr_media_settings')
 		.set(setValues)
 		.where('name', '=', current.name);
 
-	if (current.propers_repacks !== input.propersRepacks) {
-		updateQuery = updateQuery.where('propers_repacks', '=', current.propers_repacks);
-	}
-	if (current.enable_media_info !== input.enableMediaInfo) {
-		updateQuery = updateQuery.where('enable_media_info', '=', current.enable_media_info ? 1 : 0);
+	if (change.field !== 'name') {
+		query = query.where(change.field, '=', change.guardValue as never);
 	}
 
-	if (Object.keys(setValues).length === 0) {
-		return { success: true };
-	}
-
-	const updateQueryCompiled = updateQuery.compile();
-
-	const changes: Record<string, { from: unknown; to: unknown }> = {};
-	if (current.name !== input.name) changes.name = { from: current.name, to: input.name };
-	if (current.propers_repacks !== input.propersRepacks) {
-		changes.propersRepacks = { from: current.propers_repacks, to: input.propersRepacks };
-	}
-	if (current.enable_media_info !== input.enableMediaInfo) {
-		changes.enableMediaInfo = { from: current.enable_media_info, to: input.enableMediaInfo };
-	}
-
-	const changedFields = Object.keys(changes);
-	const desiredState: Record<string, unknown> = {};
-	if (changes.name) desiredState.name = { from: current.name, to: input.name };
-	if (changes.propersRepacks) {
-		desiredState.propers_repacks = {
-			from: current.propers_repacks,
-			to: input.propersRepacks
-		};
-	}
-	if (changes.enableMediaInfo) {
-		desiredState.enable_media_info = {
-			from: current.enable_media_info,
-			to: input.enableMediaInfo
-		};
-	}
-
-	return writeOperation({
-		databaseId,
-		layer,
-		description: `update-sonarr-media-settings-${input.name}`,
-		queries: [updateQueryCompiled],
-		desiredState,
-		metadata: {
-			operation: 'update',
-			entity: 'sonarr_media_settings',
-			name: input.name,
-			...(current.name !== input.name && { previousName: current.name }),
-			stableKey: { key: 'sonarr_media_settings_name', value: current.name },
-			changedFields,
-			summary: 'Update Sonarr media settings',
-			title: `Update Sonarr media settings "${input.name}"`
-		}
-	});
+	return query.compile();
 }

--- a/src/lib/server/pcd/entities/mediaManagement/media-settings/update.ts
+++ b/src/lib/server/pcd/entities/mediaManagement/media-settings/update.ts
@@ -96,7 +96,9 @@ async function updateMediaSettings(options: {
 			.executeTakeFirst();
 
 		if (existing) {
-			throw new Error(`A ${config.arrType} media settings config with name "${input.name}" already exists`);
+			throw new Error(
+				`A ${config.arrType} media settings config with name "${input.name}" already exists`
+			);
 		}
 	}
 

--- a/src/routes/media-management/[databaseId]/media-settings/+page.svelte
+++ b/src/routes/media-management/[databaseId]/media-settings/+page.svelte
@@ -24,13 +24,9 @@
 	let cloneSourceName = '';
 	let cloneEntityType: EntityType = 'radarr_media_settings';
 
-	function notifyLocked() {
-		alertStore.add('info', mediaManagementLockedMessage);
-	}
-
 	function handleClone(event: CustomEvent<{ name: string; arr_type: string }>) {
 		if (!data.canWriteToBase) {
-			notifyLocked();
+			alertStore.add('info', mediaManagementLockedMessage);
 			return;
 		}
 		cloneSourceName = event.detail.name;
@@ -76,31 +72,23 @@
 <!-- Actions Bar -->
 <ActionsBar>
 	<SearchAction searchStore={search} placeholder="Search media settings..." responsive />
-	{#if data.canWriteToBase}
-		<ActionButton icon={Plus} hasDropdown={true} dropdownPosition="right">
-			<svelte:fragment slot="dropdown" let:dropdownPosition>
-				<Dropdown position={dropdownPosition} minWidth="10rem">
-					<DropdownHeader label="New config" />
-					<DropdownItem
-						label="Radarr"
-						on:click={() =>
-							goto(
-								`/media-management/${data.currentDatabase.id}/media-settings/new?arrType=radarr`
-							)}
-					/>
-					<DropdownItem
-						label="Sonarr"
-						on:click={() =>
-							goto(
-								`/media-management/${data.currentDatabase.id}/media-settings/new?arrType=sonarr`
-							)}
-					/>
-				</Dropdown>
-			</svelte:fragment>
-		</ActionButton>
-	{:else}
-		<ActionButton icon={Plus} on:click={notifyLocked} />
-	{/if}
+	<ActionButton icon={Plus} hasDropdown={true} dropdownPosition="right">
+		<svelte:fragment slot="dropdown" let:dropdownPosition>
+			<Dropdown position={dropdownPosition} minWidth="10rem">
+				<DropdownHeader label="New config" />
+				<DropdownItem
+					label="Radarr"
+					on:click={() =>
+						goto(`/media-management/${data.currentDatabase.id}/media-settings/new?arrType=radarr`)}
+				/>
+				<DropdownItem
+					label="Sonarr"
+					on:click={() =>
+						goto(`/media-management/${data.currentDatabase.id}/media-settings/new?arrType=sonarr`)}
+				/>
+			</Dropdown>
+		</svelte:fragment>
+	</ActionButton>
 	<ViewToggle bind:value={$view} />
 </ActionsBar>
 
@@ -126,7 +114,6 @@
 		<TableView
 			configs={$filtered}
 			databaseId={data.currentDatabase.id}
-			canWriteToBase={data.canWriteToBase}
 			on:clone={handleClone}
 			on:export={handleExport}
 		/>
@@ -134,7 +121,6 @@
 		<CardView
 			configs={$filtered}
 			databaseId={data.currentDatabase.id}
-			canWriteToBase={data.canWriteToBase}
 			on:clone={handleClone}
 			on:export={handleExport}
 		/>

--- a/src/routes/media-management/[databaseId]/media-settings/components/MediaSettingsForm.svelte
+++ b/src/routes/media-management/[databaseId]/media-settings/components/MediaSettingsForm.svelte
@@ -17,7 +17,6 @@
 	import type { ArrType } from '$shared/pcd/types.ts';
 	import { PROPERS_REPACKS_OPTIONS, type PropersRepacks } from '$shared/pcd/mediaManagement.ts';
 	import type { AffectedArr } from '$shared/sync/types.ts';
-	import { mediaManagementLockedMessage } from '../../lock';
 
 	interface RadarrMediaSettingsRowFormData {
 		name: string;
@@ -67,39 +66,28 @@
 	let selectedLayer: 'user' | 'base' = canWriteToBase ? 'base' : 'user';
 	let mainFormElement: HTMLFormElement;
 	let deleteFormElement: HTMLFormElement;
-	$: readOnly = !canWriteToBase;
 
 	$: databaseId = parseInt($page.params.databaseId ?? '0', 10);
 
 	$: arrLabel = arrType === 'radarr' ? 'Radarr' : 'Sonarr';
 	$: title =
 		mode === 'create' ? `New ${arrLabel} Media Settings` : `Edit ${arrLabel} Media Settings`;
-	$: description = readOnly
-		? 'Media management configs from linked databases cannot be edited directly'
-		: mode === 'create'
+	$: description =
+		mode === 'create'
 			? `Create a new ${arrLabel} media settings configuration for ${databaseName}`
 			: `Update ${arrLabel} media settings configuration`;
 	$: isValid = formData.name.trim() !== '';
 	$: propersRepacksDescription =
 		PROPERS_REPACKS_OPTIONS.find((o) => o.value === formData.propersRepacks)?.description ?? '';
 
-	function notifyLocked() {
-		alertStore.add('info', mediaManagementLockedMessage);
-	}
-
 	function updateField<K extends keyof RadarrMediaSettingsRowFormData>(
 		field: K,
 		value: RadarrMediaSettingsRowFormData[K]
 	) {
-		if (readOnly) return;
 		update<RadarrMediaSettingsRowFormData, K>(field, value);
 	}
 
 	async function handleSaveClick() {
-		if (readOnly) {
-			notifyLocked();
-			return;
-		}
 		if (saving) return;
 		saving = true;
 		selectedLayer = canWriteToBase ? 'base' : 'user';
@@ -108,18 +96,10 @@
 	}
 
 	async function handleDeleteClick() {
-		if (readOnly) {
-			notifyLocked();
-			return;
-		}
 		showDeleteModal = true;
 	}
 
 	async function handleDeleteConfirm() {
-		if (readOnly) {
-			notifyLocked();
-			return;
-		}
 		selectedLayer = canWriteToBase ? 'base' : 'user';
 		showDeleteModal = false;
 		await tick();
@@ -137,7 +117,7 @@
 		<p class="text-sm text-neutral-500 dark:text-neutral-400">{description}</p>
 	</div>
 	<div slot="right" class="flex items-center gap-2">
-		{#if mode === 'edit' && !readOnly}
+		{#if mode === 'edit'}
 			<Button
 				text={deleting ? 'Deleting...' : 'Delete'}
 				icon={Trash2}
@@ -150,8 +130,7 @@
 			text={saving ? 'Saving...' : mode === 'create' ? 'Create' : 'Save'}
 			icon={Save}
 			iconColor="text-blue-600 dark:text-blue-400"
-			disabled={!readOnly && (saving || !isValid || !$isDirty)}
-			softDisabled={readOnly}
+			disabled={saving || !isValid || !$isDirty}
 			on:click={handleSaveClick}
 		/>
 	</div>
@@ -170,7 +149,6 @@
 				placeholder="e.g., default"
 				required
 				value={formData.name}
-				disabled={readOnly}
 				on:input={(e) => updateField('name', e.detail)}
 			/>
 		</div>
@@ -186,7 +164,6 @@
 				value={formData.propersRepacks}
 				options={PROPERS_REPACKS_OPTIONS}
 				fullWidth
-				disabled={readOnly}
 				on:change={(e) => updateField('propersRepacks', e.detail as PropersRepacks)}
 			/>
 			{#if propersRepacksDescription}
@@ -205,7 +182,6 @@
 				<Toggle
 					label="Enable Media Info"
 					checked={formData.enableMediaInfo}
-					disabled={readOnly}
 					on:change={() => updateField('enableMediaInfo', !formData.enableMediaInfo)}
 				/>
 				<p class="mt-1 px-3 text-xs text-neutral-500 dark:text-neutral-400">
@@ -269,7 +245,7 @@
 </form>
 
 <!-- Hidden delete form -->
-{#if mode === 'edit' && !readOnly}
+{#if mode === 'edit'}
 	<form
 		bind:this={deleteFormElement}
 		method="POST"

--- a/src/routes/media-management/[databaseId]/media-settings/views/CardView.svelte
+++ b/src/routes/media-management/[databaseId]/media-settings/views/CardView.svelte
@@ -9,13 +9,9 @@
 	import radarrLogo from '$lib/client/assets/Radarr.svg';
 	import sonarrLogo from '$lib/client/assets/Sonarr.svg';
 	import { FEATURES } from '$shared/features.ts';
-	import { goto } from '$app/navigation';
-	import { alertStore } from '$alerts/store';
-	import { mediaManagementLockedMessage } from '../../lock';
 
 	export let configs: MediaSettingsListItem[];
 	export let databaseId: number;
-	export let canWriteToBase: boolean = false;
 
 	const dispatch = createEventDispatcher<{
 		clone: { name: string; arr_type: string };
@@ -48,11 +44,6 @@
 			config.name
 		)}`;
 	}
-
-	function handleLockedOpen(config: MediaSettingsListItem) {
-		alertStore.add('info', mediaManagementLockedMessage);
-		goto(getConfigHref(config));
-	}
 </script>
 
 <CardGrid columns={1} flush>
@@ -61,11 +52,7 @@
 			variant: 'secondary',
 			label: config.propers_repacks
 		}}
-		<Card
-			href={canWriteToBase ? getConfigHref(config) : undefined}
-			onclick={canWriteToBase ? undefined : () => handleLockedOpen(config)}
-			hoverable
-		>
+		<Card href={getConfigHref(config)} hoverable>
 			<div class="flex items-center gap-4">
 				<!-- Logo + Name -->
 				<div class="flex min-w-0 flex-1 items-center gap-3">

--- a/src/routes/media-management/[databaseId]/media-settings/views/TableView.svelte
+++ b/src/routes/media-management/[databaseId]/media-settings/views/TableView.svelte
@@ -9,13 +9,9 @@
 	import radarrLogo from '$lib/client/assets/Radarr.svg';
 	import sonarrLogo from '$lib/client/assets/Sonarr.svg';
 	import { FEATURES } from '$shared/features.ts';
-	import { goto } from '$app/navigation';
-	import { alertStore } from '$alerts/store';
-	import { mediaManagementLockedMessage } from '../../lock';
 
 	export let configs: MediaSettingsListItem[];
 	export let databaseId: number;
-	export let canWriteToBase: boolean = false;
 
 	const dispatch = createEventDispatcher<{
 		clone: { name: string; arr_type: string };
@@ -39,11 +35,6 @@
 
 	function getRowHref(config: MediaSettingsListItem): string {
 		return `/media-management/${databaseId}/media-settings/${config.arr_type}/${encodeURIComponent(config.name)}`;
-	}
-
-	function handleLockedRowClick(config: MediaSettingsListItem) {
-		alertStore.add('info', mediaManagementLockedMessage);
-		goto(getRowHref(config));
 	}
 
 	const columns: Column<MediaSettingsListItem>[] = [
@@ -75,8 +66,7 @@
 <Table
 	{columns}
 	data={configs}
-	rowHref={canWriteToBase ? getRowHref : undefined}
-	onRowClick={canWriteToBase ? undefined : handleLockedRowClick}
+	rowHref={getRowHref}
 	hoverable={true}
 >
 	<svelte:fragment slot="cell" let:row let:column>

--- a/src/routes/media-management/[databaseId]/media-settings/views/TableView.svelte
+++ b/src/routes/media-management/[databaseId]/media-settings/views/TableView.svelte
@@ -63,12 +63,7 @@
 	];
 </script>
 
-<Table
-	{columns}
-	data={configs}
-	rowHref={getRowHref}
-	hoverable={true}
->
+<Table {columns} data={configs} rowHref={getRowHref} hoverable={true}>
 	<svelte:fragment slot="cell" let:row let:column>
 		{#if column.key === 'name'}
 			<span class="font-medium">{row.name}</span>

--- a/tests/integration/harness/ports.ts
+++ b/tests/integration/harness/ports.ts
@@ -96,7 +96,8 @@ export const PORTS = {
 		writeMediaSettingsDelete: 7614,
 		writeMediaSettingsUpdate: 7615,
 		conflictsDelayProfiles: 7700,
-		conflictsRegex: 7701
+		conflictsRegex: 7701,
+		conflictsMediaSettings: 7702
 	}
 } as const;
 

--- a/tests/integration/harness/ports.ts
+++ b/tests/integration/harness/ports.ts
@@ -92,6 +92,9 @@ export const PORTS = {
 		writeDelayProfilesCreate: 7610,
 		writeDelayProfilesDelete: 7611,
 		writeDelayProfilesUpdate: 7612,
+		writeMediaSettingsCreate: 7613,
+		writeMediaSettingsDelete: 7614,
+		writeMediaSettingsUpdate: 7615,
 		conflictsDelayProfiles: 7700,
 		conflictsRegex: 7701
 	}

--- a/tests/integration/pcd/conflicts/media-settings.test.ts
+++ b/tests/integration/pcd/conflicts/media-settings.test.ts
@@ -541,11 +541,7 @@ function upstreamUpdate(
 	};
 }
 
-function upstreamRename(
-	arrType: MediaSettingsArrType,
-	from: string,
-	to: string
-): SeedOperation {
+function upstreamRename(arrType: MediaSettingsArrType, from: string, to: string): SeedOperation {
 	return {
 		sql: `UPDATE ${tableForArrType(arrType)} SET name = ${sqlValue(to)} WHERE name = ${sqlValue(from)};`,
 		metadata: JSON.stringify({

--- a/tests/integration/pcd/conflicts/media-settings.test.ts
+++ b/tests/integration/pcd/conflicts/media-settings.test.ts
@@ -1,0 +1,596 @@
+/**
+ * PCD conflict tests: media settings.
+ */
+
+import { assert, assertEquals, assertExists } from '@std/assert';
+import { startServer, stopServer } from '$test-harness/server.ts';
+import { openDb } from '$test-harness/db.ts';
+import { run, setup, teardown, test } from '$test-harness/runner.ts';
+import { PORTS } from '$test-harness/ports.ts';
+import { base } from '../harness/fixtures.ts';
+import {
+	compilePcd,
+	insertOp,
+	opCheckpoint,
+	parseMetadata,
+	queryOpsSince,
+	seedBase,
+	setupPcd,
+	type ConflictStrategy,
+	type OpRow,
+	type PcdTestContext,
+	type SeedOperation
+} from '../harness/pcd.ts';
+import { write } from '../harness/write.ts';
+
+const PORT = PORTS.pcd.conflictsMediaSettings;
+const ORIGIN = `http://localhost:${PORT}`;
+const STRATEGIES: ConflictStrategy[] = ['ask', 'align', 'override'];
+const ARR_TYPES = ['radarr', 'sonarr'] as const;
+
+type MediaSettingsArrType = (typeof ARR_TYPES)[number];
+
+type LatestHistory = {
+	status: string;
+	conflict_reason: string | null;
+};
+
+type MediaSettingsRow = {
+	name: string;
+	propers_repacks: string;
+	enable_media_info: number;
+};
+
+let counter = 0;
+
+setup(async () => {
+	await startServer(PORT, { AUTH: 'off', ORIGIN }, 'preview');
+});
+
+teardown(async () => {
+	await stopServer(PORT);
+});
+
+/**
+ * Base
+ *   Media settings:
+ *     name='Split Conflict', propersRepacks='doNotPrefer',
+ *     enableMediaInfo=false
+ *
+ * User
+ *   POST update changes:
+ *     propersRepacks  = 'preferAndUpgrade'
+ *     enableMediaInfo = true
+ *
+ * Upstream
+ *   Published base op changes:
+ *     propers_repacks 'doNotPrefer' -> 'doNotUpgradeAutomatically'
+ *
+ * Expect
+ *   - propers_repacks conflicts by strategy
+ *   - enable_media_info applies cleanly for every strategy
+ *   - final enable_media_info is true for every strategy
+ *   - final propers_repacks is user value only for override
+ */
+test('split scalar conflicts resolve per field by strategy', async () => {
+	for (const arrType of ARR_TYPES) {
+		for (const strategy of STRATEGIES) {
+			const ctx = await seededScenario(strategy, arrType, 'split-scalar', [
+				seedFor(arrType, {
+					name: 'Split Conflict',
+					propersRepacks: 'doNotPrefer',
+					enableMediaInfo: false
+				})
+			]);
+			const checkpoint = opCheckpoint(ctx);
+
+			await write.mediaSettings.update(ctx, arrType, 'Split Conflict', {
+				name: 'Split Conflict',
+				propersRepacks: 'preferAndUpgrade',
+				enableMediaInfo: true
+			});
+
+			seedUpstream(
+				ctx,
+				upstreamUpdate(arrType, 'Split Conflict', {
+					propers_repacks: {
+						from: 'doNotPrefer',
+						to: 'doNotUpgradeAutomatically'
+					}
+				})
+			);
+			await compilePcd(ctx);
+
+			const ops = opsSince(ctx, checkpoint);
+			const propersOp = firstOpForChangedFields(ops, ['propers_repacks']);
+			const mediaInfoOp = firstOpForChangedFields(ops, ['enable_media_info']);
+
+			assertStrategyOutcome(ctx, propersOp, strategy, 'guard_mismatch');
+			assertLatestHistory(ctx, mediaInfoOp, 'applied');
+
+			const row = assertMediaSettings(ctx, arrType, 'Split Conflict');
+			assertEquals(row.enable_media_info, 1);
+			assertEquals(
+				row.propers_repacks,
+				strategy === 'override' ? 'preferAndUpgrade' : 'doNotUpgradeAutomatically'
+			);
+		}
+	}
+});
+
+/**
+ * Base
+ *   Media settings:
+ *     name='Old Media'
+ *
+ * User
+ *   POST update changes:
+ *     name = 'User Media'
+ *
+ * Upstream
+ *   Published base rename changes:
+ *     name 'Old Media' -> 'Upstream Media'
+ *
+ * Expect
+ *   - rename op conflicts by strategy
+ *   - override final row is named 'User Media'
+ *   - otherwise final row is named 'Upstream Media'
+ */
+test('rename conflict follows upstream rename by strategy', async () => {
+	for (const arrType of ARR_TYPES) {
+		for (const strategy of STRATEGIES) {
+			const ctx = await seededScenario(strategy, arrType, 'rename', [
+				seedFor(arrType, { name: 'Old Media' })
+			]);
+			const checkpoint = opCheckpoint(ctx);
+
+			await write.mediaSettings.update(ctx, arrType, 'Old Media', {
+				name: 'User Media',
+				propersRepacks: 'doNotPrefer',
+				enableMediaInfo: false
+			});
+
+			seedUpstream(ctx, upstreamRename(arrType, 'Old Media', 'Upstream Media'));
+			await compilePcd(ctx);
+
+			const op = firstOpForChangedFields(opsSince(ctx, checkpoint), ['name']);
+			assertStrategyOutcome(ctx, op, strategy, 'guard_mismatch');
+
+			if (strategy === 'override') {
+				assertMediaSettings(ctx, arrType, 'User Media');
+				assertNoMediaSettings(ctx, arrType, 'Upstream Media');
+			} else {
+				assertMediaSettings(ctx, arrType, 'Upstream Media');
+				assertNoMediaSettings(ctx, arrType, 'User Media');
+			}
+		}
+	}
+});
+
+/**
+ * Base
+ *   Empty PCD.
+ *
+ * User
+ *   POST create media settings:
+ *     name='Create Conflict', propersRepacks='preferAndUpgrade',
+ *     enableMediaInfo=true
+ *
+ * Upstream
+ *   Published base create:
+ *     name='Create Conflict', propersRepacks='doNotPrefer',
+ *     enableMediaInfo=false
+ *
+ * Expect
+ *   - create op conflicts by strategy
+ *   - final fields are user values only for override
+ */
+test('create duplicate conflict resolves by strategy', async () => {
+	for (const arrType of ARR_TYPES) {
+		for (const strategy of STRATEGIES) {
+			const ctx = await newScenario(strategy, arrType, 'create-duplicate');
+			await compilePcd(ctx);
+			const checkpoint = opCheckpoint(ctx);
+
+			await write.mediaSettings.create(ctx, arrType, {
+				name: 'Create Conflict',
+				propersRepacks: 'preferAndUpgrade',
+				enableMediaInfo: true
+			});
+
+			seedUpstream(
+				ctx,
+				seedFor(arrType, {
+					name: 'Create Conflict',
+					propersRepacks: 'doNotPrefer',
+					enableMediaInfo: false
+				})
+			);
+			await compilePcd(ctx);
+
+			const op = firstOpForOperation(opsSince(ctx, checkpoint), 'create');
+			assertStrategyOutcome(ctx, op, strategy, 'duplicate_key');
+
+			const row = assertMediaSettings(ctx, arrType, 'Create Conflict');
+			assertEquals(
+				row.propers_repacks,
+				strategy === 'override' ? 'preferAndUpgrade' : 'doNotPrefer'
+			);
+			assertEquals(row.enable_media_info, strategy === 'override' ? 1 : 0);
+		}
+	}
+});
+
+/**
+ * Base
+ *   Media settings:
+ *     name='Delete Conflict', propersRepacks='doNotPrefer'
+ *
+ * User
+ *   POST delete media settings.
+ *
+ * Upstream
+ *   Published base op changes:
+ *     propers_repacks 'doNotPrefer' -> 'preferAndUpgrade'
+ *
+ * Expect
+ *   - delete applies cleanly for every strategy
+ *   - final row is absent
+ */
+test('delete applies cleanly after upstream non-name field change', async () => {
+	for (const arrType of ARR_TYPES) {
+		for (const strategy of STRATEGIES) {
+			const ctx = await seededScenario(strategy, arrType, 'delete-after-field-change', [
+				seedFor(arrType, {
+					name: 'Delete Conflict',
+					propersRepacks: 'doNotPrefer',
+					enableMediaInfo: false
+				})
+			]);
+			const checkpoint = opCheckpoint(ctx);
+
+			await write.mediaSettings.remove(ctx, arrType, 'Delete Conflict');
+
+			seedUpstream(
+				ctx,
+				upstreamUpdate(arrType, 'Delete Conflict', {
+					propers_repacks: { from: 'doNotPrefer', to: 'preferAndUpgrade' }
+				})
+			);
+			await compilePcd(ctx);
+
+			const op = firstOpForOperation(opsSince(ctx, checkpoint), 'delete');
+			assertEquals(op.state, 'published');
+			assertLatestHistory(ctx, op, 'applied');
+			assertNoMediaSettings(ctx, arrType, 'Delete Conflict');
+		}
+	}
+});
+
+/**
+ * Base
+ *   Media settings:
+ *     name='Already Deleted'
+ *
+ * User
+ *   POST delete media settings.
+ *
+ * Upstream
+ *   Published base delete removes the same row.
+ *
+ * Expect
+ *   - all strategies auto-align/drop the user delete
+ *   - final row is absent
+ */
+test('delete missing target auto-aligns', async () => {
+	for (const arrType of ARR_TYPES) {
+		for (const strategy of STRATEGIES) {
+			const ctx = await seededScenario(strategy, arrType, 'delete-missing-target', [
+				seedFor(arrType, { name: 'Already Deleted' })
+			]);
+			const checkpoint = opCheckpoint(ctx);
+
+			await write.mediaSettings.remove(ctx, arrType, 'Already Deleted');
+
+			seedUpstream(ctx, upstreamDelete(arrType, 'Already Deleted'));
+			await compilePcd(ctx);
+
+			const op = firstOpForOperation(opsSince(ctx, checkpoint), 'delete');
+			assertEquals(op.state, 'dropped');
+			assertLatestHistory(ctx, op, 'dropped', 'aligned');
+			assertNoMediaSettings(ctx, arrType, 'Already Deleted');
+		}
+	}
+});
+
+async function newScenario(
+	strategy: ConflictStrategy,
+	arrType: MediaSettingsArrType,
+	name: string
+): Promise<PcdTestContext> {
+	counter++;
+	return setupPcd({
+		port: PORT,
+		name: `pcd-conflict-media-settings-${counter}-${arrType}-${strategy}-${name}`,
+		conflictStrategy: strategy
+	});
+}
+
+async function seededScenario(
+	strategy: ConflictStrategy,
+	arrType: MediaSettingsArrType,
+	name: string,
+	operations: Array<string | SeedOperation>
+): Promise<PcdTestContext> {
+	const ctx = await newScenario(strategy, arrType, name);
+	seedBase(ctx, operations);
+	await compilePcd(ctx);
+	return ctx;
+}
+
+function seedFor(
+	arrType: MediaSettingsArrType,
+	input: Parameters<typeof base.radarrMediaSettings>[0]
+): SeedOperation {
+	return arrType === 'radarr' ? base.radarrMediaSettings(input) : base.sonarrMediaSettings(input);
+}
+
+function seedUpstream(ctx: PcdTestContext, operation: SeedOperation): number {
+	return insertOp(ctx, {
+		...operation,
+		origin: 'base',
+		state: 'published',
+		source: 'repo'
+	});
+}
+
+function opsSince(ctx: PcdTestContext, checkpoint: number): OpRow[] {
+	return queryOpsSince(ctx, checkpoint, { origin: 'user' });
+}
+
+function firstOpForOperation(ops: OpRow[], operation: string): OpRow {
+	const op = ops.find((candidate) => parseMetadata(candidate).operation === operation);
+	assertExists(op, `Expected a user ${operation} op`);
+	return op;
+}
+
+function firstOpForChangedFields(ops: OpRow[], fields: string[]): OpRow {
+	const expected = [...fields].sort();
+	const op = ops.find((candidate) => {
+		const actual = changedFields(candidate).sort();
+		return (
+			actual.length === expected.length && actual.every((field, index) => field === expected[index])
+		);
+	});
+	assertExists(op, `Expected a user op for ${fields.join(', ')}`);
+	return op;
+}
+
+function changedFields(op: OpRow): string[] {
+	const fields = parseMetadata(op).changed_fields;
+	if (!Array.isArray(fields)) return [];
+	return fields.filter((field): field is string => typeof field === 'string');
+}
+
+function assertStrategyOutcome(
+	ctx: PcdTestContext,
+	op: OpRow,
+	strategy: ConflictStrategy,
+	reason: string
+): void {
+	if (strategy === 'ask') {
+		assertEquals(op.state, 'published');
+		assertLatestHistory(ctx, op, 'conflicted_pending', reason);
+		return;
+	}
+
+	if (strategy === 'align') {
+		assertEquals(op.state, 'dropped');
+		assertLatestHistory(ctx, op, 'dropped', 'aligned');
+		return;
+	}
+
+	assertEquals(op.state, 'superseded');
+	assert(op.superseded_by_op_id !== null, 'Expected override to link a replacement op');
+	assertLatestHistory(ctx, op, 'superseded');
+}
+
+function assertLatestHistory(
+	ctx: PcdTestContext,
+	op: OpRow,
+	status: string,
+	reason?: string
+): void {
+	const history = latestHistory(ctx, op.id);
+	assertEquals(history.status, status);
+	if (reason !== undefined) {
+		assertEquals(history.conflict_reason, reason);
+	}
+}
+
+function latestHistory(ctx: PcdTestContext, opId: number): LatestHistory {
+	const db = openDb(ctx.dbPath);
+	try {
+		const row = db
+			.prepare(
+				`SELECT status, conflict_reason
+				 FROM pcd_op_history
+				 WHERE database_id = ?
+				   AND op_id = ?
+				 ORDER BY applied_at DESC, id DESC
+				 LIMIT 1`
+			)
+			.get(ctx.dbId, opId) as LatestHistory | undefined;
+		assertExists(row, `Expected latest history for op ${opId}`);
+		return row;
+	} finally {
+		db.close();
+	}
+}
+
+function assertMediaSettings(
+	ctx: PcdTestContext,
+	arrType: MediaSettingsArrType,
+	name: string
+): MediaSettingsRow {
+	const row = compiledMediaSettings(ctx, arrType).find((settings) => settings.name === name);
+	assertExists(row, `Expected ${arrType} media settings ${name}`);
+	return row;
+}
+
+function assertNoMediaSettings(
+	ctx: PcdTestContext,
+	arrType: MediaSettingsArrType,
+	name: string
+): void {
+	const row = compiledMediaSettings(ctx, arrType).find((settings) => settings.name === name);
+	assertEquals(row, undefined);
+}
+
+function compiledMediaSettings(
+	ctx: PcdTestContext,
+	arrType: MediaSettingsArrType
+): MediaSettingsRow[] {
+	const source = openDb(ctx.dbPath);
+	const replay = openDb(':memory:');
+
+	try {
+		replay.exec('PRAGMA foreign_keys = ON');
+		replay.exec(Deno.readTextFileSync('docs/backend/0.schema.sql'));
+
+		const baseOps = source
+			.prepare(
+				`SELECT *
+				 FROM pcd_ops
+				 WHERE database_id = ?
+				   AND origin = 'base'
+				   AND state = 'published'
+				 ORDER BY COALESCE(sequence, id), id`
+			)
+			.all(ctx.dbId) as OpRow[];
+
+		const userOps = source
+			.prepare(
+				`SELECT *
+				 FROM pcd_ops
+				 WHERE database_id = ?
+				   AND origin = 'user'
+				   AND state = 'published'
+				 ORDER BY COALESCE(sequence, id), id`
+			)
+			.all(ctx.dbId) as OpRow[];
+		const histories = latestHistories(source, ctx.dbId);
+
+		for (const op of baseOps) {
+			replay.exec(op.sql);
+		}
+		for (const op of userOps) {
+			if (histories.get(op.id)?.status !== 'applied') continue;
+			replay.exec(op.sql);
+		}
+
+		return replay
+			.prepare(
+				`SELECT name, propers_repacks, enable_media_info
+				 FROM ${tableForArrType(arrType)}
+				 ORDER BY name`
+			)
+			.all() as MediaSettingsRow[];
+	} finally {
+		replay.close();
+		source.close();
+	}
+}
+
+function latestHistories(
+	db: ReturnType<typeof openDb>,
+	databaseId: number
+): Map<number, LatestHistory> {
+	const rows = db
+		.prepare(
+			`SELECT op_id, status, conflict_reason
+			 FROM pcd_op_history
+			 WHERE database_id = ?
+			 ORDER BY applied_at ASC, id ASC`
+		)
+		.all(databaseId) as Array<LatestHistory & { op_id: number }>;
+	const latest = new Map<number, LatestHistory>();
+	for (const row of rows) {
+		latest.set(row.op_id, row);
+	}
+	return latest;
+}
+
+function upstreamUpdate(
+	arrType: MediaSettingsArrType,
+	name: string,
+	changes: Record<string, { from: unknown; to: unknown }>
+): SeedOperation {
+	const fields = Object.keys(changes);
+	const setSql = fields.map((field) => `${field} = ${sqlValue(changes[field].to)}`).join(', ');
+	return {
+		sql: `UPDATE ${tableForArrType(arrType)} SET ${setSql} WHERE name = ${sqlValue(name)};`,
+		metadata: JSON.stringify({
+			operation: 'update',
+			entity: entityForArrType(arrType),
+			name,
+			stable_key: { key: stableKeyForArrType(arrType), value: name },
+			changed_fields: fields
+		}),
+		desiredState: JSON.stringify(changes)
+	};
+}
+
+function upstreamRename(
+	arrType: MediaSettingsArrType,
+	from: string,
+	to: string
+): SeedOperation {
+	return {
+		sql: `UPDATE ${tableForArrType(arrType)} SET name = ${sqlValue(to)} WHERE name = ${sqlValue(from)};`,
+		metadata: JSON.stringify({
+			operation: 'update',
+			entity: entityForArrType(arrType),
+			name: to,
+			previousName: from,
+			stable_key: { key: stableKeyForArrType(arrType), value: from },
+			changed_fields: ['name']
+		}),
+		desiredState: JSON.stringify({ name: { from, to } })
+	};
+}
+
+function upstreamDelete(arrType: MediaSettingsArrType, name: string): SeedOperation {
+	return {
+		sql: `DELETE FROM ${tableForArrType(arrType)} WHERE name = ${sqlValue(name)};`,
+		metadata: JSON.stringify({
+			operation: 'delete',
+			entity: entityForArrType(arrType),
+			name,
+			stable_key: { key: stableKeyForArrType(arrType), value: name },
+			changed_fields: ['deleted']
+		}),
+		desiredState: JSON.stringify({ deleted: true, name })
+	};
+}
+
+function tableForArrType(arrType: MediaSettingsArrType): string {
+	return arrType === 'radarr' ? 'radarr_media_settings' : 'sonarr_media_settings';
+}
+
+function entityForArrType(arrType: MediaSettingsArrType): string {
+	return tableForArrType(arrType);
+}
+
+function stableKeyForArrType(arrType: MediaSettingsArrType): string {
+	return `${tableForArrType(arrType)}_name`;
+}
+
+function sqlValue(value: unknown): string {
+	if (value === null || value === undefined) return 'NULL';
+	if (typeof value === 'number') return String(value);
+	if (typeof value === 'boolean') return value ? '1' : '0';
+	return `'${String(value).replace(/'/g, "''")}'`;
+}
+
+await run();

--- a/tests/integration/pcd/harness/fixtures.ts
+++ b/tests/integration/pcd/harness/fixtures.ts
@@ -68,6 +68,22 @@ export const base = {
 		};
 	},
 
+	radarrMediaSettings(input: {
+		name: string;
+		propersRepacks?: 'doNotPrefer' | 'doNotUpgradeAutomatically' | 'preferAndUpgrade';
+		enableMediaInfo?: boolean;
+	}): SeedOperation {
+		return mediaSettingsSeed('radarr_media_settings', input);
+	},
+
+	sonarrMediaSettings(input: {
+		name: string;
+		propersRepacks?: 'doNotPrefer' | 'doNotUpgradeAutomatically' | 'preferAndUpgrade';
+		enableMediaInfo?: boolean;
+	}): SeedOperation {
+		return mediaSettingsSeed('sonarr_media_settings', input);
+	},
+
 	customFormatRegexCondition(input: {
 		formatName: string;
 		conditionName: string;
@@ -101,4 +117,20 @@ function sqlValue(value: string | null): string {
 
 function sqlNumber(value: number | null): string {
 	return value === null ? 'NULL' : String(value);
+}
+
+function mediaSettingsSeed(
+	table: 'radarr_media_settings' | 'sonarr_media_settings',
+	input: {
+		name: string;
+		propersRepacks?: 'doNotPrefer' | 'doNotUpgradeAutomatically' | 'preferAndUpgrade';
+		enableMediaInfo?: boolean;
+	}
+): SeedOperation {
+	const propersRepacks = input.propersRepacks ?? 'doNotPrefer';
+	const enableMediaInfo = input.enableMediaInfo ?? false;
+	return {
+		sql: `INSERT INTO ${table} (name, propers_repacks, enable_media_info)
+			  VALUES (${sqlValue(input.name)}, ${sqlValue(propersRepacks)}, ${enableMediaInfo ? 1 : 0});`
+	};
 }

--- a/tests/integration/pcd/harness/write.ts
+++ b/tests/integration/pcd/harness/write.ts
@@ -21,6 +21,15 @@ export interface DelayProfileFormInput {
 	layer?: OpOrigin;
 }
 
+export type MediaSettingsArrType = 'radarr' | 'sonarr';
+
+export interface MediaSettingsFormInput {
+	name: string;
+	propersRepacks?: 'doNotPrefer' | 'doNotUpgradeAutomatically' | 'preferAndUpgrade';
+	enableMediaInfo?: boolean;
+	layer?: OpOrigin;
+}
+
 export const write = {
 	delayProfile: {
 		create: createDelayProfile,
@@ -37,6 +46,14 @@ export const write = {
 		submitCreate: submitCreateRegex,
 		submitUpdate: submitUpdateRegex,
 		submitRemove: submitRemoveRegex
+	},
+	mediaSettings: {
+		create: createMediaSettings,
+		update: updateMediaSettings,
+		remove: removeMediaSettings,
+		submitCreate: submitCreateMediaSettings,
+		submitUpdate: submitUpdateMediaSettings,
+		submitRemove: submitRemoveMediaSettings
 	}
 };
 
@@ -173,6 +190,92 @@ function delayProfileFields(input: DelayProfileFormInput): Record<string, string
 		bypassIfHighestQuality: String(input.bypassIfHighestQuality ?? false),
 		bypassIfAboveCfScore: String(input.bypassIfAboveCfScore ?? false),
 		minimumCfScore: String(input.minimumCfScore ?? 0),
+		layer: input.layer ?? 'user'
+	};
+}
+
+export async function createMediaSettings(
+	ctx: PcdTestContext,
+	arrType: MediaSettingsArrType,
+	input: MediaSettingsFormInput
+): Promise<Response> {
+	return assertSuccessfulAction(
+		await submitCreateMediaSettings(ctx, arrType, input),
+		`create ${arrType} media settings`
+	);
+}
+
+export async function updateMediaSettings(
+	ctx: PcdTestContext,
+	arrType: MediaSettingsArrType,
+	currentName: string,
+	input: MediaSettingsFormInput
+): Promise<Response> {
+	return assertSuccessfulAction(
+		await submitUpdateMediaSettings(ctx, arrType, currentName, input),
+		`update ${arrType} media settings`
+	);
+}
+
+export async function removeMediaSettings(
+	ctx: PcdTestContext,
+	arrType: MediaSettingsArrType,
+	currentName: string,
+	layer: OpOrigin = 'user'
+): Promise<Response> {
+	return assertSuccessfulAction(
+		await submitRemoveMediaSettings(ctx, arrType, currentName, layer),
+		`delete ${arrType} media settings`
+	);
+}
+
+export async function submitCreateMediaSettings(
+	ctx: PcdTestContext,
+	arrType: MediaSettingsArrType,
+	input: MediaSettingsFormInput
+): Promise<Response> {
+	return ctx.client.postForm(
+		`/media-management/${ctx.dbId}/media-settings/new`,
+		mediaSettingsFields(input, arrType),
+		{ headers: { Origin: ctx.origin } }
+	);
+}
+
+export async function submitUpdateMediaSettings(
+	ctx: PcdTestContext,
+	arrType: MediaSettingsArrType,
+	currentName: string,
+	input: MediaSettingsFormInput
+): Promise<Response> {
+	return ctx.client.postForm(
+		`/media-management/${ctx.dbId}/media-settings/${arrType}/${encodeURIComponent(currentName)}?/update`,
+		mediaSettingsFields(input, arrType),
+		{ headers: { Origin: ctx.origin } }
+	);
+}
+
+export async function submitRemoveMediaSettings(
+	ctx: PcdTestContext,
+	arrType: MediaSettingsArrType,
+	currentName: string,
+	layer: OpOrigin = 'user'
+): Promise<Response> {
+	return ctx.client.postForm(
+		`/media-management/${ctx.dbId}/media-settings/${arrType}/${encodeURIComponent(currentName)}?/delete`,
+		{ layer },
+		{ headers: { Origin: ctx.origin } }
+	);
+}
+
+function mediaSettingsFields(
+	input: MediaSettingsFormInput,
+	arrType: MediaSettingsArrType
+): Record<string, string> {
+	return {
+		arrType,
+		name: input.name,
+		propersRepacks: input.propersRepacks ?? 'doNotPrefer',
+		enableMediaInfo: String(input.enableMediaInfo ?? false),
 		layer: input.layer ?? 'user'
 	};
 }

--- a/tests/integration/pcd/write/media-settings/create.test.ts
+++ b/tests/integration/pcd/write/media-settings/create.test.ts
@@ -1,0 +1,158 @@
+/**
+ * PCD write tests: media settings create (radarr + sonarr).
+ */
+
+import { assert, assertEquals } from '@std/assert';
+import { startServer, stopServer } from '$test-harness/server.ts';
+import { run, setup, teardown, test } from '$test-harness/runner.ts';
+import { PORTS } from '$test-harness/ports.ts';
+import { base } from '../../harness/fixtures.ts';
+import {
+	compilePcd,
+	normalizeSql,
+	opCheckpoint,
+	parseDesiredState,
+	parseMetadata
+} from '../../harness/pcd.ts';
+import { write } from '../../harness/write.ts';
+import {
+	assertActionFailed,
+	createScenarioFactory,
+	entityForArrType,
+	MEDIA_SETTINGS_ARR_TYPES,
+	tableForArrType,
+	userOpsSince
+} from './helpers.ts';
+
+const PORT = PORTS.pcd.writeMediaSettingsCreate;
+const ORIGIN = `http://localhost:${PORT}`;
+
+const { newPcd, seededPcd } = createScenarioFactory(PORT, 'pcd-write-media-settings-create');
+
+setup(async () => {
+	await startServer(PORT, { AUTH: 'off', ORIGIN }, 'preview');
+});
+
+teardown(async () => {
+	await stopServer(PORT);
+});
+
+/**
+ * Context
+ *   Empty PCD (only schema seeded), compiled once.
+ *
+ * Submit (per arr-type)
+ *   POST /media-management/{ctx.dbId}/media-settings/new with form fields:
+ *     arrType                  = 'radarr' | 'sonarr'
+ *     name                     = 'Created Media'
+ *     propersRepacks           = 'doNotPrefer'
+ *     enableMediaInfo          = 'false'
+ *     layer                    = 'user'
+ *
+ * Expect
+ *   - userOpsSince(checkpoint).length === 1
+ *   - op.metadata.operation       === 'create'
+ *   - op.metadata.entity          === '<arrType>_media_settings'
+ *   - op.metadata.name            === 'Created Media'
+ *   - op.desired_state.name       === 'Created Media'
+ *   - op.desired_state.propers_repacks === 'doNotPrefer'
+ *   - op.desired_state.enable_media_info === false
+ *   - op.sql matches /insert into "?<arrType>_media_settings"?/i
+ */
+for (const arrType of MEDIA_SETTINGS_ARR_TYPES) {
+	test(`minimal ${arrType} media settings emits one create op`, async () => {
+		const ctx = await newPcd(`minimal-${arrType}`);
+		await compilePcd(ctx);
+		const checkpoint = opCheckpoint(ctx);
+
+		await write.mediaSettings.create(ctx, arrType, { name: 'Created Media' });
+
+		const ops = userOpsSince(ctx, checkpoint);
+		assertEquals(ops.length, 1);
+		const op = ops[0];
+		const metadata = parseMetadata(op);
+		assertEquals(metadata.operation, 'create');
+		assertEquals(metadata.entity, entityForArrType(arrType));
+		assertEquals(metadata.name, 'Created Media');
+		const desired = parseDesiredState(op);
+		assertEquals(desired.name, 'Created Media');
+		assertEquals(desired.propers_repacks, 'doNotPrefer');
+		assertEquals(desired.enable_media_info, false);
+		const sql = normalizeSql(op.sql);
+		const insertPattern = new RegExp(`insert into "?${tableForArrType(arrType)}"?`, 'i');
+		assert(insertPattern.test(sql));
+	});
+}
+
+/**
+ * Context (per arr-type)
+ *   Empty PCD (only schema seeded), compiled once.
+ *
+ * Submit
+ *   POST /media-management/{ctx.dbId}/media-settings/new with form fields:
+ *     arrType                  = 'radarr' | 'sonarr'
+ *     name                     = 'Tuned Media'
+ *     propersRepacks           = 'preferAndUpgrade'
+ *     enableMediaInfo          = 'true'
+ *     layer                    = 'user'
+ *
+ * Expect
+ *   - userOpsSince(checkpoint).length === 1
+ *   - op.desired_state.propers_repacks === 'preferAndUpgrade'
+ *   - op.desired_state.enable_media_info === true
+ */
+for (const arrType of MEDIA_SETTINGS_ARR_TYPES) {
+	test(`${arrType} media settings non-default values are recorded`, async () => {
+		const ctx = await newPcd(`tuned-${arrType}`);
+		await compilePcd(ctx);
+		const checkpoint = opCheckpoint(ctx);
+
+		await write.mediaSettings.create(ctx, arrType, {
+			name: 'Tuned Media',
+			propersRepacks: 'preferAndUpgrade',
+			enableMediaInfo: true
+		});
+
+		const ops = userOpsSince(ctx, checkpoint);
+		assertEquals(ops.length, 1);
+		const desired = parseDesiredState(ops[0]);
+		assertEquals(desired.propers_repacks, 'preferAndUpgrade');
+		assertEquals(desired.enable_media_info, true);
+	});
+}
+
+/**
+ * Context (per arr-type)
+ *   Base layer seeded with a row named 'Existing Media' for the arr-type.
+ *   Compiled.
+ *
+ * Submit
+ *   POST /media-management/{ctx.dbId}/media-settings/new with form fields:
+ *     arrType  = 'radarr' | 'sonarr'
+ *     name     = 'existing media'   // lowercase duplicate
+ *     layer    = 'user'
+ *
+ * Expect
+ *   - response.status >= 400 OR body contains '"type":"failure"'
+ *   - userOpsSince(checkpoint).length === 0
+ */
+for (const arrType of MEDIA_SETTINGS_ARR_TYPES) {
+	test(`duplicate ${arrType} media settings name fails without writing ops`, async () => {
+		const seed =
+			arrType === 'radarr'
+				? base.radarrMediaSettings({ name: 'Existing Media' })
+				: base.sonarrMediaSettings({ name: 'Existing Media' });
+
+		const ctx = await seededPcd(`duplicate-${arrType}`, [seed]);
+		const checkpoint = opCheckpoint(ctx);
+
+		const response = await write.mediaSettings.submitCreate(ctx, arrType, {
+			name: 'existing media'
+		});
+
+		await assertActionFailed(response);
+		assertEquals(userOpsSince(ctx, checkpoint).length, 0);
+	});
+}
+
+await run();

--- a/tests/integration/pcd/write/media-settings/delete.test.ts
+++ b/tests/integration/pcd/write/media-settings/delete.test.ts
@@ -1,0 +1,117 @@
+/**
+ * PCD write tests: media settings delete (radarr + sonarr).
+ *
+ * The name-only-guard SQL assertion will fail until the delete writer drops
+ * its non-name guards (covered by task #5). It pins the desired contract
+ * before the implementation, mirroring the regex / delay-profile pattern.
+ */
+
+import { assert, assertEquals } from '@std/assert';
+import { startServer, stopServer } from '$test-harness/server.ts';
+import { run, setup, teardown, test } from '$test-harness/runner.ts';
+import { PORTS } from '$test-harness/ports.ts';
+import { base } from '../../harness/fixtures.ts';
+import { normalizeSql, opCheckpoint, parseDesiredState, parseMetadata } from '../../harness/pcd.ts';
+import { write } from '../../harness/write.ts';
+import {
+	createScenarioFactory,
+	entityForArrType,
+	MEDIA_SETTINGS_ARR_TYPES,
+	tableForArrType,
+	userOpsSince
+} from './helpers.ts';
+
+const PORT = PORTS.pcd.writeMediaSettingsDelete;
+const ORIGIN = `http://localhost:${PORT}`;
+
+const { seededPcd } = createScenarioFactory(PORT, 'pcd-write-media-settings-delete');
+
+setup(async () => {
+	await startServer(PORT, { AUTH: 'off', ORIGIN }, 'preview');
+});
+
+teardown(async () => {
+	await stopServer(PORT);
+});
+
+function seedFor(
+	arrType: 'radarr' | 'sonarr',
+	input: Parameters<typeof base.radarrMediaSettings>[0]
+) {
+	return arrType === 'radarr' ? base.radarrMediaSettings(input) : base.sonarrMediaSettings(input);
+}
+
+/**
+ * Context (per arr-type)
+ *   Base layer seeded with one row:
+ *     name='Delete Media', propersRepacks='preferAndUpgrade', enableMediaInfo=true
+ *   Compiled.
+ *
+ * Submit
+ *   POST /media-management/{ctx.dbId}/media-settings/{arrType}/Delete%20Media?/delete
+ *     with form fields:
+ *       layer = 'user'
+ *
+ * Expect
+ *   - userOpsSince(checkpoint).length === 1
+ *   - op.metadata.operation       === 'delete'
+ *   - op.metadata.entity          === '<arr>_media_settings'
+ *   - op.metadata.name            === 'Delete Media'
+ *   - op.metadata.changed_fields  === ['deleted']
+ *   - op.desired_state.deleted    === true
+ *   - op.desired_state.name       === 'Delete Media'
+ *   - op.desired_state.propers_repacks === 'preferAndUpgrade'
+ *   - op.desired_state.enable_media_info === true
+ *   - op.sql matches /delete from "?<arr>_media_settings"?/i
+ *   - op.sql DELETE clause guards by name only (no propers_repacks /
+ *     enable_media_info in the WHERE clause). Currently fails until the
+ *     delete writer drops its non-name guards (#5).
+ */
+for (const arrType of MEDIA_SETTINGS_ARR_TYPES) {
+	test(`${arrType} media settings delete emits one name-guarded op`, async () => {
+		const ctx = await seededPcd(`simple-${arrType}`, [
+			seedFor(arrType, {
+				name: 'Delete Media',
+				propersRepacks: 'preferAndUpgrade',
+				enableMediaInfo: true
+			})
+		]);
+		const checkpoint = opCheckpoint(ctx);
+
+		await write.mediaSettings.remove(ctx, arrType, 'Delete Media');
+
+		const ops = userOpsSince(ctx, checkpoint);
+		assertEquals(ops.length, 1);
+		const op = ops[0];
+		const metadata = parseMetadata(op);
+		assertEquals(metadata.operation, 'delete');
+		assertEquals(metadata.entity, entityForArrType(arrType));
+		assertEquals(metadata.name, 'Delete Media');
+		assertEquals(metadata.changed_fields, ['deleted']);
+		const desired = parseDesiredState(op);
+		assertEquals(desired.deleted, true);
+		assertEquals(desired.name, 'Delete Media');
+		assertEquals(desired.propers_repacks, 'preferAndUpgrade');
+		assertEquals(desired.enable_media_info, true);
+
+		const sql = normalizeSql(op.sql);
+		const lowerSql = sql.toLowerCase();
+		const deletePattern = new RegExp(`delete from "?${tableForArrType(arrType)}"?`, 'i');
+		assert(deletePattern.test(sql));
+
+		const deleteIndex = lowerSql.indexOf(`delete from "${tableForArrType(arrType)}"`);
+		assert(deleteIndex >= 0, 'expected media settings delete in SQL');
+		const deleteClause = sql.slice(deleteIndex);
+		assert(/where "?name"? = /i.test(deleteClause));
+		assert(
+			!/where[^;]*"?propers_repacks"?\s*=/i.test(deleteClause),
+			`propers_repacks should not appear in delete WHERE clause, got: ${deleteClause}`
+		);
+		assert(
+			!/where[^;]*"?enable_media_info"?\s*=/i.test(deleteClause),
+			`enable_media_info should not appear in delete WHERE clause, got: ${deleteClause}`
+		);
+	});
+}
+
+await run();

--- a/tests/integration/pcd/write/media-settings/helpers.ts
+++ b/tests/integration/pcd/write/media-settings/helpers.ts
@@ -1,0 +1,103 @@
+/**
+ * Shared scenario factory and op assertions for media settings write specs.
+ */
+
+import { assert, assertEquals, assertExists } from '@std/assert';
+import {
+	compilePcd,
+	normalizeSql,
+	parseMetadata,
+	queryOpsSince,
+	seedBase,
+	setupPcd,
+	type OpRow,
+	type PcdTestContext,
+	type SetupPcdOptions
+} from '../../harness/pcd.ts';
+
+export function createScenarioFactory(port: number, prefix: string) {
+	let counter = 0;
+
+	async function newPcd(
+		name: string,
+		options: Partial<SetupPcdOptions> = {}
+	): Promise<PcdTestContext> {
+		counter++;
+		return setupPcd({
+			port,
+			name: `${prefix}-${counter}-${name}`,
+			conflictStrategy: 'ask',
+			...options
+		});
+	}
+
+	async function seededPcd(
+		name: string,
+		operations: Parameters<typeof seedBase>[1],
+		options: Partial<SetupPcdOptions> = {}
+	): Promise<PcdTestContext> {
+		const ctx = await newPcd(name, options);
+		seedBase(ctx, operations);
+		await compilePcd(ctx);
+		return ctx;
+	}
+
+	return { newPcd, seededPcd };
+}
+
+export function userOpsSince(ctx: PcdTestContext, checkpoint: number): OpRow[] {
+	return queryOpsSince(ctx, checkpoint, { origin: 'user', state: 'published' });
+}
+
+export function changedFields(op: OpRow): string[] {
+	const fields = parseMetadata(op).changed_fields;
+	if (!Array.isArray(fields)) return [];
+	return fields.filter((field): field is string => typeof field === 'string');
+}
+
+export function opForChangedField(ops: OpRow[], field: string): OpRow {
+	const op = ops.find((candidate) => {
+		const fields = changedFields(candidate);
+		return fields.length === 1 && fields[0] === field;
+	});
+	assertExists(op, `Expected a user op for ${field}`);
+	return op;
+}
+
+export function assertOnlyField(ops: OpRow[], field: string): void {
+	const op = opForChangedField(ops, field);
+	assertEquals(changedFields(op), [field]);
+	const sql = normalizeSql(op.sql).toLowerCase();
+	assert(
+		sql.includes(`"${field}"`) || sql.includes(field),
+		`Expected ${field} SQL to mention its field, got ${sql}`
+	);
+}
+
+export function assertSameGroup(ops: OpRow[]): void {
+	const groupIds = ops.map((op) => parseMetadata(op).group_id);
+	assert(groupIds.length > 0);
+	assertExists(groupIds[0]);
+	for (const groupId of groupIds) {
+		assertEquals(groupId, groupIds[0]);
+	}
+}
+
+export async function assertActionFailed(response: Response): Promise<void> {
+	const body = await response.text();
+	assert(
+		response.status >= 400 || body.includes('"type":"failure"'),
+		`Expected form action failure, got status=${response.status} body=${body}`
+	);
+}
+
+export const MEDIA_SETTINGS_ARR_TYPES = ['radarr', 'sonarr'] as const;
+export type MediaSettingsArrTypeLiteral = (typeof MEDIA_SETTINGS_ARR_TYPES)[number];
+
+export function tableForArrType(arrType: MediaSettingsArrTypeLiteral): string {
+	return arrType === 'radarr' ? 'radarr_media_settings' : 'sonarr_media_settings';
+}
+
+export function entityForArrType(arrType: MediaSettingsArrTypeLiteral): string {
+	return tableForArrType(arrType);
+}

--- a/tests/integration/pcd/write/media-settings/update.test.ts
+++ b/tests/integration/pcd/write/media-settings/update.test.ts
@@ -1,0 +1,227 @@
+/**
+ * PCD write tests: media settings update (radarr + sonarr).
+ *
+ * The split-op tests will fail until the per-field splitting work for media
+ * settings (task #4) ships. They pin the desired contract before the
+ * implementation. The unchanged-submit test passes immediately.
+ */
+
+import { assertEquals } from '@std/assert';
+import { startServer, stopServer } from '$test-harness/server.ts';
+import { run, setup, teardown, test } from '$test-harness/runner.ts';
+import { PORTS } from '$test-harness/ports.ts';
+import { base } from '../../harness/fixtures.ts';
+import { opCheckpoint, parseDesiredState, parseMetadata } from '../../harness/pcd.ts';
+import { write } from '../../harness/write.ts';
+import {
+	assertOnlyField,
+	assertSameGroup,
+	createScenarioFactory,
+	MEDIA_SETTINGS_ARR_TYPES,
+	opForChangedField,
+	userOpsSince
+} from './helpers.ts';
+
+const PORT = PORTS.pcd.writeMediaSettingsUpdate;
+const ORIGIN = `http://localhost:${PORT}`;
+
+const { seededPcd } = createScenarioFactory(PORT, 'pcd-write-media-settings-update');
+
+setup(async () => {
+	await startServer(PORT, { AUTH: 'off', ORIGIN }, 'preview');
+});
+
+teardown(async () => {
+	await stopServer(PORT);
+});
+
+function seedFor(
+	arrType: 'radarr' | 'sonarr',
+	input: Parameters<typeof base.radarrMediaSettings>[0]
+) {
+	return arrType === 'radarr' ? base.radarrMediaSettings(input) : base.sonarrMediaSettings(input);
+}
+
+/**
+ * Context (per arr-type)
+ *   Base layer seeded with one media settings row via base.<arr>MediaSettings():
+ *     name='Split Media', propersRepacks='doNotPrefer', enableMediaInfo=false
+ *   Compiled.
+ *
+ * Submit
+ *   POST /media-management/{ctx.dbId}/media-settings/{arrType}/Split%20Media?/update
+ *     with form fields:
+ *       name             = 'Split Media'           // unchanged
+ *       propersRepacks   = 'preferAndUpgrade'     // changed
+ *       enableMediaInfo  = 'true'                  // changed
+ *       layer            = 'user'
+ *
+ * Expect
+ *   - userOpsSince(checkpoint).length === 2
+ *   - one op with metadata.changed_fields === ['propers_repacks']
+ *   - one op with metadata.changed_fields === ['enable_media_info']
+ *   - both ops share the same metadata.group_id
+ */
+for (const arrType of MEDIA_SETTINGS_ARR_TYPES) {
+	test(`${arrType} independent scalar fields split into grouped ops`, async () => {
+		const ctx = await seededPcd(`scalars-${arrType}`, [
+			seedFor(arrType, {
+				name: 'Split Media',
+				propersRepacks: 'doNotPrefer',
+				enableMediaInfo: false
+			})
+		]);
+		const checkpoint = opCheckpoint(ctx);
+
+		await write.mediaSettings.update(ctx, arrType, 'Split Media', {
+			name: 'Split Media',
+			propersRepacks: 'preferAndUpgrade',
+			enableMediaInfo: true
+		});
+
+		const ops = userOpsSince(ctx, checkpoint);
+		assertEquals(ops.length, 2);
+		assertOnlyField(ops, 'propers_repacks');
+		assertOnlyField(ops, 'enable_media_info');
+		assertSameGroup(ops);
+	});
+}
+
+/**
+ * Context (per arr-type)
+ *   Base layer seeded with one row:
+ *     name='Old Media', propersRepacks='doNotPrefer', enableMediaInfo=false
+ *   Compiled.
+ *
+ * Submit
+ *   POST /media-management/{ctx.dbId}/media-settings/{arrType}/Old%20Media?/update
+ *     with form fields:
+ *       name             = 'New Media'             // changed
+ *       propersRepacks   = 'preferAndUpgrade'     // changed
+ *       enableMediaInfo  = 'false'                 // unchanged
+ *       layer            = 'user'
+ *
+ * Expect
+ *   - userOpsSince(checkpoint).length === 2
+ *   - one op with metadata.changed_fields === ['propers_repacks']
+ *   - one op with metadata.changed_fields === ['name']
+ *   - both ops share the same metadata.group_id
+ *   - rename op.metadata.name         === 'New Media'
+ *   - rename op.metadata.previousName === 'Old Media'
+ *   - rename op.desired_state.name    === { from: 'Old Media', to: 'New Media' }
+ */
+for (const arrType of MEDIA_SETTINGS_ARR_TYPES) {
+	test(`${arrType} rename plus scalar change emits grouped split ops`, async () => {
+		const ctx = await seededPcd(`rename-scalar-${arrType}`, [
+			seedFor(arrType, {
+				name: 'Old Media',
+				propersRepacks: 'doNotPrefer',
+				enableMediaInfo: false
+			})
+		]);
+		const checkpoint = opCheckpoint(ctx);
+
+		await write.mediaSettings.update(ctx, arrType, 'Old Media', {
+			name: 'New Media',
+			propersRepacks: 'preferAndUpgrade',
+			enableMediaInfo: false
+		});
+
+		const ops = userOpsSince(ctx, checkpoint);
+		assertEquals(ops.length, 2);
+		assertOnlyField(ops, 'propers_repacks');
+		assertOnlyField(ops, 'name');
+		assertSameGroup(ops);
+		const renameOp = opForChangedField(ops, 'name');
+		const metadata = parseMetadata(renameOp);
+		assertEquals(metadata.name, 'New Media');
+		assertEquals(metadata.previousName, 'Old Media');
+		assertEquals(parseDesiredState(renameOp).name, { from: 'Old Media', to: 'New Media' });
+	});
+}
+
+/**
+ * Context (per arr-type)
+ *   Base layer seeded with one row:
+ *     name='Pure Rename Media', propersRepacks='doNotPrefer', enableMediaInfo=false
+ *   Compiled.
+ *
+ * Submit
+ *   POST /media-management/{ctx.dbId}/media-settings/{arrType}/Pure%20Rename%20Media?/update
+ *     with form fields:
+ *       name             = 'Renamed Media'         // changed
+ *       propersRepacks   = 'doNotPrefer'           // unchanged
+ *       enableMediaInfo  = 'false'                 // unchanged
+ *
+ * Expect
+ *   - userOpsSince(checkpoint).length === 1
+ *   - op.metadata.changed_fields === ['name']
+ *   - op.metadata.group_id      === undefined
+ *   - op.metadata.name          === 'Renamed Media'
+ *   - op.metadata.previousName  === 'Pure Rename Media'
+ *   - op.desired_state.name     === { from: 'Pure Rename Media', to: 'Renamed Media' }
+ */
+for (const arrType of MEDIA_SETTINGS_ARR_TYPES) {
+	test(`${arrType} pure rename emits one ungrouped rename op`, async () => {
+		const ctx = await seededPcd(`pure-rename-${arrType}`, [
+			seedFor(arrType, {
+				name: 'Pure Rename Media',
+				propersRepacks: 'doNotPrefer',
+				enableMediaInfo: false
+			})
+		]);
+		const checkpoint = opCheckpoint(ctx);
+
+		await write.mediaSettings.update(ctx, arrType, 'Pure Rename Media', {
+			name: 'Renamed Media',
+			propersRepacks: 'doNotPrefer',
+			enableMediaInfo: false
+		});
+
+		const ops = userOpsSince(ctx, checkpoint);
+		assertEquals(ops.length, 1);
+		const renameOp = opForChangedField(ops, 'name');
+		const metadata = parseMetadata(renameOp);
+		assertEquals(metadata.group_id, undefined);
+		assertEquals(metadata.name, 'Renamed Media');
+		assertEquals(metadata.previousName, 'Pure Rename Media');
+		assertEquals(parseDesiredState(renameOp).name, {
+			from: 'Pure Rename Media',
+			to: 'Renamed Media'
+		});
+	});
+}
+
+/**
+ * Context (per arr-type)
+ *   Base layer seeded with one row:
+ *     name='Noop Media', propersRepacks='doNotPrefer', enableMediaInfo=false
+ *   Compiled.
+ *
+ * Submit identical values.
+ *
+ * Expect
+ *   - userOpsSince(checkpoint).length === 0
+ */
+for (const arrType of MEDIA_SETTINGS_ARR_TYPES) {
+	test(`${arrType} unchanged submit writes no ops`, async () => {
+		const ctx = await seededPcd(`noop-${arrType}`, [
+			seedFor(arrType, {
+				name: 'Noop Media',
+				propersRepacks: 'doNotPrefer',
+				enableMediaInfo: false
+			})
+		]);
+		const checkpoint = opCheckpoint(ctx);
+
+		await write.mediaSettings.update(ctx, arrType, 'Noop Media', {
+			name: 'Noop Media',
+			propersRepacks: 'doNotPrefer',
+			enableMediaInfo: false
+		});
+
+		assertEquals(userOpsSince(ctx, checkpoint).length, 0);
+	});
+}
+
+await run();


### PR DESCRIPTION
## Summary

- Adds media settings write coverage for Radarr and Sonarr create, update, and delete flows, including split-update and name-only-delete assertions.
- Splits media settings updates into grouped per-field ops for name, propers_repacks, and enable_media_info.
- Changes media settings delete ops to guard by name only, matching regex and delay profile delete behavior.
- Adds media settings conflict coverage for split scalar changes, rename conflicts, duplicate creates, delete after upstream non-name changes, and missing-target auto-align.
- Removes the linked-database read-only gate for media settings. Edits now write user-layer ops.
- Updates PCD docs for media settings write, conflict, and linked-edit behavior.