### PR TITLE
feat: enable editing for naming on linked databases

### DIFF
--- a/docs/backend/pcd-entities.md
+++ b/docs/backend/pcd-entities.md
@@ -264,9 +264,9 @@ Some field pairs stay atomic to satisfy schema constraints:
 **Source:** `entities/mediaManagement/`
 
 Media management covers three sub-entity types, each with Radarr and Sonarr
-variants. Media settings are editable on linked databases through user-layer
-ops. Naming and quality definitions still use atomic writes and base-origin
-locking while their conflict strategy is pending
+variants. Media settings and naming are editable on linked databases through
+user-layer ops. Quality definitions still uses atomic writes and base-origin
+locking while its conflict strategy is pending
 ([#421](https://github.com/Dictionarry-Hub/profilarr/issues/421)).
 
 ### Naming
@@ -278,6 +278,14 @@ folder format. Sonarr adds standard/daily/anime episode formats, series
 folder format, season folder format, and multi-episode style. Both share
 rename toggle, illegal character replacement, and colon replacement
 settings.
+
+Create uses one insert op. Delete is name-only guarded, so upstream changes
+to format strings or other fields do not block a delete. Update splits into
+per-field ops with value guards on each changed field; Sonarr's int-coded
+`colon_replacement_format` and `multi_episode_style` use the int form in the
+SET and guard while `desired_state` records the string enum. Pure rename
+writes one `name` op with `previousName`; if the same submit changes other
+fields, all emitted ops share a `groupId`.
 
 ### Media Settings
 
@@ -309,6 +317,6 @@ consistency.
 | Quality profile     | per-field, per-score         | --                      | explicit sub-entity removal + FK |
 | Regular expression  | main + dependents            | condition_patterns refs | dependent conditions + FK        |
 | Delay profile       | per-field, constrained pairs | --                      | FK cascade                       |
-| Media naming        | none (atomic)                | --                      | --                               |
+| Media naming        | per-field                    | --                      | --                               |
 | Media settings      | per-field                    | --                      | --                               |
 | Quality definitions | full-list replace            | --                      | --                               |

--- a/docs/backend/pcd.md
+++ b/docs/backend/pcd.md
@@ -277,14 +277,21 @@ the description op conflicts -- the tag op still applies cleanly.
 
 Op splitting is implemented for custom format general/conditions, quality
 profile general/qualities/scoring, regular expressions, delay profile
-updates, and media settings updates. Delay profiles keep schema-constrained
-field pairs in one op when needed: protocol changes with delay NULLing, and
-bypass-score changes with minimum custom format score NULLing.
+updates, media settings updates, and naming updates. Delay profiles keep
+schema-constrained field pairs in one op when needed: protocol changes with
+delay NULLing, and bypass-score changes with minimum custom format score
+NULLing.
 
 Media settings split `name`, `propers_repacks`, and `enable_media_info`
 changes into independent ops. A rename plus scalar changes share a `groupId`
 so the conflict UI can present them as one user action while still resolving
 each field independently.
+
+Naming follows the same split pattern across Radarr and Sonarr. Sonarr's
+int-coded fields (`colon_replacement_format`, `multi_episode_style`) write
+the int form in SET and guard while recording the string enum in
+`desired_state` so override handlers and the conflict UI work with stable
+labels.
 
 ## Conflicts
 
@@ -436,6 +443,6 @@ Run via `deno task generate:pcd-types` (default version) or
 ## Open Work
 
 - [**#421**](https://github.com/Dictionarry-Hub/profilarr/issues/421):
-  Op splitting is done for CF, QP, regular expression, delay profile, and
-  media settings updates. Media management naming and quality definitions
-  still need their write enablement and conflict strategy decided.
+  Op splitting is done for CF, QP, regular expression, delay profile, media
+  settings, and naming updates. Quality definitions still need their write
+  enablement and conflict strategy decided.

--- a/src/lib/server/pcd/entities/mediaManagement/naming/delete.ts
+++ b/src/lib/server/pcd/entities/mediaManagement/naming/delete.ts
@@ -5,7 +5,6 @@
 import type { PCDCache } from '$pcd/index.ts';
 import { writeOperation, type OperationLayer } from '$pcd/index.ts';
 import type { RadarrNamingRow, SonarrNamingRow } from '$shared/pcd/display.ts';
-import { colonReplacementToDb, multiEpisodeStyleToDb } from '$shared/pcd/mediaManagement.ts';
 
 export interface RemoveRadarrNamingOptions {
 	databaseId: number;
@@ -18,15 +17,7 @@ export async function removeRadarrNaming(options: RemoveRadarrNamingOptions) {
 	const { databaseId, cache, layer, current } = options;
 	const db = cache.kb;
 
-	const deleteQuery = db
-		.deleteFrom('radarr_naming')
-		.where('name', '=', current.name)
-		.where('rename', '=', current.rename ? 1 : 0)
-		.where('movie_format', '=', current.movie_format)
-		.where('movie_folder_format', '=', current.movie_folder_format)
-		.where('replace_illegal_characters', '=', current.replace_illegal_characters ? 1 : 0)
-		.where('colon_replacement_format', '=', current.colon_replacement_format)
-		.compile();
+	const deleteQuery = db.deleteFrom('radarr_naming').where('name', '=', current.name).compile();
 
 	return writeOperation({
 		databaseId,
@@ -65,37 +56,13 @@ export async function removeSonarrNaming(options: RemoveSonarrNamingOptions) {
 	const { databaseId, cache, layer, current } = options;
 	const db = cache.kb;
 
-	const currentColonReplacement = colonReplacementToDb(current.colon_replacement_format);
-	const currentMultiEpisode = multiEpisodeStyleToDb(current.multi_episode_style);
-
-	let deleteQuery = db
-		.deleteFrom('sonarr_naming')
-		.where('name', '=', current.name)
-		.where('rename', '=', current.rename ? 1 : 0)
-		.where('standard_episode_format', '=', current.standard_episode_format)
-		.where('daily_episode_format', '=', current.daily_episode_format)
-		.where('anime_episode_format', '=', current.anime_episode_format)
-		.where('series_folder_format', '=', current.series_folder_format)
-		.where('season_folder_format', '=', current.season_folder_format)
-		.where('replace_illegal_characters', '=', current.replace_illegal_characters ? 1 : 0)
-		.where('colon_replacement_format', '=', currentColonReplacement)
-		.where('multi_episode_style', '=', currentMultiEpisode);
-
-	if (current.custom_colon_replacement_format === null) {
-		deleteQuery = deleteQuery.where('custom_colon_replacement_format', 'is', null);
-	} else {
-		deleteQuery = deleteQuery.where(
-			'custom_colon_replacement_format',
-			'=',
-			current.custom_colon_replacement_format
-		);
-	}
+	const deleteQuery = db.deleteFrom('sonarr_naming').where('name', '=', current.name).compile();
 
 	return writeOperation({
 		databaseId,
 		layer,
 		description: `delete-sonarr-naming-${current.name}`,
-		queries: [deleteQuery.compile()],
+		queries: [deleteQuery],
 		desiredState: {
 			deleted: true,
 			name: current.name,

--- a/src/lib/server/pcd/entities/mediaManagement/naming/update.ts
+++ b/src/lib/server/pcd/entities/mediaManagement/naming/update.ts
@@ -2,10 +2,30 @@
  * Update naming config operations
  */
 
-import type { PCDCache } from '$pcd/index.ts';
+import type { CompiledQuery } from 'kysely';
+import type { PCDCache, WriteResult } from '$pcd/index.ts';
 import { writeOperation, type OperationLayer } from '$pcd/index.ts';
 import type { RadarrNamingRow, SonarrNamingRow } from '$shared/pcd/display.ts';
 import { colonReplacementToDb, multiEpisodeStyleToDb } from '$shared/pcd/mediaManagement.ts';
+import { uuid } from '$shared/utils/uuid.ts';
+
+// ── Radarr ──
+
+type RadarrField =
+	| 'rename'
+	| 'movie_format'
+	| 'movie_folder_format'
+	| 'replace_illegal_characters'
+	| 'colon_replacement_format'
+	| 'name';
+
+interface RadarrFieldChange {
+	field: RadarrField;
+	from: unknown;
+	to: unknown;
+	setValue: unknown;
+	guardValue: unknown;
+}
 
 export interface UpdateRadarrNamingInput {
 	name: string;
@@ -24,11 +44,10 @@ export interface UpdateRadarrNamingOptions {
 	input: UpdateRadarrNamingInput;
 }
 
-export async function updateRadarrNaming(options: UpdateRadarrNamingOptions) {
+export async function updateRadarrNaming(options: UpdateRadarrNamingOptions): Promise<WriteResult> {
 	const { databaseId, cache, layer, current, input } = options;
 	const db = cache.kb;
 
-	// If renaming, check if new name already exists
 	if (input.name !== current.name) {
 		const existing = await db
 			.selectFrom('radarr_naming')
@@ -41,120 +60,142 @@ export async function updateRadarrNaming(options: UpdateRadarrNamingOptions) {
 		}
 	}
 
-	const setValues: Record<string, unknown> = {};
-	if (current.name !== input.name) setValues.name = input.name;
-	if (current.rename !== input.rename) setValues.rename = input.rename ? 1 : 0;
-	if (current.movie_format !== input.movieFormat) setValues.movie_format = input.movieFormat;
-	if (current.movie_folder_format !== input.movieFolderFormat) {
-		setValues.movie_folder_format = input.movieFolderFormat;
-	}
-	if (current.replace_illegal_characters !== input.replaceIllegalCharacters) {
-		setValues.replace_illegal_characters = input.replaceIllegalCharacters ? 1 : 0;
-	}
-	if (current.colon_replacement_format !== input.colonReplacementFormat) {
-		setValues.colon_replacement_format = input.colonReplacementFormat;
-	}
-
-	let updateQuery = db.updateTable('radarr_naming').set(setValues).where('name', '=', current.name);
+	const changes: RadarrFieldChange[] = [];
 
 	if (current.rename !== input.rename) {
-		updateQuery = updateQuery.where('rename', '=', current.rename ? 1 : 0);
+		changes.push({
+			field: 'rename',
+			from: current.rename,
+			to: input.rename,
+			setValue: input.rename ? 1 : 0,
+			guardValue: current.rename ? 1 : 0
+		});
 	}
 	if (current.movie_format !== input.movieFormat) {
-		updateQuery = updateQuery.where('movie_format', '=', current.movie_format);
+		changes.push({
+			field: 'movie_format',
+			from: current.movie_format,
+			to: input.movieFormat,
+			setValue: input.movieFormat,
+			guardValue: current.movie_format
+		});
 	}
 	if (current.movie_folder_format !== input.movieFolderFormat) {
-		updateQuery = updateQuery.where('movie_folder_format', '=', current.movie_folder_format);
+		changes.push({
+			field: 'movie_folder_format',
+			from: current.movie_folder_format,
+			to: input.movieFolderFormat,
+			setValue: input.movieFolderFormat,
+			guardValue: current.movie_folder_format
+		});
 	}
 	if (current.replace_illegal_characters !== input.replaceIllegalCharacters) {
-		updateQuery = updateQuery.where(
-			'replace_illegal_characters',
-			'=',
-			current.replace_illegal_characters ? 1 : 0
-		);
+		changes.push({
+			field: 'replace_illegal_characters',
+			from: current.replace_illegal_characters,
+			to: input.replaceIllegalCharacters,
+			setValue: input.replaceIllegalCharacters ? 1 : 0,
+			guardValue: current.replace_illegal_characters ? 1 : 0
+		});
 	}
 	if (current.colon_replacement_format !== input.colonReplacementFormat) {
-		updateQuery = updateQuery.where(
-			'colon_replacement_format',
-			'=',
-			current.colon_replacement_format
-		);
+		changes.push({
+			field: 'colon_replacement_format',
+			from: current.colon_replacement_format,
+			to: input.colonReplacementFormat,
+			setValue: input.colonReplacementFormat,
+			guardValue: current.colon_replacement_format
+		});
+	}
+	if (current.name !== input.name) {
+		changes.push({
+			field: 'name',
+			from: current.name,
+			to: input.name,
+			setValue: input.name,
+			guardValue: current.name
+		});
 	}
 
-	if (Object.keys(setValues).length === 0) {
+	if (changes.length === 0) {
 		return { success: true };
 	}
 
-	const updateQueryCompiled = updateQuery.compile();
+	const groupId = changes.length > 1 ? uuid() : undefined;
+	let lastResult: WriteResult | null = null;
 
-	const changes: Record<string, { from: unknown; to: unknown }> = {};
-	if (current.name !== input.name) changes.name = { from: current.name, to: input.name };
-	if (current.rename !== input.rename) changes.rename = { from: current.rename, to: input.rename };
-	if (current.movie_format !== input.movieFormat) {
-		changes.movieFormat = { from: current.movie_format, to: input.movieFormat };
-	}
-	if (current.movie_folder_format !== input.movieFolderFormat) {
-		changes.movieFolderFormat = {
-			from: current.movie_folder_format,
-			to: input.movieFolderFormat
-		};
-	}
-	if (current.replace_illegal_characters !== input.replaceIllegalCharacters) {
-		changes.replaceIllegalCharacters = {
-			from: current.replace_illegal_characters,
-			to: input.replaceIllegalCharacters
-		};
-	}
-	if (current.colon_replacement_format !== input.colonReplacementFormat) {
-		changes.colonReplacementFormat = {
-			from: current.colon_replacement_format,
-			to: input.colonReplacementFormat
-		};
-	}
+	for (let index = 0; index < changes.length; index++) {
+		const change = changes[index];
+		const isRename = change.field === 'name';
+		const result = await writeOperation({
+			databaseId,
+			layer,
+			description: `update-radarr-naming-${change.field}-${input.name}`,
+			queries: [buildRadarrUpdateQuery(cache, current, change)],
+			desiredState: {
+				[change.field]: { from: change.from, to: change.to }
+			},
+			metadata: {
+				operation: 'update',
+				entity: 'radarr_naming',
+				name: input.name,
+				...(isRename && { previousName: current.name }),
+				stableKey: { key: 'radarr_naming_name', value: current.name },
+				...(groupId && { groupId }),
+				changedFields: [change.field],
+				summary: isRename ? 'Rename Radarr naming config' : 'Update Radarr naming config',
+				title: isRename
+					? `Rename Radarr naming "${current.name}"`
+					: `Update Radarr naming "${input.name}"`
+			},
+			skipRecompile: index < changes.length - 1
+		});
 
-	const changedFields = Object.keys(changes);
-	const desiredState: Record<string, unknown> = {};
-	if (changes.name) desiredState.name = { from: current.name, to: input.name };
-	if (changes.rename) desiredState.rename = { from: current.rename, to: input.rename };
-	if (changes.movieFormat) {
-		desiredState.movie_format = { from: current.movie_format, to: input.movieFormat };
-	}
-	if (changes.movieFolderFormat) {
-		desiredState.movie_folder_format = {
-			from: current.movie_folder_format,
-			to: input.movieFolderFormat
-		};
-	}
-	if (changes.replaceIllegalCharacters) {
-		desiredState.replace_illegal_characters = {
-			from: current.replace_illegal_characters,
-			to: input.replaceIllegalCharacters
-		};
-	}
-	if (changes.colonReplacementFormat) {
-		desiredState.colon_replacement_format = {
-			from: current.colon_replacement_format,
-			to: input.colonReplacementFormat
-		};
-	}
-
-	return writeOperation({
-		databaseId,
-		layer,
-		description: `update-radarr-naming-${input.name}`,
-		queries: [updateQueryCompiled],
-		desiredState,
-		metadata: {
-			operation: 'update',
-			entity: 'radarr_naming',
-			name: input.name,
-			...(current.name !== input.name && { previousName: current.name }),
-			stableKey: { key: 'radarr_naming_name', value: current.name },
-			changedFields,
-			summary: 'Update Radarr naming config',
-			title: `Update Radarr naming "${input.name}"`
+		if (!result.success) {
+			return result;
 		}
-	});
+		lastResult = result;
+	}
+
+	return lastResult ?? { success: true };
+}
+
+function buildRadarrUpdateQuery(
+	cache: PCDCache,
+	current: RadarrNamingRow,
+	change: RadarrFieldChange
+): CompiledQuery {
+	const setValues: Record<string, unknown> = { [change.field]: change.setValue };
+	let query = cache.kb.updateTable('radarr_naming').set(setValues).where('name', '=', current.name);
+
+	if (change.field !== 'name') {
+		query = query.where(change.field, '=', change.guardValue as never);
+	}
+
+	return query.compile();
+}
+
+// ── Sonarr ──
+
+type SonarrField =
+	| 'rename'
+	| 'standard_episode_format'
+	| 'daily_episode_format'
+	| 'anime_episode_format'
+	| 'series_folder_format'
+	| 'season_folder_format'
+	| 'replace_illegal_characters'
+	| 'colon_replacement_format'
+	| 'custom_colon_replacement_format'
+	| 'multi_episode_style'
+	| 'name';
+
+interface SonarrFieldChange {
+	field: SonarrField;
+	from: unknown;
+	to: unknown;
+	setValue: unknown;
+	guardValue: unknown;
 }
 
 export interface UpdateSonarrNamingInput {
@@ -179,11 +220,10 @@ export interface UpdateSonarrNamingOptions {
 	input: UpdateSonarrNamingInput;
 }
 
-export async function updateSonarrNaming(options: UpdateSonarrNamingOptions) {
+export async function updateSonarrNaming(options: UpdateSonarrNamingOptions): Promise<WriteResult> {
 	const { databaseId, cache, layer, current, input } = options;
 	const db = cache.kb;
 
-	// If renaming, check if new name already exists
 	if (input.name !== current.name) {
 		const existing = await db
 			.selectFrom('sonarr_naming')
@@ -196,229 +236,168 @@ export async function updateSonarrNaming(options: UpdateSonarrNamingOptions) {
 		}
 	}
 
-	const currentColonReplacement = colonReplacementToDb(current.colon_replacement_format);
-	const nextColonReplacement = colonReplacementToDb(input.colonReplacementFormat);
-	const currentMultiEpisode = multiEpisodeStyleToDb(current.multi_episode_style);
-	const nextMultiEpisode = multiEpisodeStyleToDb(input.multiEpisodeStyle);
-
-	const setValues: Record<string, unknown> = {};
-	if (current.name !== input.name) setValues.name = input.name;
-	if (current.rename !== input.rename) setValues.rename = input.rename ? 1 : 0;
-	if (current.standard_episode_format !== input.standardEpisodeFormat) {
-		setValues.standard_episode_format = input.standardEpisodeFormat;
-	}
-	if (current.daily_episode_format !== input.dailyEpisodeFormat) {
-		setValues.daily_episode_format = input.dailyEpisodeFormat;
-	}
-	if (current.anime_episode_format !== input.animeEpisodeFormat) {
-		setValues.anime_episode_format = input.animeEpisodeFormat;
-	}
-	if (current.series_folder_format !== input.seriesFolderFormat) {
-		setValues.series_folder_format = input.seriesFolderFormat;
-	}
-	if (current.season_folder_format !== input.seasonFolderFormat) {
-		setValues.season_folder_format = input.seasonFolderFormat;
-	}
-	if (current.replace_illegal_characters !== input.replaceIllegalCharacters) {
-		setValues.replace_illegal_characters = input.replaceIllegalCharacters ? 1 : 0;
-	}
-	if (currentColonReplacement !== nextColonReplacement) {
-		setValues.colon_replacement_format = nextColonReplacement;
-	}
-	if (current.custom_colon_replacement_format !== input.customColonReplacementFormat) {
-		setValues.custom_colon_replacement_format = input.customColonReplacementFormat;
-	}
-	if (currentMultiEpisode !== nextMultiEpisode) {
-		setValues.multi_episode_style = nextMultiEpisode;
-	}
-
-	let updateQuery = db.updateTable('sonarr_naming').set(setValues).where('name', '=', current.name);
+	const changes: SonarrFieldChange[] = [];
 
 	if (current.rename !== input.rename) {
-		updateQuery = updateQuery.where('rename', '=', current.rename ? 1 : 0);
+		changes.push({
+			field: 'rename',
+			from: current.rename,
+			to: input.rename,
+			setValue: input.rename ? 1 : 0,
+			guardValue: current.rename ? 1 : 0
+		});
 	}
 	if (current.standard_episode_format !== input.standardEpisodeFormat) {
-		updateQuery = updateQuery.where(
-			'standard_episode_format',
-			'=',
-			current.standard_episode_format
-		);
+		changes.push({
+			field: 'standard_episode_format',
+			from: current.standard_episode_format,
+			to: input.standardEpisodeFormat,
+			setValue: input.standardEpisodeFormat,
+			guardValue: current.standard_episode_format
+		});
 	}
 	if (current.daily_episode_format !== input.dailyEpisodeFormat) {
-		updateQuery = updateQuery.where('daily_episode_format', '=', current.daily_episode_format);
+		changes.push({
+			field: 'daily_episode_format',
+			from: current.daily_episode_format,
+			to: input.dailyEpisodeFormat,
+			setValue: input.dailyEpisodeFormat,
+			guardValue: current.daily_episode_format
+		});
 	}
 	if (current.anime_episode_format !== input.animeEpisodeFormat) {
-		updateQuery = updateQuery.where('anime_episode_format', '=', current.anime_episode_format);
+		changes.push({
+			field: 'anime_episode_format',
+			from: current.anime_episode_format,
+			to: input.animeEpisodeFormat,
+			setValue: input.animeEpisodeFormat,
+			guardValue: current.anime_episode_format
+		});
 	}
 	if (current.series_folder_format !== input.seriesFolderFormat) {
-		updateQuery = updateQuery.where('series_folder_format', '=', current.series_folder_format);
+		changes.push({
+			field: 'series_folder_format',
+			from: current.series_folder_format,
+			to: input.seriesFolderFormat,
+			setValue: input.seriesFolderFormat,
+			guardValue: current.series_folder_format
+		});
 	}
 	if (current.season_folder_format !== input.seasonFolderFormat) {
-		updateQuery = updateQuery.where('season_folder_format', '=', current.season_folder_format);
+		changes.push({
+			field: 'season_folder_format',
+			from: current.season_folder_format,
+			to: input.seasonFolderFormat,
+			setValue: input.seasonFolderFormat,
+			guardValue: current.season_folder_format
+		});
 	}
 	if (current.replace_illegal_characters !== input.replaceIllegalCharacters) {
-		updateQuery = updateQuery.where(
-			'replace_illegal_characters',
-			'=',
-			current.replace_illegal_characters ? 1 : 0
-		);
+		changes.push({
+			field: 'replace_illegal_characters',
+			from: current.replace_illegal_characters,
+			to: input.replaceIllegalCharacters,
+			setValue: input.replaceIllegalCharacters ? 1 : 0,
+			guardValue: current.replace_illegal_characters ? 1 : 0
+		});
 	}
-	if (currentColonReplacement !== nextColonReplacement) {
-		updateQuery = updateQuery.where('colon_replacement_format', '=', currentColonReplacement);
+	if (current.colon_replacement_format !== input.colonReplacementFormat) {
+		changes.push({
+			field: 'colon_replacement_format',
+			from: current.colon_replacement_format,
+			to: input.colonReplacementFormat,
+			setValue: colonReplacementToDb(input.colonReplacementFormat),
+			guardValue: colonReplacementToDb(current.colon_replacement_format)
+		});
 	}
 	if (current.custom_colon_replacement_format !== input.customColonReplacementFormat) {
-		if (current.custom_colon_replacement_format === null) {
-			updateQuery = updateQuery.where('custom_colon_replacement_format', 'is', null);
-		} else {
-			updateQuery = updateQuery.where(
-				'custom_colon_replacement_format',
-				'=',
-				current.custom_colon_replacement_format
-			);
-		}
+		changes.push({
+			field: 'custom_colon_replacement_format',
+			from: current.custom_colon_replacement_format,
+			to: input.customColonReplacementFormat,
+			setValue: input.customColonReplacementFormat,
+			guardValue: current.custom_colon_replacement_format
+		});
 	}
-	if (currentMultiEpisode !== nextMultiEpisode) {
-		updateQuery = updateQuery.where('multi_episode_style', '=', currentMultiEpisode);
+	if (current.multi_episode_style !== input.multiEpisodeStyle) {
+		changes.push({
+			field: 'multi_episode_style',
+			from: current.multi_episode_style,
+			to: input.multiEpisodeStyle,
+			setValue: multiEpisodeStyleToDb(input.multiEpisodeStyle),
+			guardValue: multiEpisodeStyleToDb(current.multi_episode_style)
+		});
+	}
+	if (current.name !== input.name) {
+		changes.push({
+			field: 'name',
+			from: current.name,
+			to: input.name,
+			setValue: input.name,
+			guardValue: current.name
+		});
 	}
 
-	if (Object.keys(setValues).length === 0) {
+	if (changes.length === 0) {
 		return { success: true };
 	}
 
-	const updateQueryCompiled = updateQuery.compile();
+	const groupId = changes.length > 1 ? uuid() : undefined;
+	let lastResult: WriteResult | null = null;
 
-	const changes: Record<string, { from: unknown; to: unknown }> = {};
-	if (current.name !== input.name) changes.name = { from: current.name, to: input.name };
-	if (current.rename !== input.rename) changes.rename = { from: current.rename, to: input.rename };
-	if (current.standard_episode_format !== input.standardEpisodeFormat) {
-		changes.standardEpisodeFormat = {
-			from: current.standard_episode_format,
-			to: input.standardEpisodeFormat
-		};
-	}
-	if (current.daily_episode_format !== input.dailyEpisodeFormat) {
-		changes.dailyEpisodeFormat = {
-			from: current.daily_episode_format,
-			to: input.dailyEpisodeFormat
-		};
-	}
-	if (current.anime_episode_format !== input.animeEpisodeFormat) {
-		changes.animeEpisodeFormat = {
-			from: current.anime_episode_format,
-			to: input.animeEpisodeFormat
-		};
-	}
-	if (current.series_folder_format !== input.seriesFolderFormat) {
-		changes.seriesFolderFormat = {
-			from: current.series_folder_format,
-			to: input.seriesFolderFormat
-		};
-	}
-	if (current.season_folder_format !== input.seasonFolderFormat) {
-		changes.seasonFolderFormat = {
-			from: current.season_folder_format,
-			to: input.seasonFolderFormat
-		};
-	}
-	if (current.replace_illegal_characters !== input.replaceIllegalCharacters) {
-		changes.replaceIllegalCharacters = {
-			from: current.replace_illegal_characters,
-			to: input.replaceIllegalCharacters
-		};
-	}
-	if (currentColonReplacement !== nextColonReplacement) {
-		changes.colonReplacementFormat = {
-			from: current.colon_replacement_format,
-			to: input.colonReplacementFormat
-		};
-	}
-	if (current.custom_colon_replacement_format !== input.customColonReplacementFormat) {
-		changes.customColonReplacementFormat = {
-			from: current.custom_colon_replacement_format,
-			to: input.customColonReplacementFormat
-		};
-	}
-	if (currentMultiEpisode !== nextMultiEpisode) {
-		changes.multiEpisodeStyle = {
-			from: current.multi_episode_style,
-			to: input.multiEpisodeStyle
-		};
-	}
+	for (let index = 0; index < changes.length; index++) {
+		const change = changes[index];
+		const isRename = change.field === 'name';
+		const result = await writeOperation({
+			databaseId,
+			layer,
+			description: `update-sonarr-naming-${change.field}-${input.name}`,
+			queries: [buildSonarrUpdateQuery(cache, current, change)],
+			desiredState: {
+				[change.field]: { from: change.from, to: change.to }
+			},
+			metadata: {
+				operation: 'update',
+				entity: 'sonarr_naming',
+				name: input.name,
+				...(isRename && { previousName: current.name }),
+				stableKey: { key: 'sonarr_naming_name', value: current.name },
+				...(groupId && { groupId }),
+				changedFields: [change.field],
+				summary: isRename ? 'Rename Sonarr naming config' : 'Update Sonarr naming config',
+				title: isRename
+					? `Rename Sonarr naming "${current.name}"`
+					: `Update Sonarr naming "${input.name}"`
+			},
+			skipRecompile: index < changes.length - 1
+		});
 
-	const changedFields = Object.keys(changes);
-	const desiredState: Record<string, unknown> = {};
-	if (changes.name) desiredState.name = { from: current.name, to: input.name };
-	if (changes.rename) desiredState.rename = { from: current.rename, to: input.rename };
-	if (changes.standardEpisodeFormat) {
-		desiredState.standard_episode_format = {
-			from: current.standard_episode_format,
-			to: input.standardEpisodeFormat
-		};
-	}
-	if (changes.dailyEpisodeFormat) {
-		desiredState.daily_episode_format = {
-			from: current.daily_episode_format,
-			to: input.dailyEpisodeFormat
-		};
-	}
-	if (changes.animeEpisodeFormat) {
-		desiredState.anime_episode_format = {
-			from: current.anime_episode_format,
-			to: input.animeEpisodeFormat
-		};
-	}
-	if (changes.seriesFolderFormat) {
-		desiredState.series_folder_format = {
-			from: current.series_folder_format,
-			to: input.seriesFolderFormat
-		};
-	}
-	if (changes.seasonFolderFormat) {
-		desiredState.season_folder_format = {
-			from: current.season_folder_format,
-			to: input.seasonFolderFormat
-		};
-	}
-	if (changes.replaceIllegalCharacters) {
-		desiredState.replace_illegal_characters = {
-			from: current.replace_illegal_characters,
-			to: input.replaceIllegalCharacters
-		};
-	}
-	if (changes.colonReplacementFormat) {
-		desiredState.colon_replacement_format = {
-			from: current.colon_replacement_format,
-			to: input.colonReplacementFormat
-		};
-	}
-	if (changes.customColonReplacementFormat) {
-		desiredState.custom_colon_replacement_format = {
-			from: current.custom_colon_replacement_format,
-			to: input.customColonReplacementFormat
-		};
-	}
-	if (changes.multiEpisodeStyle) {
-		desiredState.multi_episode_style = {
-			from: current.multi_episode_style,
-			to: input.multiEpisodeStyle
-		};
-	}
-
-	return writeOperation({
-		databaseId,
-		layer,
-		description: `update-sonarr-naming-${input.name}`,
-		queries: [updateQueryCompiled],
-		desiredState,
-		metadata: {
-			operation: 'update',
-			entity: 'sonarr_naming',
-			name: input.name,
-			...(current.name !== input.name && { previousName: current.name }),
-			stableKey: { key: 'sonarr_naming_name', value: current.name },
-			changedFields,
-			summary: 'Update Sonarr naming config',
-			title: `Update Sonarr naming "${input.name}"`
+		if (!result.success) {
+			return result;
 		}
-	});
+		lastResult = result;
+	}
+
+	return lastResult ?? { success: true };
+}
+
+function buildSonarrUpdateQuery(
+	cache: PCDCache,
+	current: SonarrNamingRow,
+	change: SonarrFieldChange
+): CompiledQuery {
+	const setValues: Record<string, unknown> = { [change.field]: change.setValue };
+	let query = cache.kb.updateTable('sonarr_naming').set(setValues).where('name', '=', current.name);
+
+	if (change.field === 'name') {
+		return query.compile();
+	}
+
+	if (change.field === 'custom_colon_replacement_format' && change.guardValue === null) {
+		query = query.where('custom_colon_replacement_format', 'is', null);
+	} else {
+		query = query.where(change.field, '=', change.guardValue as never);
+	}
+
+	return query.compile();
 }

--- a/src/routes/media-management/[databaseId]/naming/+page.svelte
+++ b/src/routes/media-management/[databaseId]/naming/+page.svelte
@@ -24,13 +24,9 @@
 	let cloneSourceName = '';
 	let cloneEntityType: EntityType = 'radarr_naming';
 
-	function notifyLocked() {
-		alertStore.add('info', mediaManagementLockedMessage);
-	}
-
 	function handleClone(event: CustomEvent<{ name: string; arr_type: string }>) {
 		if (!data.canWriteToBase) {
-			notifyLocked();
+			alertStore.add('info', mediaManagementLockedMessage);
 			return;
 		}
 		cloneSourceName = event.detail.name;
@@ -76,27 +72,23 @@
 <!-- Actions Bar -->
 <ActionsBar>
 	<SearchAction searchStore={search} placeholder="Search naming configs..." responsive />
-	{#if data.canWriteToBase}
-		<ActionButton icon={Plus} hasDropdown={true} dropdownPosition="right">
-			<svelte:fragment slot="dropdown" let:dropdownPosition>
-				<Dropdown position={dropdownPosition} minWidth="10rem">
-					<DropdownHeader label="New config" />
-					<DropdownItem
-						label="Radarr"
-						on:click={() =>
-							goto(`/media-management/${data.currentDatabase.id}/naming/new?arrType=radarr`)}
-					/>
-					<DropdownItem
-						label="Sonarr"
-						on:click={() =>
-							goto(`/media-management/${data.currentDatabase.id}/naming/new?arrType=sonarr`)}
-					/>
-				</Dropdown>
-			</svelte:fragment>
-		</ActionButton>
-	{:else}
-		<ActionButton icon={Plus} on:click={notifyLocked} />
-	{/if}
+	<ActionButton icon={Plus} hasDropdown={true} dropdownPosition="right">
+		<svelte:fragment slot="dropdown" let:dropdownPosition>
+			<Dropdown position={dropdownPosition} minWidth="10rem">
+				<DropdownHeader label="New config" />
+				<DropdownItem
+					label="Radarr"
+					on:click={() =>
+						goto(`/media-management/${data.currentDatabase.id}/naming/new?arrType=radarr`)}
+				/>
+				<DropdownItem
+					label="Sonarr"
+					on:click={() =>
+						goto(`/media-management/${data.currentDatabase.id}/naming/new?arrType=sonarr`)}
+				/>
+			</Dropdown>
+		</svelte:fragment>
+	</ActionButton>
 	<ViewToggle bind:value={$view} />
 </ActionsBar>
 
@@ -120,7 +112,6 @@
 		<TableView
 			configs={$filtered}
 			databaseId={data.currentDatabase.id}
-			canWriteToBase={data.canWriteToBase}
 			on:clone={handleClone}
 			on:export={handleExport}
 		/>
@@ -128,7 +119,6 @@
 		<CardView
 			configs={$filtered}
 			databaseId={data.currentDatabase.id}
-			canWriteToBase={data.canWriteToBase}
 			on:clone={handleClone}
 			on:export={handleExport}
 		/>

--- a/src/routes/media-management/[databaseId]/naming/components/RadarrNamingForm.svelte
+++ b/src/routes/media-management/[databaseId]/naming/components/RadarrNamingForm.svelte
@@ -22,7 +22,6 @@
 	} from '$shared/pcd/mediaManagement.ts';
 	import { resolveRadarrFormat, getRadarrTokenCategories } from '$shared/pcd/namingTokens.ts';
 	import NamingPreview from './NamingPreview.svelte';
-	import { mediaManagementLockedMessage } from '../../lock';
 
 	import TokenAutocomplete from './TokenAutocomplete.svelte';
 
@@ -83,7 +82,6 @@
 	let selectedLayer: 'user' | 'base' = canWriteToBase ? 'base' : 'user';
 	let mainFormElement: HTMLFormElement;
 	let deleteFormElement: HTMLFormElement;
-	$: readOnly = !canWriteToBase;
 
 	$: databaseId = parseInt($page.params.databaseId ?? '0', 10);
 	let movieFormatInput: HTMLInputElement | HTMLTextAreaElement | null = null;
@@ -92,30 +90,20 @@
 	const radarrTokenCategories = getRadarrTokenCategories();
 
 	$: title = mode === 'create' ? 'New Radarr Naming Config' : 'Edit Radarr Naming Config';
-	$: description = readOnly
-		? 'Media management configs from linked databases cannot be edited directly'
-		: mode === 'create'
+	$: description =
+		mode === 'create'
 			? `Create a new Radarr naming configuration for ${databaseName}`
 			: `Update Radarr naming configuration`;
 	$: isValid = formData.name.trim() !== '';
-
-	function notifyLocked() {
-		alertStore.add('info', mediaManagementLockedMessage);
-	}
 
 	function updateField<K extends keyof RadarrNamingFormData>(
 		field: K,
 		value: RadarrNamingFormData[K]
 	) {
-		if (readOnly) return;
 		update<RadarrNamingFormData, K>(field, value);
 	}
 
 	async function handleSaveClick() {
-		if (readOnly) {
-			notifyLocked();
-			return;
-		}
 		if (saving) return;
 		saving = true;
 		selectedLayer = canWriteToBase ? 'base' : 'user';
@@ -124,18 +112,10 @@
 	}
 
 	async function handleDeleteClick() {
-		if (readOnly) {
-			notifyLocked();
-			return;
-		}
 		showDeleteModal = true;
 	}
 
 	async function handleDeleteConfirm() {
-		if (readOnly) {
-			notifyLocked();
-			return;
-		}
 		selectedLayer = canWriteToBase ? 'base' : 'user';
 		showDeleteModal = false;
 		await tick();
@@ -159,7 +139,7 @@
 			iconColor="text-blue-600 dark:text-blue-400"
 			on:click={() => (showInfoModal = true)}
 		/>
-		{#if mode === 'edit' && !readOnly}
+		{#if mode === 'edit'}
 			<Button
 				text={deleting ? 'Deleting...' : 'Delete'}
 				icon={Trash2}
@@ -172,8 +152,7 @@
 			text={saving ? 'Saving...' : mode === 'create' ? 'Create' : 'Save'}
 			icon={Save}
 			iconColor="text-blue-600 dark:text-blue-400"
-			disabled={!readOnly && (saving || !isValid || !$isDirty)}
-			softDisabled={readOnly}
+			disabled={saving || !isValid || !$isDirty}
 			on:click={handleSaveClick}
 		/>
 	</div>
@@ -192,7 +171,6 @@
 				required
 				value={formData.name}
 				placeholder="e.g., default"
-				disabled={readOnly}
 				on:input={(e) => updateField('name', e.detail)}
 			/>
 
@@ -202,7 +180,6 @@
 					label="Rename Movies"
 					ariaLabel="Rename Movies"
 					color={formData.rename ? 'green' : 'neutral'}
-					disabled={readOnly}
 					on:change={(e) => updateField('rename', e.detail)}
 				/>
 				<p class="text-xs text-neutral-500 dark:text-neutral-400">
@@ -230,7 +207,6 @@
 						placeholder="e.g., Movie Title (Year) Quality"
 						categories={radarrTokenCategories}
 						bind:inputElement={movieFormatInput}
-						disabled={readOnly}
 						on:input={(e) => updateField('movieFormat', e.detail)}
 					/>
 					<NamingPreview format={formData.movieFormat} resolver={resolveRadarrFormat} />
@@ -244,7 +220,6 @@
 						placeholder="e.g., Movie Title (Year)"
 						categories={radarrTokenCategories}
 						bind:inputElement={movieFolderFormatInput}
-						disabled={readOnly}
 						on:input={(e) => updateField('movieFolderFormat', e.detail)}
 					/>
 					<NamingPreview format={formData.movieFolderFormat} resolver={resolveRadarrFormat} />
@@ -268,7 +243,6 @@
 						label="Replace Illegal Characters"
 						ariaLabel="Replace Illegal Characters"
 						color={formData.replaceIllegalCharacters ? 'green' : 'neutral'}
-						disabled={readOnly}
 						on:change={(e) => updateField('replaceIllegalCharacters', e.detail)}
 					/>
 					<p class="text-xs text-neutral-500 dark:text-neutral-400">
@@ -281,7 +255,6 @@
 						label="Colon Replacement"
 						value={formData.colonReplacementFormat}
 						options={RADARR_COLON_REPLACEMENT_OPTIONS}
-						disabled={readOnly}
 						on:change={(e) =>
 							updateField('colonReplacementFormat', e.detail as RadarrColonReplacementFormat)}
 					/>
@@ -347,7 +320,7 @@
 </form>
 
 <!-- Hidden delete form -->
-{#if mode === 'edit' && !readOnly}
+{#if mode === 'edit'}
 	<form
 		bind:this={deleteFormElement}
 		method="POST"

--- a/src/routes/media-management/[databaseId]/naming/components/SonarrNamingForm.svelte
+++ b/src/routes/media-management/[databaseId]/naming/components/SonarrNamingForm.svelte
@@ -24,7 +24,6 @@
 	} from '$shared/pcd/mediaManagement.ts';
 	import { resolveSonarrFormat, getSonarrTokenCategories } from '$shared/pcd/namingTokens.ts';
 	import NamingPreview from './NamingPreview.svelte';
-	import { mediaManagementLockedMessage } from '../../lock';
 
 	import TokenAutocomplete from './TokenAutocomplete.svelte';
 
@@ -102,7 +101,6 @@
 	let selectedLayer: 'user' | 'base' = canWriteToBase ? 'base' : 'user';
 	let mainFormElement: HTMLFormElement;
 	let deleteFormElement: HTMLFormElement;
-	$: readOnly = !canWriteToBase;
 
 	$: databaseId = parseInt($page.params.databaseId ?? '0', 10);
 	let standardEpisodeFormatInput: HTMLInputElement | HTMLTextAreaElement | null = null;
@@ -114,31 +112,21 @@
 	const sonarrTokenCategories = getSonarrTokenCategories();
 
 	$: title = mode === 'create' ? 'New Sonarr Naming Config' : 'Edit Sonarr Naming Config';
-	$: description = readOnly
-		? 'Media management configs from linked databases cannot be edited directly'
-		: mode === 'create'
+	$: description =
+		mode === 'create'
 			? `Create a new Sonarr naming configuration for ${databaseName}`
 			: `Update Sonarr naming configuration`;
 	$: isValid = formData.name.trim() !== '';
 	$: showCustomColonInput = formData.colonReplacementFormat === 'custom';
 
-	function notifyLocked() {
-		alertStore.add('info', mediaManagementLockedMessage);
-	}
-
 	function updateField<K extends keyof SonarrNamingFormData>(
 		field: K,
 		value: SonarrNamingFormData[K]
 	) {
-		if (readOnly) return;
 		update<SonarrNamingFormData, K>(field, value);
 	}
 
 	async function handleSaveClick() {
-		if (readOnly) {
-			notifyLocked();
-			return;
-		}
 		if (saving) return;
 		saving = true;
 		selectedLayer = canWriteToBase ? 'base' : 'user';
@@ -147,18 +135,10 @@
 	}
 
 	async function handleDeleteClick() {
-		if (readOnly) {
-			notifyLocked();
-			return;
-		}
 		showDeleteModal = true;
 	}
 
 	async function handleDeleteConfirm() {
-		if (readOnly) {
-			notifyLocked();
-			return;
-		}
 		selectedLayer = canWriteToBase ? 'base' : 'user';
 		showDeleteModal = false;
 		await tick();
@@ -182,7 +162,7 @@
 			iconColor="text-blue-600 dark:text-blue-400"
 			on:click={() => (showInfoModal = true)}
 		/>
-		{#if mode === 'edit' && !readOnly}
+		{#if mode === 'edit'}
 			<Button
 				text={deleting ? 'Deleting...' : 'Delete'}
 				icon={Trash2}
@@ -195,8 +175,7 @@
 			text={saving ? 'Saving...' : mode === 'create' ? 'Create' : 'Save'}
 			icon={Save}
 			iconColor="text-blue-600 dark:text-blue-400"
-			disabled={!readOnly && (saving || !isValid || !$isDirty)}
-			softDisabled={readOnly}
+			disabled={saving || !isValid || !$isDirty}
 			on:click={handleSaveClick}
 		/>
 	</div>
@@ -215,7 +194,6 @@
 				required
 				value={formData.name}
 				placeholder="e.g., default"
-				disabled={readOnly}
 				on:input={(e) => updateField('name', e.detail)}
 			/>
 
@@ -225,7 +203,6 @@
 					label="Rename Episodes"
 					ariaLabel="Rename Episodes"
 					color={formData.rename ? 'green' : 'neutral'}
-					disabled={readOnly}
 					on:change={(e) => updateField('rename', e.detail)}
 				/>
 				<p class="text-xs text-neutral-500 dark:text-neutral-400">
@@ -252,7 +229,6 @@
 						value={formData.standardEpisodeFormat}
 						categories={sonarrTokenCategories}
 						bind:inputElement={standardEpisodeFormatInput}
-						disabled={readOnly}
 						on:input={(e) => updateField('standardEpisodeFormat', e.detail)}
 					/>
 					<NamingPreview format={formData.standardEpisodeFormat} resolver={resolveSonarrFormat} />
@@ -265,7 +241,6 @@
 						value={formData.dailyEpisodeFormat}
 						categories={sonarrTokenCategories}
 						bind:inputElement={dailyEpisodeFormatInput}
-						disabled={readOnly}
 						on:input={(e) => updateField('dailyEpisodeFormat', e.detail)}
 					/>
 					<NamingPreview format={formData.dailyEpisodeFormat} resolver={resolveSonarrFormat} />
@@ -278,7 +253,6 @@
 						value={formData.animeEpisodeFormat}
 						categories={sonarrTokenCategories}
 						bind:inputElement={animeEpisodeFormatInput}
-						disabled={readOnly}
 						on:input={(e) => updateField('animeEpisodeFormat', e.detail)}
 					/>
 					<NamingPreview format={formData.animeEpisodeFormat} resolver={resolveSonarrFormat} />
@@ -299,7 +273,6 @@
 						value={formData.seriesFolderFormat}
 						categories={sonarrTokenCategories}
 						bind:inputElement={seriesFolderFormatInput}
-						disabled={readOnly}
 						on:input={(e) => updateField('seriesFolderFormat', e.detail)}
 					/>
 					<NamingPreview format={formData.seriesFolderFormat} resolver={resolveSonarrFormat} />
@@ -312,7 +285,6 @@
 						value={formData.seasonFolderFormat}
 						categories={sonarrTokenCategories}
 						bind:inputElement={seasonFolderFormatInput}
-						disabled={readOnly}
 						on:input={(e) => updateField('seasonFolderFormat', e.detail)}
 					/>
 					<NamingPreview format={formData.seasonFolderFormat} resolver={resolveSonarrFormat} />
@@ -329,7 +301,6 @@
 				<DropdownSelect
 					value={formData.multiEpisodeStyle}
 					options={MULTI_EPISODE_STYLE_OPTIONS}
-					disabled={readOnly}
 					on:change={(e) => updateField('multiEpisodeStyle', e.detail as MultiEpisodeStyle)}
 				/>
 			</div>
@@ -351,7 +322,6 @@
 						label="Replace Illegal Characters"
 						ariaLabel="Replace Illegal Characters"
 						color={formData.replaceIllegalCharacters ? 'green' : 'neutral'}
-						disabled={readOnly}
 						on:change={(e) => updateField('replaceIllegalCharacters', e.detail)}
 					/>
 					<p class="text-xs text-neutral-500 dark:text-neutral-400">
@@ -364,7 +334,6 @@
 						label="Colon Replacement"
 						value={formData.colonReplacementFormat}
 						options={SONARR_COLON_REPLACEMENT_OPTIONS}
-						disabled={readOnly}
 						on:change={(e) =>
 							updateField('colonReplacementFormat', e.detail as SonarrColonReplacementFormat)}
 					/>
@@ -375,7 +344,6 @@
 							name="customColonReplacementFormat"
 							value={formData.customColonReplacementFormat}
 							placeholder="Enter custom replacement character(s)"
-							disabled={readOnly}
 							on:input={(e) => updateField('customColonReplacementFormat', e.detail)}
 						/>
 					{/if}
@@ -450,7 +418,7 @@
 </form>
 
 <!-- Hidden delete form -->
-{#if mode === 'edit' && !readOnly}
+{#if mode === 'edit'}
 	<form
 		bind:this={deleteFormElement}
 		method="POST"

--- a/src/routes/media-management/[databaseId]/naming/views/CardView.svelte
+++ b/src/routes/media-management/[databaseId]/naming/views/CardView.svelte
@@ -9,13 +9,9 @@
 	import radarrLogo from '$lib/client/assets/Radarr.svg';
 	import sonarrLogo from '$lib/client/assets/Sonarr.svg';
 	import { FEATURES } from '$shared/features.ts';
-	import { goto } from '$app/navigation';
-	import { alertStore } from '$alerts/store';
-	import { mediaManagementLockedMessage } from '../../lock';
 
 	export let configs: NamingListItem[];
 	export let databaseId: number;
-	export let canWriteToBase: boolean = false;
 
 	const dispatch = createEventDispatcher<{
 		clone: { name: string; arr_type: string };
@@ -39,20 +35,11 @@
 			config.name
 		)}`;
 	}
-
-	function handleLockedOpen(config: NamingListItem) {
-		alertStore.add('info', mediaManagementLockedMessage);
-		goto(getConfigHref(config));
-	}
 </script>
 
 <CardGrid columns={1} flush>
 	{#each configs as config}
-		<Card
-			href={canWriteToBase ? getConfigHref(config) : undefined}
-			onclick={canWriteToBase ? undefined : () => handleLockedOpen(config)}
-			hoverable
-		>
+		<Card href={getConfigHref(config)} hoverable>
 			<div class="flex items-center gap-4">
 				<!-- Logo + Name -->
 				<div class="flex min-w-0 flex-1 items-center gap-3">

--- a/src/routes/media-management/[databaseId]/naming/views/TableView.svelte
+++ b/src/routes/media-management/[databaseId]/naming/views/TableView.svelte
@@ -9,13 +9,9 @@
 	import radarrLogo from '$lib/client/assets/Radarr.svg';
 	import sonarrLogo from '$lib/client/assets/Sonarr.svg';
 	import { FEATURES } from '$shared/features.ts';
-	import { goto } from '$app/navigation';
-	import { alertStore } from '$alerts/store';
-	import { mediaManagementLockedMessage } from '../../lock';
 
 	export let configs: NamingListItem[];
 	export let databaseId: number;
-	export let canWriteToBase: boolean = false;
 
 	const dispatch = createEventDispatcher<{
 		clone: { name: string; arr_type: string };
@@ -29,11 +25,6 @@
 
 	function getRowHref(config: NamingListItem): string {
 		return `/media-management/${databaseId}/naming/${config.arr_type}/${encodeURIComponent(config.name)}`;
-	}
-
-	function handleLockedRowClick(config: NamingListItem) {
-		alertStore.add('info', mediaManagementLockedMessage);
-		goto(getRowHref(config));
 	}
 
 	const columns: Column<NamingListItem>[] = [
@@ -57,13 +48,7 @@
 	];
 </script>
 
-<Table
-	{columns}
-	data={configs}
-	rowHref={canWriteToBase ? getRowHref : undefined}
-	onRowClick={canWriteToBase ? undefined : handleLockedRowClick}
-	hoverable={true}
->
+<Table {columns} data={configs} rowHref={getRowHref} hoverable={true}>
 	<svelte:fragment slot="cell" let:row let:column>
 		{#if column.key === 'name'}
 			<span class="font-medium">{row.name}</span>

--- a/tests/integration/harness/ports.ts
+++ b/tests/integration/harness/ports.ts
@@ -103,7 +103,9 @@ export const PORTS = {
 		writeNamingSonarrDelete: 7621,
 		conflictsDelayProfiles: 7700,
 		conflictsRegex: 7701,
-		conflictsMediaSettings: 7702
+		conflictsMediaSettings: 7702,
+		conflictsNamingRadarr: 7703,
+		conflictsNamingSonarr: 7704
 	}
 } as const;
 

--- a/tests/integration/harness/ports.ts
+++ b/tests/integration/harness/ports.ts
@@ -95,6 +95,12 @@ export const PORTS = {
 		writeMediaSettingsCreate: 7613,
 		writeMediaSettingsDelete: 7614,
 		writeMediaSettingsUpdate: 7615,
+		writeNamingRadarrCreate: 7616,
+		writeNamingRadarrUpdate: 7617,
+		writeNamingRadarrDelete: 7618,
+		writeNamingSonarrCreate: 7619,
+		writeNamingSonarrUpdate: 7620,
+		writeNamingSonarrDelete: 7621,
 		conflictsDelayProfiles: 7700,
 		conflictsRegex: 7701,
 		conflictsMediaSettings: 7702

--- a/tests/integration/pcd/conflicts/naming-radarr.test.ts
+++ b/tests/integration/pcd/conflicts/naming-radarr.test.ts
@@ -1,0 +1,605 @@
+/**
+ * PCD conflict tests: radarr naming.
+ */
+
+import { assert, assertEquals, assertExists, assertStringIncludes } from '@std/assert';
+import { startServer, stopServer } from '$test-harness/server.ts';
+import { openDb } from '$test-harness/db.ts';
+import { run, setup, teardown, test } from '$test-harness/runner.ts';
+import { PORTS } from '$test-harness/ports.ts';
+import { base } from '../harness/fixtures.ts';
+import {
+	compilePcd,
+	insertOp,
+	opCheckpoint,
+	parseMetadata,
+	queryOpsSince,
+	seedBase,
+	setupPcd,
+	type ConflictStrategy,
+	type OpRow,
+	type PcdTestContext,
+	type SeedOperation
+} from '../harness/pcd.ts';
+import { write } from '../harness/write.ts';
+
+const PORT = PORTS.pcd.conflictsNamingRadarr;
+const ORIGIN = `http://localhost:${PORT}`;
+const STRATEGIES: ConflictStrategy[] = ['ask', 'align', 'override'];
+
+type LatestHistory = {
+	status: string;
+	conflict_reason: string | null;
+};
+
+type RadarrNamingRow = {
+	name: string;
+	movie_format: string;
+	movie_folder_format: string;
+	rename: number;
+	replace_illegal_characters: number;
+	colon_replacement_format: string;
+};
+
+let counter = 0;
+
+setup(async () => {
+	await startServer(PORT, { AUTH: 'off', ORIGIN }, 'preview');
+});
+
+teardown(async () => {
+	await stopServer(PORT);
+});
+
+/**
+ * Base
+ *   Radarr naming:
+ *     name='Split Conflict', movieFormat='{Movie Title}',
+ *     replaceIllegalCharacters=false
+ *
+ * User
+ *   POST update changes:
+ *     movieFormat              = '{Movie Title} ({Release Year})'
+ *     replaceIllegalCharacters = true
+ *
+ * Upstream
+ *   Published base op changes:
+ *     movie_format '{Movie Title}' -> '{Movie Title} - upstream'
+ *
+ * Expect
+ *   - movie_format conflicts by strategy
+ *   - replace_illegal_characters applies cleanly for every strategy
+ *   - final replace_illegal_characters is 1 for every strategy
+ *   - final movie_format is the user value only for override
+ */
+test('split scalar conflicts resolve per field by strategy', async () => {
+	for (const strategy of STRATEGIES) {
+		const ctx = await seededScenario(strategy, 'split-scalar', [
+			base.radarrNaming({
+				name: 'Split Conflict',
+				movieFormat: '{Movie Title}',
+				movieFolderFormat: '{Movie Title}',
+				replaceIllegalCharacters: false
+			})
+		]);
+		const checkpoint = opCheckpoint(ctx);
+
+		await write.namingRadarr.update(ctx, 'Split Conflict', {
+			name: 'Split Conflict',
+			rename: true,
+			movieFormat: '{Movie Title} ({Release Year})',
+			movieFolderFormat: '{Movie Title}',
+			replaceIllegalCharacters: true,
+			colonReplacementFormat: 'delete'
+		});
+
+		seedUpstream(
+			ctx,
+			upstreamUpdate('Split Conflict', {
+				movie_format: {
+					from: '{Movie Title}',
+					to: '{Movie Title} - upstream'
+				}
+			})
+		);
+		await compilePcd(ctx);
+
+		const ops = opsSince(ctx, checkpoint);
+		const movieFormatOp = firstOpForChangedFields(ops, ['movie_format']);
+		const replaceIllegalOp = firstOpForChangedFields(ops, ['replace_illegal_characters']);
+
+		assertStrategyOutcome(ctx, movieFormatOp, strategy, 'guard_mismatch');
+		assertLatestHistory(ctx, replaceIllegalOp, 'applied');
+
+		const row = assertRadarrNaming(ctx, 'Split Conflict');
+		assertEquals(row.replace_illegal_characters, 1);
+		assertEquals(
+			row.movie_format,
+			strategy === 'override' ? '{Movie Title} ({Release Year})' : '{Movie Title} - upstream'
+		);
+	}
+});
+
+/**
+ * Base
+ *   Radarr naming:
+ *     name='Old Naming'
+ *
+ * User
+ *   POST update changes:
+ *     name = 'User Naming'
+ *
+ * Upstream
+ *   Published base rename changes:
+ *     name 'Old Naming' -> 'Upstream Naming'
+ *
+ * Expect
+ *   - rename op conflicts by strategy
+ *   - override final row is named 'User Naming'
+ *   - otherwise final row is named 'Upstream Naming'
+ */
+test('rename conflict follows upstream rename by strategy', async () => {
+	for (const strategy of STRATEGIES) {
+		const ctx = await seededScenario(strategy, 'rename', [
+			base.radarrNaming({ name: 'Old Naming' })
+		]);
+		const checkpoint = opCheckpoint(ctx);
+
+		await write.namingRadarr.update(ctx, 'Old Naming', {
+			name: 'User Naming',
+			rename: true,
+			movieFormat: '',
+			movieFolderFormat: '',
+			replaceIllegalCharacters: false,
+			colonReplacementFormat: 'delete'
+		});
+
+		seedUpstream(ctx, upstreamRename('Old Naming', 'Upstream Naming'));
+		await compilePcd(ctx);
+
+		const op = firstOpForChangedFields(opsSince(ctx, checkpoint), ['name']);
+		assertStrategyOutcome(ctx, op, strategy, 'guard_mismatch');
+
+		if (strategy === 'override') {
+			assertRadarrNaming(ctx, 'User Naming');
+			assertNoRadarrNaming(ctx, 'Upstream Naming');
+		} else {
+			assertRadarrNaming(ctx, 'Upstream Naming');
+			assertNoRadarrNaming(ctx, 'User Naming');
+		}
+	}
+});
+
+/**
+ * Base
+ *   Radarr naming:
+ *     name='Old Naming', movieFormat='{Movie Title}'
+ *
+ * User
+ *   POST update changes:
+ *     name        = 'User Naming'
+ *     movieFormat = '{Movie Title} ({Release Year})'
+ *
+ * Upstream
+ *   Published base rename changes:
+ *     name 'Old Naming' -> 'Upstream Naming'
+ *
+ * Expect
+ *   - conflict page field detail follows the upstream rename
+ *   - upstream name renders as 'Upstream Naming' instead of missing value
+ */
+test('conflict page field details follow upstream rename', async () => {
+	const ctx = await seededScenario('ask', 'field-detail-upstream-rename', [
+		base.radarrNaming({
+			name: 'Old Naming',
+			movieFormat: '{Movie Title}',
+			movieFolderFormat: '{Movie Title}'
+		})
+	]);
+
+	await write.namingRadarr.update(ctx, 'Old Naming', {
+		name: 'User Naming',
+		rename: true,
+		movieFormat: '{Movie Title} ({Release Year})',
+		movieFolderFormat: '{Movie Title}',
+		replaceIllegalCharacters: false,
+		colonReplacementFormat: 'delete'
+	});
+
+	seedUpstream(ctx, upstreamRename('Old Naming', 'Upstream Naming'));
+	await compilePcd(ctx);
+
+	const response = await ctx.client.get(`/databases/${ctx.dbId}/conflicts`);
+	assertEquals(response.status, 200);
+	const body = await response.text();
+	assertStringIncludes(body, 'Upstream Naming');
+});
+
+/**
+ * Base
+ *   Empty PCD.
+ *
+ * User
+ *   POST create radarr naming:
+ *     name='Create Conflict', movieFormat='{Movie Title} ({Release Year})',
+ *     replaceIllegalCharacters=true
+ *
+ * Upstream
+ *   Published base create:
+ *     name='Create Conflict', movieFormat='{Movie Title}',
+ *     replaceIllegalCharacters=false
+ *
+ * Expect
+ *   - create op conflicts by strategy
+ *   - final fields are user values only for override
+ */
+test('create duplicate conflict resolves by strategy', async () => {
+	for (const strategy of STRATEGIES) {
+		const ctx = await newScenario(strategy, 'create-duplicate');
+		await compilePcd(ctx);
+		const checkpoint = opCheckpoint(ctx);
+
+		await write.namingRadarr.create(ctx, {
+			name: 'Create Conflict',
+			rename: true,
+			movieFormat: '{Movie Title} ({Release Year})',
+			movieFolderFormat: '{Movie Title}',
+			replaceIllegalCharacters: true,
+			colonReplacementFormat: 'delete'
+		});
+
+		seedUpstream(
+			ctx,
+			base.radarrNaming({
+				name: 'Create Conflict',
+				movieFormat: '{Movie Title}',
+				movieFolderFormat: '{Movie Title}',
+				replaceIllegalCharacters: false
+			})
+		);
+		await compilePcd(ctx);
+
+		const op = firstOpForOperation(opsSince(ctx, checkpoint), 'create');
+		assertStrategyOutcome(ctx, op, strategy, 'duplicate_key');
+
+		const row = assertRadarrNaming(ctx, 'Create Conflict');
+		assertEquals(
+			row.movie_format,
+			strategy === 'override' ? '{Movie Title} ({Release Year})' : '{Movie Title}'
+		);
+		assertEquals(row.replace_illegal_characters, strategy === 'override' ? 1 : 0);
+	}
+});
+
+/**
+ * Base
+ *   Radarr naming:
+ *     name='Delete Conflict', movieFormat='{Movie Title}'
+ *
+ * User
+ *   POST delete radarr naming.
+ *
+ * Upstream
+ *   Published base op changes:
+ *     movie_format '{Movie Title}' -> '{Movie Title} ({Release Year})'
+ *
+ * Expect
+ *   - delete applies cleanly for every strategy
+ *   - final row is absent
+ */
+test('delete applies cleanly after upstream non-name field change', async () => {
+	for (const strategy of STRATEGIES) {
+		const ctx = await seededScenario(strategy, 'delete-after-field-change', [
+			base.radarrNaming({
+				name: 'Delete Conflict',
+				movieFormat: '{Movie Title}',
+				movieFolderFormat: '{Movie Title}'
+			})
+		]);
+		const checkpoint = opCheckpoint(ctx);
+
+		await write.namingRadarr.remove(ctx, 'Delete Conflict');
+
+		seedUpstream(
+			ctx,
+			upstreamUpdate('Delete Conflict', {
+				movie_format: {
+					from: '{Movie Title}',
+					to: '{Movie Title} ({Release Year})'
+				}
+			})
+		);
+		await compilePcd(ctx);
+
+		const op = firstOpForOperation(opsSince(ctx, checkpoint), 'delete');
+		assertEquals(op.state, 'published');
+		assertLatestHistory(ctx, op, 'applied');
+		assertNoRadarrNaming(ctx, 'Delete Conflict');
+	}
+});
+
+/**
+ * Base
+ *   Radarr naming:
+ *     name='Already Deleted'
+ *
+ * User
+ *   POST delete radarr naming.
+ *
+ * Upstream
+ *   Published base delete removes the same row.
+ *
+ * Expect
+ *   - all strategies auto-align/drop the user delete
+ *   - final row is absent
+ */
+test('delete missing target auto-aligns', async () => {
+	for (const strategy of STRATEGIES) {
+		const ctx = await seededScenario(strategy, 'delete-missing-target', [
+			base.radarrNaming({ name: 'Already Deleted' })
+		]);
+		const checkpoint = opCheckpoint(ctx);
+
+		await write.namingRadarr.remove(ctx, 'Already Deleted');
+
+		seedUpstream(ctx, upstreamDelete('Already Deleted'));
+		await compilePcd(ctx);
+
+		const op = firstOpForOperation(opsSince(ctx, checkpoint), 'delete');
+		assertEquals(op.state, 'dropped');
+		assertLatestHistory(ctx, op, 'dropped', 'aligned');
+		assertNoRadarrNaming(ctx, 'Already Deleted');
+	}
+});
+
+async function newScenario(strategy: ConflictStrategy, name: string): Promise<PcdTestContext> {
+	counter++;
+	return setupPcd({
+		port: PORT,
+		name: `pcd-conflict-naming-radarr-${counter}-${strategy}-${name}`,
+		conflictStrategy: strategy
+	});
+}
+
+async function seededScenario(
+	strategy: ConflictStrategy,
+	name: string,
+	operations: Array<string | SeedOperation>
+): Promise<PcdTestContext> {
+	const ctx = await newScenario(strategy, name);
+	seedBase(ctx, operations);
+	await compilePcd(ctx);
+	return ctx;
+}
+
+function seedUpstream(ctx: PcdTestContext, operation: SeedOperation): number {
+	return insertOp(ctx, {
+		...operation,
+		origin: 'base',
+		state: 'published',
+		source: 'repo'
+	});
+}
+
+function opsSince(ctx: PcdTestContext, checkpoint: number): OpRow[] {
+	return queryOpsSince(ctx, checkpoint, { origin: 'user' });
+}
+
+function firstOpForOperation(ops: OpRow[], operation: string): OpRow {
+	const op = ops.find((candidate) => parseMetadata(candidate).operation === operation);
+	assertExists(op, `Expected a user ${operation} op`);
+	return op;
+}
+
+function firstOpForChangedFields(ops: OpRow[], fields: string[]): OpRow {
+	const expected = [...fields].sort();
+	const op = ops.find((candidate) => {
+		const actual = changedFields(candidate).sort();
+		return (
+			actual.length === expected.length && actual.every((field, index) => field === expected[index])
+		);
+	});
+	assertExists(op, `Expected a user op for ${fields.join(', ')}`);
+	return op;
+}
+
+function changedFields(op: OpRow): string[] {
+	const fields = parseMetadata(op).changed_fields;
+	if (!Array.isArray(fields)) return [];
+	return fields.filter((field): field is string => typeof field === 'string');
+}
+
+function assertStrategyOutcome(
+	ctx: PcdTestContext,
+	op: OpRow,
+	strategy: ConflictStrategy,
+	reason: string
+): void {
+	if (strategy === 'ask') {
+		assertEquals(op.state, 'published');
+		assertLatestHistory(ctx, op, 'conflicted_pending', reason);
+		return;
+	}
+
+	if (strategy === 'align') {
+		assertEquals(op.state, 'dropped');
+		assertLatestHistory(ctx, op, 'dropped', 'aligned');
+		return;
+	}
+
+	assertEquals(op.state, 'superseded');
+	assert(op.superseded_by_op_id !== null, 'Expected override to link a replacement op');
+	assertLatestHistory(ctx, op, 'superseded');
+}
+
+function assertLatestHistory(
+	ctx: PcdTestContext,
+	op: OpRow,
+	status: string,
+	reason?: string
+): void {
+	const history = latestHistory(ctx, op.id);
+	assertEquals(history.status, status);
+	if (reason !== undefined) {
+		assertEquals(history.conflict_reason, reason);
+	}
+}
+
+function latestHistory(ctx: PcdTestContext, opId: number): LatestHistory {
+	const db = openDb(ctx.dbPath);
+	try {
+		const row = db
+			.prepare(
+				`SELECT status, conflict_reason
+				 FROM pcd_op_history
+				 WHERE database_id = ?
+				   AND op_id = ?
+				 ORDER BY applied_at DESC, id DESC
+				 LIMIT 1`
+			)
+			.get(ctx.dbId, opId) as LatestHistory | undefined;
+		assertExists(row, `Expected latest history for op ${opId}`);
+		return row;
+	} finally {
+		db.close();
+	}
+}
+
+function assertRadarrNaming(ctx: PcdTestContext, name: string): RadarrNamingRow {
+	const row = compiledRadarrNaming(ctx).find((r) => r.name === name);
+	assertExists(row, `Expected radarr naming ${name}`);
+	return row;
+}
+
+function assertNoRadarrNaming(ctx: PcdTestContext, name: string): void {
+	const row = compiledRadarrNaming(ctx).find((r) => r.name === name);
+	assertEquals(row, undefined);
+}
+
+function compiledRadarrNaming(ctx: PcdTestContext): RadarrNamingRow[] {
+	const source = openDb(ctx.dbPath);
+	const replay = openDb(':memory:');
+
+	try {
+		replay.exec('PRAGMA foreign_keys = ON');
+		replay.exec(Deno.readTextFileSync('docs/backend/0.schema.sql'));
+
+		const baseOps = source
+			.prepare(
+				`SELECT *
+				 FROM pcd_ops
+				 WHERE database_id = ?
+				   AND origin = 'base'
+				   AND state = 'published'
+				 ORDER BY COALESCE(sequence, id), id`
+			)
+			.all(ctx.dbId) as OpRow[];
+
+		const userOps = source
+			.prepare(
+				`SELECT *
+				 FROM pcd_ops
+				 WHERE database_id = ?
+				   AND origin = 'user'
+				   AND state = 'published'
+				 ORDER BY COALESCE(sequence, id), id`
+			)
+			.all(ctx.dbId) as OpRow[];
+		const histories = latestHistories(source, ctx.dbId);
+
+		for (const op of baseOps) {
+			replay.exec(op.sql);
+		}
+		for (const op of userOps) {
+			if (histories.get(op.id)?.status !== 'applied') continue;
+			replay.exec(op.sql);
+		}
+
+		return replay
+			.prepare(
+				`SELECT name, movie_format, movie_folder_format, rename, replace_illegal_characters, colon_replacement_format
+				 FROM radarr_naming
+				 ORDER BY name`
+			)
+			.all() as RadarrNamingRow[];
+	} finally {
+		replay.close();
+		source.close();
+	}
+}
+
+function latestHistories(
+	db: ReturnType<typeof openDb>,
+	databaseId: number
+): Map<number, LatestHistory> {
+	const rows = db
+		.prepare(
+			`SELECT op_id, status, conflict_reason
+			 FROM pcd_op_history
+			 WHERE database_id = ?
+			 ORDER BY applied_at ASC, id ASC`
+		)
+		.all(databaseId) as Array<LatestHistory & { op_id: number }>;
+	const latest = new Map<number, LatestHistory>();
+	for (const row of rows) {
+		latest.set(row.op_id, row);
+	}
+	return latest;
+}
+
+function upstreamUpdate(
+	name: string,
+	changes: Record<string, { from: unknown; to: unknown }>
+): SeedOperation {
+	const fields = Object.keys(changes);
+	const setSql = fields.map((field) => `${field} = ${sqlValue(changes[field].to)}`).join(', ');
+	return {
+		sql: `UPDATE radarr_naming SET ${setSql} WHERE name = ${sqlValue(name)};`,
+		metadata: JSON.stringify({
+			operation: 'update',
+			entity: 'radarr_naming',
+			name,
+			stable_key: { key: 'radarr_naming_name', value: name },
+			changed_fields: fields
+		}),
+		desiredState: JSON.stringify(changes)
+	};
+}
+
+function upstreamRename(from: string, to: string): SeedOperation {
+	return {
+		sql: `UPDATE radarr_naming SET name = ${sqlValue(to)} WHERE name = ${sqlValue(from)};`,
+		metadata: JSON.stringify({
+			operation: 'update',
+			entity: 'radarr_naming',
+			name: to,
+			previousName: from,
+			stable_key: { key: 'radarr_naming_name', value: from },
+			changed_fields: ['name']
+		}),
+		desiredState: JSON.stringify({ name: { from, to } })
+	};
+}
+
+function upstreamDelete(name: string): SeedOperation {
+	return {
+		sql: `DELETE FROM radarr_naming WHERE name = ${sqlValue(name)};`,
+		metadata: JSON.stringify({
+			operation: 'delete',
+			entity: 'radarr_naming',
+			name,
+			stable_key: { key: 'radarr_naming_name', value: name },
+			changed_fields: ['deleted']
+		}),
+		desiredState: JSON.stringify({ deleted: true, name })
+	};
+}
+
+function sqlValue(value: unknown): string {
+	if (value === null || value === undefined) return 'NULL';
+	if (typeof value === 'number') return String(value);
+	if (typeof value === 'boolean') return value ? '1' : '0';
+	return `'${String(value).replace(/'/g, "''")}'`;
+}
+
+await run();

--- a/tests/integration/pcd/conflicts/naming-sonarr.test.ts
+++ b/tests/integration/pcd/conflicts/naming-sonarr.test.ts
@@ -1,0 +1,628 @@
+/**
+ * PCD conflict tests: sonarr naming.
+ */
+
+import { assert, assertEquals, assertExists, assertStringIncludes } from '@std/assert';
+import { startServer, stopServer } from '$test-harness/server.ts';
+import { openDb } from '$test-harness/db.ts';
+import { run, setup, teardown, test } from '$test-harness/runner.ts';
+import { PORTS } from '$test-harness/ports.ts';
+import { base } from '../harness/fixtures.ts';
+import {
+	compilePcd,
+	insertOp,
+	opCheckpoint,
+	parseMetadata,
+	queryOpsSince,
+	seedBase,
+	setupPcd,
+	type ConflictStrategy,
+	type OpRow,
+	type PcdTestContext,
+	type SeedOperation
+} from '../harness/pcd.ts';
+import { write } from '../harness/write.ts';
+import { multiEpisodeStyleToDb } from '$shared/pcd/mediaManagement.ts';
+
+const PORT = PORTS.pcd.conflictsNamingSonarr;
+const ORIGIN = `http://localhost:${PORT}`;
+const STRATEGIES: ConflictStrategy[] = ['ask', 'align', 'override'];
+
+type LatestHistory = {
+	status: string;
+	conflict_reason: string | null;
+};
+
+type SonarrNamingRow = {
+	name: string;
+	standard_episode_format: string;
+	rename: number;
+	replace_illegal_characters: number;
+	colon_replacement_format: number;
+	multi_episode_style: number;
+};
+
+let counter = 0;
+
+setup(async () => {
+	await startServer(PORT, { AUTH: 'off', ORIGIN }, 'preview');
+});
+
+teardown(async () => {
+	await stopServer(PORT);
+});
+
+/**
+ * Base
+ *   Sonarr naming:
+ *     name='Split Conflict', standardEpisodeFormat='{Series Title}',
+ *     multiEpisodeStyle='extend'
+ *
+ * User
+ *   POST update changes:
+ *     standardEpisodeFormat = '{Series Title} - S{season:00}E{episode:00}'
+ *     multiEpisodeStyle     = 'range'
+ *
+ * Upstream
+ *   Published base op changes:
+ *     standard_episode_format '{Series Title}' -> '{Series Title} (upstream)'
+ *
+ * Expect
+ *   - standard_episode_format conflicts by strategy
+ *   - multi_episode_style applies cleanly for every strategy (exercises the
+ *     int-coded splitter path under conflict)
+ *   - final multi_episode_style is 'range' (int 4) for every strategy
+ *   - final standard_episode_format is the user value only for override
+ */
+test('split scalar conflicts resolve per field by strategy', async () => {
+	for (const strategy of STRATEGIES) {
+		const ctx = await seededScenario(strategy, 'split-scalar', [
+			base.sonarrNaming({
+				name: 'Split Conflict',
+				standardEpisodeFormat: '{Series Title}',
+				multiEpisodeStyle: 'extend'
+			})
+		]);
+		const checkpoint = opCheckpoint(ctx);
+
+		await write.namingSonarr.update(ctx, 'Split Conflict', {
+			name: 'Split Conflict',
+			rename: true,
+			standardEpisodeFormat: '{Series Title} - S{season:00}E{episode:00}',
+			dailyEpisodeFormat: '',
+			animeEpisodeFormat: '',
+			seriesFolderFormat: '',
+			seasonFolderFormat: '',
+			replaceIllegalCharacters: false,
+			colonReplacementFormat: 'delete',
+			customColonReplacementFormat: null,
+			multiEpisodeStyle: 'range'
+		});
+
+		seedUpstream(
+			ctx,
+			upstreamUpdate('Split Conflict', {
+				standard_episode_format: {
+					from: '{Series Title}',
+					to: '{Series Title} (upstream)'
+				}
+			})
+		);
+		await compilePcd(ctx);
+
+		const ops = opsSince(ctx, checkpoint);
+		const standardOp = firstOpForChangedFields(ops, ['standard_episode_format']);
+		const multiOp = firstOpForChangedFields(ops, ['multi_episode_style']);
+
+		assertStrategyOutcome(ctx, standardOp, strategy, 'guard_mismatch');
+		assertLatestHistory(ctx, multiOp, 'applied');
+
+		const row = assertSonarrNaming(ctx, 'Split Conflict');
+		assertEquals(row.multi_episode_style, multiEpisodeStyleToDb('range'));
+		assertEquals(
+			row.standard_episode_format,
+			strategy === 'override'
+				? '{Series Title} - S{season:00}E{episode:00}'
+				: '{Series Title} (upstream)'
+		);
+	}
+});
+
+/**
+ * Base
+ *   Sonarr naming:
+ *     name='Old Naming'
+ *
+ * User
+ *   POST update changes:
+ *     name = 'User Naming'
+ *
+ * Upstream
+ *   Published base rename changes:
+ *     name 'Old Naming' -> 'Upstream Naming'
+ *
+ * Expect
+ *   - rename op conflicts by strategy
+ *   - override final row is named 'User Naming'
+ *   - otherwise final row is named 'Upstream Naming'
+ */
+test('rename conflict follows upstream rename by strategy', async () => {
+	for (const strategy of STRATEGIES) {
+		const ctx = await seededScenario(strategy, 'rename', [
+			base.sonarrNaming({ name: 'Old Naming' })
+		]);
+		const checkpoint = opCheckpoint(ctx);
+
+		await write.namingSonarr.update(ctx, 'Old Naming', {
+			name: 'User Naming',
+			rename: true,
+			standardEpisodeFormat: '',
+			dailyEpisodeFormat: '',
+			animeEpisodeFormat: '',
+			seriesFolderFormat: '',
+			seasonFolderFormat: '',
+			replaceIllegalCharacters: false,
+			colonReplacementFormat: 'delete',
+			customColonReplacementFormat: null,
+			multiEpisodeStyle: 'extend'
+		});
+
+		seedUpstream(ctx, upstreamRename('Old Naming', 'Upstream Naming'));
+		await compilePcd(ctx);
+
+		const op = firstOpForChangedFields(opsSince(ctx, checkpoint), ['name']);
+		assertStrategyOutcome(ctx, op, strategy, 'guard_mismatch');
+
+		if (strategy === 'override') {
+			assertSonarrNaming(ctx, 'User Naming');
+			assertNoSonarrNaming(ctx, 'Upstream Naming');
+		} else {
+			assertSonarrNaming(ctx, 'Upstream Naming');
+			assertNoSonarrNaming(ctx, 'User Naming');
+		}
+	}
+});
+
+/**
+ * Base
+ *   Sonarr naming:
+ *     name='Old Naming', standardEpisodeFormat='{Series Title}'
+ *
+ * User
+ *   POST update changes:
+ *     name                  = 'User Naming'
+ *     standardEpisodeFormat = '{Series Title} - S{season:00}E{episode:00}'
+ *
+ * Upstream
+ *   Published base rename changes:
+ *     name 'Old Naming' -> 'Upstream Naming'
+ *
+ * Expect
+ *   - conflict page field detail follows the upstream rename
+ *   - upstream name renders as 'Upstream Naming' instead of missing value
+ */
+test('conflict page field details follow upstream rename', async () => {
+	const ctx = await seededScenario('ask', 'field-detail-upstream-rename', [
+		base.sonarrNaming({
+			name: 'Old Naming',
+			standardEpisodeFormat: '{Series Title}'
+		})
+	]);
+
+	await write.namingSonarr.update(ctx, 'Old Naming', {
+		name: 'User Naming',
+		rename: true,
+		standardEpisodeFormat: '{Series Title} - S{season:00}E{episode:00}',
+		dailyEpisodeFormat: '',
+		animeEpisodeFormat: '',
+		seriesFolderFormat: '',
+		seasonFolderFormat: '',
+		replaceIllegalCharacters: false,
+		colonReplacementFormat: 'delete',
+		customColonReplacementFormat: null,
+		multiEpisodeStyle: 'extend'
+	});
+
+	seedUpstream(ctx, upstreamRename('Old Naming', 'Upstream Naming'));
+	await compilePcd(ctx);
+
+	const response = await ctx.client.get(`/databases/${ctx.dbId}/conflicts`);
+	assertEquals(response.status, 200);
+	const body = await response.text();
+	assertStringIncludes(body, 'Upstream Naming');
+});
+
+/**
+ * Base
+ *   Empty PCD.
+ *
+ * User
+ *   POST create sonarr naming:
+ *     name='Create Conflict', standardEpisodeFormat='{Series Title} - S{season:00}E{episode:00}',
+ *     multiEpisodeStyle='range'
+ *
+ * Upstream
+ *   Published base create:
+ *     name='Create Conflict', standardEpisodeFormat='{Series Title}',
+ *     multiEpisodeStyle='extend'
+ *
+ * Expect
+ *   - create op conflicts by strategy
+ *   - final fields are user values only for override
+ */
+test('create duplicate conflict resolves by strategy', async () => {
+	for (const strategy of STRATEGIES) {
+		const ctx = await newScenario(strategy, 'create-duplicate');
+		await compilePcd(ctx);
+		const checkpoint = opCheckpoint(ctx);
+
+		await write.namingSonarr.create(ctx, {
+			name: 'Create Conflict',
+			rename: true,
+			standardEpisodeFormat: '{Series Title} - S{season:00}E{episode:00}',
+			dailyEpisodeFormat: '',
+			animeEpisodeFormat: '',
+			seriesFolderFormat: '',
+			seasonFolderFormat: '',
+			replaceIllegalCharacters: false,
+			colonReplacementFormat: 'delete',
+			customColonReplacementFormat: null,
+			multiEpisodeStyle: 'range'
+		});
+
+		seedUpstream(
+			ctx,
+			base.sonarrNaming({
+				name: 'Create Conflict',
+				standardEpisodeFormat: '{Series Title}',
+				multiEpisodeStyle: 'extend'
+			})
+		);
+		await compilePcd(ctx);
+
+		const op = firstOpForOperation(opsSince(ctx, checkpoint), 'create');
+		assertStrategyOutcome(ctx, op, strategy, 'duplicate_key');
+
+		const row = assertSonarrNaming(ctx, 'Create Conflict');
+		assertEquals(
+			row.standard_episode_format,
+			strategy === 'override' ? '{Series Title} - S{season:00}E{episode:00}' : '{Series Title}'
+		);
+		assertEquals(
+			row.multi_episode_style,
+			strategy === 'override' ? multiEpisodeStyleToDb('range') : multiEpisodeStyleToDb('extend')
+		);
+	}
+});
+
+/**
+ * Base
+ *   Sonarr naming:
+ *     name='Delete Conflict', standardEpisodeFormat='{Series Title}'
+ *
+ * User
+ *   POST delete sonarr naming.
+ *
+ * Upstream
+ *   Published base op changes:
+ *     standard_episode_format '{Series Title}' -> '{Series Title} (upstream)'
+ *
+ * Expect
+ *   - delete applies cleanly for every strategy
+ *   - final row is absent
+ */
+test('delete applies cleanly after upstream non-name field change', async () => {
+	for (const strategy of STRATEGIES) {
+		const ctx = await seededScenario(strategy, 'delete-after-field-change', [
+			base.sonarrNaming({
+				name: 'Delete Conflict',
+				standardEpisodeFormat: '{Series Title}'
+			})
+		]);
+		const checkpoint = opCheckpoint(ctx);
+
+		await write.namingSonarr.remove(ctx, 'Delete Conflict');
+
+		seedUpstream(
+			ctx,
+			upstreamUpdate('Delete Conflict', {
+				standard_episode_format: {
+					from: '{Series Title}',
+					to: '{Series Title} (upstream)'
+				}
+			})
+		);
+		await compilePcd(ctx);
+
+		const op = firstOpForOperation(opsSince(ctx, checkpoint), 'delete');
+		assertEquals(op.state, 'published');
+		assertLatestHistory(ctx, op, 'applied');
+		assertNoSonarrNaming(ctx, 'Delete Conflict');
+	}
+});
+
+/**
+ * Base
+ *   Sonarr naming:
+ *     name='Already Deleted'
+ *
+ * User
+ *   POST delete sonarr naming.
+ *
+ * Upstream
+ *   Published base delete removes the same row.
+ *
+ * Expect
+ *   - all strategies auto-align/drop the user delete
+ *   - final row is absent
+ */
+test('delete missing target auto-aligns', async () => {
+	for (const strategy of STRATEGIES) {
+		const ctx = await seededScenario(strategy, 'delete-missing-target', [
+			base.sonarrNaming({ name: 'Already Deleted' })
+		]);
+		const checkpoint = opCheckpoint(ctx);
+
+		await write.namingSonarr.remove(ctx, 'Already Deleted');
+
+		seedUpstream(ctx, upstreamDelete('Already Deleted'));
+		await compilePcd(ctx);
+
+		const op = firstOpForOperation(opsSince(ctx, checkpoint), 'delete');
+		assertEquals(op.state, 'dropped');
+		assertLatestHistory(ctx, op, 'dropped', 'aligned');
+		assertNoSonarrNaming(ctx, 'Already Deleted');
+	}
+});
+
+async function newScenario(strategy: ConflictStrategy, name: string): Promise<PcdTestContext> {
+	counter++;
+	return setupPcd({
+		port: PORT,
+		name: `pcd-conflict-naming-sonarr-${counter}-${strategy}-${name}`,
+		conflictStrategy: strategy
+	});
+}
+
+async function seededScenario(
+	strategy: ConflictStrategy,
+	name: string,
+	operations: Array<string | SeedOperation>
+): Promise<PcdTestContext> {
+	const ctx = await newScenario(strategy, name);
+	seedBase(ctx, operations);
+	await compilePcd(ctx);
+	return ctx;
+}
+
+function seedUpstream(ctx: PcdTestContext, operation: SeedOperation): number {
+	return insertOp(ctx, {
+		...operation,
+		origin: 'base',
+		state: 'published',
+		source: 'repo'
+	});
+}
+
+function opsSince(ctx: PcdTestContext, checkpoint: number): OpRow[] {
+	return queryOpsSince(ctx, checkpoint, { origin: 'user' });
+}
+
+function firstOpForOperation(ops: OpRow[], operation: string): OpRow {
+	const op = ops.find((candidate) => parseMetadata(candidate).operation === operation);
+	assertExists(op, `Expected a user ${operation} op`);
+	return op;
+}
+
+function firstOpForChangedFields(ops: OpRow[], fields: string[]): OpRow {
+	const expected = [...fields].sort();
+	const op = ops.find((candidate) => {
+		const actual = changedFields(candidate).sort();
+		return (
+			actual.length === expected.length && actual.every((field, index) => field === expected[index])
+		);
+	});
+	assertExists(op, `Expected a user op for ${fields.join(', ')}`);
+	return op;
+}
+
+function changedFields(op: OpRow): string[] {
+	const fields = parseMetadata(op).changed_fields;
+	if (!Array.isArray(fields)) return [];
+	return fields.filter((field): field is string => typeof field === 'string');
+}
+
+function assertStrategyOutcome(
+	ctx: PcdTestContext,
+	op: OpRow,
+	strategy: ConflictStrategy,
+	reason: string
+): void {
+	if (strategy === 'ask') {
+		assertEquals(op.state, 'published');
+		assertLatestHistory(ctx, op, 'conflicted_pending', reason);
+		return;
+	}
+
+	if (strategy === 'align') {
+		assertEquals(op.state, 'dropped');
+		assertLatestHistory(ctx, op, 'dropped', 'aligned');
+		return;
+	}
+
+	assertEquals(op.state, 'superseded');
+	assert(op.superseded_by_op_id !== null, 'Expected override to link a replacement op');
+	assertLatestHistory(ctx, op, 'superseded');
+}
+
+function assertLatestHistory(
+	ctx: PcdTestContext,
+	op: OpRow,
+	status: string,
+	reason?: string
+): void {
+	const history = latestHistory(ctx, op.id);
+	assertEquals(history.status, status);
+	if (reason !== undefined) {
+		assertEquals(history.conflict_reason, reason);
+	}
+}
+
+function latestHistory(ctx: PcdTestContext, opId: number): LatestHistory {
+	const db = openDb(ctx.dbPath);
+	try {
+		const row = db
+			.prepare(
+				`SELECT status, conflict_reason
+				 FROM pcd_op_history
+				 WHERE database_id = ?
+				   AND op_id = ?
+				 ORDER BY applied_at DESC, id DESC
+				 LIMIT 1`
+			)
+			.get(ctx.dbId, opId) as LatestHistory | undefined;
+		assertExists(row, `Expected latest history for op ${opId}`);
+		return row;
+	} finally {
+		db.close();
+	}
+}
+
+function assertSonarrNaming(ctx: PcdTestContext, name: string): SonarrNamingRow {
+	const row = compiledSonarrNaming(ctx).find((r) => r.name === name);
+	assertExists(row, `Expected sonarr naming ${name}`);
+	return row;
+}
+
+function assertNoSonarrNaming(ctx: PcdTestContext, name: string): void {
+	const row = compiledSonarrNaming(ctx).find((r) => r.name === name);
+	assertEquals(row, undefined);
+}
+
+function compiledSonarrNaming(ctx: PcdTestContext): SonarrNamingRow[] {
+	const source = openDb(ctx.dbPath);
+	const replay = openDb(':memory:');
+
+	try {
+		replay.exec('PRAGMA foreign_keys = ON');
+		replay.exec(Deno.readTextFileSync('docs/backend/0.schema.sql'));
+
+		const baseOps = source
+			.prepare(
+				`SELECT *
+				 FROM pcd_ops
+				 WHERE database_id = ?
+				   AND origin = 'base'
+				   AND state = 'published'
+				 ORDER BY COALESCE(sequence, id), id`
+			)
+			.all(ctx.dbId) as OpRow[];
+
+		const userOps = source
+			.prepare(
+				`SELECT *
+				 FROM pcd_ops
+				 WHERE database_id = ?
+				   AND origin = 'user'
+				   AND state = 'published'
+				 ORDER BY COALESCE(sequence, id), id`
+			)
+			.all(ctx.dbId) as OpRow[];
+		const histories = latestHistories(source, ctx.dbId);
+
+		for (const op of baseOps) {
+			replay.exec(op.sql);
+		}
+		for (const op of userOps) {
+			if (histories.get(op.id)?.status !== 'applied') continue;
+			replay.exec(op.sql);
+		}
+
+		return replay
+			.prepare(
+				`SELECT name, standard_episode_format, rename, replace_illegal_characters, colon_replacement_format, multi_episode_style
+				 FROM sonarr_naming
+				 ORDER BY name`
+			)
+			.all() as SonarrNamingRow[];
+	} finally {
+		replay.close();
+		source.close();
+	}
+}
+
+function latestHistories(
+	db: ReturnType<typeof openDb>,
+	databaseId: number
+): Map<number, LatestHistory> {
+	const rows = db
+		.prepare(
+			`SELECT op_id, status, conflict_reason
+			 FROM pcd_op_history
+			 WHERE database_id = ?
+			 ORDER BY applied_at ASC, id ASC`
+		)
+		.all(databaseId) as Array<LatestHistory & { op_id: number }>;
+	const latest = new Map<number, LatestHistory>();
+	for (const row of rows) {
+		latest.set(row.op_id, row);
+	}
+	return latest;
+}
+
+function upstreamUpdate(
+	name: string,
+	changes: Record<string, { from: unknown; to: unknown }>
+): SeedOperation {
+	const fields = Object.keys(changes);
+	const setSql = fields.map((field) => `${field} = ${sqlValue(changes[field].to)}`).join(', ');
+	return {
+		sql: `UPDATE sonarr_naming SET ${setSql} WHERE name = ${sqlValue(name)};`,
+		metadata: JSON.stringify({
+			operation: 'update',
+			entity: 'sonarr_naming',
+			name,
+			stable_key: { key: 'sonarr_naming_name', value: name },
+			changed_fields: fields
+		}),
+		desiredState: JSON.stringify(changes)
+	};
+}
+
+function upstreamRename(from: string, to: string): SeedOperation {
+	return {
+		sql: `UPDATE sonarr_naming SET name = ${sqlValue(to)} WHERE name = ${sqlValue(from)};`,
+		metadata: JSON.stringify({
+			operation: 'update',
+			entity: 'sonarr_naming',
+			name: to,
+			previousName: from,
+			stable_key: { key: 'sonarr_naming_name', value: from },
+			changed_fields: ['name']
+		}),
+		desiredState: JSON.stringify({ name: { from, to } })
+	};
+}
+
+function upstreamDelete(name: string): SeedOperation {
+	return {
+		sql: `DELETE FROM sonarr_naming WHERE name = ${sqlValue(name)};`,
+		metadata: JSON.stringify({
+			operation: 'delete',
+			entity: 'sonarr_naming',
+			name,
+			stable_key: { key: 'sonarr_naming_name', value: name },
+			changed_fields: ['deleted']
+		}),
+		desiredState: JSON.stringify({ deleted: true, name })
+	};
+}
+
+function sqlValue(value: unknown): string {
+	if (value === null || value === undefined) return 'NULL';
+	if (typeof value === 'number') return String(value);
+	if (typeof value === 'boolean') return value ? '1' : '0';
+	return `'${String(value).replace(/'/g, "''")}'`;
+}
+
+await run();

--- a/tests/integration/pcd/harness/fixtures.ts
+++ b/tests/integration/pcd/harness/fixtures.ts
@@ -1,4 +1,11 @@
 import type { SeedOperation } from './pcd.ts';
+import {
+	colonReplacementToDb,
+	multiEpisodeStyleToDb,
+	type MultiEpisodeStyle,
+	type RadarrColonReplacementFormat,
+	type SonarrColonReplacementFormat
+} from '$shared/pcd/mediaManagement.ts';
 
 export const base = {
 	delayProfile(input: {
@@ -82,6 +89,92 @@ export const base = {
 		enableMediaInfo?: boolean;
 	}): SeedOperation {
 		return mediaSettingsSeed('sonarr_media_settings', input);
+	},
+
+	radarrNaming(input: {
+		name: string;
+		rename?: boolean;
+		movieFormat?: string;
+		movieFolderFormat?: string;
+		replaceIllegalCharacters?: boolean;
+		colonReplacementFormat?: RadarrColonReplacementFormat;
+	}): SeedOperation {
+		const rename = input.rename ?? true;
+		const movieFormat = input.movieFormat ?? '';
+		const movieFolderFormat = input.movieFolderFormat ?? '';
+		const replaceIllegal = input.replaceIllegalCharacters ?? false;
+		const colon = input.colonReplacementFormat ?? 'delete';
+		return {
+			sql: `INSERT INTO radarr_naming (
+			              name,
+			              rename,
+			              movie_format,
+			              movie_folder_format,
+			              replace_illegal_characters,
+			              colon_replacement_format
+			          )
+			          VALUES (
+			              ${sqlValue(input.name)},
+			              ${rename ? 1 : 0},
+			              ${sqlValue(movieFormat)},
+			              ${sqlValue(movieFolderFormat)},
+			              ${replaceIllegal ? 1 : 0},
+			              ${sqlValue(colon)}
+			          );`
+		};
+	},
+
+	sonarrNaming(input: {
+		name: string;
+		rename?: boolean;
+		standardEpisodeFormat?: string;
+		dailyEpisodeFormat?: string;
+		animeEpisodeFormat?: string;
+		seriesFolderFormat?: string;
+		seasonFolderFormat?: string;
+		replaceIllegalCharacters?: boolean;
+		colonReplacementFormat?: SonarrColonReplacementFormat;
+		customColonReplacementFormat?: string | null;
+		multiEpisodeStyle?: MultiEpisodeStyle;
+	}): SeedOperation {
+		const rename = input.rename ?? true;
+		const standardEpisode = input.standardEpisodeFormat ?? '';
+		const dailyEpisode = input.dailyEpisodeFormat ?? '';
+		const animeEpisode = input.animeEpisodeFormat ?? '';
+		const seriesFolder = input.seriesFolderFormat ?? '';
+		const seasonFolder = input.seasonFolderFormat ?? '';
+		const replaceIllegal = input.replaceIllegalCharacters ?? false;
+		const colon = colonReplacementToDb(input.colonReplacementFormat ?? 'delete');
+		const customColon = input.customColonReplacementFormat ?? null;
+		const multi = multiEpisodeStyleToDb(input.multiEpisodeStyle ?? 'extend');
+		return {
+			sql: `INSERT INTO sonarr_naming (
+			              name,
+			              rename,
+			              standard_episode_format,
+			              daily_episode_format,
+			              anime_episode_format,
+			              series_folder_format,
+			              season_folder_format,
+			              replace_illegal_characters,
+			              colon_replacement_format,
+			              custom_colon_replacement_format,
+			              multi_episode_style
+			          )
+			          VALUES (
+			              ${sqlValue(input.name)},
+			              ${rename ? 1 : 0},
+			              ${sqlValue(standardEpisode)},
+			              ${sqlValue(dailyEpisode)},
+			              ${sqlValue(animeEpisode)},
+			              ${sqlValue(seriesFolder)},
+			              ${sqlValue(seasonFolder)},
+			              ${replaceIllegal ? 1 : 0},
+			              ${colon},
+			              ${sqlValue(customColon)},
+			              ${multi}
+			          );`
+		};
 	},
 
 	customFormatRegexCondition(input: {

--- a/tests/integration/pcd/harness/write.ts
+++ b/tests/integration/pcd/harness/write.ts
@@ -30,6 +30,47 @@ export interface MediaSettingsFormInput {
 	layer?: OpOrigin;
 }
 
+export type RadarrColonFormat = 'delete' | 'dash' | 'spaceDash' | 'spaceDashSpace' | 'smart';
+export type SonarrColonFormat =
+	| 'delete'
+	| 'dash'
+	| 'spaceDash'
+	| 'spaceDashSpace'
+	| 'smart'
+	| 'custom';
+export type SonarrMultiEpisodeStyle =
+	| 'extend'
+	| 'duplicate'
+	| 'repeat'
+	| 'scene'
+	| 'range'
+	| 'prefixedRange';
+
+export interface RadarrNamingFormInput {
+	name: string;
+	rename?: boolean;
+	movieFormat?: string;
+	movieFolderFormat?: string;
+	replaceIllegalCharacters?: boolean;
+	colonReplacementFormat?: RadarrColonFormat;
+	layer?: OpOrigin;
+}
+
+export interface SonarrNamingFormInput {
+	name: string;
+	rename?: boolean;
+	standardEpisodeFormat?: string;
+	dailyEpisodeFormat?: string;
+	animeEpisodeFormat?: string;
+	seriesFolderFormat?: string;
+	seasonFolderFormat?: string;
+	replaceIllegalCharacters?: boolean;
+	colonReplacementFormat?: SonarrColonFormat;
+	customColonReplacementFormat?: string | null;
+	multiEpisodeStyle?: SonarrMultiEpisodeStyle;
+	layer?: OpOrigin;
+}
+
 export const write = {
 	delayProfile: {
 		create: createDelayProfile,
@@ -54,6 +95,22 @@ export const write = {
 		submitCreate: submitCreateMediaSettings,
 		submitUpdate: submitUpdateMediaSettings,
 		submitRemove: submitRemoveMediaSettings
+	},
+	namingRadarr: {
+		create: createRadarrNaming,
+		update: updateRadarrNaming,
+		remove: removeRadarrNaming,
+		submitCreate: submitCreateRadarrNaming,
+		submitUpdate: submitUpdateRadarrNaming,
+		submitRemove: submitRemoveRadarrNaming
+	},
+	namingSonarr: {
+		create: createSonarrNaming,
+		update: updateSonarrNaming,
+		remove: removeSonarrNaming,
+		submitCreate: submitCreateSonarrNaming,
+		submitUpdate: submitUpdateSonarrNaming,
+		submitRemove: submitRemoveSonarrNaming
 	}
 };
 
@@ -276,6 +333,165 @@ function mediaSettingsFields(
 		name: input.name,
 		propersRepacks: input.propersRepacks ?? 'doNotPrefer',
 		enableMediaInfo: String(input.enableMediaInfo ?? false),
+		layer: input.layer ?? 'user'
+	};
+}
+
+export async function createRadarrNaming(
+	ctx: PcdTestContext,
+	input: RadarrNamingFormInput
+): Promise<Response> {
+	return assertSuccessfulAction(await submitCreateRadarrNaming(ctx, input), 'create radarr naming');
+}
+
+export async function updateRadarrNaming(
+	ctx: PcdTestContext,
+	currentName: string,
+	input: RadarrNamingFormInput
+): Promise<Response> {
+	return assertSuccessfulAction(
+		await submitUpdateRadarrNaming(ctx, currentName, input),
+		'update radarr naming'
+	);
+}
+
+export async function removeRadarrNaming(
+	ctx: PcdTestContext,
+	currentName: string,
+	layer: OpOrigin = 'user'
+): Promise<Response> {
+	return assertSuccessfulAction(
+		await submitRemoveRadarrNaming(ctx, currentName, layer),
+		'delete radarr naming'
+	);
+}
+
+export async function submitCreateRadarrNaming(
+	ctx: PcdTestContext,
+	input: RadarrNamingFormInput
+): Promise<Response> {
+	return ctx.client.postForm(
+		`/media-management/${ctx.dbId}/naming/new`,
+		radarrNamingFields(input),
+		{ headers: { Origin: ctx.origin } }
+	);
+}
+
+export async function submitUpdateRadarrNaming(
+	ctx: PcdTestContext,
+	currentName: string,
+	input: RadarrNamingFormInput
+): Promise<Response> {
+	return ctx.client.postForm(
+		`/media-management/${ctx.dbId}/naming/radarr/${encodeURIComponent(currentName)}?/update`,
+		radarrNamingFields(input),
+		{ headers: { Origin: ctx.origin } }
+	);
+}
+
+export async function submitRemoveRadarrNaming(
+	ctx: PcdTestContext,
+	currentName: string,
+	layer: OpOrigin = 'user'
+): Promise<Response> {
+	return ctx.client.postForm(
+		`/media-management/${ctx.dbId}/naming/radarr/${encodeURIComponent(currentName)}?/delete`,
+		{ layer },
+		{ headers: { Origin: ctx.origin } }
+	);
+}
+
+export async function createSonarrNaming(
+	ctx: PcdTestContext,
+	input: SonarrNamingFormInput
+): Promise<Response> {
+	return assertSuccessfulAction(await submitCreateSonarrNaming(ctx, input), 'create sonarr naming');
+}
+
+export async function updateSonarrNaming(
+	ctx: PcdTestContext,
+	currentName: string,
+	input: SonarrNamingFormInput
+): Promise<Response> {
+	return assertSuccessfulAction(
+		await submitUpdateSonarrNaming(ctx, currentName, input),
+		'update sonarr naming'
+	);
+}
+
+export async function removeSonarrNaming(
+	ctx: PcdTestContext,
+	currentName: string,
+	layer: OpOrigin = 'user'
+): Promise<Response> {
+	return assertSuccessfulAction(
+		await submitRemoveSonarrNaming(ctx, currentName, layer),
+		'delete sonarr naming'
+	);
+}
+
+export async function submitCreateSonarrNaming(
+	ctx: PcdTestContext,
+	input: SonarrNamingFormInput
+): Promise<Response> {
+	return ctx.client.postForm(
+		`/media-management/${ctx.dbId}/naming/new`,
+		sonarrNamingFields(input),
+		{ headers: { Origin: ctx.origin } }
+	);
+}
+
+export async function submitUpdateSonarrNaming(
+	ctx: PcdTestContext,
+	currentName: string,
+	input: SonarrNamingFormInput
+): Promise<Response> {
+	return ctx.client.postForm(
+		`/media-management/${ctx.dbId}/naming/sonarr/${encodeURIComponent(currentName)}?/update`,
+		sonarrNamingFields(input),
+		{ headers: { Origin: ctx.origin } }
+	);
+}
+
+export async function submitRemoveSonarrNaming(
+	ctx: PcdTestContext,
+	currentName: string,
+	layer: OpOrigin = 'user'
+): Promise<Response> {
+	return ctx.client.postForm(
+		`/media-management/${ctx.dbId}/naming/sonarr/${encodeURIComponent(currentName)}?/delete`,
+		{ layer },
+		{ headers: { Origin: ctx.origin } }
+	);
+}
+
+function radarrNamingFields(input: RadarrNamingFormInput): Record<string, string> {
+	return {
+		arrType: 'radarr',
+		name: input.name,
+		rename: String(input.rename ?? true),
+		movieFormat: input.movieFormat ?? '',
+		movieFolderFormat: input.movieFolderFormat ?? '',
+		replaceIllegalCharacters: String(input.replaceIllegalCharacters ?? false),
+		colonReplacementFormat: input.colonReplacementFormat ?? 'delete',
+		layer: input.layer ?? 'user'
+	};
+}
+
+function sonarrNamingFields(input: SonarrNamingFormInput): Record<string, string> {
+	return {
+		arrType: 'sonarr',
+		name: input.name,
+		rename: String(input.rename ?? true),
+		standardEpisodeFormat: input.standardEpisodeFormat ?? '',
+		dailyEpisodeFormat: input.dailyEpisodeFormat ?? '',
+		animeEpisodeFormat: input.animeEpisodeFormat ?? '',
+		seriesFolderFormat: input.seriesFolderFormat ?? '',
+		seasonFolderFormat: input.seasonFolderFormat ?? '',
+		replaceIllegalCharacters: String(input.replaceIllegalCharacters ?? false),
+		colonReplacementFormat: input.colonReplacementFormat ?? 'delete',
+		customColonReplacementFormat: input.customColonReplacementFormat ?? '',
+		multiEpisodeStyle: input.multiEpisodeStyle ?? 'extend',
 		layer: input.layer ?? 'user'
 	};
 }

--- a/tests/integration/pcd/write/naming/helpers.ts
+++ b/tests/integration/pcd/write/naming/helpers.ts
@@ -1,0 +1,92 @@
+/**
+ * Shared scenario factory and op assertions for naming write specs.
+ */
+
+import { assert, assertEquals, assertExists } from '@std/assert';
+import {
+	compilePcd,
+	normalizeSql,
+	parseMetadata,
+	queryOpsSince,
+	seedBase,
+	setupPcd,
+	type OpRow,
+	type PcdTestContext,
+	type SetupPcdOptions
+} from '../../harness/pcd.ts';
+
+export function createScenarioFactory(port: number, prefix: string) {
+	let counter = 0;
+
+	async function newPcd(
+		name: string,
+		options: Partial<SetupPcdOptions> = {}
+	): Promise<PcdTestContext> {
+		counter++;
+		return setupPcd({
+			port,
+			name: `${prefix}-${counter}-${name}`,
+			conflictStrategy: 'ask',
+			...options
+		});
+	}
+
+	async function seededPcd(
+		name: string,
+		operations: Parameters<typeof seedBase>[1],
+		options: Partial<SetupPcdOptions> = {}
+	): Promise<PcdTestContext> {
+		const ctx = await newPcd(name, options);
+		seedBase(ctx, operations);
+		await compilePcd(ctx);
+		return ctx;
+	}
+
+	return { newPcd, seededPcd };
+}
+
+export function userOpsSince(ctx: PcdTestContext, checkpoint: number): OpRow[] {
+	return queryOpsSince(ctx, checkpoint, { origin: 'user', state: 'published' });
+}
+
+export function changedFields(op: OpRow): string[] {
+	const fields = parseMetadata(op).changed_fields;
+	if (!Array.isArray(fields)) return [];
+	return fields.filter((field): field is string => typeof field === 'string');
+}
+
+export function opForChangedField(ops: OpRow[], field: string): OpRow {
+	const op = ops.find((candidate) => {
+		const fields = changedFields(candidate);
+		return fields.length === 1 && fields[0] === field;
+	});
+	assertExists(op, `Expected a user op for ${field}`);
+	return op;
+}
+
+export function assertOnlyField(ops: OpRow[], field: string): void {
+	const op = opForChangedField(ops, field);
+	assertEquals(changedFields(op), [field]);
+	const sql = normalizeSql(op.sql).toLowerCase();
+	assert(
+		sql.includes(`"${field}"`) || sql.includes(field),
+		`Expected ${field} SQL to mention its field, got ${sql}`
+	);
+}
+
+export function assertSameGroup(ops: OpRow[]): void {
+	const groupIds = ops.map((op) => parseMetadata(op).group_id);
+	assert(groupIds.length > 0);
+	assertExists(groupIds[0]);
+	for (const groupId of groupIds) {
+		assertEquals(groupId, groupIds[0]);
+	}
+}
+
+export async function assertActionFailed(response: Response): Promise<void> {
+	const body = await response.text();
+	assert(
+		response.status >= 400 || body.includes('"type":"failure"'),
+		`Expected form action failure, got status=${response.status} body=${body}`
+	);
+}

--- a/tests/integration/pcd/write/naming/radarr-create.test.ts
+++ b/tests/integration/pcd/write/naming/radarr-create.test.ts
@@ -1,0 +1,156 @@
+/**
+ * PCD write tests: radarr naming create.
+ */
+
+import { assert, assertEquals } from '@std/assert';
+import { startServer, stopServer } from '$test-harness/server.ts';
+import { run, setup, teardown, test } from '$test-harness/runner.ts';
+import { PORTS } from '$test-harness/ports.ts';
+import { base } from '../../harness/fixtures.ts';
+import {
+	compilePcd,
+	normalizeSql,
+	opCheckpoint,
+	parseDesiredState,
+	parseMetadata
+} from '../../harness/pcd.ts';
+import { write } from '../../harness/write.ts';
+import { assertActionFailed, createScenarioFactory, userOpsSince } from './helpers.ts';
+
+const PORT = PORTS.pcd.writeNamingRadarrCreate;
+const ORIGIN = `http://localhost:${PORT}`;
+
+const { newPcd, seededPcd } = createScenarioFactory(PORT, 'pcd-write-naming-radarr-create');
+
+setup(async () => {
+	await startServer(PORT, { AUTH: 'off', ORIGIN }, 'preview');
+});
+
+teardown(async () => {
+	await stopServer(PORT);
+});
+
+/**
+ * Context
+ *   Empty PCD (only schema seeded), compiled once.
+ *
+ * Submit
+ *   POST /media-management/{ctx.dbId}/naming/new with form fields:
+ *     arrType                  = 'radarr'
+ *     name                     = 'Created Naming'
+ *     rename                   = 'true'
+ *     movieFormat              = ''
+ *     movieFolderFormat        = ''
+ *     replaceIllegalCharacters = 'false'
+ *     colonReplacementFormat   = 'delete'
+ *     layer                    = 'user'
+ *
+ * Expect
+ *   - userOpsSince(checkpoint).length === 1
+ *   - op.metadata.operation === 'create'
+ *   - op.metadata.entity    === 'radarr_naming'
+ *   - op.metadata.name      === 'Created Naming'
+ *   - op.desired_state.name                       === 'Created Naming'
+ *   - op.desired_state.rename                     === true
+ *   - op.desired_state.movie_format               === ''
+ *   - op.desired_state.movie_folder_format        === ''
+ *   - op.desired_state.replace_illegal_characters === false
+ *   - op.desired_state.colon_replacement_format   === 'delete'
+ *   - op.sql matches /insert into "?radarr_naming"?/i
+ */
+test('minimal radarr naming emits one create op', async () => {
+	const ctx = await newPcd('minimal');
+	await compilePcd(ctx);
+	const checkpoint = opCheckpoint(ctx);
+
+	await write.namingRadarr.create(ctx, { name: 'Created Naming' });
+
+	const ops = userOpsSince(ctx, checkpoint);
+	assertEquals(ops.length, 1);
+	const op = ops[0];
+	const metadata = parseMetadata(op);
+	assertEquals(metadata.operation, 'create');
+	assertEquals(metadata.entity, 'radarr_naming');
+	assertEquals(metadata.name, 'Created Naming');
+	const desired = parseDesiredState(op);
+	assertEquals(desired.name, 'Created Naming');
+	assertEquals(desired.rename, true);
+	assertEquals(desired.movie_format, '');
+	assertEquals(desired.movie_folder_format, '');
+	assertEquals(desired.replace_illegal_characters, false);
+	assertEquals(desired.colon_replacement_format, 'delete');
+	const sql = normalizeSql(op.sql);
+	assert(/insert into "?radarr_naming"?/i.test(sql));
+});
+
+/**
+ * Context
+ *   Empty PCD (only schema seeded), compiled once.
+ *
+ * Submit
+ *   POST /media-management/{ctx.dbId}/naming/new with form fields:
+ *     arrType                  = 'radarr'
+ *     name                     = 'Tuned Naming'
+ *     rename                   = 'false'
+ *     movieFormat              = '{Movie Title} ({Release Year})'
+ *     movieFolderFormat        = '{Movie Title} ({Release Year})'
+ *     replaceIllegalCharacters = 'true'
+ *     colonReplacementFormat   = 'dash'
+ *
+ * Expect
+ *   - userOpsSince(checkpoint).length === 1
+ *   - op.desired_state.rename                     === false
+ *   - op.desired_state.movie_format               === '{Movie Title} ({Release Year})'
+ *   - op.desired_state.movie_folder_format        === '{Movie Title} ({Release Year})'
+ *   - op.desired_state.replace_illegal_characters === true
+ *   - op.desired_state.colon_replacement_format   === 'dash'
+ */
+test('radarr naming non-default values are recorded', async () => {
+	const ctx = await newPcd('tuned');
+	await compilePcd(ctx);
+	const checkpoint = opCheckpoint(ctx);
+
+	await write.namingRadarr.create(ctx, {
+		name: 'Tuned Naming',
+		rename: false,
+		movieFormat: '{Movie Title} ({Release Year})',
+		movieFolderFormat: '{Movie Title} ({Release Year})',
+		replaceIllegalCharacters: true,
+		colonReplacementFormat: 'dash'
+	});
+
+	const ops = userOpsSince(ctx, checkpoint);
+	assertEquals(ops.length, 1);
+	const desired = parseDesiredState(ops[0]);
+	assertEquals(desired.rename, false);
+	assertEquals(desired.movie_format, '{Movie Title} ({Release Year})');
+	assertEquals(desired.movie_folder_format, '{Movie Title} ({Release Year})');
+	assertEquals(desired.replace_illegal_characters, true);
+	assertEquals(desired.colon_replacement_format, 'dash');
+});
+
+/**
+ * Context
+ *   Base layer seeded with one row named 'Existing Naming'. Compiled.
+ *
+ * Submit
+ *   POST /media-management/{ctx.dbId}/naming/new with form fields:
+ *     arrType  = 'radarr'
+ *     name     = 'existing naming'   // lowercase duplicate
+ *     layer    = 'user'
+ *
+ * Expect
+ *   - response.status >= 400 OR body contains '"type":"failure"'
+ *   - userOpsSince(checkpoint).length === 0
+ */
+test('duplicate radarr naming name fails without writing ops', async () => {
+	const ctx = await seededPcd('duplicate', [base.radarrNaming({ name: 'Existing Naming' })]);
+	const checkpoint = opCheckpoint(ctx);
+
+	const response = await write.namingRadarr.submitCreate(ctx, { name: 'existing naming' });
+
+	await assertActionFailed(response);
+	assertEquals(userOpsSince(ctx, checkpoint).length, 0);
+});
+
+await run();

--- a/tests/integration/pcd/write/naming/radarr-delete.test.ts
+++ b/tests/integration/pcd/write/naming/radarr-delete.test.ts
@@ -1,0 +1,119 @@
+/**
+ * PCD write tests: radarr naming delete.
+ *
+ * The name-only-guard SQL assertion will fail until the delete writer drops
+ * its non-name guards (covered by task #10). It pins the desired contract
+ * before the implementation, mirroring the regex / delay-profile / media-settings
+ * pattern.
+ */
+
+import { assert, assertEquals } from '@std/assert';
+import { startServer, stopServer } from '$test-harness/server.ts';
+import { run, setup, teardown, test } from '$test-harness/runner.ts';
+import { PORTS } from '$test-harness/ports.ts';
+import { base } from '../../harness/fixtures.ts';
+import { normalizeSql, opCheckpoint, parseDesiredState, parseMetadata } from '../../harness/pcd.ts';
+import { write } from '../../harness/write.ts';
+import { createScenarioFactory, userOpsSince } from './helpers.ts';
+
+const PORT = PORTS.pcd.writeNamingRadarrDelete;
+const ORIGIN = `http://localhost:${PORT}`;
+
+const { seededPcd } = createScenarioFactory(PORT, 'pcd-write-naming-radarr-delete');
+
+setup(async () => {
+	await startServer(PORT, { AUTH: 'off', ORIGIN }, 'preview');
+});
+
+teardown(async () => {
+	await stopServer(PORT);
+});
+
+/**
+ * Context
+ *   Base layer seeded with one row:
+ *     name='Delete Naming', rename=false, movieFormat='{Movie Title} ({Release Year})',
+ *     movieFolderFormat='{Movie Title}', replaceIllegalCharacters=true,
+ *     colonReplacementFormat='dash'
+ *   Compiled.
+ *
+ * Submit
+ *   POST /media-management/{ctx.dbId}/naming/radarr/Delete%20Naming?/delete
+ *     with form fields: layer = 'user'
+ *
+ * Expect
+ *   - userOpsSince(checkpoint).length === 1
+ *   - op.metadata.operation       === 'delete'
+ *   - op.metadata.entity          === 'radarr_naming'
+ *   - op.metadata.name            === 'Delete Naming'
+ *   - op.metadata.changed_fields  === ['deleted']
+ *   - op.desired_state.deleted                       === true
+ *   - op.desired_state.name                          === 'Delete Naming'
+ *   - op.desired_state.movie_format                  === '{Movie Title} ({Release Year})'
+ *   - op.desired_state.colon_replacement_format      === 'dash'
+ *   - op.sql matches /delete from "?radarr_naming"?/i
+ *   - op.sql DELETE clause guards by name only (no rename, movie_format,
+ *     movie_folder_format, replace_illegal_characters, or colon_replacement_format
+ *     in the WHERE). Currently fails until the delete writer drops its non-name
+ *     guards (#10).
+ */
+test('radarr naming delete emits one name-guarded op', async () => {
+	const ctx = await seededPcd('simple', [
+		base.radarrNaming({
+			name: 'Delete Naming',
+			rename: false,
+			movieFormat: '{Movie Title} ({Release Year})',
+			movieFolderFormat: '{Movie Title}',
+			replaceIllegalCharacters: true,
+			colonReplacementFormat: 'dash'
+		})
+	]);
+	const checkpoint = opCheckpoint(ctx);
+
+	await write.namingRadarr.remove(ctx, 'Delete Naming');
+
+	const ops = userOpsSince(ctx, checkpoint);
+	assertEquals(ops.length, 1);
+	const op = ops[0];
+	const metadata = parseMetadata(op);
+	assertEquals(metadata.operation, 'delete');
+	assertEquals(metadata.entity, 'radarr_naming');
+	assertEquals(metadata.name, 'Delete Naming');
+	assertEquals(metadata.changed_fields, ['deleted']);
+	const desired = parseDesiredState(op);
+	assertEquals(desired.deleted, true);
+	assertEquals(desired.name, 'Delete Naming');
+	assertEquals(desired.movie_format, '{Movie Title} ({Release Year})');
+	assertEquals(desired.colon_replacement_format, 'dash');
+
+	const sql = normalizeSql(op.sql);
+	const lowerSql = sql.toLowerCase();
+	assert(/delete from "?radarr_naming"?/i.test(sql));
+
+	const deleteIndex = lowerSql.indexOf('delete from "radarr_naming"');
+	assert(deleteIndex >= 0, 'expected radarr_naming delete in SQL');
+	const deleteClause = sql.slice(deleteIndex);
+	assert(/where "?name"? = /i.test(deleteClause));
+	assert(
+		!/where[^;]*"?rename"?\s*=/i.test(deleteClause),
+		`rename should not appear in delete WHERE clause, got: ${deleteClause}`
+	);
+	assert(
+		!/where[^;]*"?movie_format"?\s*=/i.test(deleteClause),
+		`movie_format should not appear in delete WHERE clause, got: ${deleteClause}`
+	);
+	assert(
+		!/where[^;]*"?movie_folder_format"?\s*=/i.test(deleteClause),
+		`movie_folder_format should not appear in delete WHERE clause, got: ${deleteClause}`
+	);
+	assert(
+		!/where[^;]*"?replace_illegal_characters"?\s*=/i.test(deleteClause),
+		`replace_illegal_characters should not appear in delete WHERE clause, got: ${deleteClause}`
+	);
+	assert(
+		!/where[^;]*"?colon_replacement_format"?\s*=/i.test(deleteClause),
+		`colon_replacement_format should not appear in delete WHERE clause, got: ${deleteClause}`
+	);
+});
+
+await run();

--- a/tests/integration/pcd/write/naming/radarr-update.test.ts
+++ b/tests/integration/pcd/write/naming/radarr-update.test.ts
@@ -1,0 +1,210 @@
+/**
+ * PCD write tests: radarr naming update.
+ *
+ * The split-op tests will fail until the per-field splitting work for naming
+ * (task #9) ships. They pin the desired contract before the implementation,
+ * mirroring the regex / delay-profile / media-settings pattern.
+ */
+
+import { assertEquals } from '@std/assert';
+import { startServer, stopServer } from '$test-harness/server.ts';
+import { run, setup, teardown, test } from '$test-harness/runner.ts';
+import { PORTS } from '$test-harness/ports.ts';
+import { base } from '../../harness/fixtures.ts';
+import { opCheckpoint, parseDesiredState, parseMetadata } from '../../harness/pcd.ts';
+import { write } from '../../harness/write.ts';
+import {
+	assertOnlyField,
+	assertSameGroup,
+	createScenarioFactory,
+	opForChangedField,
+	userOpsSince
+} from './helpers.ts';
+
+const PORT = PORTS.pcd.writeNamingRadarrUpdate;
+const ORIGIN = `http://localhost:${PORT}`;
+
+const { seededPcd } = createScenarioFactory(PORT, 'pcd-write-naming-radarr-update');
+
+setup(async () => {
+	await startServer(PORT, { AUTH: 'off', ORIGIN }, 'preview');
+});
+
+teardown(async () => {
+	await stopServer(PORT);
+});
+
+/**
+ * Context
+ *   Base layer seeded with one radarr_naming row:
+ *     name='Split Naming', rename=true, movieFormat='{Movie Title}',
+ *     movieFolderFormat='{Movie Title}', replaceIllegalCharacters=false,
+ *     colonReplacementFormat='delete'
+ *   Compiled.
+ *
+ * Submit
+ *   POST /media-management/{ctx.dbId}/naming/radarr/Split%20Naming?/update
+ *     with form fields:
+ *       name                     = 'Split Naming'                 // unchanged
+ *       rename                   = 'true'                         // unchanged
+ *       movieFormat              = '{Movie Title} ({Release Year})'  // changed
+ *       movieFolderFormat        = '{Movie Title}'                // unchanged
+ *       replaceIllegalCharacters = 'true'                         // changed (bool)
+ *       colonReplacementFormat   = 'delete'                       // unchanged
+ *
+ * Expect
+ *   - userOpsSince(checkpoint).length === 2
+ *   - one op with metadata.changed_fields === ['movie_format']
+ *   - one op with metadata.changed_fields === ['replace_illegal_characters']
+ *   - both ops share the same metadata.group_id
+ */
+test('representative scalar fields split into grouped ops', async () => {
+	const ctx = await seededPcd('scalars', [
+		base.radarrNaming({
+			name: 'Split Naming',
+			movieFormat: '{Movie Title}',
+			movieFolderFormat: '{Movie Title}'
+		})
+	]);
+	const checkpoint = opCheckpoint(ctx);
+
+	await write.namingRadarr.update(ctx, 'Split Naming', {
+		name: 'Split Naming',
+		rename: true,
+		movieFormat: '{Movie Title} ({Release Year})',
+		movieFolderFormat: '{Movie Title}',
+		replaceIllegalCharacters: true,
+		colonReplacementFormat: 'delete'
+	});
+
+	const ops = userOpsSince(ctx, checkpoint);
+	assertEquals(ops.length, 2);
+	assertOnlyField(ops, 'movie_format');
+	assertOnlyField(ops, 'replace_illegal_characters');
+	assertSameGroup(ops);
+});
+
+/**
+ * Context
+ *   Base layer seeded with one row:
+ *     name='Old Naming', movieFormat='{Movie Title}', other fields default
+ *   Compiled.
+ *
+ * Submit
+ *   POST /media-management/{ctx.dbId}/naming/radarr/Old%20Naming?/update
+ *     with form fields:
+ *       name                     = 'New Naming'           // changed
+ *       movieFormat              = '{Movie Title} ({Release Year})'  // changed
+ *       (others unchanged)
+ *
+ * Expect
+ *   - userOpsSince(checkpoint).length === 2
+ *   - one op with metadata.changed_fields === ['movie_format']
+ *   - one op with metadata.changed_fields === ['name']
+ *   - both ops share the same metadata.group_id
+ *   - rename op.metadata.name         === 'New Naming'
+ *   - rename op.metadata.previousName === 'Old Naming'
+ *   - rename op.desired_state.name    === { from: 'Old Naming', to: 'New Naming' }
+ */
+test('rename plus scalar change emits grouped split ops', async () => {
+	const ctx = await seededPcd('rename-scalar', [
+		base.radarrNaming({
+			name: 'Old Naming',
+			movieFormat: '{Movie Title}',
+			movieFolderFormat: '{Movie Title}'
+		})
+	]);
+	const checkpoint = opCheckpoint(ctx);
+
+	await write.namingRadarr.update(ctx, 'Old Naming', {
+		name: 'New Naming',
+		rename: true,
+		movieFormat: '{Movie Title} ({Release Year})',
+		movieFolderFormat: '{Movie Title}',
+		replaceIllegalCharacters: false,
+		colonReplacementFormat: 'delete'
+	});
+
+	const ops = userOpsSince(ctx, checkpoint);
+	assertEquals(ops.length, 2);
+	assertOnlyField(ops, 'movie_format');
+	assertOnlyField(ops, 'name');
+	assertSameGroup(ops);
+	const renameOp = opForChangedField(ops, 'name');
+	const metadata = parseMetadata(renameOp);
+	assertEquals(metadata.name, 'New Naming');
+	assertEquals(metadata.previousName, 'Old Naming');
+	assertEquals(parseDesiredState(renameOp).name, { from: 'Old Naming', to: 'New Naming' });
+});
+
+/**
+ * Context
+ *   Base layer seeded with one row:
+ *     name='Pure Rename', other fields default
+ *   Compiled.
+ *
+ * Submit
+ *   POST /media-management/{ctx.dbId}/naming/radarr/Pure%20Rename?/update
+ *     with form fields:
+ *       name = 'Renamed'   // changed
+ *       (all others unchanged)
+ *
+ * Expect
+ *   - userOpsSince(checkpoint).length === 1
+ *   - op.metadata.changed_fields === ['name']
+ *   - op.metadata.group_id      === undefined
+ *   - op.metadata.name          === 'Renamed'
+ *   - op.metadata.previousName  === 'Pure Rename'
+ *   - op.desired_state.name     === { from: 'Pure Rename', to: 'Renamed' }
+ */
+test('pure rename emits one ungrouped rename op', async () => {
+	const ctx = await seededPcd('pure-rename', [base.radarrNaming({ name: 'Pure Rename' })]);
+	const checkpoint = opCheckpoint(ctx);
+
+	await write.namingRadarr.update(ctx, 'Pure Rename', {
+		name: 'Renamed',
+		rename: true,
+		movieFormat: '',
+		movieFolderFormat: '',
+		replaceIllegalCharacters: false,
+		colonReplacementFormat: 'delete'
+	});
+
+	const ops = userOpsSince(ctx, checkpoint);
+	assertEquals(ops.length, 1);
+	const renameOp = opForChangedField(ops, 'name');
+	const metadata = parseMetadata(renameOp);
+	assertEquals(metadata.group_id, undefined);
+	assertEquals(metadata.name, 'Renamed');
+	assertEquals(metadata.previousName, 'Pure Rename');
+	assertEquals(parseDesiredState(renameOp).name, { from: 'Pure Rename', to: 'Renamed' });
+});
+
+/**
+ * Context
+ *   Base layer seeded with one row:
+ *     name='Noop Naming', defaults
+ *   Compiled.
+ *
+ * Submit identical values.
+ *
+ * Expect
+ *   - userOpsSince(checkpoint).length === 0
+ */
+test('unchanged submit writes no ops', async () => {
+	const ctx = await seededPcd('noop', [base.radarrNaming({ name: 'Noop Naming' })]);
+	const checkpoint = opCheckpoint(ctx);
+
+	await write.namingRadarr.update(ctx, 'Noop Naming', {
+		name: 'Noop Naming',
+		rename: true,
+		movieFormat: '',
+		movieFolderFormat: '',
+		replaceIllegalCharacters: false,
+		colonReplacementFormat: 'delete'
+	});
+
+	assertEquals(userOpsSince(ctx, checkpoint).length, 0);
+});
+
+await run();

--- a/tests/integration/pcd/write/naming/sonarr-create.test.ts
+++ b/tests/integration/pcd/write/naming/sonarr-create.test.ts
@@ -1,0 +1,182 @@
+/**
+ * PCD write tests: sonarr naming create.
+ */
+
+import { assert, assertEquals } from '@std/assert';
+import { startServer, stopServer } from '$test-harness/server.ts';
+import { run, setup, teardown, test } from '$test-harness/runner.ts';
+import { PORTS } from '$test-harness/ports.ts';
+import { base } from '../../harness/fixtures.ts';
+import {
+	compilePcd,
+	normalizeSql,
+	opCheckpoint,
+	parseDesiredState,
+	parseMetadata
+} from '../../harness/pcd.ts';
+import { write } from '../../harness/write.ts';
+import { assertActionFailed, createScenarioFactory, userOpsSince } from './helpers.ts';
+
+const PORT = PORTS.pcd.writeNamingSonarrCreate;
+const ORIGIN = `http://localhost:${PORT}`;
+
+const { newPcd, seededPcd } = createScenarioFactory(PORT, 'pcd-write-naming-sonarr-create');
+
+setup(async () => {
+	await startServer(PORT, { AUTH: 'off', ORIGIN }, 'preview');
+});
+
+teardown(async () => {
+	await stopServer(PORT);
+});
+
+/**
+ * Context
+ *   Empty PCD (only schema seeded), compiled once.
+ *
+ * Submit
+ *   POST /media-management/{ctx.dbId}/naming/new with form fields:
+ *     arrType                       = 'sonarr'
+ *     name                          = 'Created Naming'
+ *     rename                        = 'true'
+ *     standardEpisodeFormat         = ''
+ *     dailyEpisodeFormat            = ''
+ *     animeEpisodeFormat            = ''
+ *     seriesFolderFormat            = ''
+ *     seasonFolderFormat            = ''
+ *     replaceIllegalCharacters      = 'false'
+ *     colonReplacementFormat        = 'delete'
+ *     customColonReplacementFormat  = ''   // null when blank
+ *     multiEpisodeStyle             = 'extend'
+ *
+ * Expect
+ *   - userOpsSince(checkpoint).length === 1
+ *   - op.metadata.operation === 'create'
+ *   - op.metadata.entity    === 'sonarr_naming'
+ *   - op.metadata.name      === 'Created Naming'
+ *   - op.desired_state.name                            === 'Created Naming'
+ *   - op.desired_state.rename                          === true
+ *   - op.desired_state.standard_episode_format         === ''
+ *   - op.desired_state.daily_episode_format            === ''
+ *   - op.desired_state.anime_episode_format            === ''
+ *   - op.desired_state.series_folder_format            === ''
+ *   - op.desired_state.season_folder_format            === ''
+ *   - op.desired_state.replace_illegal_characters      === false
+ *   - op.desired_state.colon_replacement_format        === 'delete'
+ *   - op.desired_state.custom_colon_replacement_format === null
+ *   - op.desired_state.multi_episode_style             === 'extend'
+ *   - op.sql matches /insert into "?sonarr_naming"?/i
+ */
+test('minimal sonarr naming emits one create op', async () => {
+	const ctx = await newPcd('minimal');
+	await compilePcd(ctx);
+	const checkpoint = opCheckpoint(ctx);
+
+	await write.namingSonarr.create(ctx, { name: 'Created Naming' });
+
+	const ops = userOpsSince(ctx, checkpoint);
+	assertEquals(ops.length, 1);
+	const op = ops[0];
+	const metadata = parseMetadata(op);
+	assertEquals(metadata.operation, 'create');
+	assertEquals(metadata.entity, 'sonarr_naming');
+	assertEquals(metadata.name, 'Created Naming');
+	const desired = parseDesiredState(op);
+	assertEquals(desired.name, 'Created Naming');
+	assertEquals(desired.rename, true);
+	assertEquals(desired.standard_episode_format, '');
+	assertEquals(desired.daily_episode_format, '');
+	assertEquals(desired.anime_episode_format, '');
+	assertEquals(desired.series_folder_format, '');
+	assertEquals(desired.season_folder_format, '');
+	assertEquals(desired.replace_illegal_characters, false);
+	assertEquals(desired.colon_replacement_format, 'delete');
+	assertEquals(desired.custom_colon_replacement_format, null);
+	assertEquals(desired.multi_episode_style, 'extend');
+	const sql = normalizeSql(op.sql);
+	assert(/insert into "?sonarr_naming"?/i.test(sql));
+});
+
+/**
+ * Context
+ *   Empty PCD (only schema seeded), compiled once.
+ *
+ * Submit
+ *   POST /media-management/{ctx.dbId}/naming/new with form fields:
+ *     arrType                       = 'sonarr'
+ *     name                          = 'Tuned Naming'
+ *     rename                        = 'false'
+ *     standardEpisodeFormat         = '{Series Title}'
+ *     dailyEpisodeFormat            = '{Series Title}'
+ *     animeEpisodeFormat            = '{Series Title}'
+ *     seriesFolderFormat            = '{Series Title}'
+ *     seasonFolderFormat            = 'Season {season:00}'
+ *     replaceIllegalCharacters      = 'true'
+ *     colonReplacementFormat        = 'custom'
+ *     customColonReplacementFormat  = ' - '
+ *     multiEpisodeStyle             = 'range'
+ *
+ * Expect
+ *   - userOpsSince(checkpoint).length === 1
+ *   - op.desired_state.rename                          === false
+ *   - op.desired_state.standard_episode_format         === '{Series Title}'
+ *   - op.desired_state.replace_illegal_characters      === true
+ *   - op.desired_state.colon_replacement_format        === 'custom'
+ *   - op.desired_state.custom_colon_replacement_format === ' - '
+ *   - op.desired_state.multi_episode_style             === 'range'
+ */
+test('sonarr naming non-default values are recorded', async () => {
+	const ctx = await newPcd('tuned');
+	await compilePcd(ctx);
+	const checkpoint = opCheckpoint(ctx);
+
+	await write.namingSonarr.create(ctx, {
+		name: 'Tuned Naming',
+		rename: false,
+		standardEpisodeFormat: '{Series Title}',
+		dailyEpisodeFormat: '{Series Title}',
+		animeEpisodeFormat: '{Series Title}',
+		seriesFolderFormat: '{Series Title}',
+		seasonFolderFormat: 'Season {season:00}',
+		replaceIllegalCharacters: true,
+		colonReplacementFormat: 'custom',
+		customColonReplacementFormat: ' - ',
+		multiEpisodeStyle: 'range'
+	});
+
+	const ops = userOpsSince(ctx, checkpoint);
+	assertEquals(ops.length, 1);
+	const desired = parseDesiredState(ops[0]);
+	assertEquals(desired.rename, false);
+	assertEquals(desired.standard_episode_format, '{Series Title}');
+	assertEquals(desired.replace_illegal_characters, true);
+	assertEquals(desired.colon_replacement_format, 'custom');
+	assertEquals(desired.custom_colon_replacement_format, ' - ');
+	assertEquals(desired.multi_episode_style, 'range');
+});
+
+/**
+ * Context
+ *   Base layer seeded with one row named 'Existing Naming'. Compiled.
+ *
+ * Submit
+ *   POST /media-management/{ctx.dbId}/naming/new with form fields:
+ *     arrType  = 'sonarr'
+ *     name     = 'existing naming'   // lowercase duplicate
+ *     layer    = 'user'
+ *
+ * Expect
+ *   - response.status >= 400 OR body contains '"type":"failure"'
+ *   - userOpsSince(checkpoint).length === 0
+ */
+test('duplicate sonarr naming name fails without writing ops', async () => {
+	const ctx = await seededPcd('duplicate', [base.sonarrNaming({ name: 'Existing Naming' })]);
+	const checkpoint = opCheckpoint(ctx);
+
+	const response = await write.namingSonarr.submitCreate(ctx, { name: 'existing naming' });
+
+	await assertActionFailed(response);
+	assertEquals(userOpsSince(ctx, checkpoint).length, 0);
+});
+
+await run();

--- a/tests/integration/pcd/write/naming/sonarr-delete.test.ts
+++ b/tests/integration/pcd/write/naming/sonarr-delete.test.ts
@@ -1,0 +1,125 @@
+/**
+ * PCD write tests: sonarr naming delete.
+ *
+ * The name-only-guard SQL assertion will fail until the delete writer drops
+ * its non-name guards (covered by task #10). It pins the desired contract
+ * before the implementation.
+ */
+
+import { assert, assertEquals } from '@std/assert';
+import { startServer, stopServer } from '$test-harness/server.ts';
+import { run, setup, teardown, test } from '$test-harness/runner.ts';
+import { PORTS } from '$test-harness/ports.ts';
+import { base } from '../../harness/fixtures.ts';
+import { normalizeSql, opCheckpoint, parseDesiredState, parseMetadata } from '../../harness/pcd.ts';
+import { write } from '../../harness/write.ts';
+import { createScenarioFactory, userOpsSince } from './helpers.ts';
+
+const PORT = PORTS.pcd.writeNamingSonarrDelete;
+const ORIGIN = `http://localhost:${PORT}`;
+
+const { seededPcd } = createScenarioFactory(PORT, 'pcd-write-naming-sonarr-delete');
+
+setup(async () => {
+	await startServer(PORT, { AUTH: 'off', ORIGIN }, 'preview');
+});
+
+teardown(async () => {
+	await stopServer(PORT);
+});
+
+/**
+ * Context
+ *   Base layer seeded with one row:
+ *     name='Delete Naming', rename=false, every episode/folder format set,
+ *     replaceIllegalCharacters=true, colonReplacementFormat='custom',
+ *     customColonReplacementFormat=' - ', multiEpisodeStyle='range'
+ *   Compiled.
+ *
+ * Submit
+ *   POST /media-management/{ctx.dbId}/naming/sonarr/Delete%20Naming?/delete
+ *     with form fields: layer = 'user'
+ *
+ * Expect
+ *   - userOpsSince(checkpoint).length === 1
+ *   - op.metadata.operation       === 'delete'
+ *   - op.metadata.entity          === 'sonarr_naming'
+ *   - op.metadata.name            === 'Delete Naming'
+ *   - op.metadata.changed_fields  === ['deleted']
+ *   - op.desired_state.deleted                          === true
+ *   - op.desired_state.name                             === 'Delete Naming'
+ *   - op.desired_state.standard_episode_format          === '{Series Title}'
+ *   - op.desired_state.custom_colon_replacement_format  === ' - '
+ *   - op.desired_state.multi_episode_style              === 'range'
+ *   - op.sql matches /delete from "?sonarr_naming"?/i
+ *   - op.sql DELETE clause guards by name only (no episode/folder formats,
+ *     rename, replace_illegal_characters, colon_replacement_format,
+ *     custom_colon_replacement_format, or multi_episode_style in the WHERE).
+ *     Currently fails until the delete writer drops its non-name guards (#10).
+ */
+test('sonarr naming delete emits one name-guarded op', async () => {
+	const ctx = await seededPcd('simple', [
+		base.sonarrNaming({
+			name: 'Delete Naming',
+			rename: false,
+			standardEpisodeFormat: '{Series Title}',
+			dailyEpisodeFormat: '{Series Title}',
+			animeEpisodeFormat: '{Series Title}',
+			seriesFolderFormat: '{Series Title}',
+			seasonFolderFormat: 'Season {season}',
+			replaceIllegalCharacters: true,
+			colonReplacementFormat: 'custom',
+			customColonReplacementFormat: ' - ',
+			multiEpisodeStyle: 'range'
+		})
+	]);
+	const checkpoint = opCheckpoint(ctx);
+
+	await write.namingSonarr.remove(ctx, 'Delete Naming');
+
+	const ops = userOpsSince(ctx, checkpoint);
+	assertEquals(ops.length, 1);
+	const op = ops[0];
+	const metadata = parseMetadata(op);
+	assertEquals(metadata.operation, 'delete');
+	assertEquals(metadata.entity, 'sonarr_naming');
+	assertEquals(metadata.name, 'Delete Naming');
+	assertEquals(metadata.changed_fields, ['deleted']);
+	const desired = parseDesiredState(op);
+	assertEquals(desired.deleted, true);
+	assertEquals(desired.name, 'Delete Naming');
+	assertEquals(desired.standard_episode_format, '{Series Title}');
+	assertEquals(desired.custom_colon_replacement_format, ' - ');
+	assertEquals(desired.multi_episode_style, 'range');
+
+	const sql = normalizeSql(op.sql);
+	const lowerSql = sql.toLowerCase();
+	assert(/delete from "?sonarr_naming"?/i.test(sql));
+
+	const deleteIndex = lowerSql.indexOf('delete from "sonarr_naming"');
+	assert(deleteIndex >= 0, 'expected sonarr_naming delete in SQL');
+	const deleteClause = sql.slice(deleteIndex);
+	assert(/where "?name"? = /i.test(deleteClause));
+
+	const forbidden = [
+		'rename',
+		'standard_episode_format',
+		'daily_episode_format',
+		'anime_episode_format',
+		'series_folder_format',
+		'season_folder_format',
+		'replace_illegal_characters',
+		'colon_replacement_format',
+		'custom_colon_replacement_format',
+		'multi_episode_style'
+	];
+	for (const field of forbidden) {
+		const pattern = new RegExp(`where[^;]*"?${field}"?\\s*=`, 'i');
+		assert(
+			!pattern.test(deleteClause),
+			`${field} should not appear in delete WHERE clause, got: ${deleteClause}`
+		);
+	}
+});
+
+await run();

--- a/tests/integration/pcd/write/naming/sonarr-update.test.ts
+++ b/tests/integration/pcd/write/naming/sonarr-update.test.ts
@@ -1,0 +1,239 @@
+/**
+ * PCD write tests: sonarr naming update.
+ *
+ * The split-op tests will fail until the per-field splitting work for naming
+ * (task #9) ships. They pin the desired contract before the implementation.
+ *
+ * The Sonarr split test deliberately exercises every distinct datatype shape
+ * the splitter must handle: string, bool, nullable text, and int-coded enum.
+ */
+
+import { assertEquals } from '@std/assert';
+import { startServer, stopServer } from '$test-harness/server.ts';
+import { run, setup, teardown, test } from '$test-harness/runner.ts';
+import { PORTS } from '$test-harness/ports.ts';
+import { base } from '../../harness/fixtures.ts';
+import { opCheckpoint, parseDesiredState, parseMetadata } from '../../harness/pcd.ts';
+import { write } from '../../harness/write.ts';
+import {
+	assertOnlyField,
+	assertSameGroup,
+	createScenarioFactory,
+	opForChangedField,
+	userOpsSince
+} from './helpers.ts';
+
+const PORT = PORTS.pcd.writeNamingSonarrUpdate;
+const ORIGIN = `http://localhost:${PORT}`;
+
+const { seededPcd } = createScenarioFactory(PORT, 'pcd-write-naming-sonarr-update');
+
+setup(async () => {
+	await startServer(PORT, { AUTH: 'off', ORIGIN }, 'preview');
+});
+
+teardown(async () => {
+	await stopServer(PORT);
+});
+
+/**
+ * Context
+ *   Base layer seeded with one sonarr_naming row:
+ *     name='Split Naming', standardEpisodeFormat='{Series Title}',
+ *     dailyEpisodeFormat='{Series Title}', animeEpisodeFormat='{Series Title}',
+ *     seriesFolderFormat='{Series Title}', seasonFolderFormat='Season {season}',
+ *     replaceIllegalCharacters=false, colonReplacementFormat='delete',
+ *     customColonReplacementFormat=null, multiEpisodeStyle='extend'
+ *   Compiled.
+ *
+ * Submit
+ *   POST /media-management/{ctx.dbId}/naming/sonarr/Split%20Naming?/update
+ *     with form fields changing:
+ *       standardEpisodeFormat        = '{Series Title} - S{season:00}E{episode:00}'  // string
+ *       replaceIllegalCharacters     = 'true'                                        // bool
+ *       customColonReplacementFormat = ' - '                                         // nullable text (null -> value)
+ *       multiEpisodeStyle            = 'range'                                       // int-coded enum
+ *     and keeping all other fields unchanged.
+ *
+ * Expect
+ *   - userOpsSince(checkpoint).length === 4
+ *   - one op with changed_fields === ['standard_episode_format']
+ *   - one op with changed_fields === ['replace_illegal_characters']
+ *   - one op with changed_fields === ['custom_colon_replacement_format']
+ *   - one op with changed_fields === ['multi_episode_style']
+ *   - all four ops share the same metadata.group_id
+ */
+test('representative scalar fields across datatype shapes split into grouped ops', async () => {
+	const ctx = await seededPcd('scalars', [
+		base.sonarrNaming({
+			name: 'Split Naming',
+			standardEpisodeFormat: '{Series Title}',
+			dailyEpisodeFormat: '{Series Title}',
+			animeEpisodeFormat: '{Series Title}',
+			seriesFolderFormat: '{Series Title}',
+			seasonFolderFormat: 'Season {season:00}'
+		})
+	]);
+	const checkpoint = opCheckpoint(ctx);
+
+	await write.namingSonarr.update(ctx, 'Split Naming', {
+		name: 'Split Naming',
+		rename: true,
+		standardEpisodeFormat: '{Series Title} - S{season:00}E{episode:00}',
+		dailyEpisodeFormat: '{Series Title}',
+		animeEpisodeFormat: '{Series Title}',
+		seriesFolderFormat: '{Series Title}',
+		seasonFolderFormat: 'Season {season:00}',
+		replaceIllegalCharacters: true,
+		colonReplacementFormat: 'delete',
+		customColonReplacementFormat: ' - ',
+		multiEpisodeStyle: 'range'
+	});
+
+	const ops = userOpsSince(ctx, checkpoint);
+	assertEquals(ops.length, 4);
+	assertOnlyField(ops, 'standard_episode_format');
+	assertOnlyField(ops, 'replace_illegal_characters');
+	assertOnlyField(ops, 'custom_colon_replacement_format');
+	assertOnlyField(ops, 'multi_episode_style');
+	assertSameGroup(ops);
+});
+
+/**
+ * Context
+ *   Base layer seeded with one row:
+ *     name='Old Naming', standardEpisodeFormat='{Series Title}', other defaults
+ *   Compiled.
+ *
+ * Submit
+ *   POST /media-management/{ctx.dbId}/naming/sonarr/Old%20Naming?/update
+ *     with form fields:
+ *       name                  = 'New Naming'                                  // changed
+ *       standardEpisodeFormat = '{Series Title} - S{season:00}E{episode:00}'  // changed
+ *       (others unchanged)
+ *
+ * Expect
+ *   - userOpsSince(checkpoint).length === 2
+ *   - one op with changed_fields === ['standard_episode_format']
+ *   - one op with changed_fields === ['name']
+ *   - both ops share the same metadata.group_id
+ *   - rename op.metadata.name         === 'New Naming'
+ *   - rename op.metadata.previousName === 'Old Naming'
+ *   - rename op.desired_state.name    === { from: 'Old Naming', to: 'New Naming' }
+ */
+test('rename plus scalar change emits grouped split ops', async () => {
+	const ctx = await seededPcd('rename-scalar', [
+		base.sonarrNaming({
+			name: 'Old Naming',
+			standardEpisodeFormat: '{Series Title}'
+		})
+	]);
+	const checkpoint = opCheckpoint(ctx);
+
+	await write.namingSonarr.update(ctx, 'Old Naming', {
+		name: 'New Naming',
+		rename: true,
+		standardEpisodeFormat: '{Series Title} - S{season:00}E{episode:00}',
+		dailyEpisodeFormat: '',
+		animeEpisodeFormat: '',
+		seriesFolderFormat: '',
+		seasonFolderFormat: '',
+		replaceIllegalCharacters: false,
+		colonReplacementFormat: 'delete',
+		customColonReplacementFormat: null,
+		multiEpisodeStyle: 'extend'
+	});
+
+	const ops = userOpsSince(ctx, checkpoint);
+	assertEquals(ops.length, 2);
+	assertOnlyField(ops, 'standard_episode_format');
+	assertOnlyField(ops, 'name');
+	assertSameGroup(ops);
+	const renameOp = opForChangedField(ops, 'name');
+	const metadata = parseMetadata(renameOp);
+	assertEquals(metadata.name, 'New Naming');
+	assertEquals(metadata.previousName, 'Old Naming');
+	assertEquals(parseDesiredState(renameOp).name, { from: 'Old Naming', to: 'New Naming' });
+});
+
+/**
+ * Context
+ *   Base layer seeded with one row:
+ *     name='Pure Rename', defaults
+ *   Compiled.
+ *
+ * Submit
+ *   POST /media-management/{ctx.dbId}/naming/sonarr/Pure%20Rename?/update
+ *     with form fields:
+ *       name = 'Renamed'   // changed
+ *       (all others unchanged)
+ *
+ * Expect
+ *   - userOpsSince(checkpoint).length === 1
+ *   - op.metadata.changed_fields === ['name']
+ *   - op.metadata.group_id      === undefined
+ *   - op.metadata.name          === 'Renamed'
+ *   - op.metadata.previousName  === 'Pure Rename'
+ *   - op.desired_state.name     === { from: 'Pure Rename', to: 'Renamed' }
+ */
+test('pure rename emits one ungrouped rename op', async () => {
+	const ctx = await seededPcd('pure-rename', [base.sonarrNaming({ name: 'Pure Rename' })]);
+	const checkpoint = opCheckpoint(ctx);
+
+	await write.namingSonarr.update(ctx, 'Pure Rename', {
+		name: 'Renamed',
+		rename: true,
+		standardEpisodeFormat: '',
+		dailyEpisodeFormat: '',
+		animeEpisodeFormat: '',
+		seriesFolderFormat: '',
+		seasonFolderFormat: '',
+		replaceIllegalCharacters: false,
+		colonReplacementFormat: 'delete',
+		customColonReplacementFormat: null,
+		multiEpisodeStyle: 'extend'
+	});
+
+	const ops = userOpsSince(ctx, checkpoint);
+	assertEquals(ops.length, 1);
+	const renameOp = opForChangedField(ops, 'name');
+	const metadata = parseMetadata(renameOp);
+	assertEquals(metadata.group_id, undefined);
+	assertEquals(metadata.name, 'Renamed');
+	assertEquals(metadata.previousName, 'Pure Rename');
+	assertEquals(parseDesiredState(renameOp).name, { from: 'Pure Rename', to: 'Renamed' });
+});
+
+/**
+ * Context
+ *   Base layer seeded with one row:
+ *     name='Noop Naming', defaults
+ *   Compiled.
+ *
+ * Submit identical values.
+ *
+ * Expect
+ *   - userOpsSince(checkpoint).length === 0
+ */
+test('unchanged submit writes no ops', async () => {
+	const ctx = await seededPcd('noop', [base.sonarrNaming({ name: 'Noop Naming' })]);
+	const checkpoint = opCheckpoint(ctx);
+
+	await write.namingSonarr.update(ctx, 'Noop Naming', {
+		name: 'Noop Naming',
+		rename: true,
+		standardEpisodeFormat: '',
+		dailyEpisodeFormat: '',
+		animeEpisodeFormat: '',
+		seriesFolderFormat: '',
+		seasonFolderFormat: '',
+		replaceIllegalCharacters: false,
+		colonReplacementFormat: 'delete',
+		customColonReplacementFormat: null,
+		multiEpisodeStyle: 'extend'
+	});
+
+	assertEquals(userOpsSince(ctx, checkpoint).length, 0);
+});
+
+await run();


### PR DESCRIPTION
## Summary

- Adds naming write coverage for Radarr and Sonarr create, update, and delete flows, including split-update, rename, duplicate-name, and name-only-delete assertions.
- Splits naming updates into grouped per-field ops across both arrs. Sonarr's int-coded colon_replacement_format and multi_episode_style use the int form in SET and guard while desired_state records the string enum.
- Changes naming delete ops to guard by name only, matching regex, delay profile, and media settings delete behavior.
- Adds naming conflict coverage for split scalar changes, rename conflicts, duplicate creates, delete after upstream non-name changes, missing-target auto-align, and conflict-page field detail rendering after upstream rename.
- Removes the linked-database read-only gate for naming. Edits now write user-layer ops; the clone gate is retained since clone produces base-origin ops.
- Updates PCD docs for naming write, conflict, and linked-edit behavior.