### PR TITLE
feat: add selectable date format

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -1502,7 +1502,7 @@
         "npm:@jsr/db__sqlite@0.12",
         "npm:@playwright/test@^1.59.1",
         "npm:@sveltejs/kit@^2.59.1",
-        "npm:@sveltejs/vite-plugin-svelte@^7.1.0",
+        "npm:@sveltejs/vite-plugin-svelte@^7.1.1",
         "npm:@tailwindcss/vite@^4.2.4",
         "npm:@types/better-sqlite3@^7.6.13",
         "npm:@types/deno@^2.5.0",

--- a/docs/backend/datetime.md
+++ b/docs/backend/datetime.md
@@ -1,6 +1,6 @@
 # Date and Time
 
-**Source:** `src/lib/shared/utils/dates.ts`, `src/lib/client/stores/timezone.ts`
+**Source:** `src/lib/shared/utils/dates.ts`, `src/lib/client/stores/timezone.ts`, `src/lib/client/stores/dateFormat.ts`
 
 ## Table of Contents
 
@@ -10,13 +10,13 @@
   - [Query Layer](#query-layer)
   - [API](#api)
   - [Frontend](#frontend)
-- [Timezone Store](#timezone-store)
+- [Display Stores](#display-stores)
 - [Formatting](#formatting)
 - [Lint Enforcement](#lint-enforcement)
 
 ## Principles
 
-Three rules govern how Profilarr handles time:
+Four rules govern how Profilarr handles time:
 
 1. **Store UTC.** The database and API deal exclusively in UTC. No local
    timestamps enter the persistence layer.
@@ -26,6 +26,9 @@ Three rules govern how Profilarr handles time:
 3. **Display in server TZ.** The frontend converts UTC timestamps to the
    server's configured timezone (`TZ` environment variable) before rendering.
    Browser-local time is never used.
+4. **Format by app setting.** Date ordering comes from the app-wide date
+   format setting. `auto` preserves browser-locale formatting, while explicit
+   formats render stable numeric dates.
 
 ## Layers
 
@@ -106,34 +109,37 @@ discover the server's configured TZ without a separate call:
 
 The frontend receives normalized UTC strings from page server load
 functions (which get them from the query layer). It converts these to the
-server's configured timezone for display using the `timezone` store
-(populated from `/api/v1/status` on app startup) and `Intl.DateTimeFormat`
-with the `timeZone` option. Browser-local time is never used.
+server's configured timezone for display using the `timezone` store and
+uses the `dateFormat` store to choose date ordering. Browser-local time is
+never used for timezone conversion.
 
 All date display goes through a single formatting function. Raw calls to
 `Date.toLocaleString()`, `toLocaleDateString()`, or `toLocaleTimeString()`
 are banned in Svelte files (see [Lint Enforcement](#lint-enforcement)).
 
-## Timezone Store
+## Display Stores
 
 ```
 src/lib/client/stores/timezone.ts
+src/lib/client/stores/dateFormat.ts
 ```
 
-A read-only store that holds the IANA timezone string from the server. It is
-initialized once during app startup from the `/api/v1/status` response and
-does not change for the lifetime of the session.
+Read-only stores that hold display preferences from server data. They are
+initialized from root layout data and do not change for the lifetime of the
+session unless the layout reloads after settings are saved.
 
 ```ts
 import { serverTimezone } from '$stores/timezone';
+import { dateFormat } from '$stores/dateFormat';
 
 // In a component
 const tz = $serverTimezone; // "Asia/Kuala_Lumpur"
+const fmt = $dateFormat; // "auto", "mdy", "dmy", or "ymd"
 ```
 
-The store is the single source of truth for what timezone to display dates in.
-Components never hardcode a timezone or read it from `Intl.DateTimeFormat()
-.resolvedOptions()`.
+The timezone store is the single source of truth for what timezone to display
+dates in. Components never hardcode a timezone or read it from
+`Intl.DateTimeFormat().resolvedOptions()`.
 
 ## Formatting
 
@@ -148,15 +154,16 @@ bare-timestamp problem described in [Database](#database). Called in the
 query layer only (see [Query Layer](#query-layer)).
 
 **Display.** `formatDateTime()`, `formatDate()`, and `formatRelative()`
-accept a UTC timestamp string and the server timezone, and return a
-human-readable string. These are the only functions that produce text shown
+accept a UTC timestamp string, the server timezone, and where relevant the
+date format preference. These are the only functions that produce text shown
 to users. Called in Svelte components only.
 
 ```ts
 import { formatDateTime } from '$shared/utils/dates';
 import { serverTimezone } from '$stores/timezone';
+import { dateFormat } from '$stores/dateFormat';
 
-const display = formatDateTime(job.createdAt, $serverTimezone);
+const display = formatDateTime(job.createdAt, $serverTimezone, $dateFormat);
 // "4/19/2026, 10:30:45 PM"  (in Asia/Kuala_Lumpur)
 ```
 

--- a/docs/frontend/ui.md
+++ b/docs/frontend/ui.md
@@ -205,9 +205,10 @@ a markdown toolbar, a live preview toggle, and auto-grow behavior. Pass
 
 #### DateInput and TimeInput
 
-**`$ui/form/DateInput.svelte`** composes three `DropdownCombobox`s
-(month / day / year) with days-in-month validation so February never accepts
-day 30. Value format is `YYYY-MM-DD`.
+**`$ui/form/DateInput.svelte`** composes three `DropdownCombobox`s for
+month, day, and year. The visible order follows the app date-format setting;
+the value format stays `YYYY-MM-DD`. It includes days-in-month validation so
+February never accepts day 30.
 
 **`$ui/form/TimeInput.svelte`** is two dropdowns (`HH` / `MM`).
 

--- a/src/lib/client/stores/dateFormat.ts
+++ b/src/lib/client/stores/dateFormat.ts
@@ -1,0 +1,20 @@
+/**
+ * Date format preference store.
+ *
+ * Holds the app-wide date display format from general settings. Set once from
+ * layout server data and used with serverTimezone for all date display.
+ */
+
+import { writable } from 'svelte/store';
+import type { DateFormat } from '$shared/utils/dates.ts';
+
+function createDateFormatStore() {
+	const { subscribe, set } = writable<DateFormat>('auto');
+
+	return {
+		subscribe,
+		set
+	};
+}
+
+export const dateFormat = createDateFormatStore();

--- a/src/lib/client/ui/datetime/DateTime.svelte
+++ b/src/lib/client/ui/datetime/DateTime.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { dateFormat } from '$lib/client/stores/dateFormat.ts';
 	import { serverTimezone } from '$lib/client/stores/timezone.ts';
 	import { formatDateTime, formatDate } from '$shared/utils/dates.ts';
 
@@ -8,7 +9,7 @@
 </script>
 
 {#if date}
-	{formatDate(value, $serverTimezone, options)}
+	{formatDate(value, $serverTimezone, $dateFormat, options)}
 {:else}
-	{formatDateTime(value, $serverTimezone, options)}
+	{formatDateTime(value, $serverTimezone, $dateFormat, options)}
 {/if}

--- a/src/lib/client/ui/form/DateInput.svelte
+++ b/src/lib/client/ui/form/DateInput.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import { createEventDispatcher } from 'svelte';
 	import DropdownCombobox from '$ui/dropdown/DropdownCombobox.svelte';
+	import { dateFormat } from '$lib/client/stores/dateFormat.ts';
+	import { getDatePartOrder } from '$shared/utils/dates.ts';
 
 	export let label: string;
 	export let description: string = '';
@@ -81,6 +83,7 @@
 	$: dayMinWidth = fullWidth ? '0' : '4rem';
 	$: yearWidthClass = fullWidth ? (shortLabels ? 'w-fit md:flex-1' : 'flex-1') : 'w-24';
 	$: yearMinWidth = fullWidth ? '0' : '6rem';
+	$: datePartOrder = getDatePartOrder($dateFormat);
 
 	function parseValue(nextValue: string) {
 		if (/^\d{4}-\d{2}-\d{2}$/.test(nextValue)) {
@@ -151,53 +154,59 @@
 	{/if}
 
 	<div class="flex items-center {fieldGapClass}" class:w-full={fullWidth}>
-		<DropdownCombobox
-			value={month}
-			options={monthOptions}
-			placeholder="Month"
-			minWidth={monthMinWidth}
-			width={monthWidthClass}
-			fullWidth
-			limit={6}
-			{fixed}
-			buttonSize={responsiveButtonSize}
-			responsiveButton={responsive}
-			responsiveDropdown={responsive}
-			compactDropdownThreshold={7}
-			disabled={effectiveDisabled}
-			on:change={(event) => onMonthChange(event.detail)}
-		/>
-		<DropdownCombobox
-			value={day}
-			options={dayOptions}
-			placeholder="Day"
-			minWidth={dayMinWidth}
-			width={dayWidthClass}
-			fullWidth
-			limit={6}
-			{fixed}
-			buttonSize={responsiveButtonSize}
-			responsiveButton={responsive}
-			responsiveDropdown={responsive}
-			compactDropdownThreshold={7}
-			disabled={effectiveDisabled}
-			on:change={(event) => onDayChange(event.detail)}
-		/>
-		<DropdownCombobox
-			value={year}
-			options={yearOptions}
-			placeholder="Year"
-			minWidth={yearMinWidth}
-			width={yearWidthClass}
-			fullWidth
-			limit={6}
-			{fixed}
-			buttonSize={responsiveButtonSize}
-			responsiveButton={responsive}
-			responsiveDropdown={responsive}
-			compactDropdownThreshold={7}
-			disabled={effectiveDisabled}
-			on:change={(event) => onYearChange(event.detail)}
-		/>
+		{#each datePartOrder as part (part)}
+			{#if part === 'month'}
+				<DropdownCombobox
+					value={month}
+					options={monthOptions}
+					placeholder="Month"
+					minWidth={monthMinWidth}
+					width={monthWidthClass}
+					fullWidth
+					limit={6}
+					{fixed}
+					buttonSize={responsiveButtonSize}
+					responsiveButton={responsive}
+					responsiveDropdown={responsive}
+					compactDropdownThreshold={7}
+					disabled={effectiveDisabled}
+					on:change={(event) => onMonthChange(event.detail)}
+				/>
+			{:else if part === 'day'}
+				<DropdownCombobox
+					value={day}
+					options={dayOptions}
+					placeholder="Day"
+					minWidth={dayMinWidth}
+					width={dayWidthClass}
+					fullWidth
+					limit={6}
+					{fixed}
+					buttonSize={responsiveButtonSize}
+					responsiveButton={responsive}
+					responsiveDropdown={responsive}
+					compactDropdownThreshold={7}
+					disabled={effectiveDisabled}
+					on:change={(event) => onDayChange(event.detail)}
+				/>
+			{:else}
+				<DropdownCombobox
+					value={year}
+					options={yearOptions}
+					placeholder="Year"
+					minWidth={yearMinWidth}
+					width={yearWidthClass}
+					fullWidth
+					limit={6}
+					{fixed}
+					buttonSize={responsiveButtonSize}
+					responsiveButton={responsive}
+					responsiveDropdown={responsive}
+					compactDropdownThreshold={7}
+					disabled={effectiveDisabled}
+					on:change={(event) => onYearChange(event.detail)}
+				/>
+			{/if}
+		{/each}
 	</div>
 </div>

--- a/src/lib/client/ui/form/DateInput.svelte
+++ b/src/lib/client/ui/form/DateInput.svelte
@@ -168,7 +168,7 @@
 					buttonSize={responsiveButtonSize}
 					responsiveButton={responsive}
 					responsiveDropdown={responsive}
-					compactDropdownThreshold={7}
+					compactDropdown={compact ? true : undefined}
 					disabled={effectiveDisabled}
 					on:change={(event) => onMonthChange(event.detail)}
 				/>
@@ -185,7 +185,7 @@
 					buttonSize={responsiveButtonSize}
 					responsiveButton={responsive}
 					responsiveDropdown={responsive}
-					compactDropdownThreshold={7}
+					compactDropdown={compact ? true : undefined}
 					disabled={effectiveDisabled}
 					on:change={(event) => onDayChange(event.detail)}
 				/>
@@ -202,7 +202,7 @@
 					buttonSize={responsiveButtonSize}
 					responsiveButton={responsive}
 					responsiveDropdown={responsive}
-					compactDropdownThreshold={7}
+					compactDropdown={compact ? true : undefined}
 					disabled={effectiveDisabled}
 					on:change={(event) => onYearChange(event.detail)}
 				/>

--- a/src/lib/server/db/migrations.ts
+++ b/src/lib/server/db/migrations.ts
@@ -67,6 +67,7 @@ import { migration as migration062 } from './migrations/062_drop_onboarding_show
 import { migration as migration063 } from './migrations/063_create_database_announcements.ts';
 import { migration as migration064 } from './migrations/064_add_fail_on_referenced_delete.ts';
 import { migration as migration065 } from './migrations/065_create_arr_drift_tables.ts';
+import { migration as migration066 } from './migrations/066_add_date_format_setting.ts';
 
 export interface Migration {
 	version: number;
@@ -352,7 +353,8 @@ export function loadMigrations(): Migration[] {
 		migration062,
 		migration063,
 		migration064,
-		migration065
+		migration065,
+		migration066
 	];
 
 	// Sort by version number

--- a/src/lib/server/db/migrations/066_add_date_format_setting.ts
+++ b/src/lib/server/db/migrations/066_add_date_format_setting.ts
@@ -1,0 +1,22 @@
+import type { Migration } from '../migrations.ts';
+
+/**
+ * Migration 066: Add date format setting
+ *
+ * Stores the app-wide date display preference used by the interface.
+ */
+
+export const migration: Migration = {
+	version: 66,
+	name: 'Add date format setting',
+
+	up: `
+		ALTER TABLE general_settings
+		ADD COLUMN date_format TEXT NOT NULL DEFAULT 'auto'
+		CHECK (date_format IN ('auto', 'mdy', 'dmy', 'ymd'));
+	`,
+
+	down: `
+		ALTER TABLE general_settings DROP COLUMN date_format;
+	`
+};

--- a/src/lib/server/db/queries/generalSettings.ts
+++ b/src/lib/server/db/queries/generalSettings.ts
@@ -1,6 +1,7 @@
 import { db } from '../db.ts';
+import type { DateFormat } from '$shared/utils/dates.ts';
 
-export type DateFormat = 'auto' | 'mdy' | 'dmy' | 'ymd';
+export type { DateFormat } from '$shared/utils/dates.ts';
 
 /**
  * Types for general_settings table

--- a/src/lib/server/db/queries/generalSettings.ts
+++ b/src/lib/server/db/queries/generalSettings.ts
@@ -1,10 +1,13 @@
 import { db } from '../db.ts';
 
+export type DateFormat = 'auto' | 'mdy' | 'dmy' | 'ymd';
+
 /**
  * Types for general_settings table
  */
 export interface GeneralSettings {
 	id: number;
+	date_format: DateFormat;
 	apply_default_delay_profiles: number; // 1=true, 0=false
 	fail_on_referenced_delete: number; // 1=true, 0=false
 	created_at: string;
@@ -12,6 +15,7 @@ export interface GeneralSettings {
 }
 
 export interface UpdateGeneralSettingsInput {
+	dateFormat?: DateFormat;
 	applyDefaultDelayProfiles?: boolean;
 	failOnReferencedDelete?: boolean;
 }
@@ -50,6 +54,11 @@ export const generalSettingsQueries = {
 	update(input: UpdateGeneralSettingsInput): boolean {
 		const updates: string[] = [];
 		const params: (string | number)[] = [];
+
+		if (input.dateFormat !== undefined) {
+			updates.push('date_format = ?');
+			params.push(input.dateFormat);
+		}
 
 		if (input.applyDefaultDelayProfiles !== undefined) {
 			updates.push('apply_default_delay_profiles = ?');

--- a/src/lib/server/db/schema.sql
+++ b/src/lib/server/db/schema.sql
@@ -841,11 +841,14 @@ CREATE INDEX idx_rename_runs_status ON rename_runs(status);
 -- ==============================================================================
 -- TABLE: general_settings
 -- Purpose: Store general app-wide settings (singleton pattern with id=1)
--- Migration: 030_create_general_settings.ts, 064_add_fail_on_referenced_delete.ts
+-- Migration: 030_create_general_settings.ts, 064_add_fail_on_referenced_delete.ts, 066_add_date_format_setting.ts
 -- ==============================================================================
 
 CREATE TABLE general_settings (
     id INTEGER PRIMARY KEY CHECK (id = 1),
+
+    -- Interface settings
+    date_format TEXT NOT NULL DEFAULT 'auto' CHECK (date_format IN ('auto', 'mdy', 'dmy', 'ymd')),
 
     -- Default delay profile settings
     apply_default_delay_profiles INTEGER NOT NULL DEFAULT 1,  -- 1=apply defaults when adding arr, 0=don't

--- a/src/lib/shared/utils/dates.ts
+++ b/src/lib/shared/utils/dates.ts
@@ -51,6 +51,8 @@ export function parseUTC(timestamp: string | null | undefined): Date | null {
 	return new Date(normalized);
 }
 
+export type DateFormat = 'auto' | 'mdy' | 'dmy' | 'ymd';
+
 // ---------------------------------------------------------------------------
 // Display formatting
 //
@@ -58,6 +60,83 @@ export function parseUTC(timestamp: string | null | undefined): Date | null {
 // the server timezone (from the serverTimezone store). They are the only
 // way dates should be rendered in the UI.
 // ---------------------------------------------------------------------------
+
+function resolveDisplayArgs(
+	dateFormatOrOptions?: DateFormat | Intl.DateTimeFormatOptions,
+	options?: Intl.DateTimeFormatOptions
+): { dateFormat: DateFormat; options?: Intl.DateTimeFormatOptions } {
+	if (typeof dateFormatOrOptions === 'string') {
+		return { dateFormat: dateFormatOrOptions, options };
+	}
+	return { dateFormat: 'auto', options: dateFormatOrOptions };
+}
+
+function formatExplicitDate(
+	date: Date,
+	timezone: string,
+	dateFormat: Exclude<DateFormat, 'auto'>
+): string {
+	const parts = new Intl.DateTimeFormat('en-US', {
+		timeZone: timezone,
+		year: 'numeric',
+		month: '2-digit',
+		day: '2-digit'
+	}).formatToParts(date);
+	const values = Object.fromEntries(parts.map((part) => [part.type, part.value]));
+	const year = values.year;
+	const month = values.month;
+	const day = values.day;
+
+	if (dateFormat === 'mdy') return `${month}/${day}/${year}`;
+	if (dateFormat === 'dmy') return `${day}/${month}/${year}`;
+	return `${year}-${month}-${day}`;
+}
+
+function pickTimeOptions(
+	options?: Intl.DateTimeFormatOptions
+): Intl.DateTimeFormatOptions | undefined {
+	if (!options) return undefined;
+	const timeOptions: Intl.DateTimeFormatOptions = {};
+	let hasTimeOptions = false;
+
+	if (options.hour !== undefined) {
+		timeOptions.hour = options.hour;
+		hasTimeOptions = true;
+	}
+	if (options.minute !== undefined) {
+		timeOptions.minute = options.minute;
+		hasTimeOptions = true;
+	}
+	if (options.second !== undefined) {
+		timeOptions.second = options.second;
+		hasTimeOptions = true;
+	}
+	if (options.fractionalSecondDigits !== undefined) {
+		timeOptions.fractionalSecondDigits = options.fractionalSecondDigits;
+		hasTimeOptions = true;
+	}
+	if (options.hour12 !== undefined) {
+		timeOptions.hour12 = options.hour12;
+		hasTimeOptions = true;
+	}
+	if (options.hourCycle !== undefined) {
+		timeOptions.hourCycle = options.hourCycle;
+		hasTimeOptions = true;
+	}
+	if (options.timeZoneName !== undefined) {
+		timeOptions.timeZoneName = options.timeZoneName;
+		hasTimeOptions = true;
+	}
+
+	return hasTimeOptions ? timeOptions : undefined;
+}
+
+function formatTime(date: Date, timezone: string, options?: Intl.DateTimeFormatOptions): string {
+	return date.toLocaleTimeString(undefined, {
+		timeZone: timezone,
+		...pickTimeOptions(options)
+	});
+}
 
 /**
  * Formats a UTC timestamp as a full date and time in the given timezone.
@@ -72,12 +151,21 @@ export function parseUTC(timestamp: string | null | undefined): Date | null {
 export function formatDateTime(
 	timestamp: string | null | undefined,
 	timezone: string,
+	dateFormatOrOptions?: DateFormat | Intl.DateTimeFormatOptions,
 	options?: Intl.DateTimeFormatOptions
 ): string {
 	if (!timestamp) return '-';
 	const date = new Date(timestamp);
 	if (Number.isNaN(date.getTime())) return '-';
-	return date.toLocaleString(undefined, { timeZone: timezone, ...options });
+	const args = resolveDisplayArgs(dateFormatOrOptions, options);
+	if (args.dateFormat === 'auto') {
+		return date.toLocaleString(undefined, { timeZone: timezone, ...args.options });
+	}
+	return `${formatExplicitDate(date, timezone, args.dateFormat)}, ${formatTime(
+		date,
+		timezone,
+		args.options
+	)}`;
 }
 
 /**
@@ -93,12 +181,17 @@ export function formatDateTime(
 export function formatDate(
 	timestamp: string | null | undefined,
 	timezone: string,
+	dateFormatOrOptions?: DateFormat | Intl.DateTimeFormatOptions,
 	options?: Intl.DateTimeFormatOptions
 ): string {
 	if (!timestamp) return '-';
 	const date = new Date(timestamp);
 	if (Number.isNaN(date.getTime())) return '-';
-	return date.toLocaleDateString(undefined, { timeZone: timezone, ...options });
+	const args = resolveDisplayArgs(dateFormatOrOptions, options);
+	if (args.dateFormat === 'auto') {
+		return date.toLocaleDateString(undefined, { timeZone: timezone, ...args.options });
+	}
+	return formatExplicitDate(date, timezone, args.dateFormat);
 }
 
 /**
@@ -113,7 +206,8 @@ export function formatDate(
  */
 export function formatSmartDateTime(
 	timestamp: string | null | undefined,
-	timezone: string
+	timezone: string,
+	dateFormat: DateFormat = 'auto'
 ): string {
 	if (!timestamp) return '-';
 	const date = new Date(timestamp);
@@ -139,8 +233,7 @@ export function formatSmartDateTime(
 	if (dateDay === todayDay) return `Today, ${timeStr}`;
 	if (dateDay === yesterdayDay) return `Yesterday, ${timeStr}`;
 
-	const dateStr = date.toLocaleDateString(undefined, {
-		timeZone: timezone,
+	const dateStr = formatDate(timestamp, timezone, dateFormat, {
 		month: 'short',
 		day: 'numeric'
 	});

--- a/src/lib/shared/utils/dates.ts
+++ b/src/lib/shared/utils/dates.ts
@@ -52,6 +52,7 @@ export function parseUTC(timestamp: string | null | undefined): Date | null {
 }
 
 export type DateFormat = 'auto' | 'mdy' | 'dmy' | 'ymd';
+export type DatePart = 'month' | 'day' | 'year';
 
 // ---------------------------------------------------------------------------
 // Display formatting
@@ -69,6 +70,24 @@ function resolveDisplayArgs(
 		return { dateFormat: dateFormatOrOptions, options };
 	}
 	return { dateFormat: 'auto', options: dateFormatOrOptions };
+}
+
+export function getDatePartOrder(dateFormat: DateFormat): DatePart[] {
+	if (dateFormat === 'mdy') return ['month', 'day', 'year'];
+	if (dateFormat === 'dmy') return ['day', 'month', 'year'];
+	if (dateFormat === 'ymd') return ['year', 'month', 'day'];
+
+	const parts = new Intl.DateTimeFormat(undefined, {
+		year: 'numeric',
+		month: 'numeric',
+		day: 'numeric'
+	})
+		.formatToParts(new Date(Date.UTC(2006, 10, 22)))
+		.map((part) => part.type)
+		.filter((part): part is DatePart => part === 'month' || part === 'day' || part === 'year');
+
+	const uniqueParts = [...new Set(parts)];
+	return uniqueParts.length === 3 ? uniqueParts : ['month', 'day', 'year'];
 }
 
 function formatExplicitDate(

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -5,6 +5,7 @@ import { isParserHealthy } from '$lib/server/utils/arr/parser/client.ts';
 import { config } from '$lib/server/utils/config/config.ts';
 import { build } from '$lib/shared/build.ts';
 import { getVersionStatus, inbox } from '$announcements/index.ts';
+import { generalSettingsQueries } from '$db/queries/generalSettings.ts';
 
 async function readPendingRestore(): Promise<{ filename: string } | null> {
 	try {
@@ -33,6 +34,7 @@ export const load: LayoutServerLoad = async () => {
 		version: build.version,
 		versionStatus: getVersionStatus(),
 		timezone: config.timezone,
+		dateFormat: generalSettingsQueries.get()?.date_format ?? 'auto',
 		arrInstances,
 		databases,
 		parserAvailable: await isParserHealthy(),

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -12,6 +12,7 @@
 	import CutsceneComplete from '$lib/client/cutscene/CutsceneComplete.svelte';
 	import { cutscene } from '$lib/client/cutscene/store';
 	import { sidebarCollapsed } from '$stores/sidebar';
+	import { dateFormat } from '$stores/dateFormat';
 	import { serverTimezone } from '$stores/timezone';
 	import { FEATURES } from '$lib/shared/features';
 	import { dev } from '$app/environment';
@@ -26,6 +27,7 @@
 
 	// Set timezone from server data (available immediately, no async fetch)
 	$: serverTimezone.set(data.timezone);
+	$: dateFormat.set(data.dateFormat);
 
 	// Hide navigation on auth pages (login, setup, etc.)
 	$: isAuthPage = $page.url.pathname.startsWith('/auth/');

--- a/src/routes/arr/[id]/drift/+page.svelte
+++ b/src/routes/arr/[id]/drift/+page.svelte
@@ -7,6 +7,7 @@
 	import { initEdit, update as updateDirty, clear, isDirty } from '$lib/client/stores/dirty';
 	import { jobStatus } from '$stores/jobStatus';
 	import { formatSmartDateTime } from '$shared/utils/dates';
+	import { dateFormat } from '$lib/client/stores/dateFormat';
 	import { serverTimezone } from '$lib/client/stores/timezone';
 	import Button from '$ui/button/Button.svelte';
 	import StickyCard from '$ui/card/StickyCard.svelte';
@@ -204,7 +205,11 @@
 								</Label>
 							{/if}
 							<Label variant="secondary" size="md" rounded="md" mono>
-								Last {formatSmartDateTime(data.status.lastCheckedAt, $serverTimezone)}
+								Last {formatSmartDateTime(
+									data.status.lastCheckedAt,
+									$serverTimezone,
+									$dateFormat
+								)}
 							</Label>
 						</div>
 					{/if}

--- a/src/routes/arr/[id]/drift/+page.svelte
+++ b/src/routes/arr/[id]/drift/+page.svelte
@@ -205,11 +205,7 @@
 								</Label>
 							{/if}
 							<Label variant="secondary" size="md" rounded="md" mono>
-								Last {formatSmartDateTime(
-									data.status.lastCheckedAt,
-									$serverTimezone,
-									$dateFormat
-								)}
+								Last {formatSmartDateTime(data.status.lastCheckedAt, $serverTimezone, $dateFormat)}
 							</Label>
 						</div>
 					{/if}

--- a/src/routes/arr/[id]/library/components/MovieRow.svelte
+++ b/src/routes/arr/[id]/library/components/MovieRow.svelte
@@ -9,6 +9,7 @@
 	import type { RadarrLibraryItem } from '$utils/arr/types.ts';
 	import type { Column } from '$ui/table/types';
 	import { formatDate } from '$shared/utils/dates.ts';
+	import { dateFormat } from '$lib/client/stores/dateFormat.ts';
 	import { serverTimezone } from '$lib/client/stores/timezone.ts';
 
 	export let row: RadarrLibraryItem;
@@ -26,7 +27,7 @@
 
 	function fmtDate(isoString?: string): string {
 		if (!isoString) return '-';
-		return formatDate(isoString, $serverTimezone, {
+		return formatDate(isoString, $serverTimezone, $dateFormat, {
 			month: 'short',
 			day: 'numeric',
 			year: '2-digit'

--- a/src/routes/arr/[id]/library/components/SeriesRow.svelte
+++ b/src/routes/arr/[id]/library/components/SeriesRow.svelte
@@ -7,6 +7,7 @@
 	import type { SonarrSeriesItem } from '$utils/arr/types.ts';
 	import type { Column } from '$ui/table/types';
 	import { formatDate } from '$shared/utils/dates.ts';
+	import { dateFormat } from '$lib/client/stores/dateFormat.ts';
 	import { serverTimezone } from '$lib/client/stores/timezone.ts';
 
 	export let row: SonarrSeriesItem;
@@ -24,7 +25,7 @@
 
 	function fmtDate(isoString?: string): string {
 		if (!isoString) return '-';
-		return formatDate(isoString, $serverTimezone, {
+		return formatDate(isoString, $serverTimezone, $dateFormat, {
 			month: 'short',
 			day: 'numeric',
 			year: '2-digit'

--- a/src/routes/arr/[id]/logs/+page.svelte
+++ b/src/routes/arr/[id]/logs/+page.svelte
@@ -17,6 +17,7 @@
 	import type { Column } from '$ui/table/types';
 	import { getPersistentSearchStore, type SearchStore } from '$lib/client/stores/search';
 	import { formatDateTime } from '$shared/utils/dates.ts';
+	import { dateFormat } from '$lib/client/stores/dateFormat.ts';
 	import { serverTimezone } from '$lib/client/stores/timezone.ts';
 	import { copyToClipboard } from '$lib/client/utils/clipboard';
 	import type { PageData } from './$types';
@@ -69,7 +70,7 @@
 			width: '180px',
 			cell: (row) => ({
 				// nosemgrep: profilarr.xss.table-cell-html-unescaped — arr API data, not user content
-				html: `<span class="font-mono text-xs text-neutral-600 dark:text-neutral-400">${formatDateTime(row.time, $serverTimezone)}</span>`
+				html: `<span class="font-mono text-xs text-neutral-600 dark:text-neutral-400">${formatDateTime(row.time, $serverTimezone, $dateFormat)}</span>`
 			})
 		},
 		{

--- a/src/routes/arr/[id]/rename/components/RenameRunHistory.svelte
+++ b/src/routes/arr/[id]/rename/components/RenameRunHistory.svelte
@@ -28,6 +28,7 @@
 	import Label from '$ui/label/Label.svelte';
 	import type { Column } from '$ui/table/types';
 	import { formatSmartDateTime } from '$shared/utils/dates';
+	import { dateFormat } from '$lib/client/stores/dateFormat';
 	import { serverTimezone } from '$lib/client/stores/timezone';
 
 	let searchStore: SearchStore = createSearchStore();
@@ -195,7 +196,7 @@
 			{:else if column.key === 'date'}
 				<div class="flex items-center gap-2">
 					<span class="text-neutral-600 dark:text-neutral-400">
-						{formatSmartDateTime(row.startedAt, $serverTimezone)}
+						{formatSmartDateTime(row.startedAt, $serverTimezone, $dateFormat)}
 					</span>
 					{#if row.config.dryRun}
 						<Label variant="info" size="sm" rounded="md"><FlaskConical size={10} /> Dry Run</Label>

--- a/src/routes/arr/[id]/rename/components/RenameSettings.svelte
+++ b/src/routes/arr/[id]/rename/components/RenameSettings.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { onMount, onDestroy } from 'svelte';
 	import { formatSmartDateTime } from '$shared/utils/dates';
+	import { dateFormat } from '$lib/client/stores/dateFormat';
 	import { serverTimezone } from '$lib/client/stores/timezone';
 	import FormInput from '$ui/form/FormInput.svelte';
 	import CronInput from '$ui/cron/CronInput.svelte';
@@ -150,7 +151,7 @@
 				</Label>
 			{/if}
 			<Label variant="secondary" size="md" rounded="md" mono>
-				Last {formatSmartDateTime(lastRunAt, $serverTimezone)}
+				Last {formatSmartDateTime(lastRunAt, $serverTimezone, $dateFormat)}
 			</Label>
 		</div>
 	{/if}

--- a/src/routes/arr/[id]/upgrades/components/CoreSettings.svelte
+++ b/src/routes/arr/[id]/upgrades/components/CoreSettings.svelte
@@ -2,6 +2,7 @@
 	import { onMount, onDestroy } from 'svelte';
 	import { filterModes, type FilterMode } from '$shared/upgrades/filters';
 	import { formatSmartDateTime } from '$shared/utils/dates';
+	import { dateFormat } from '$lib/client/stores/dateFormat';
 	import { serverTimezone } from '$lib/client/stores/timezone';
 	import DropdownSelect from '$ui/dropdown/DropdownSelect.svelte';
 	import CronInput from '$ui/cron/CronInput.svelte';
@@ -116,7 +117,7 @@
 				</Label>
 			{/if}
 			<Label variant="secondary" size="md" rounded="md" mono>
-				Last {formatSmartDateTime(lastRunAt, $serverTimezone)}
+				Last {formatSmartDateTime(lastRunAt, $serverTimezone, $dateFormat)}
 			</Label>
 		</div>
 	{/if}

--- a/src/routes/arr/[id]/upgrades/components/RunHistory.svelte
+++ b/src/routes/arr/[id]/upgrades/components/RunHistory.svelte
@@ -37,6 +37,7 @@
 	import Tooltip from '$ui/tooltip/Tooltip.svelte';
 	import type { Column } from '$ui/table/types';
 	import { formatSmartDateTime } from '$shared/utils/dates';
+	import { dateFormat } from '$lib/client/stores/dateFormat';
 	import { serverTimezone } from '$lib/client/stores/timezone';
 
 	let searchStore: SearchStore = createSearchStore();
@@ -312,7 +313,7 @@
 				</div>
 			{:else if column.key === 'date'}
 				<span class="text-neutral-600 dark:text-neutral-400">
-					{formatSmartDateTime(row.startedAt, $serverTimezone)}
+					{formatSmartDateTime(row.startedAt, $serverTimezone, $dateFormat)}
 				</span>
 			{:else if column.key === 'duration'}
 				<span class="font-mono text-xs text-neutral-600 dark:text-neutral-400">

--- a/src/routes/arr/components/InstanceForm.svelte
+++ b/src/routes/arr/components/InstanceForm.svelte
@@ -3,6 +3,7 @@
 	import { enhance } from '$app/forms';
 	import { Save, Wifi, Trash2, Eraser, Loader2 } from 'lucide-svelte';
 	import { formatSmartDateTime } from '$shared/utils/dates';
+	import { dateFormat } from '$lib/client/stores/dateFormat';
 	import { serverTimezone } from '$lib/client/stores/timezone';
 	import CleanupModal from './CleanupModal.svelte';
 	import { alertStore } from '$alerts/store';
@@ -470,7 +471,11 @@
 									<span>
 										Last: <span
 											class="rounded bg-neutral-100 px-1.5 py-0.5 font-mono text-neutral-700 dark:bg-neutral-800 dark:text-neutral-300"
-											>{formatSmartDateTime(cleanupSettings.lastRunAt, $serverTimezone)}</span
+											>{formatSmartDateTime(
+												cleanupSettings.lastRunAt,
+												$serverTimezone,
+												$dateFormat
+											)}</span
 										>
 									</span>
 								</div>

--- a/src/routes/databases/[id]/changes/+page.svelte
+++ b/src/routes/databases/[id]/changes/+page.svelte
@@ -44,6 +44,7 @@
 	import type { Column } from '$ui/table/types';
 	import type { DraftEntityChange } from './components/types';
 	import { parseUTC, formatDate, formatDateTime } from '$shared/utils/dates';
+	import { dateFormat } from '$lib/client/stores/dateFormat.ts';
 	import { serverTimezone } from '$lib/client/stores/timezone.ts';
 
 	export let data: PageData;
@@ -620,7 +621,7 @@
 		const diffMs = now.getTime() - date.getTime();
 		const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
 
-		if (diffMs < 0) return formatDate(dateStr, $serverTimezone);
+		if (diffMs < 0) return formatDate(dateStr, $serverTimezone, $dateFormat);
 		if (diffDays === 0) {
 			const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
 			if (diffHours === 0) {
@@ -632,12 +633,12 @@
 		if (diffDays === 1) return 'Yesterday';
 		if (diffDays < 7) return `${diffDays}d ago`;
 
-		return formatDate(dateStr, $serverTimezone);
+		return formatDate(dateStr, $serverTimezone, $dateFormat);
 	}
 
 	function formatExportedAt(value: string | null | undefined): string {
 		if (!value) return '-';
-		return formatDateTime(value, $serverTimezone, {
+		return formatDateTime(value, $serverTimezone, $dateFormat, {
 			year: 'numeric',
 			month: 'short',
 			day: '2-digit',

--- a/src/routes/databases/[id]/commits/+page.svelte
+++ b/src/routes/databases/[id]/commits/+page.svelte
@@ -8,6 +8,7 @@
 	import type { PageData } from './$types';
 	import type { Commit } from '$utils/git/types';
 	import { parseUTC, formatDate } from '$shared/utils/dates';
+	import { dateFormat } from '$lib/client/stores/dateFormat.ts';
 	import { serverTimezone } from '$lib/client/stores/timezone.ts';
 
 	export let data: PageData;
@@ -74,7 +75,7 @@
 		const diffMs = now.getTime() - date.getTime();
 		const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
 
-		if (diffMs < 0) return formatDate(dateStr, $serverTimezone);
+		if (diffMs < 0) return formatDate(dateStr, $serverTimezone, $dateFormat);
 		if (diffDays === 0) {
 			const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
 			if (diffHours === 0) {
@@ -87,7 +88,7 @@
 		if (diffDays < 7) return `${diffDays}d ago`;
 		if (diffDays < 30) return `${Math.floor(diffDays / 7)}w ago`;
 
-		return formatDate(dateStr, $serverTimezone);
+		return formatDate(dateStr, $serverTimezone, $dateFormat);
 	}
 
 	function getCommitUrl(hash: string): string {

--- a/src/routes/databases/views/CardView.svelte
+++ b/src/routes/databases/views/CardView.svelte
@@ -14,6 +14,7 @@
 	import Label from '$ui/label/Label.svelte';
 	import type { DatabaseInstanceSummary } from '../+page.server.ts';
 	import { formatDateTime } from '$shared/utils/dates';
+	import { dateFormat } from '$lib/client/stores/dateFormat';
 	import { serverTimezone } from '$lib/client/stores/timezone';
 	import { createEventDispatcher } from 'svelte';
 	import DatabaseAvatar from '../components/DatabaseAvatar.svelte';
@@ -34,7 +35,7 @@
 
 	function formatLastSynced(date: string | null): string {
 		if (!date) return 'Never';
-		return formatDateTime(date, $serverTimezone, {
+		return formatDateTime(date, $serverTimezone, $dateFormat, {
 			month: 'short',
 			day: 'numeric',
 			hour: 'numeric',

--- a/src/routes/databases/views/TableView.svelte
+++ b/src/routes/databases/views/TableView.svelte
@@ -6,6 +6,7 @@
 	import type { Column } from '$ui/table/types';
 	import type { DatabaseInstanceSummary } from '../+page.server.ts';
 	import { formatDateTime } from '$shared/utils/dates';
+	import { dateFormat } from '$lib/client/stores/dateFormat';
 	import { serverTimezone } from '$lib/client/stores/timezone';
 	import { createEventDispatcher } from 'svelte';
 	import DatabaseAvatar from '../components/DatabaseAvatar.svelte';
@@ -26,7 +27,7 @@
 
 	function formatLastSynced(date: string | null): string {
 		if (!date) return 'Never';
-		return formatDateTime(date, $serverTimezone, {
+		return formatDateTime(date, $serverTimezone, $dateFormat, {
 			month: 'short',
 			day: 'numeric',
 			hour: 'numeric',

--- a/src/routes/settings/backups/+page.svelte
+++ b/src/routes/settings/backups/+page.svelte
@@ -254,7 +254,9 @@
 		>
 			<svelte:fragment slot="cell" let:row let:column>
 				{#if column.key === 'created'}
-					<span class="font-medium">{formatDateTime(row.created, $serverTimezone, $dateFormat)}</span>
+					<span class="font-medium"
+						>{formatDateTime(row.created, $serverTimezone, $dateFormat)}</span
+					>
 				{:else if column.key === 'filename'}
 					<span class="font-mono text-neutral-500 dark:text-neutral-400">{row.filename}</span>
 				{:else if column.key === 'sizeFormatted'}

--- a/src/routes/settings/backups/+page.svelte
+++ b/src/routes/settings/backups/+page.svelte
@@ -16,6 +16,7 @@
 	import { jobStatus } from '$lib/client/stores/jobStatus';
 	import { onMount } from 'svelte';
 	import { formatDateTime } from '$shared/utils/dates';
+	import { dateFormat } from '$lib/client/stores/dateFormat';
 	import { serverTimezone } from '$lib/client/stores/timezone';
 
 	export let data: PageData;
@@ -253,7 +254,7 @@
 		>
 			<svelte:fragment slot="cell" let:row let:column>
 				{#if column.key === 'created'}
-					<span class="font-medium">{formatDateTime(row.created, $serverTimezone)}</span>
+					<span class="font-medium">{formatDateTime(row.created, $serverTimezone, $dateFormat)}</span>
 				{:else if column.key === 'filename'}
 					<span class="font-mono text-neutral-500 dark:text-neutral-400">{row.filename}</span>
 				{:else if column.key === 'sizeFormatted'}

--- a/src/routes/settings/general/+page.server.ts
+++ b/src/routes/settings/general/+page.server.ts
@@ -4,11 +4,13 @@ import { logSettingsQueries } from '$db/queries/logSettings.ts';
 import { backupSettingsQueries } from '$db/queries/backupSettings.ts';
 import { aiSettingsQueries } from '$db/queries/aiSettings.ts';
 import { tmdbSettingsQueries } from '$db/queries/tmdbSettings.ts';
-import { generalSettingsQueries } from '$db/queries/generalSettings.ts';
+import { generalSettingsQueries, type DateFormat } from '$db/queries/generalSettings.ts';
 import { logSettings } from '$logger/settings.ts';
 import { logger } from '$logger/logger.ts';
 import { scheduleBackupJobs, scheduleLogCleanup } from '$lib/server/jobs/init.ts';
 import { FEATURES } from '$shared/features.ts';
+
+const DATE_FORMATS = ['auto', 'mdy', 'dmy', 'ymd'] as const;
 
 export const load = () => {
 	const logSetting = logSettingsQueries.get();
@@ -66,6 +68,7 @@ export const load = () => {
 			hasApiKey: !!tmdbSetting.api_key
 		},
 		generalSettings: {
+			date_format: generalSetting.date_format,
 			apply_default_delay_profiles: generalSetting.apply_default_delay_profiles === 1,
 			fail_on_referenced_delete: generalSetting.fail_on_referenced_delete === 1
 		}
@@ -130,6 +133,13 @@ export const actions: Actions = {
 		const tmdbApiKeyInput = formData.get('tmdb_api_key') as string;
 		const tmdbApiKey = tmdbApiKeyInput || tmdbSettingsQueries.get()?.api_key || '';
 
+		// --- Interface ---
+		const dateFormat = formData.get('date_format') as DateFormat;
+
+		if (!DATE_FORMATS.includes(dateFormat)) {
+			return fail(400, { error: 'Invalid date format' });
+		}
+
 		// --- Behavior ---
 		const arrApplyDefaultDelayProfiles = formData.get('arr_apply_default_delay_profiles') === 'on';
 		const failOnReferencedDelete = formData.get('fail_on_referenced_delete') === 'on';
@@ -191,6 +201,7 @@ export const actions: Actions = {
 		}
 
 		const arrUpdated = generalSettingsQueries.update({
+			dateFormat,
 			applyDefaultDelayProfiles: arrApplyDefaultDelayProfiles,
 			failOnReferencedDelete
 		});
@@ -219,6 +230,7 @@ export const actions: Actions = {
 				aiEnabled,
 				aiApiUrl,
 				aiModel,
+				dateFormat,
 				arrApplyDefaultDelayProfiles,
 				failOnReferencedDelete
 			}

--- a/src/routes/settings/general/+page.svelte
+++ b/src/routes/settings/general/+page.svelte
@@ -5,6 +5,7 @@
 	import { alertStore } from '$alerts/store';
 	import { navIconStore, type NavIconStyle } from '$stores/navIcons';
 	import { alertSettingsStore, type AlertPosition, DEFAULT_ALERT_SETTINGS } from '$alerts/settings';
+	import { dateFormat as dateFormatStore } from '$stores/dateFormat';
 	import {
 		fontStore,
 		sansFontOptions,
@@ -259,6 +260,7 @@
 				const durationMs = Math.max(0, Math.round((uiAlertDurationSeconds ?? 0) * 1000));
 				navIconStore.setStyle(uiNavIconStyle);
 				alertSettingsStore.setSettings({ position: uiAlertPosition, durationMs });
+				dateFormatStore.set(dateFormat);
 				fontStore.setFonts({ sans: uiFontSans, mono: uiFontMono });
 
 				// Reset dirty tracking

--- a/src/routes/settings/general/+page.svelte
+++ b/src/routes/settings/general/+page.svelte
@@ -33,6 +33,8 @@
 	import NumberInput from '$ui/form/NumberInput.svelte';
 	import type { PageData } from './$types';
 
+	type DateFormat = 'auto' | 'mdy' | 'dmy' | 'ymd';
+
 	export let data: PageData;
 
 	let saving = false;
@@ -71,6 +73,7 @@
 	let uiAlertDurationSeconds: number | undefined = Math.round(
 		DEFAULT_ALERT_SETTINGS.durationMs / 1000
 	);
+	let dateFormat: DateFormat = data.generalSettings.date_format;
 	let uiFontSans: SansFont = 'dm-sans';
 	let uiFontMono: MonoFont = 'geist-mono';
 
@@ -99,6 +102,13 @@
 		{ value: 'bottom-left', label: 'Bottom left' },
 		{ value: 'bottom-center', label: 'Bottom center' },
 		{ value: 'bottom-right', label: 'Bottom right' }
+	];
+
+	const dateFormatOptions = [
+		{ value: 'auto', label: 'Auto' },
+		{ value: 'mdy', label: 'MM/DD/YYYY' },
+		{ value: 'dmy', label: 'DD/MM/YYYY' },
+		{ value: 'ymd', label: 'YYYY-MM-DD' }
 	];
 
 	// --- Logging defaults ---
@@ -144,6 +154,7 @@
 			ui_nav_icon_style: uiNavIconStyle,
 			ui_alert_position: uiAlertPosition,
 			ui_alert_duration_seconds: uiAlertDurationSeconds,
+			date_format: dateFormat,
 			ui_font_sans: uiFontSans,
 			ui_font_mono: uiFontMono
 		};
@@ -367,6 +378,23 @@
 									update('ui_alert_duration_seconds', v);
 								}}
 							/>
+						</div>
+
+						<div>
+							<span class="mb-1 block text-sm font-medium text-neutral-900 dark:text-neutral-50">
+								Date Format
+							</span>
+							<DropdownSelect
+								value={dateFormat}
+								options={dateFormatOptions}
+								fullWidth
+								fixed
+								on:change={(e) => {
+									dateFormat = e.detail as DateFormat;
+									update('date_format', dateFormat);
+								}}
+							/>
+							<input type="hidden" name="date_format" value={dateFormat} />
 						</div>
 
 						<div>

--- a/src/routes/settings/general/+page.svelte
+++ b/src/routes/settings/general/+page.svelte
@@ -328,7 +328,7 @@
 					</div>
 				</svelte:fragment>
 				<div class="px-6 py-4">
-					<div class="grid grid-cols-1 gap-4 sm:grid-cols-5">
+					<div class="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-5">
 						<div>
 							<span class="mb-1 block text-sm font-medium text-neutral-900 dark:text-neutral-50">
 								Emoji Icons
@@ -344,7 +344,7 @@
 							/>
 						</div>
 
-						<div class="sm:col-span-2">
+						<div class="xl:col-span-2">
 							<span class="mb-1 block text-sm font-medium text-neutral-900 dark:text-neutral-50">
 								Alert Position
 							</span>
@@ -360,7 +360,7 @@
 							/>
 						</div>
 
-						<div class="sm:col-span-2">
+						<div class="xl:col-span-2">
 							<label
 								for="ui_alert_duration"
 								class="mb-1 block text-sm font-medium text-neutral-900 dark:text-neutral-50"
@@ -438,7 +438,7 @@
 				description="Configure application defaults and safeguards"
 				onboardingId="general-behavior"
 			>
-				<div class="grid gap-4 px-6 py-4 sm:grid-cols-5">
+				<div class="grid gap-4 px-6 py-4 sm:grid-cols-2 xl:grid-cols-5">
 					<Toggle
 						label="Apply Default Delay Profile"
 						checked={arrApplyDefaultDelayProfiles}
@@ -480,7 +480,7 @@
 				description="Configure automatic backups, schedule, and retention policy"
 				onboardingId="general-backups"
 			>
-				<div class="grid gap-4 px-6 py-4" class:sm:grid-cols-5={backupEnabled}>
+				<div class="grid gap-4 px-6 py-4" class:sm:grid-cols-2={backupEnabled} class:xl:grid-cols-5={backupEnabled}>
 					<div>
 						<span class="mb-1 block text-sm font-medium text-neutral-900 dark:text-neutral-50">
 							Automatic Backups
@@ -498,7 +498,7 @@
 					<input type="hidden" name="backup_enabled" value={backupEnabled ? 'on' : ''} />
 
 					{#if backupEnabled}
-						<div class="sm:col-span-2">
+						<div class="xl:col-span-2">
 							<span class="mb-1 block text-sm font-medium text-neutral-900 dark:text-neutral-50">
 								Schedule
 							</span>
@@ -514,7 +514,7 @@
 							/>
 						</div>
 
-						<div class="sm:col-span-2">
+						<div class="xl:col-span-2">
 							<label
 								for="backup_retention_days"
 								class="mb-1 block text-sm font-medium text-neutral-900 dark:text-neutral-50"
@@ -552,7 +552,7 @@
 					</div>
 				</svelte:fragment>
 				<div class="space-y-4 px-6 py-4">
-					<div class="grid gap-4" class:sm:grid-cols-7={logEnabled}>
+					<div class="grid gap-4" class:sm:grid-cols-2={logEnabled} class:xl:grid-cols-7={logEnabled}>
 						<div>
 							<span class="mb-1 block text-sm font-medium text-neutral-900 dark:text-neutral-50">
 								Logging
@@ -600,7 +600,7 @@
 								/>
 							</div>
 
-							<div class="sm:col-span-2">
+							<div class="xl:col-span-2">
 								<span class="mb-1 block text-sm font-medium text-neutral-900 dark:text-neutral-50">
 									Minimum Level
 								</span>
@@ -618,7 +618,7 @@
 								</div>
 							</div>
 
-							<div class="sm:col-span-2">
+							<div class="xl:col-span-2">
 								<label
 									for="log_retention_days"
 									class="mb-1 block text-sm font-medium text-neutral-900 dark:text-neutral-50"

--- a/src/routes/settings/general/+page.svelte
+++ b/src/routes/settings/general/+page.svelte
@@ -482,7 +482,11 @@
 				description="Configure automatic backups, schedule, and retention policy"
 				onboardingId="general-backups"
 			>
-				<div class="grid gap-4 px-6 py-4" class:sm:grid-cols-2={backupEnabled} class:xl:grid-cols-5={backupEnabled}>
+				<div
+					class="grid gap-4 px-6 py-4"
+					class:sm:grid-cols-2={backupEnabled}
+					class:xl:grid-cols-5={backupEnabled}
+				>
 					<div>
 						<span class="mb-1 block text-sm font-medium text-neutral-900 dark:text-neutral-50">
 							Automatic Backups
@@ -554,7 +558,11 @@
 					</div>
 				</svelte:fragment>
 				<div class="space-y-4 px-6 py-4">
-					<div class="grid gap-4" class:sm:grid-cols-2={logEnabled} class:xl:grid-cols-7={logEnabled}>
+					<div
+						class="grid gap-4"
+						class:sm:grid-cols-2={logEnabled}
+						class:xl:grid-cols-7={logEnabled}
+					>
 						<div>
 							<span class="mb-1 block text-sm font-medium text-neutral-900 dark:text-neutral-50">
 								Logging

--- a/src/routes/settings/jobs/+page.svelte
+++ b/src/routes/settings/jobs/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import type { PageData } from './$types';
 	import { formatDateTime as formatDT, formatRelative } from '$shared/utils/dates';
+	import { dateFormat } from '$lib/client/stores/dateFormat';
 	import { serverTimezone } from '$lib/client/stores/timezone';
 	import type { Column } from '$lib/client/ui/table/types';
 	import ExpandableTable from '$lib/client/ui/table/ExpandableTable.svelte';
@@ -43,7 +44,7 @@
 	// Format date/time
 	function formatDateTime(dateStr: string | null): string {
 		if (!dateStr) return 'Never';
-		return formatDT(dateStr, $serverTimezone);
+		return formatDT(dateStr, $serverTimezone, $dateFormat);
 	}
 
 	// Get relative time (e.g., "in 5 minutes", "2 hours ago")

--- a/src/routes/settings/logs/+page.svelte
+++ b/src/routes/settings/logs/+page.svelte
@@ -13,6 +13,7 @@
 	import LogLevelLabelCell from './components/LogLevelLabelCell.svelte';
 	import { getPersistentSearchStore } from '$lib/client/stores/search';
 	import { formatDateTime } from '$shared/utils/dates.ts';
+	import { dateFormat } from '$lib/client/stores/dateFormat.ts';
 	import { serverTimezone } from '$lib/client/stores/timezone.ts';
 	import { copyToClipboard } from '$lib/client/utils/clipboard';
 	import { invalidateAll } from '$app/navigation';
@@ -66,7 +67,7 @@
 			sortAccessor: (row) => new Date(row.timestamp).getTime(),
 			cell: (row) => ({
 				// nosemgrep: profilarr.xss.table-cell-html-unescaped — date formatting, not user content
-				html: `<span class="font-mono text-xs text-neutral-600 dark:text-neutral-400">${formatDateTime(row.timestamp, $serverTimezone)}</span>`
+				html: `<span class="font-mono text-xs text-neutral-600 dark:text-neutral-400">${formatDateTime(row.timestamp, $serverTimezone, $dateFormat)}</span>`
 			})
 		},
 		{

--- a/src/routes/settings/security/+page.svelte
+++ b/src/routes/settings/security/+page.svelte
@@ -14,6 +14,7 @@
 		Clock
 	} from 'lucide-svelte';
 	import { parseUTC, formatDateTime, formatDate } from '$shared/utils/dates';
+	import { dateFormat } from '$lib/client/stores/dateFormat.ts';
 	import { serverTimezone } from '$lib/client/stores/timezone.ts';
 	import Button from '$ui/button/Button.svelte';
 	import ExpandableCard from '$ui/card/ExpandableCard.svelte';
@@ -75,7 +76,7 @@
 	}
 
 	function fmtDateTime(dateStr: string): string {
-		return formatDateTime(dateStr, $serverTimezone);
+		return formatDateTime(dateStr, $serverTimezone, $dateFormat);
 	}
 
 	interface SessionRow {
@@ -106,7 +107,7 @@
 		if (diffMins < 60) return `${diffMins}m ago`;
 		if (diffHours < 24) return `${diffHours}h ago`;
 		if (diffDays < 7) return `${diffDays}d ago`;
-		return formatDate(dateStr, $serverTimezone);
+		return formatDate(dateStr, $serverTimezone, $dateFormat);
 	}
 
 	const sessionColumns: Column<SessionRow>[] = [


### PR DESCRIPTION
## Summary

- Adds an app-wide selectable date format setting with Auto, MM/DD/YYYY, DD/MM/YYYY, and YYYY-MM-DD options.
- Wires date display helpers and existing UI date call sites to use the saved preference while keeping server timezone handling unchanged.
- Updates DateInput so its visible month/day/year order follows the selected format, including browser-locale order for Auto.
- Improves the General Settings layout across mid-sized viewports and relaxes DateInput dropdown density on desktop.
- Updates date/time and UI docs.