### PR TITLE
fix: clarify drift result labels

### DIFF
--- a/docs/backend/drift.md
+++ b/docs/backend/drift.md
@@ -214,8 +214,8 @@ Layout:
   (`Paused` / `Ready` / `Next ...` / `Last ...`).
 - Entities section: an `ExpandableTable` with `Name` / `Entity` / `State`
   columns, mirroring the dev changes-page diff idiom. Each drifted entity is
-  one row; expanding shows a `DriftFieldDiffTable` with `Field` / `Expected`
-  / `Actual` columns rendering the entity's `changes[]`.
+  one row; expanding shows a `DriftFieldDiffTable` with `Field` / `Profilarr`
+  / `<Arr type> - <Arr name>` columns rendering the entity's `changes[]`.
 
 State rendering inside the entities section:
 

--- a/src/routes/arr/[id]/drift/+page.svelte
+++ b/src/routes/arr/[id]/drift/+page.svelte
@@ -40,6 +40,11 @@
 		{ key: 'state', header: 'State', width: 'w-32' }
 	];
 
+	const arrTypeLabels: Record<string, string> = {
+		radarr: 'Radarr',
+		sonarr: 'Sonarr'
+	};
+
 	const emptyDriftEntities: DriftDisplayEntity[] = [];
 
 	let saving = false;
@@ -82,6 +87,7 @@
 	$: updateDirty('cron', cron);
 	$: nextRunTime = nextRunAt ? new Date(nextRunAt).getTime() : null;
 	$: timeUntilNext = nextRunTime ? nextRunTime - now : null;
+	$: driftArrLabel = `${arrTypeLabels[data.instance.type] ?? data.instance.type} - ${data.instance.name}`;
 
 	$: if (form && form !== lastFormId) {
 		lastFormId = form;
@@ -291,7 +297,7 @@
 
 						<svelte:fragment slot="expanded" let:row>
 							<div class="px-4 py-3 md:px-6 md:py-4">
-								<DriftFieldDiffTable changes={row.changes} />
+								<DriftFieldDiffTable changes={row.changes} arrLabel={driftArrLabel} />
 							</div>
 						</svelte:fragment>
 					</ExpandableTable>

--- a/src/routes/arr/[id]/drift/components/DriftFieldDiffTable.svelte
+++ b/src/routes/arr/[id]/drift/components/DriftFieldDiffTable.svelte
@@ -6,6 +6,7 @@
 	import QualityListDiff from './QualityListDiff.svelte';
 
 	export let changes: DriftDisplayChange[];
+	export let arrLabel = 'Arr';
 
 	type LabelVariant = 'default' | 'secondary' | 'success' | 'warning' | 'danger' | 'info';
 
@@ -21,11 +22,11 @@
 		return toneToVariant[value.tone ?? 'neutral'];
 	}
 
-	const columns: Column<DriftDisplayChange>[] = [
+	$: columns = [
 		{ key: 'label', header: 'Field' },
-		{ key: 'expected', header: 'Expected' },
-		{ key: 'actual', header: 'Actual' }
-	];
+		{ key: 'expected', header: 'Profilarr' },
+		{ key: 'actual', header: arrLabel }
+	] satisfies Column<DriftDisplayChange>[];
 </script>
 
 <Table {columns} data={changes} compact hoverable={false} responsive>


### PR DESCRIPTION
- Clarifies drift result headers by comparing Profilarr against the specific Arr instance.
- Updates drift docs to match the new wording.