### PR TITLE
refactor: rework media management UI

### DIFF
--- a/src/lib/client/ui/card/StickyCard.svelte
+++ b/src/lib/client/ui/card/StickyCard.svelte
@@ -1,28 +1,10 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
-
 	import Breadcrumb from '$ui/navigation/breadcrumb/Breadcrumb.svelte';
 
 	export let position: 'top' | 'bottom' = 'top';
 	export let variant: 'default' | 'transparent' | 'blur' = 'default';
 	export let breadcrumbItems: { label: string; href: string }[] = [];
 	export let breadcrumbCurrent: string = '';
-
-	let isStuck = false;
-	let sentinel: HTMLDivElement;
-
-	onMount(() => {
-		const observer = new IntersectionObserver(
-			([entry]) => {
-				isStuck = !entry.isIntersecting;
-			},
-			{ threshold: 0 }
-		);
-
-		if (sentinel) observer.observe(sentinel);
-
-		return () => observer.disconnect();
-	});
 
 	$: bgClass =
 		variant === 'default'
@@ -32,40 +14,39 @@
 				: '';
 </script>
 
-<div
-	bind:this={sentinel}
-	class="absolute {position === 'top' ? 'top-0' : 'bottom-0'} h-px w-px"
-></div>
-
-<div
-	class="sticky z-10 -mx-4 md:-mx-8 {bgClass}
-		{position === 'top' ? 'top-0' : 'bottom-0'}"
->
+<div class="contents">
 	{#if breadcrumbItems.length > 0}
-		<div class="px-4 py-2 md:px-12">
-			<Breadcrumb items={breadcrumbItems} current={breadcrumbCurrent} />
-		</div>
-		<div class="mx-4 border-b border-neutral-200 md:mx-8 dark:border-neutral-800"></div>
-	{/if}
-	<div class="px-4 py-3 md:px-12 md:py-4">
-		<div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between md:gap-4">
-			<div
-				class="min-w-0 [&_h1]:text-base [&_h1]:font-semibold [&_h1]:md:text-xl [&_p]:text-xs [&_p]:md:text-sm"
-			>
-				<slot name="left" />
+		<div class="-mx-4 md:-mx-8 {bgClass}">
+			<div class="px-4 py-2 md:px-12">
+				<Breadcrumb items={breadcrumbItems} current={breadcrumbCurrent} />
 			</div>
-			<div class="border-t border-neutral-200 pt-3 md:border-0 md:pt-0 dark:border-neutral-800">
-				<div class="flex flex-shrink-0 flex-wrap items-center gap-2">
-					<slot name="right" />
+			<div class="mx-4 border-b border-neutral-200 md:mx-8 dark:border-neutral-800"></div>
+		</div>
+	{/if}
+	<div
+		class="sticky z-10 -mx-4 md:-mx-8 {bgClass}
+			{position === 'top' ? 'top-0' : 'bottom-0'}"
+	>
+		<div class="px-4 py-3 md:px-12 md:py-4">
+			<div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between md:gap-4">
+				<div
+					class="min-w-0 [&_h1]:text-base [&_h1]:font-semibold [&_h1]:md:text-xl [&_p]:text-xs [&_p]:md:text-sm"
+				>
+					<slot name="left" />
+				</div>
+				<div class="border-t border-neutral-200 pt-3 md:border-0 md:pt-0 dark:border-neutral-800">
+					<div class="flex flex-shrink-0 flex-wrap items-center gap-2">
+						<slot name="right" />
+					</div>
 				</div>
 			</div>
 		</div>
-	</div>
-	{#if variant === 'default'}
-		{#if position === 'top'}
-			<div class="mx-4 border-b border-neutral-200 md:mx-8 dark:border-neutral-800"></div>
-		{:else}
-			<div class="mx-4 border-t border-neutral-200 md:mx-8 dark:border-neutral-800"></div>
+		{#if variant === 'default'}
+			{#if position === 'top'}
+				<div class="mx-4 border-b border-neutral-200 md:mx-8 dark:border-neutral-800"></div>
+			{:else}
+				<div class="mx-4 border-t border-neutral-200 md:mx-8 dark:border-neutral-800"></div>
+			{/if}
 		{/if}
-	{/if}
+	</div>
 </div>

--- a/src/lib/client/ui/card/StickyCard.svelte
+++ b/src/lib/client/ui/card/StickyCard.svelte
@@ -5,6 +5,7 @@
 	export let variant: 'default' | 'transparent' | 'blur' = 'default';
 	export let breadcrumbItems: { label: string; href: string }[] = [];
 	export let breadcrumbCurrent: string = '';
+	export let stickyBreadcrumb: boolean = true;
 
 	$: bgClass =
 		variant === 'default'
@@ -12,41 +13,41 @@
 			: variant === 'blur'
 				? 'backdrop-blur-sm bg-neutral-50/50 dark:bg-neutral-900/50'
 				: '';
+	$: hasBreadcrumb = breadcrumbItems.length > 0;
+	$: stickyPositionClass =
+		position === 'bottom'
+			? 'bottom-0'
+			: hasBreadcrumb && !stickyBreadcrumb
+				? 'top-[-37px]'
+				: 'top-0';
 </script>
 
-<div class="contents">
-	{#if breadcrumbItems.length > 0}
-		<div class="-mx-4 md:-mx-8 {bgClass}">
-			<div class="px-4 py-2 md:px-12">
-				<Breadcrumb items={breadcrumbItems} current={breadcrumbCurrent} />
-			</div>
-			<div class="mx-4 border-b border-neutral-200 md:mx-8 dark:border-neutral-800"></div>
+<div class="sticky z-10 -mx-4 md:-mx-8 {bgClass} {stickyPositionClass}">
+	{#if hasBreadcrumb}
+		<div class="px-4 py-2 md:px-12">
+			<Breadcrumb items={breadcrumbItems} current={breadcrumbCurrent} />
 		</div>
+		<div class="mx-4 border-b border-neutral-200 md:mx-8 dark:border-neutral-800"></div>
 	{/if}
-	<div
-		class="sticky z-10 -mx-4 md:-mx-8 {bgClass}
-			{position === 'top' ? 'top-0' : 'bottom-0'}"
-	>
-		<div class="px-4 py-3 md:px-12 md:py-4">
-			<div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between md:gap-4">
-				<div
-					class="min-w-0 [&_h1]:text-base [&_h1]:font-semibold [&_h1]:md:text-xl [&_p]:text-xs [&_p]:md:text-sm"
-				>
-					<slot name="left" />
-				</div>
-				<div class="border-t border-neutral-200 pt-3 md:border-0 md:pt-0 dark:border-neutral-800">
-					<div class="flex flex-shrink-0 flex-wrap items-center gap-2">
-						<slot name="right" />
-					</div>
+	<div class="px-4 py-3 md:px-12 md:py-4">
+		<div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between md:gap-4">
+			<div
+				class="min-w-0 [&_h1]:text-base [&_h1]:font-semibold [&_h1]:md:text-xl [&_p]:text-xs [&_p]:md:text-sm"
+			>
+				<slot name="left" />
+			</div>
+			<div class="border-t border-neutral-200 pt-3 md:border-0 md:pt-0 dark:border-neutral-800">
+				<div class="flex flex-shrink-0 flex-wrap items-center gap-2">
+					<slot name="right" />
 				</div>
 			</div>
 		</div>
-		{#if variant === 'default'}
-			{#if position === 'top'}
-				<div class="mx-4 border-b border-neutral-200 md:mx-8 dark:border-neutral-800"></div>
-			{:else}
-				<div class="mx-4 border-t border-neutral-200 md:mx-8 dark:border-neutral-800"></div>
-			{/if}
-		{/if}
 	</div>
+	{#if variant === 'default'}
+		{#if position === 'top'}
+			<div class="mx-4 border-b border-neutral-200 md:mx-8 dark:border-neutral-800"></div>
+		{:else}
+			<div class="mx-4 border-t border-neutral-200 md:mx-8 dark:border-neutral-800"></div>
+		{/if}
+	{/if}
 </div>

--- a/src/lib/server/pcd/entities/mediaManagement/naming/read.ts
+++ b/src/lib/server/pcd/entities/mediaManagement/naming/read.ts
@@ -4,7 +4,11 @@
 
 import type { PCDCache } from '$pcd/index.ts';
 import type { RadarrNamingRow, SonarrNamingRow, NamingListItem } from '$shared/pcd/display.ts';
-import { colonReplacementFromDb, multiEpisodeStyleFromDb } from '$shared/pcd/mediaManagement.ts';
+import {
+	colonReplacementFromDb,
+	multiEpisodeStyleFromDb,
+	type SonarrColonReplacementFormat
+} from '$shared/pcd/mediaManagement.ts';
 
 // Note: name is PRIMARY KEY so never null, but Kysely types it as nullable
 // because the generator doesn't detect non-INTEGER primary keys
@@ -13,8 +17,27 @@ export async function list(cache: PCDCache): Promise<NamingListItem[]> {
 	const db = cache.kb;
 
 	const [radarrRows, sonarrRows] = await Promise.all([
-		db.selectFrom('radarr_naming').select(['name', 'rename', 'updated_at']).execute(),
-		db.selectFrom('sonarr_naming').select(['name', 'rename', 'updated_at']).execute()
+		db
+			.selectFrom('radarr_naming')
+			.select([
+				'name',
+				'rename',
+				'replace_illegal_characters',
+				'colon_replacement_format',
+				'updated_at'
+			])
+			.execute(),
+		db
+			.selectFrom('sonarr_naming')
+			.select([
+				'name',
+				'rename',
+				'replace_illegal_characters',
+				'colon_replacement_format',
+				'multi_episode_style',
+				'updated_at'
+			])
+			.execute()
 	]);
 
 	const items: NamingListItem[] = [];
@@ -24,6 +47,9 @@ export async function list(cache: PCDCache): Promise<NamingListItem[]> {
 			name: row.name!,
 			arr_type: 'radarr',
 			rename: row.rename === 1,
+			replace_illegal_characters: row.replace_illegal_characters === 1,
+			colon_replacement_format: row.colon_replacement_format as SonarrColonReplacementFormat,
+			multi_episode_style: null,
 			updated_at: row.updated_at
 		});
 	}
@@ -33,6 +59,9 @@ export async function list(cache: PCDCache): Promise<NamingListItem[]> {
 			name: row.name!,
 			arr_type: 'sonarr',
 			rename: row.rename === 1,
+			replace_illegal_characters: row.replace_illegal_characters === 1,
+			colon_replacement_format: colonReplacementFromDb(row.colon_replacement_format),
+			multi_episode_style: multiEpisodeStyleFromDb(row.multi_episode_style),
 			updated_at: row.updated_at
 		});
 	}

--- a/src/lib/shared/pcd/display.ts
+++ b/src/lib/shared/pcd/display.ts
@@ -48,10 +48,15 @@ import type { ArrType } from './types.ts';
 // Naming
 export type { RadarrNamingRow, SonarrNamingRow } from './types.ts';
 
+import type { SonarrColonReplacementFormat, MultiEpisodeStyle } from './mediaManagement.ts';
+
 export interface NamingListItem {
 	name: string;
 	arr_type: Exclude<ArrType, 'all'>;
 	rename: boolean;
+	replace_illegal_characters: boolean;
+	colon_replacement_format: SonarrColonReplacementFormat;
+	multi_episode_style: MultiEpisodeStyle | null;
 	updated_at: string;
 }
 

--- a/src/routes/delay-profiles/[databaseId]/components/DelayProfileForm.svelte
+++ b/src/routes/delay-profiles/[databaseId]/components/DelayProfileForm.svelte
@@ -225,131 +225,131 @@
 		<input type="hidden" name="layer" value={selectedLayer} />
 
 		<div class="space-y-6">
-				<!-- Name -->
-				<div data-onboarding="delay-general-name">
-					<FormInput
-						label="Name"
-						name="name"
-						placeholder="e.g., Standard Delay"
-						required
-						value={formData.name}
-						on:input={(e) => updateField('name', e.detail)}
-					/>
-				</div>
+			<!-- Name -->
+			<div data-onboarding="delay-general-name">
+				<FormInput
+					label="Name"
+					name="name"
+					placeholder="e.g., Standard Delay"
+					required
+					value={formData.name}
+					on:input={(e) => updateField('name', e.detail)}
+				/>
+			</div>
 
-				<!-- Protocol Preference -->
-				<div class="space-y-2" data-onboarding="delay-general-protocol">
-					<h3 class="text-sm font-semibold text-neutral-900 dark:text-neutral-100">
-						Protocol Preference
-					</h3>
-					<DropdownSelect
-						value={formData.preferredProtocol}
-						options={protocolOptions}
-						fullWidth
-						on:change={(e) => updateField('preferredProtocol', e.detail as PreferredProtocol)}
-					/>
-					{#if protocolDescription}
-						<p class="text-xs text-neutral-500 dark:text-neutral-400">
-							{protocolDescription}
-						</p>
-					{/if}
-				</div>
-
-				<!-- Delays -->
-				<div data-onboarding="delay-general-delays">
-					<h3 class="text-sm font-semibold text-neutral-900 dark:text-neutral-100">Delays</h3>
-					<p class="mt-1 text-xs text-neutral-500 dark:text-neutral-400">
-						Time to wait before downloading from each source. Set to 0 for no delay.
+			<!-- Protocol Preference -->
+			<div class="space-y-2" data-onboarding="delay-general-protocol">
+				<h3 class="text-sm font-semibold text-neutral-900 dark:text-neutral-100">
+					Protocol Preference
+				</h3>
+				<DropdownSelect
+					value={formData.preferredProtocol}
+					options={protocolOptions}
+					fullWidth
+					on:change={(e) => updateField('preferredProtocol', e.detail as PreferredProtocol)}
+				/>
+				{#if protocolDescription}
+					<p class="text-xs text-neutral-500 dark:text-neutral-400">
+						{protocolDescription}
 					</p>
-					<div class="mt-3 grid gap-4 sm:grid-cols-2">
-						<div>
-							<label
-								for="usenet-delay"
-								class="block text-sm font-medium text-neutral-700 dark:text-neutral-300"
-							>
-								Usenet Delay (minutes)
-							</label>
-							<div class="mt-1">
-								<NumberInput
-									name="usenet-delay"
-									id="usenet-delay"
-									value={formData.usenetDelay}
-									onchange={(v) => updateField('usenetDelay', v)}
-									min={0}
-									font="mono"
-									disabled={!usenetEnabled}
-								/>
-							</div>
-						</div>
+				{/if}
+			</div>
 
-						<div>
-							<label
-								for="torrent-delay"
-								class="block text-sm font-medium text-neutral-700 dark:text-neutral-300"
-							>
-								Torrent Delay (minutes)
-							</label>
-							<div class="mt-1">
-								<NumberInput
-									name="torrent-delay"
-									id="torrent-delay"
-									value={formData.torrentDelay}
-									onchange={(v) => updateField('torrentDelay', v)}
-									min={0}
-									font="mono"
-									disabled={!torrentEnabled}
-								/>
-							</div>
+			<!-- Delays -->
+			<div data-onboarding="delay-general-delays">
+				<h3 class="text-sm font-semibold text-neutral-900 dark:text-neutral-100">Delays</h3>
+				<p class="mt-1 text-xs text-neutral-500 dark:text-neutral-400">
+					Time to wait before downloading from each source. Set to 0 for no delay.
+				</p>
+				<div class="mt-3 grid gap-4 sm:grid-cols-2">
+					<div>
+						<label
+							for="usenet-delay"
+							class="block text-sm font-medium text-neutral-700 dark:text-neutral-300"
+						>
+							Usenet Delay (minutes)
+						</label>
+						<div class="mt-1">
+							<NumberInput
+								name="usenet-delay"
+								id="usenet-delay"
+								value={formData.usenetDelay}
+								onchange={(v) => updateField('usenetDelay', v)}
+								min={0}
+								font="mono"
+								disabled={!usenetEnabled}
+							/>
+						</div>
+					</div>
+
+					<div>
+						<label
+							for="torrent-delay"
+							class="block text-sm font-medium text-neutral-700 dark:text-neutral-300"
+						>
+							Torrent Delay (minutes)
+						</label>
+						<div class="mt-1">
+							<NumberInput
+								name="torrent-delay"
+								id="torrent-delay"
+								value={formData.torrentDelay}
+								onchange={(v) => updateField('torrentDelay', v)}
+								min={0}
+								font="mono"
+								disabled={!torrentEnabled}
+							/>
 						</div>
 					</div>
 				</div>
+			</div>
 
-				<!-- Bypass Conditions -->
-				<div data-onboarding="delay-general-bypass">
-					<h3 class="text-sm font-semibold text-neutral-900 dark:text-neutral-100">
-						Bypass Conditions
-					</h3>
-					<p class="mt-1 text-xs text-neutral-500 dark:text-neutral-400">
-						Skip the delay when these conditions are met.
-					</p>
-					<div class="mt-3 space-y-3">
-						<div>
+			<!-- Bypass Conditions -->
+			<div data-onboarding="delay-general-bypass">
+				<h3 class="text-sm font-semibold text-neutral-900 dark:text-neutral-100">
+					Bypass Conditions
+				</h3>
+				<p class="mt-1 text-xs text-neutral-500 dark:text-neutral-400">
+					Skip the delay when these conditions are met.
+				</p>
+				<div class="mt-3 space-y-3">
+					<div>
+						<Toggle
+							label="Bypass if Highest Quality"
+							checked={formData.bypassIfHighestQuality}
+							fullWidth
+							on:change={() =>
+								updateField('bypassIfHighestQuality', !formData.bypassIfHighestQuality)}
+						/>
+						<p class="mt-1 px-3 text-xs text-neutral-500 dark:text-neutral-400">
+							Skip delay when release is already the highest quality in profile
+						</p>
+					</div>
+
+					<div>
+						<div class="grid grid-cols-1 items-center gap-3 sm:grid-cols-2">
 							<Toggle
-								label="Bypass if Highest Quality"
-								checked={formData.bypassIfHighestQuality}
+								label="Bypass if Above Custom Format Score"
+								checked={formData.bypassIfAboveCfScore}
 								fullWidth
 								on:change={() =>
-									updateField('bypassIfHighestQuality', !formData.bypassIfHighestQuality)}
+									updateField('bypassIfAboveCfScore', !formData.bypassIfAboveCfScore)}
 							/>
-							<p class="mt-1 px-3 text-xs text-neutral-500 dark:text-neutral-400">
-								Skip delay when release is already the highest quality in profile
-							</p>
+							<NumberInput
+								name="min-cf-score"
+								id="min-cf-score"
+								value={formData.minimumCfScore}
+								onchange={(v) => updateField('minimumCfScore', v)}
+								disabled={!formData.bypassIfAboveCfScore}
+								font="mono"
+							/>
 						</div>
-
-						<div>
-							<div class="grid grid-cols-1 items-center gap-3 sm:grid-cols-2">
-								<Toggle
-									label="Bypass if Above Custom Format Score"
-									checked={formData.bypassIfAboveCfScore}
-									fullWidth
-									on:change={() =>
-										updateField('bypassIfAboveCfScore', !formData.bypassIfAboveCfScore)}
-								/>
-								<NumberInput
-									name="min-cf-score"
-									id="min-cf-score"
-									value={formData.minimumCfScore}
-									onchange={(v) => updateField('minimumCfScore', v)}
-									disabled={!formData.bypassIfAboveCfScore}
-									font="mono"
-								/>
-							</div>
-							<p class="mt-1 px-3 text-xs text-neutral-500 dark:text-neutral-400">
-								Skip delay when release exceeds minimum score
-							</p>
-						</div>
+						<p class="mt-1 px-3 text-xs text-neutral-500 dark:text-neutral-400">
+							Skip delay when release exceeds minimum score
+						</p>
 					</div>
 				</div>
+			</div>
 		</div>
 	</form>
 

--- a/src/routes/delay-profiles/[databaseId]/components/DelayProfileForm.svelte
+++ b/src/routes/delay-profiles/[databaseId]/components/DelayProfileForm.svelte
@@ -8,7 +8,6 @@
 	import Toggle from '$ui/toggle/Toggle.svelte';
 	import DropdownSelect from '$ui/dropdown/DropdownSelect.svelte';
 	import StickyCard from '$ui/card/StickyCard.svelte';
-	import Card from '$ui/card/Card.svelte';
 	import Button from '$ui/button/Button.svelte';
 	import Modal from '$ui/modal/Modal.svelte';
 	import SyncPromptModal from '$ui/modal/SyncPromptModal.svelte';
@@ -142,7 +141,7 @@
 </script>
 
 <div class="space-y-6">
-	<StickyCard position="top" {breadcrumbItems} {breadcrumbCurrent}>
+	<StickyCard position="top" {breadcrumbItems} {breadcrumbCurrent} stickyBreadcrumb={false}>
 		<svelte:fragment slot="left">
 			<div>
 				<h2 class="text-lg font-semibold text-neutral-900 dark:text-neutral-50">{title}</h2>
@@ -225,8 +224,7 @@
 		<input type="hidden" name="minimumCfScore" value={formData.minimumCfScore} />
 		<input type="hidden" name="layer" value={selectedLayer} />
 
-		<Card flush padding="lg">
-			<div class="space-y-6">
+		<div class="space-y-6">
 				<!-- Name -->
 				<div data-onboarding="delay-general-name">
 					<FormInput
@@ -352,8 +350,7 @@
 						</div>
 					</div>
 				</div>
-			</div>
-		</Card>
+		</div>
 	</form>
 
 	<!-- Hidden delete form -->

--- a/src/routes/delay-profiles/[databaseId]/views/CardView.svelte
+++ b/src/routes/delay-profiles/[databaseId]/views/CardView.svelte
@@ -2,10 +2,11 @@
 	import { createEventDispatcher } from 'svelte';
 	import type { DelayProfilesRow } from '$shared/pcd/display.ts';
 	import { page } from '$app/stores';
-	import { Clock, Zap, Shield, Copy, Download } from 'lucide-svelte';
+	import { Clock, Zap, Copy, Download } from 'lucide-svelte';
 	import CardGrid from '$ui/card/CardGrid.svelte';
 	import Card from '$ui/card/Card.svelte';
 	import Button from '$ui/button/Button.svelte';
+	import Label from '$ui/label/Label.svelte';
 	import { createProgressiveList } from '$lib/client/utils/progressiveList';
 	import { FEATURES } from '$shared/features.ts';
 
@@ -35,6 +36,12 @@
 		}
 	}
 
+	function protocolVariant(protocol: string): 'info' | 'warning' | 'secondary' {
+		if (protocol.startsWith('prefer_')) return 'info';
+		if (protocol.startsWith('only_')) return 'warning';
+		return 'secondary';
+	}
+
 	function formatDelay(minutes: number | null): string {
 		if (minutes === null) return '-';
 		if (minutes === 0) return 'No delay';
@@ -54,10 +61,15 @@
 		<Card href={getProfileHref(profile)} hoverable>
 			<svelte:fragment slot="header">
 				<!-- svelte-ignore a11y-click-events-have-key-events a11y-no-static-element-interactions -->
-				<div class="flex items-center justify-between">
-					<h3 class="text-sm font-semibold text-neutral-900 dark:text-neutral-100">
-						{profile.name}
-					</h3>
+				<div class="flex items-center justify-between gap-2">
+					<div class="flex min-w-0 items-center gap-2">
+						<h3 class="truncate text-sm font-semibold text-neutral-900 dark:text-neutral-100">
+							{profile.name}
+						</h3>
+						<Label variant={protocolVariant(profile.preferred_protocol)} size="sm" rounded="md">
+							{formatProtocol(profile.preferred_protocol)}
+						</Label>
+					</div>
 					<div class="flex items-center gap-0.5" on:click|stopPropagation|preventDefault>
 						{#if FEATURES.importExport}
 							<Button
@@ -80,11 +92,6 @@
 			</svelte:fragment>
 
 			<div class="space-y-2.5">
-				<div class="flex items-center gap-1.5 text-xs text-neutral-500 dark:text-neutral-400">
-					<Zap size={12} />
-					<span>{formatProtocol(profile.preferred_protocol)}</span>
-				</div>
-
 				<div class="space-y-1">
 					{#if profile.usenet_delay !== null}
 						<div class="flex items-center justify-between text-xs">
@@ -111,19 +118,21 @@
 				{#if profile.bypass_if_highest_quality || profile.bypass_if_above_custom_format_score}
 					<div class="space-y-1 border-t border-neutral-200 pt-2.5 dark:border-neutral-700/60">
 						{#if profile.bypass_if_highest_quality}
-							<div
-								class="flex items-center gap-1.5 text-[11px] text-emerald-700 dark:text-emerald-400"
-							>
-								<Shield size={11} />
-								<span>Highest Quality</span>
+							<div class="flex items-center justify-between text-xs">
+								<span class="flex items-center gap-1.5 text-neutral-500 dark:text-neutral-400">
+									<Zap size={11} />Highest quality
+								</span>
+								<span class="font-mono text-neutral-900 dark:text-neutral-100">✓</span>
 							</div>
 						{/if}
 						{#if profile.bypass_if_above_custom_format_score && profile.minimum_custom_format_score !== null}
-							<div
-								class="flex items-center gap-1.5 text-[11px] text-emerald-700 dark:text-emerald-400"
-							>
-								<Shield size={11} />
-								<span>CF ≥ {profile.minimum_custom_format_score}</span>
+							<div class="flex items-center justify-between text-xs">
+								<span class="flex items-center gap-1.5 text-neutral-500 dark:text-neutral-400">
+									<Zap size={11} />Min CF score
+								</span>
+								<span class="font-mono text-neutral-900 dark:text-neutral-100"
+									>≥ {profile.minimum_custom_format_score}</span
+								>
 							</div>
 						{/if}
 					</div>

--- a/src/routes/media-management/[databaseId]/+layout.svelte
+++ b/src/routes/media-management/[databaseId]/+layout.svelte
@@ -31,7 +31,7 @@
 	<title>Media Management - {data.currentDatabase?.name} - Profilarr</title>
 </svelte:head>
 
-<div class="space-y-6 px-4 pb-8 md:px-8">
+<div class="space-y-6 px-4 pb-8 md:px-8 {isNestedPage ? 'pt-3 md:pt-7' : ''}">
 	<!-- Database Tabs -->
 	{#if !isNestedPage}
 		<Tabs tabs={databaseTabs} />

--- a/src/routes/media-management/[databaseId]/media-settings/components/MediaSettingsForm.svelte
+++ b/src/routes/media-management/[databaseId]/media-settings/components/MediaSettingsForm.svelte
@@ -111,7 +111,7 @@
 	}
 </script>
 
-<StickyCard position="top" {breadcrumbItems} {breadcrumbCurrent}>
+<StickyCard position="top" {breadcrumbItems} {breadcrumbCurrent} stickyBreadcrumb={false}>
 	<div slot="left">
 		<h1 class="text-neutral-900 dark:text-neutral-50">{title}</h1>
 		<p class="text-neutral-600 dark:text-neutral-400">{description}</p>
@@ -136,7 +136,7 @@
 	</div>
 </StickyCard>
 
-<div class="mt-6 md:px-4">
+<div class="md:px-4">
 	<div class="space-y-6">
 		<div data-onboarding="media-settings-name">
 			<FormInput

--- a/src/routes/media-management/[databaseId]/media-settings/components/MediaSettingsForm.svelte
+++ b/src/routes/media-management/[databaseId]/media-settings/components/MediaSettingsForm.svelte
@@ -113,8 +113,8 @@
 
 <StickyCard position="top" {breadcrumbItems} {breadcrumbCurrent}>
 	<div slot="left">
-		<h1 class="text-xl font-semibold text-neutral-900 dark:text-neutral-50">{title}</h1>
-		<p class="text-sm text-neutral-500 dark:text-neutral-400">{description}</p>
+		<h1 class="text-neutral-900 dark:text-neutral-50">{title}</h1>
+		<p class="text-neutral-600 dark:text-neutral-400">{description}</p>
 	</div>
 	<div slot="right" class="flex items-center gap-2">
 		{#if mode === 'edit'}
@@ -137,29 +137,28 @@
 </StickyCard>
 
 <div class="mt-6 md:px-4">
-	<div
-		class="space-y-6 rounded-xl border border-neutral-300 bg-white p-6 dark:border-neutral-700/60 dark:bg-neutral-800/50"
-	>
-		<!-- Basic Info -->
-		<div class="space-y-4" data-onboarding="media-settings-name">
-			<h2 class="text-base font-semibold text-neutral-900 dark:text-neutral-100">Basic Info</h2>
+	<div class="space-y-6">
+		<div data-onboarding="media-settings-name">
 			<FormInput
 				label="Name"
 				name="name"
 				placeholder="e.g., default"
 				required
+				description="The name of this media settings configuration."
 				value={formData.name}
 				on:input={(e) => updateField('name', e.detail)}
 			/>
 		</div>
 
-		<hr class="border-neutral-200 dark:border-neutral-700" />
-
-		<!-- Propers and Repacks -->
-		<div class="space-y-4" data-onboarding="media-settings-propers-repacks">
-			<h2 class="text-base font-semibold text-neutral-900 dark:text-neutral-100">
-				Propers and Repacks
-			</h2>
+		<div class="space-y-2" data-onboarding="media-settings-propers-repacks">
+			<div class="space-y-1">
+				<div class="text-sm font-medium text-neutral-900 dark:text-neutral-100">
+					Propers and Repacks
+				</div>
+				<p class="text-xs text-neutral-600 dark:text-neutral-400">
+					Choose how {arrLabel} handles proper and repack releases.
+				</p>
+			</div>
 			<DropdownSelect
 				value={formData.propersRepacks}
 				options={PROPERS_REPACKS_OPTIONS}
@@ -167,27 +166,24 @@
 				on:change={(e) => updateField('propersRepacks', e.detail as PropersRepacks)}
 			/>
 			{#if propersRepacksDescription}
-				<p class="text-xs text-neutral-500 dark:text-neutral-400">
+				<p class="text-xs text-neutral-600 dark:text-neutral-400">
 					{propersRepacksDescription}
 				</p>
 			{/if}
 		</div>
 
-		<hr class="border-neutral-200 dark:border-neutral-700" />
-
-		<!-- Media Info -->
-		<div class="space-y-4" data-onboarding="media-settings-file-analysis">
-			<h2 class="text-base font-semibold text-neutral-900 dark:text-neutral-100">File Analysis</h2>
-			<div>
-				<Toggle
-					label="Enable Media Info"
-					checked={formData.enableMediaInfo}
-					on:change={() => updateField('enableMediaInfo', !formData.enableMediaInfo)}
-				/>
-				<p class="mt-1 px-3 text-xs text-neutral-500 dark:text-neutral-400">
-					Scan files to extract media information (codec, resolution, audio tracks, etc.)
+		<div class="space-y-2" data-onboarding="media-settings-file-analysis">
+			<div class="space-y-1">
+				<div class="text-sm font-medium text-neutral-900 dark:text-neutral-100">File Analysis</div>
+				<p class="text-xs text-neutral-600 dark:text-neutral-400">
+					Scan files to extract media information such as codec, resolution, and audio tracks.
 				</p>
 			</div>
+			<Toggle
+				label="Enable Media Info"
+				checked={formData.enableMediaInfo}
+				on:change={() => updateField('enableMediaInfo', !formData.enableMediaInfo)}
+			/>
 		</div>
 	</div>
 </div>

--- a/src/routes/media-management/[databaseId]/media-settings/views/CardView.svelte
+++ b/src/routes/media-management/[databaseId]/media-settings/views/CardView.svelte
@@ -4,7 +4,7 @@
 	import Card from '$ui/card/Card.svelte';
 	import Label from '$ui/label/Label.svelte';
 	import Button from '$ui/button/Button.svelte';
-	import { Copy, Download } from 'lucide-svelte';
+	import { Copy, Download, Info, RefreshCw } from 'lucide-svelte';
 	import type { MediaSettingsListItem } from '$shared/pcd/display.ts';
 	import radarrLogo from '$lib/client/assets/Radarr.svg';
 	import sonarrLogo from '$lib/client/assets/Sonarr.svg';
@@ -46,64 +46,74 @@
 	}
 </script>
 
-<CardGrid columns={1} flush>
+<CardGrid columns={4} flush>
 	{#each configs as config}
 		{@const prConfig = propersRepacksConfig[config.propers_repacks] || {
-			variant: 'secondary',
+			variant: 'secondary' as const,
 			label: config.propers_repacks
 		}}
 		<Card href={getConfigHref(config)} hoverable>
-			<div class="flex items-center gap-4">
-				<!-- Logo + Name -->
-				<div class="flex min-w-0 flex-1 items-center gap-3">
-					<div class="relative h-10 w-10 flex-shrink-0">
-						{#if !loadedImages.has(config.name)}
-							<div
-								class="absolute inset-0 animate-pulse rounded-lg bg-neutral-200 dark:bg-neutral-700"
-							></div>
-						{/if}
-						<img
-							src={logos[config.arr_type]}
-							alt="{config.arr_type} logo"
-							class="h-10 w-10 rounded-lg {loadedImages.has(config.name)
-								? 'opacity-100'
-								: 'opacity-0'}"
-							on:load={() => handleImageLoad(config.name)}
-						/>
-					</div>
-					<div class="min-w-0">
+			<svelte:fragment slot="header">
+				<!-- svelte-ignore a11y-click-events-have-key-events a11y-no-static-element-interactions -->
+				<div class="flex items-center justify-between gap-2">
+					<div class="flex min-w-0 items-center gap-2">
+						<div class="relative h-6 w-6 flex-shrink-0">
+							{#if !loadedImages.has(config.name)}
+								<div
+									class="absolute inset-0 animate-pulse rounded bg-neutral-200 dark:bg-neutral-700"
+								></div>
+							{/if}
+							<img
+								src={logos[config.arr_type]}
+								alt="{config.arr_type} logo"
+								class="h-6 w-6 rounded {loadedImages.has(config.name)
+									? 'opacity-100'
+									: 'opacity-0'}"
+								on:load={() => handleImageLoad(config.name)}
+							/>
+						</div>
 						<h3 class="truncate text-sm font-semibold text-neutral-900 dark:text-neutral-100">
 							{config.name}
 						</h3>
-						<div class="mt-1 flex flex-wrap items-center gap-1">
-							<Label variant={prConfig.variant} size="sm" rounded="md">{prConfig.label}</Label>
-							{#if config.enable_media_info}
-								<Label variant="success" size="sm" rounded="md">Media Info</Label>
-							{:else}
-								<Label variant="secondary" size="sm" rounded="md">No Media Info</Label>
-							{/if}
-						</div>
 					</div>
-				</div>
-
-				<!-- svelte-ignore a11y-click-events-have-key-events a11y-no-static-element-interactions -->
-				<div class="flex items-center gap-0.5" on:click|stopPropagation|preventDefault>
-					{#if FEATURES.importExport}
+					<div class="flex items-center gap-0.5" on:click|stopPropagation|preventDefault>
+						{#if FEATURES.importExport}
+							<Button
+								icon={Download}
+								size="xs"
+								variant="ghost"
+								tooltip="Export"
+								on:click={() =>
+									dispatch('export', { name: config.name, arr_type: config.arr_type })}
+							/>
+						{/if}
 						<Button
-							icon={Download}
+							icon={Copy}
 							size="xs"
 							variant="ghost"
-							tooltip="Export"
-							on:click={() => dispatch('export', { name: config.name, arr_type: config.arr_type })}
+							tooltip="Clone"
+							on:click={() => dispatch('clone', { name: config.name, arr_type: config.arr_type })}
 						/>
-					{/if}
-					<Button
-						icon={Copy}
-						size="xs"
-						variant="ghost"
-						tooltip="Clone"
-						on:click={() => dispatch('clone', { name: config.name, arr_type: config.arr_type })}
-					/>
+					</div>
+				</div>
+			</svelte:fragment>
+
+			<div class="space-y-1">
+				<div class="flex items-center justify-between gap-2 text-xs">
+					<span class="flex items-center gap-1.5 text-neutral-500 dark:text-neutral-400">
+						<RefreshCw size={11} />Propers / Repacks
+					</span>
+					<Label variant={prConfig.variant} size="sm" rounded="md">
+						{prConfig.label}
+					</Label>
+				</div>
+				<div class="flex items-center justify-between text-xs">
+					<span class="flex items-center gap-1.5 text-neutral-500 dark:text-neutral-400">
+						<Info size={11} />Media info
+					</span>
+					<span class="font-mono text-neutral-900 dark:text-neutral-100">
+						{config.enable_media_info ? '✓' : '✗'}
+					</span>
 				</div>
 			</div>
 		</Card>

--- a/src/routes/media-management/[databaseId]/naming/components/RadarrNamingForm.svelte
+++ b/src/routes/media-management/[databaseId]/naming/components/RadarrNamingForm.svelte
@@ -129,8 +129,8 @@
 
 <StickyCard position="top" {breadcrumbItems} {breadcrumbCurrent}>
 	<div slot="left">
-		<h1 class="text-xl font-semibold text-neutral-900 dark:text-neutral-50">{title}</h1>
-		<p class="text-sm text-neutral-500 dark:text-neutral-400">{description}</p>
+		<h1 class="text-neutral-900 dark:text-neutral-50">{title}</h1>
+		<p class="text-neutral-600 dark:text-neutral-400">{description}</p>
 	</div>
 	<div slot="right" class="flex items-center gap-2">
 		<Button
@@ -160,43 +160,44 @@
 
 <div class="mt-6 md:px-4">
 	<div class="space-y-6">
-		<!-- Basic Info -->
-		<div class="space-y-4">
-			<h2 class="text-base font-semibold text-neutral-900 dark:text-neutral-100">Basic Info</h2>
+		<div class="space-y-6">
 			<FormInput
 				label="Name"
 				name="name"
 				required
 				value={formData.name}
 				placeholder="e.g., default"
+				description="The name of this Radarr naming configuration."
 				on:input={(e) => updateField('name', e.detail)}
 			/>
 
 			<div class="space-y-2">
+				<div class="space-y-1">
+					<div class="text-sm font-medium text-neutral-900 dark:text-neutral-100">Rename Movies</div>
+					<p class="text-xs text-neutral-600 dark:text-neutral-400">
+						Rename movie files to match the naming format.
+					</p>
+				</div>
 				<Toggle
 					checked={formData.rename}
-					label="Rename Movies"
+					label={formData.rename ? 'Enabled' : 'Disabled'}
 					ariaLabel="Rename Movies"
 					color={formData.rename ? 'green' : 'neutral'}
 					on:change={(e) => updateField('rename', e.detail)}
 				/>
-				<p class="text-xs text-neutral-500 dark:text-neutral-400">
-					Rename movie files to match the naming format
-				</p>
 			</div>
 		</div>
 
 		{#if formData.rename}
-			<hr class="border-neutral-200 dark:border-neutral-700" />
-
-			<!-- Naming Formats -->
-			<div class="space-y-4">
-				<h2
-					data-onboarding="media-naming-formats"
-					class="text-base font-semibold text-neutral-900 dark:text-neutral-100"
-				>
-					Naming Formats
-				</h2>
+			<div class="space-y-4" data-onboarding="media-naming-formats">
+				<div class="space-y-1">
+					<div class="text-sm font-medium text-neutral-900 dark:text-neutral-100">
+						Naming Formats
+					</div>
+					<p class="text-xs text-neutral-600 dark:text-neutral-400">
+						Control how Radarr names movie files and folders.
+					</p>
+				</div>
 				<div>
 					<TokenAutocomplete
 						label="Movie Format"
@@ -224,16 +225,15 @@
 				</div>
 			</div>
 
-			<hr class="border-neutral-200 dark:border-neutral-700" />
-
-			<!-- Character Replacement -->
-			<div class="space-y-4">
-				<h2
-					data-onboarding="media-naming-character-replacement"
-					class="text-base font-semibold text-neutral-900 dark:text-neutral-100"
-				>
-					Character Replacement
-				</h2>
+			<div class="space-y-4" data-onboarding="media-naming-character-replacement">
+				<div class="space-y-1">
+					<div class="text-sm font-medium text-neutral-900 dark:text-neutral-100">
+						Character Replacement
+					</div>
+					<p class="text-xs text-neutral-600 dark:text-neutral-400">
+						Control how illegal filesystem characters are handled in generated names.
+					</p>
+				</div>
 
 				<div class="space-y-2">
 					<Toggle
@@ -243,8 +243,8 @@
 						color={formData.replaceIllegalCharacters ? 'green' : 'neutral'}
 						on:change={(e) => updateField('replaceIllegalCharacters', e.detail)}
 					/>
-					<p class="text-xs text-neutral-500 dark:text-neutral-400">
-						Replace characters that are not allowed in file names
+					<p class="text-xs text-neutral-600 dark:text-neutral-400">
+						Replace characters that are not allowed in file names.
 					</p>
 				</div>
 

--- a/src/routes/media-management/[databaseId]/naming/components/RadarrNamingForm.svelte
+++ b/src/routes/media-management/[databaseId]/naming/components/RadarrNamingForm.svelte
@@ -127,7 +127,7 @@
 	}
 </script>
 
-<StickyCard position="top" {breadcrumbItems} {breadcrumbCurrent}>
+<StickyCard position="top" {breadcrumbItems} {breadcrumbCurrent} stickyBreadcrumb={false}>
 	<div slot="left">
 		<h1 class="text-neutral-900 dark:text-neutral-50">{title}</h1>
 		<p class="text-neutral-600 dark:text-neutral-400">{description}</p>
@@ -158,31 +158,41 @@
 	</div>
 </StickyCard>
 
-<div class="mt-6 md:px-4">
+<div class="md:px-4">
 	<div class="space-y-6">
-		<div class="space-y-6">
-			<FormInput
-				label="Name"
-				name="name"
-				required
-				value={formData.name}
-				placeholder="e.g., default"
-				description="The name of this Radarr naming configuration."
-				on:input={(e) => updateField('name', e.detail)}
-			/>
-
-			<div class="space-y-2">
-				<div class="space-y-1">
-					<div class="text-sm font-medium text-neutral-900 dark:text-neutral-100">Rename Movies</div>
-					<p class="text-xs text-neutral-600 dark:text-neutral-400">
-						Rename movie files to match the naming format.
-					</p>
+		<div class="space-y-2">
+			<div class="flex items-center justify-between gap-4">
+				<div>
+					<div class="text-sm font-medium text-neutral-900 dark:text-neutral-100">
+						Name<span class="text-red-500">*</span>
+					</div>
 				</div>
+				<div class="text-sm font-medium text-neutral-900 dark:text-neutral-100">Rename Movies</div>
+			</div>
+			<div class="flex items-center justify-between gap-4">
+				<p class="text-xs text-neutral-600 dark:text-neutral-400">
+					The name of this Radarr naming configuration.
+				</p>
+				<p class="text-right text-xs text-neutral-600 dark:text-neutral-400">
+					Rename movie files to match the naming format.
+				</p>
+			</div>
+			<div class="grid gap-4 md:grid-cols-[minmax(0,1fr)_14rem] md:items-end">
+				<FormInput
+					label="Name"
+					name="name"
+					required
+					hideLabel
+					value={formData.name}
+					placeholder="e.g., default"
+					on:input={(e) => updateField('name', e.detail)}
+				/>
 				<Toggle
 					checked={formData.rename}
 					label={formData.rename ? 'Enabled' : 'Disabled'}
 					ariaLabel="Rename Movies"
 					color={formData.rename ? 'green' : 'neutral'}
+					fullWidth
 					on:change={(e) => updateField('rename', e.detail)}
 				/>
 			</div>
@@ -249,13 +259,17 @@
 				</div>
 
 				{#if formData.replaceIllegalCharacters}
-					<DropdownSelect
-						label="Colon Replacement"
-						value={formData.colonReplacementFormat}
-						options={RADARR_COLON_REPLACEMENT_OPTIONS}
-						on:change={(e) =>
-							updateField('colonReplacementFormat', e.detail as RadarrColonReplacementFormat)}
-					/>
+					<div class="space-y-2">
+						<div class="text-sm font-medium text-neutral-900 dark:text-neutral-100">
+							Colon Replacement
+						</div>
+						<DropdownSelect
+							value={formData.colonReplacementFormat}
+							options={RADARR_COLON_REPLACEMENT_OPTIONS}
+							on:change={(e) =>
+								updateField('colonReplacementFormat', e.detail as RadarrColonReplacementFormat)}
+						/>
+					</div>
 				{/if}
 			</div>
 		{/if}

--- a/src/routes/media-management/[databaseId]/naming/components/RadarrNamingForm.svelte
+++ b/src/routes/media-management/[databaseId]/naming/components/RadarrNamingForm.svelte
@@ -198,8 +198,7 @@
 			</div>
 		</div>
 
-		{#if formData.rename}
-			<div class="space-y-4" data-onboarding="media-naming-formats">
+		<div class="space-y-4" class:opacity-60={!formData.rename} data-onboarding="media-naming-formats">
 				<div class="space-y-1">
 					<div class="text-sm font-medium text-neutral-900 dark:text-neutral-100">
 						Naming Formats
@@ -215,6 +214,7 @@
 						value={formData.movieFormat}
 						placeholder="e.g., Movie Title (Year) Quality"
 						categories={radarrTokenCategories}
+						disabled={!formData.rename}
 						bind:inputElement={movieFormatInput}
 						on:input={(e) => updateField('movieFormat', e.detail)}
 					/>
@@ -228,6 +228,7 @@
 						value={formData.movieFolderFormat}
 						placeholder="e.g., Movie Title (Year)"
 						categories={radarrTokenCategories}
+						disabled={!formData.rename}
 						bind:inputElement={movieFolderFormatInput}
 						on:input={(e) => updateField('movieFolderFormat', e.detail)}
 					/>
@@ -235,7 +236,11 @@
 				</div>
 			</div>
 
-			<div class="space-y-4" data-onboarding="media-naming-character-replacement">
+			<div
+				class="space-y-4"
+				class:opacity-60={!formData.rename}
+				data-onboarding="media-naming-character-replacement"
+			>
 				<div class="space-y-1">
 					<div class="text-sm font-medium text-neutral-900 dark:text-neutral-100">
 						Character Replacement
@@ -251,6 +256,7 @@
 						label="Replace Illegal Characters"
 						ariaLabel="Replace Illegal Characters"
 						color={formData.replaceIllegalCharacters ? 'green' : 'neutral'}
+						disabled={!formData.rename}
 						on:change={(e) => updateField('replaceIllegalCharacters', e.detail)}
 					/>
 					<p class="text-xs text-neutral-600 dark:text-neutral-400">
@@ -258,21 +264,19 @@
 					</p>
 				</div>
 
-				{#if formData.replaceIllegalCharacters}
-					<div class="space-y-2">
-						<div class="text-sm font-medium text-neutral-900 dark:text-neutral-100">
-							Colon Replacement
-						</div>
-						<DropdownSelect
-							value={formData.colonReplacementFormat}
-							options={RADARR_COLON_REPLACEMENT_OPTIONS}
-							on:change={(e) =>
-								updateField('colonReplacementFormat', e.detail as RadarrColonReplacementFormat)}
-						/>
+				<div class="space-y-2">
+					<div class="text-sm font-medium text-neutral-900 dark:text-neutral-100">
+						Colon Replacement
 					</div>
-				{/if}
+					<DropdownSelect
+						value={formData.colonReplacementFormat}
+						options={RADARR_COLON_REPLACEMENT_OPTIONS}
+						disabled={!formData.rename || !formData.replaceIllegalCharacters}
+						on:change={(e) =>
+							updateField('colonReplacementFormat', e.detail as RadarrColonReplacementFormat)}
+					/>
+				</div>
 			</div>
-		{/if}
 	</div>
 </div>
 

--- a/src/routes/media-management/[databaseId]/naming/components/RadarrNamingForm.svelte
+++ b/src/routes/media-management/[databaseId]/naming/components/RadarrNamingForm.svelte
@@ -159,9 +159,7 @@
 </StickyCard>
 
 <div class="mt-6 md:px-4">
-	<div
-		class="space-y-6 rounded-lg border border-neutral-200 bg-white p-6 dark:border-neutral-800 dark:bg-neutral-900"
-	>
+	<div class="space-y-6">
 		<!-- Basic Info -->
 		<div class="space-y-4">
 			<h2 class="text-base font-semibold text-neutral-900 dark:text-neutral-100">Basic Info</h2>

--- a/src/routes/media-management/[databaseId]/naming/components/RadarrNamingForm.svelte
+++ b/src/routes/media-management/[databaseId]/naming/components/RadarrNamingForm.svelte
@@ -198,85 +198,87 @@
 			</div>
 		</div>
 
-		<div class="space-y-4" class:opacity-60={!formData.rename} data-onboarding="media-naming-formats">
-				<div class="space-y-1">
-					<div class="text-sm font-medium text-neutral-900 dark:text-neutral-100">
-						Naming Formats
-					</div>
-					<p class="text-xs text-neutral-600 dark:text-neutral-400">
-						Control how Radarr names movie files and folders.
-					</p>
-				</div>
-				<div>
-					<TokenAutocomplete
-						label="Movie Format"
-						name="movieFormat"
-						value={formData.movieFormat}
-						placeholder="e.g., Movie Title (Year) Quality"
-						categories={radarrTokenCategories}
-						disabled={!formData.rename}
-						bind:inputElement={movieFormatInput}
-						on:input={(e) => updateField('movieFormat', e.detail)}
-					/>
-					<NamingPreview format={formData.movieFormat} resolver={resolveRadarrFormat} />
-				</div>
-
-				<div>
-					<TokenAutocomplete
-						label="Movie Folder Format"
-						name="movieFolderFormat"
-						value={formData.movieFolderFormat}
-						placeholder="e.g., Movie Title (Year)"
-						categories={radarrTokenCategories}
-						disabled={!formData.rename}
-						bind:inputElement={movieFolderFormatInput}
-						on:input={(e) => updateField('movieFolderFormat', e.detail)}
-					/>
-					<NamingPreview format={formData.movieFolderFormat} resolver={resolveRadarrFormat} />
-				</div>
+		<div
+			class="space-y-4"
+			class:opacity-60={!formData.rename}
+			data-onboarding="media-naming-formats"
+		>
+			<div class="space-y-1">
+				<div class="text-sm font-medium text-neutral-900 dark:text-neutral-100">Naming Formats</div>
+				<p class="text-xs text-neutral-600 dark:text-neutral-400">
+					Control how Radarr names movie files and folders.
+				</p>
+			</div>
+			<div>
+				<TokenAutocomplete
+					label="Movie Format"
+					name="movieFormat"
+					value={formData.movieFormat}
+					placeholder="e.g., Movie Title (Year) Quality"
+					categories={radarrTokenCategories}
+					disabled={!formData.rename}
+					bind:inputElement={movieFormatInput}
+					on:input={(e) => updateField('movieFormat', e.detail)}
+				/>
+				<NamingPreview format={formData.movieFormat} resolver={resolveRadarrFormat} />
 			</div>
 
-			<div
-				class="space-y-4"
-				class:opacity-60={!formData.rename}
-				data-onboarding="media-naming-character-replacement"
-			>
-				<div class="space-y-1">
-					<div class="text-sm font-medium text-neutral-900 dark:text-neutral-100">
-						Character Replacement
-					</div>
-					<p class="text-xs text-neutral-600 dark:text-neutral-400">
-						Control how illegal filesystem characters are handled in generated names.
-					</p>
-				</div>
-
-				<div class="space-y-2">
-					<Toggle
-						checked={formData.replaceIllegalCharacters}
-						label="Replace Illegal Characters"
-						ariaLabel="Replace Illegal Characters"
-						color={formData.replaceIllegalCharacters ? 'green' : 'neutral'}
-						disabled={!formData.rename}
-						on:change={(e) => updateField('replaceIllegalCharacters', e.detail)}
-					/>
-					<p class="text-xs text-neutral-600 dark:text-neutral-400">
-						Replace characters that are not allowed in file names.
-					</p>
-				</div>
-
-				<div class="space-y-2">
-					<div class="text-sm font-medium text-neutral-900 dark:text-neutral-100">
-						Colon Replacement
-					</div>
-					<DropdownSelect
-						value={formData.colonReplacementFormat}
-						options={RADARR_COLON_REPLACEMENT_OPTIONS}
-						disabled={!formData.rename || !formData.replaceIllegalCharacters}
-						on:change={(e) =>
-							updateField('colonReplacementFormat', e.detail as RadarrColonReplacementFormat)}
-					/>
-				</div>
+			<div>
+				<TokenAutocomplete
+					label="Movie Folder Format"
+					name="movieFolderFormat"
+					value={formData.movieFolderFormat}
+					placeholder="e.g., Movie Title (Year)"
+					categories={radarrTokenCategories}
+					disabled={!formData.rename}
+					bind:inputElement={movieFolderFormatInput}
+					on:input={(e) => updateField('movieFolderFormat', e.detail)}
+				/>
+				<NamingPreview format={formData.movieFolderFormat} resolver={resolveRadarrFormat} />
 			</div>
+		</div>
+
+		<div
+			class="space-y-4"
+			class:opacity-60={!formData.rename}
+			data-onboarding="media-naming-character-replacement"
+		>
+			<div class="space-y-1">
+				<div class="text-sm font-medium text-neutral-900 dark:text-neutral-100">
+					Character Replacement
+				</div>
+				<p class="text-xs text-neutral-600 dark:text-neutral-400">
+					Control how illegal filesystem characters are handled in generated names.
+				</p>
+			</div>
+
+			<div class="space-y-2">
+				<Toggle
+					checked={formData.replaceIllegalCharacters}
+					label="Replace Illegal Characters"
+					ariaLabel="Replace Illegal Characters"
+					color={formData.replaceIllegalCharacters ? 'green' : 'neutral'}
+					disabled={!formData.rename}
+					on:change={(e) => updateField('replaceIllegalCharacters', e.detail)}
+				/>
+				<p class="text-xs text-neutral-600 dark:text-neutral-400">
+					Replace characters that are not allowed in file names.
+				</p>
+			</div>
+
+			<div class="space-y-2">
+				<div class="text-sm font-medium text-neutral-900 dark:text-neutral-100">
+					Colon Replacement
+				</div>
+				<DropdownSelect
+					value={formData.colonReplacementFormat}
+					options={RADARR_COLON_REPLACEMENT_OPTIONS}
+					disabled={!formData.rename || !formData.replaceIllegalCharacters}
+					on:change={(e) =>
+						updateField('colonReplacementFormat', e.detail as RadarrColonReplacementFormat)}
+				/>
+			</div>
+		</div>
 	</div>
 </div>
 

--- a/src/routes/media-management/[databaseId]/naming/components/SonarrNamingForm.svelte
+++ b/src/routes/media-management/[databaseId]/naming/components/SonarrNamingForm.svelte
@@ -152,8 +152,8 @@
 
 <StickyCard position="top" {breadcrumbItems} {breadcrumbCurrent}>
 	<div slot="left">
-		<h1 class="text-xl font-semibold text-neutral-900 dark:text-neutral-50">{title}</h1>
-		<p class="text-sm text-neutral-500 dark:text-neutral-400">{description}</p>
+		<h1 class="text-neutral-900 dark:text-neutral-50">{title}</h1>
+		<p class="text-neutral-600 dark:text-neutral-400">{description}</p>
 	</div>
 	<div slot="right" class="flex items-center gap-2">
 		<Button
@@ -183,43 +183,46 @@
 
 <div class="mt-6 md:px-4">
 	<div class="space-y-6">
-		<!-- Basic Info -->
-		<div class="space-y-4">
-			<h2 class="text-base font-semibold text-neutral-900 dark:text-neutral-100">Basic Info</h2>
+		<div class="space-y-6">
 			<FormInput
 				label="Name"
 				name="name"
 				required
 				value={formData.name}
 				placeholder="e.g., default"
+				description="The name of this Sonarr naming configuration."
 				on:input={(e) => updateField('name', e.detail)}
 			/>
 
 			<div class="space-y-2">
+				<div class="space-y-1">
+					<div class="text-sm font-medium text-neutral-900 dark:text-neutral-100">
+						Rename Episodes
+					</div>
+					<p class="text-xs text-neutral-600 dark:text-neutral-400">
+						Rename episode files to match the naming format.
+					</p>
+				</div>
 				<Toggle
 					checked={formData.rename}
-					label="Rename Episodes"
+					label={formData.rename ? 'Enabled' : 'Disabled'}
 					ariaLabel="Rename Episodes"
 					color={formData.rename ? 'green' : 'neutral'}
 					on:change={(e) => updateField('rename', e.detail)}
 				/>
-				<p class="text-xs text-neutral-500 dark:text-neutral-400">
-					Rename episode files to match the naming format
-				</p>
 			</div>
 		</div>
 
 		{#if formData.rename}
-			<hr class="border-neutral-200 dark:border-neutral-700" />
-
-			<!-- Episode Formats -->
-			<div class="space-y-4">
-				<h2
-					data-onboarding="media-naming-formats"
-					class="text-base font-semibold text-neutral-900 dark:text-neutral-100"
-				>
-					Episode Formats
-				</h2>
+			<div class="space-y-4" data-onboarding="media-naming-formats">
+				<div class="space-y-1">
+					<div class="text-sm font-medium text-neutral-900 dark:text-neutral-100">
+						Episode Formats
+					</div>
+					<p class="text-xs text-neutral-600 dark:text-neutral-400">
+						Control how Sonarr names standard, daily, and anime episodes.
+					</p>
+				</div>
 				<div>
 					<TokenAutocomplete
 						label="Standard Episode Format"
@@ -257,13 +260,15 @@
 				</div>
 			</div>
 
-			<hr class="border-neutral-200 dark:border-neutral-700" />
-
-			<!-- Folder Formats -->
 			<div class="space-y-4">
-				<h2 class="text-base font-semibold text-neutral-900 dark:text-neutral-100">
-					Folder Formats
-				</h2>
+				<div class="space-y-1">
+					<div class="text-sm font-medium text-neutral-900 dark:text-neutral-100">
+						Folder Formats
+					</div>
+					<p class="text-xs text-neutral-600 dark:text-neutral-400">
+						Control how Sonarr names series and season folders.
+					</p>
+				</div>
 				<div>
 					<TokenAutocomplete
 						label="Series Folder Format"
@@ -289,13 +294,15 @@
 				</div>
 			</div>
 
-			<hr class="border-neutral-200 dark:border-neutral-700" />
-
-			<!-- Multi-Episode Style -->
-			<div class="space-y-4">
-				<h2 class="text-base font-semibold text-neutral-900 dark:text-neutral-100">
-					Multi-Episode Style
-				</h2>
+			<div class="space-y-2">
+				<div class="space-y-1">
+					<div class="text-sm font-medium text-neutral-900 dark:text-neutral-100">
+						Multi-Episode Style
+					</div>
+					<p class="text-xs text-neutral-600 dark:text-neutral-400">
+						Choose how multi-episode files are represented in generated names.
+					</p>
+				</div>
 				<DropdownSelect
 					value={formData.multiEpisodeStyle}
 					options={MULTI_EPISODE_STYLE_OPTIONS}
@@ -303,16 +310,15 @@
 				/>
 			</div>
 
-			<hr class="border-neutral-200 dark:border-neutral-700" />
-
-			<!-- Character Replacement -->
-			<div class="space-y-4">
-				<h2
-					data-onboarding="media-naming-character-replacement"
-					class="text-base font-semibold text-neutral-900 dark:text-neutral-100"
-				>
-					Character Replacement
-				</h2>
+			<div class="space-y-4" data-onboarding="media-naming-character-replacement">
+				<div class="space-y-1">
+					<div class="text-sm font-medium text-neutral-900 dark:text-neutral-100">
+						Character Replacement
+					</div>
+					<p class="text-xs text-neutral-600 dark:text-neutral-400">
+						Control how illegal filesystem characters are handled in generated names.
+					</p>
+				</div>
 
 				<div class="space-y-2">
 					<Toggle
@@ -322,8 +328,8 @@
 						color={formData.replaceIllegalCharacters ? 'green' : 'neutral'}
 						on:change={(e) => updateField('replaceIllegalCharacters', e.detail)}
 					/>
-					<p class="text-xs text-neutral-500 dark:text-neutral-400">
-						Replace characters that are not allowed in file names
+					<p class="text-xs text-neutral-600 dark:text-neutral-400">
+						Replace characters that are not allowed in file names.
 					</p>
 				</div>
 

--- a/src/routes/media-management/[databaseId]/naming/components/SonarrNamingForm.svelte
+++ b/src/routes/media-management/[databaseId]/naming/components/SonarrNamingForm.svelte
@@ -221,8 +221,7 @@
 			</div>
 		</div>
 
-		{#if formData.rename}
-			<div class="space-y-4" data-onboarding="media-naming-formats">
+		<div class="space-y-4" class:opacity-60={!formData.rename} data-onboarding="media-naming-formats">
 				<div class="space-y-1">
 					<div class="text-sm font-medium text-neutral-900 dark:text-neutral-100">
 						Episode Formats
@@ -237,6 +236,7 @@
 						name="standardEpisodeFormat"
 						value={formData.standardEpisodeFormat}
 						categories={sonarrTokenCategories}
+						disabled={!formData.rename}
 						bind:inputElement={standardEpisodeFormatInput}
 						on:input={(e) => updateField('standardEpisodeFormat', e.detail)}
 					/>
@@ -249,6 +249,7 @@
 						name="dailyEpisodeFormat"
 						value={formData.dailyEpisodeFormat}
 						categories={sonarrTokenCategories}
+						disabled={!formData.rename}
 						bind:inputElement={dailyEpisodeFormatInput}
 						on:input={(e) => updateField('dailyEpisodeFormat', e.detail)}
 					/>
@@ -261,6 +262,7 @@
 						name="animeEpisodeFormat"
 						value={formData.animeEpisodeFormat}
 						categories={sonarrTokenCategories}
+						disabled={!formData.rename}
 						bind:inputElement={animeEpisodeFormatInput}
 						on:input={(e) => updateField('animeEpisodeFormat', e.detail)}
 					/>
@@ -268,7 +270,7 @@
 				</div>
 			</div>
 
-			<div class="space-y-4">
+			<div class="space-y-4" class:opacity-60={!formData.rename}>
 				<div class="space-y-1">
 					<div class="text-sm font-medium text-neutral-900 dark:text-neutral-100">
 						Folder Formats
@@ -283,6 +285,7 @@
 						name="seriesFolderFormat"
 						value={formData.seriesFolderFormat}
 						categories={sonarrTokenCategories}
+						disabled={!formData.rename}
 						bind:inputElement={seriesFolderFormatInput}
 						on:input={(e) => updateField('seriesFolderFormat', e.detail)}
 					/>
@@ -295,6 +298,7 @@
 						name="seasonFolderFormat"
 						value={formData.seasonFolderFormat}
 						categories={sonarrTokenCategories}
+						disabled={!formData.rename}
 						bind:inputElement={seasonFolderFormatInput}
 						on:input={(e) => updateField('seasonFolderFormat', e.detail)}
 					/>
@@ -302,7 +306,7 @@
 				</div>
 			</div>
 
-			<div class="space-y-2">
+			<div class="space-y-2" class:opacity-60={!formData.rename}>
 				<div class="space-y-1">
 					<div class="text-sm font-medium text-neutral-900 dark:text-neutral-100">
 						Multi-Episode Style
@@ -314,11 +318,16 @@
 				<DropdownSelect
 					value={formData.multiEpisodeStyle}
 					options={MULTI_EPISODE_STYLE_OPTIONS}
+					disabled={!formData.rename}
 					on:change={(e) => updateField('multiEpisodeStyle', e.detail as MultiEpisodeStyle)}
 				/>
 			</div>
 
-			<div class="space-y-4" data-onboarding="media-naming-character-replacement">
+			<div
+				class="space-y-4"
+				class:opacity-60={!formData.rename}
+				data-onboarding="media-naming-character-replacement"
+			>
 				<div class="space-y-1">
 					<div class="text-sm font-medium text-neutral-900 dark:text-neutral-100">
 						Character Replacement
@@ -334,6 +343,7 @@
 						label="Replace Illegal Characters"
 						ariaLabel="Replace Illegal Characters"
 						color={formData.replaceIllegalCharacters ? 'green' : 'neutral'}
+						disabled={!formData.rename}
 						on:change={(e) => updateField('replaceIllegalCharacters', e.detail)}
 					/>
 					<p class="text-xs text-neutral-600 dark:text-neutral-400">
@@ -341,31 +351,30 @@
 					</p>
 				</div>
 
-				{#if formData.replaceIllegalCharacters}
-					<div class="space-y-2">
-						<div class="text-sm font-medium text-neutral-900 dark:text-neutral-100">
-							Colon Replacement
-						</div>
-						<DropdownSelect
-							value={formData.colonReplacementFormat}
-							options={SONARR_COLON_REPLACEMENT_OPTIONS}
-							on:change={(e) =>
-								updateField('colonReplacementFormat', e.detail as SonarrColonReplacementFormat)}
-						/>
+				<div class="space-y-2">
+					<div class="text-sm font-medium text-neutral-900 dark:text-neutral-100">
+						Colon Replacement
 					</div>
+					<DropdownSelect
+						value={formData.colonReplacementFormat}
+						options={SONARR_COLON_REPLACEMENT_OPTIONS}
+						disabled={!formData.rename || !formData.replaceIllegalCharacters}
+						on:change={(e) =>
+							updateField('colonReplacementFormat', e.detail as SonarrColonReplacementFormat)}
+					/>
+				</div>
 
-					{#if showCustomColonInput}
-						<FormInput
-							label="Custom Replacement"
-							name="customColonReplacementFormat"
-							value={formData.customColonReplacementFormat}
-							placeholder="Enter custom replacement character(s)"
-							on:input={(e) => updateField('customColonReplacementFormat', e.detail)}
-						/>
-					{/if}
+				{#if showCustomColonInput}
+					<FormInput
+						label="Custom Replacement"
+						name="customColonReplacementFormat"
+						value={formData.customColonReplacementFormat}
+						placeholder="Enter custom replacement character(s)"
+						disabled={!formData.rename || !formData.replaceIllegalCharacters}
+						on:input={(e) => updateField('customColonReplacementFormat', e.detail)}
+					/>
 				{/if}
 			</div>
-		{/if}
 	</div>
 </div>
 

--- a/src/routes/media-management/[databaseId]/naming/components/SonarrNamingForm.svelte
+++ b/src/routes/media-management/[databaseId]/naming/components/SonarrNamingForm.svelte
@@ -182,9 +182,7 @@
 </StickyCard>
 
 <div class="mt-6 md:px-4">
-	<div
-		class="space-y-6 rounded-lg border border-neutral-200 bg-white p-6 dark:border-neutral-800 dark:bg-neutral-900"
-	>
+	<div class="space-y-6">
 		<!-- Basic Info -->
 		<div class="space-y-4">
 			<h2 class="text-base font-semibold text-neutral-900 dark:text-neutral-100">Basic Info</h2>

--- a/src/routes/media-management/[databaseId]/naming/components/SonarrNamingForm.svelte
+++ b/src/routes/media-management/[databaseId]/naming/components/SonarrNamingForm.svelte
@@ -150,7 +150,7 @@
 	}
 </script>
 
-<StickyCard position="top" {breadcrumbItems} {breadcrumbCurrent}>
+<StickyCard position="top" {breadcrumbItems} {breadcrumbCurrent} stickyBreadcrumb={false}>
 	<div slot="left">
 		<h1 class="text-neutral-900 dark:text-neutral-50">{title}</h1>
 		<p class="text-neutral-600 dark:text-neutral-400">{description}</p>
@@ -181,33 +181,41 @@
 	</div>
 </StickyCard>
 
-<div class="mt-6 md:px-4">
+<div class="md:px-4">
 	<div class="space-y-6">
-		<div class="space-y-6">
-			<FormInput
-				label="Name"
-				name="name"
-				required
-				value={formData.name}
-				placeholder="e.g., default"
-				description="The name of this Sonarr naming configuration."
-				on:input={(e) => updateField('name', e.detail)}
-			/>
-
-			<div class="space-y-2">
-				<div class="space-y-1">
+		<div class="space-y-2">
+			<div class="flex items-center justify-between gap-4">
+				<div>
 					<div class="text-sm font-medium text-neutral-900 dark:text-neutral-100">
-						Rename Episodes
+						Name<span class="text-red-500">*</span>
 					</div>
-					<p class="text-xs text-neutral-600 dark:text-neutral-400">
-						Rename episode files to match the naming format.
-					</p>
 				</div>
+				<div class="text-sm font-medium text-neutral-900 dark:text-neutral-100">Rename Episodes</div>
+			</div>
+			<div class="flex items-center justify-between gap-4">
+				<p class="text-xs text-neutral-600 dark:text-neutral-400">
+					The name of this Sonarr naming configuration.
+				</p>
+				<p class="text-right text-xs text-neutral-600 dark:text-neutral-400">
+					Rename episode files to match the naming format.
+				</p>
+			</div>
+			<div class="grid gap-4 md:grid-cols-[minmax(0,1fr)_14rem] md:items-end">
+				<FormInput
+					label="Name"
+					name="name"
+					required
+					hideLabel
+					value={formData.name}
+					placeholder="e.g., default"
+					on:input={(e) => updateField('name', e.detail)}
+				/>
 				<Toggle
 					checked={formData.rename}
 					label={formData.rename ? 'Enabled' : 'Disabled'}
 					ariaLabel="Rename Episodes"
 					color={formData.rename ? 'green' : 'neutral'}
+					fullWidth
 					on:change={(e) => updateField('rename', e.detail)}
 				/>
 			</div>
@@ -334,13 +342,17 @@
 				</div>
 
 				{#if formData.replaceIllegalCharacters}
-					<DropdownSelect
-						label="Colon Replacement"
-						value={formData.colonReplacementFormat}
-						options={SONARR_COLON_REPLACEMENT_OPTIONS}
-						on:change={(e) =>
-							updateField('colonReplacementFormat', e.detail as SonarrColonReplacementFormat)}
-					/>
+					<div class="space-y-2">
+						<div class="text-sm font-medium text-neutral-900 dark:text-neutral-100">
+							Colon Replacement
+						</div>
+						<DropdownSelect
+							value={formData.colonReplacementFormat}
+							options={SONARR_COLON_REPLACEMENT_OPTIONS}
+							on:change={(e) =>
+								updateField('colonReplacementFormat', e.detail as SonarrColonReplacementFormat)}
+						/>
+					</div>
 
 					{#if showCustomColonInput}
 						<FormInput

--- a/src/routes/media-management/[databaseId]/naming/components/SonarrNamingForm.svelte
+++ b/src/routes/media-management/[databaseId]/naming/components/SonarrNamingForm.svelte
@@ -190,7 +190,9 @@
 						Name<span class="text-red-500">*</span>
 					</div>
 				</div>
-				<div class="text-sm font-medium text-neutral-900 dark:text-neutral-100">Rename Episodes</div>
+				<div class="text-sm font-medium text-neutral-900 dark:text-neutral-100">
+					Rename Episodes
+				</div>
 			</div>
 			<div class="flex items-center justify-between gap-4">
 				<p class="text-xs text-neutral-600 dark:text-neutral-400">
@@ -221,160 +223,162 @@
 			</div>
 		</div>
 
-		<div class="space-y-4" class:opacity-60={!formData.rename} data-onboarding="media-naming-formats">
-				<div class="space-y-1">
-					<div class="text-sm font-medium text-neutral-900 dark:text-neutral-100">
-						Episode Formats
-					</div>
-					<p class="text-xs text-neutral-600 dark:text-neutral-400">
-						Control how Sonarr names standard, daily, and anime episodes.
-					</p>
+		<div
+			class="space-y-4"
+			class:opacity-60={!formData.rename}
+			data-onboarding="media-naming-formats"
+		>
+			<div class="space-y-1">
+				<div class="text-sm font-medium text-neutral-900 dark:text-neutral-100">
+					Episode Formats
 				</div>
-				<div>
-					<TokenAutocomplete
-						label="Standard Episode Format"
-						name="standardEpisodeFormat"
-						value={formData.standardEpisodeFormat}
-						categories={sonarrTokenCategories}
-						disabled={!formData.rename}
-						bind:inputElement={standardEpisodeFormatInput}
-						on:input={(e) => updateField('standardEpisodeFormat', e.detail)}
-					/>
-					<NamingPreview format={formData.standardEpisodeFormat} resolver={resolveSonarrFormat} />
-				</div>
-
-				<div>
-					<TokenAutocomplete
-						label="Daily Episode Format"
-						name="dailyEpisodeFormat"
-						value={formData.dailyEpisodeFormat}
-						categories={sonarrTokenCategories}
-						disabled={!formData.rename}
-						bind:inputElement={dailyEpisodeFormatInput}
-						on:input={(e) => updateField('dailyEpisodeFormat', e.detail)}
-					/>
-					<NamingPreview format={formData.dailyEpisodeFormat} resolver={resolveSonarrFormat} />
-				</div>
-
-				<div>
-					<TokenAutocomplete
-						label="Anime Episode Format"
-						name="animeEpisodeFormat"
-						value={formData.animeEpisodeFormat}
-						categories={sonarrTokenCategories}
-						disabled={!formData.rename}
-						bind:inputElement={animeEpisodeFormatInput}
-						on:input={(e) => updateField('animeEpisodeFormat', e.detail)}
-					/>
-					<NamingPreview format={formData.animeEpisodeFormat} resolver={resolveSonarrFormat} />
-				</div>
+				<p class="text-xs text-neutral-600 dark:text-neutral-400">
+					Control how Sonarr names standard, daily, and anime episodes.
+				</p>
+			</div>
+			<div>
+				<TokenAutocomplete
+					label="Standard Episode Format"
+					name="standardEpisodeFormat"
+					value={formData.standardEpisodeFormat}
+					categories={sonarrTokenCategories}
+					disabled={!formData.rename}
+					bind:inputElement={standardEpisodeFormatInput}
+					on:input={(e) => updateField('standardEpisodeFormat', e.detail)}
+				/>
+				<NamingPreview format={formData.standardEpisodeFormat} resolver={resolveSonarrFormat} />
 			</div>
 
-			<div class="space-y-4" class:opacity-60={!formData.rename}>
-				<div class="space-y-1">
-					<div class="text-sm font-medium text-neutral-900 dark:text-neutral-100">
-						Folder Formats
-					</div>
-					<p class="text-xs text-neutral-600 dark:text-neutral-400">
-						Control how Sonarr names series and season folders.
-					</p>
-				</div>
-				<div>
-					<TokenAutocomplete
-						label="Series Folder Format"
-						name="seriesFolderFormat"
-						value={formData.seriesFolderFormat}
-						categories={sonarrTokenCategories}
-						disabled={!formData.rename}
-						bind:inputElement={seriesFolderFormatInput}
-						on:input={(e) => updateField('seriesFolderFormat', e.detail)}
-					/>
-					<NamingPreview format={formData.seriesFolderFormat} resolver={resolveSonarrFormat} />
-				</div>
-
-				<div>
-					<TokenAutocomplete
-						label="Season Folder Format"
-						name="seasonFolderFormat"
-						value={formData.seasonFolderFormat}
-						categories={sonarrTokenCategories}
-						disabled={!formData.rename}
-						bind:inputElement={seasonFolderFormatInput}
-						on:input={(e) => updateField('seasonFolderFormat', e.detail)}
-					/>
-					<NamingPreview format={formData.seasonFolderFormat} resolver={resolveSonarrFormat} />
-				</div>
+			<div>
+				<TokenAutocomplete
+					label="Daily Episode Format"
+					name="dailyEpisodeFormat"
+					value={formData.dailyEpisodeFormat}
+					categories={sonarrTokenCategories}
+					disabled={!formData.rename}
+					bind:inputElement={dailyEpisodeFormatInput}
+					on:input={(e) => updateField('dailyEpisodeFormat', e.detail)}
+				/>
+				<NamingPreview format={formData.dailyEpisodeFormat} resolver={resolveSonarrFormat} />
 			</div>
 
-			<div class="space-y-2" class:opacity-60={!formData.rename}>
-				<div class="space-y-1">
-					<div class="text-sm font-medium text-neutral-900 dark:text-neutral-100">
-						Multi-Episode Style
-					</div>
-					<p class="text-xs text-neutral-600 dark:text-neutral-400">
-						Choose how multi-episode files are represented in generated names.
-					</p>
+			<div>
+				<TokenAutocomplete
+					label="Anime Episode Format"
+					name="animeEpisodeFormat"
+					value={formData.animeEpisodeFormat}
+					categories={sonarrTokenCategories}
+					disabled={!formData.rename}
+					bind:inputElement={animeEpisodeFormatInput}
+					on:input={(e) => updateField('animeEpisodeFormat', e.detail)}
+				/>
+				<NamingPreview format={formData.animeEpisodeFormat} resolver={resolveSonarrFormat} />
+			</div>
+		</div>
+
+		<div class="space-y-4" class:opacity-60={!formData.rename}>
+			<div class="space-y-1">
+				<div class="text-sm font-medium text-neutral-900 dark:text-neutral-100">Folder Formats</div>
+				<p class="text-xs text-neutral-600 dark:text-neutral-400">
+					Control how Sonarr names series and season folders.
+				</p>
+			</div>
+			<div>
+				<TokenAutocomplete
+					label="Series Folder Format"
+					name="seriesFolderFormat"
+					value={formData.seriesFolderFormat}
+					categories={sonarrTokenCategories}
+					disabled={!formData.rename}
+					bind:inputElement={seriesFolderFormatInput}
+					on:input={(e) => updateField('seriesFolderFormat', e.detail)}
+				/>
+				<NamingPreview format={formData.seriesFolderFormat} resolver={resolveSonarrFormat} />
+			</div>
+
+			<div>
+				<TokenAutocomplete
+					label="Season Folder Format"
+					name="seasonFolderFormat"
+					value={formData.seasonFolderFormat}
+					categories={sonarrTokenCategories}
+					disabled={!formData.rename}
+					bind:inputElement={seasonFolderFormatInput}
+					on:input={(e) => updateField('seasonFolderFormat', e.detail)}
+				/>
+				<NamingPreview format={formData.seasonFolderFormat} resolver={resolveSonarrFormat} />
+			</div>
+		</div>
+
+		<div class="space-y-2" class:opacity-60={!formData.rename}>
+			<div class="space-y-1">
+				<div class="text-sm font-medium text-neutral-900 dark:text-neutral-100">
+					Multi-Episode Style
+				</div>
+				<p class="text-xs text-neutral-600 dark:text-neutral-400">
+					Choose how multi-episode files are represented in generated names.
+				</p>
+			</div>
+			<DropdownSelect
+				value={formData.multiEpisodeStyle}
+				options={MULTI_EPISODE_STYLE_OPTIONS}
+				disabled={!formData.rename}
+				on:change={(e) => updateField('multiEpisodeStyle', e.detail as MultiEpisodeStyle)}
+			/>
+		</div>
+
+		<div
+			class="space-y-4"
+			class:opacity-60={!formData.rename}
+			data-onboarding="media-naming-character-replacement"
+		>
+			<div class="space-y-1">
+				<div class="text-sm font-medium text-neutral-900 dark:text-neutral-100">
+					Character Replacement
+				</div>
+				<p class="text-xs text-neutral-600 dark:text-neutral-400">
+					Control how illegal filesystem characters are handled in generated names.
+				</p>
+			</div>
+
+			<div class="space-y-2">
+				<Toggle
+					checked={formData.replaceIllegalCharacters}
+					label="Replace Illegal Characters"
+					ariaLabel="Replace Illegal Characters"
+					color={formData.replaceIllegalCharacters ? 'green' : 'neutral'}
+					disabled={!formData.rename}
+					on:change={(e) => updateField('replaceIllegalCharacters', e.detail)}
+				/>
+				<p class="text-xs text-neutral-600 dark:text-neutral-400">
+					Replace characters that are not allowed in file names.
+				</p>
+			</div>
+
+			<div class="space-y-2">
+				<div class="text-sm font-medium text-neutral-900 dark:text-neutral-100">
+					Colon Replacement
 				</div>
 				<DropdownSelect
-					value={formData.multiEpisodeStyle}
-					options={MULTI_EPISODE_STYLE_OPTIONS}
-					disabled={!formData.rename}
-					on:change={(e) => updateField('multiEpisodeStyle', e.detail as MultiEpisodeStyle)}
+					value={formData.colonReplacementFormat}
+					options={SONARR_COLON_REPLACEMENT_OPTIONS}
+					disabled={!formData.rename || !formData.replaceIllegalCharacters}
+					on:change={(e) =>
+						updateField('colonReplacementFormat', e.detail as SonarrColonReplacementFormat)}
 				/>
 			</div>
 
-			<div
-				class="space-y-4"
-				class:opacity-60={!formData.rename}
-				data-onboarding="media-naming-character-replacement"
-			>
-				<div class="space-y-1">
-					<div class="text-sm font-medium text-neutral-900 dark:text-neutral-100">
-						Character Replacement
-					</div>
-					<p class="text-xs text-neutral-600 dark:text-neutral-400">
-						Control how illegal filesystem characters are handled in generated names.
-					</p>
-				</div>
-
-				<div class="space-y-2">
-					<Toggle
-						checked={formData.replaceIllegalCharacters}
-						label="Replace Illegal Characters"
-						ariaLabel="Replace Illegal Characters"
-						color={formData.replaceIllegalCharacters ? 'green' : 'neutral'}
-						disabled={!formData.rename}
-						on:change={(e) => updateField('replaceIllegalCharacters', e.detail)}
-					/>
-					<p class="text-xs text-neutral-600 dark:text-neutral-400">
-						Replace characters that are not allowed in file names.
-					</p>
-				</div>
-
-				<div class="space-y-2">
-					<div class="text-sm font-medium text-neutral-900 dark:text-neutral-100">
-						Colon Replacement
-					</div>
-					<DropdownSelect
-						value={formData.colonReplacementFormat}
-						options={SONARR_COLON_REPLACEMENT_OPTIONS}
-						disabled={!formData.rename || !formData.replaceIllegalCharacters}
-						on:change={(e) =>
-							updateField('colonReplacementFormat', e.detail as SonarrColonReplacementFormat)}
-					/>
-				</div>
-
-				{#if showCustomColonInput}
-					<FormInput
-						label="Custom Replacement"
-						name="customColonReplacementFormat"
-						value={formData.customColonReplacementFormat}
-						placeholder="Enter custom replacement character(s)"
-						disabled={!formData.rename || !formData.replaceIllegalCharacters}
-						on:input={(e) => updateField('customColonReplacementFormat', e.detail)}
-					/>
-				{/if}
-			</div>
+			{#if showCustomColonInput}
+				<FormInput
+					label="Custom Replacement"
+					name="customColonReplacementFormat"
+					value={formData.customColonReplacementFormat}
+					placeholder="Enter custom replacement character(s)"
+					disabled={!formData.rename || !formData.replaceIllegalCharacters}
+					on:input={(e) => updateField('customColonReplacementFormat', e.detail)}
+				/>
+			{/if}
+		</div>
 	</div>
 </div>
 

--- a/src/routes/media-management/[databaseId]/naming/components/TokenAutocomplete.svelte
+++ b/src/routes/media-management/[databaseId]/naming/components/TokenAutocomplete.svelte
@@ -172,6 +172,7 @@
 		{placeholder}
 		mono
 		wrap
+		inputClass="text-xs"
 		bind:inputElement
 		{disabled}
 		on:input={handleInput}

--- a/src/routes/media-management/[databaseId]/naming/views/CardView.svelte
+++ b/src/routes/media-management/[databaseId]/naming/views/CardView.svelte
@@ -2,10 +2,13 @@
 	import { createEventDispatcher } from 'svelte';
 	import CardGrid from '$ui/card/CardGrid.svelte';
 	import Card from '$ui/card/Card.svelte';
-	import Label from '$ui/label/Label.svelte';
 	import Button from '$ui/button/Button.svelte';
-	import { Copy, Download } from 'lucide-svelte';
+	import { Copy, Download, Pencil, Ban, Replace, List } from 'lucide-svelte';
 	import type { NamingListItem } from '$shared/pcd/display.ts';
+	import {
+		getMultiEpisodeStyleLabel,
+		type SonarrColonReplacementFormat
+	} from '$shared/pcd/mediaManagement.ts';
 	import radarrLogo from '$lib/client/assets/Radarr.svg';
 	import sonarrLogo from '$lib/client/assets/Sonarr.svg';
 	import { FEATURES } from '$shared/features.ts';
@@ -35,62 +38,110 @@
 			config.name
 		)}`;
 	}
+
+	function formatColonReplacement(value: SonarrColonReplacementFormat): string {
+		switch (value) {
+			case 'delete':
+				return 'Delete';
+			case 'dash':
+				return 'Dash';
+			case 'spaceDash':
+				return 'Space dash';
+			case 'spaceDashSpace':
+				return 'Space dash space';
+			case 'smart':
+				return 'Smart';
+			case 'custom':
+				return 'Custom';
+		}
+	}
 </script>
 
-<CardGrid columns={1} flush>
+<CardGrid columns={3} flush>
 	{#each configs as config}
 		<Card href={getConfigHref(config)} hoverable>
-			<div class="flex items-center gap-4">
-				<!-- Logo + Name -->
-				<div class="flex min-w-0 flex-1 items-center gap-3">
-					<div class="relative h-10 w-10 flex-shrink-0">
-						{#if !loadedImages.has(config.name)}
-							<div
-								class="absolute inset-0 animate-pulse rounded-lg bg-neutral-200 dark:bg-neutral-700"
-							></div>
-						{/if}
-						<img
-							src={logos[config.arr_type]}
-							alt="{config.arr_type} logo"
-							class="h-10 w-10 rounded-lg {loadedImages.has(config.name)
-								? 'opacity-100'
-								: 'opacity-0'}"
-							on:load={() => handleImageLoad(config.name)}
-						/>
-					</div>
-					<div class="min-w-0">
+			<svelte:fragment slot="header">
+				<!-- svelte-ignore a11y-click-events-have-key-events a11y-no-static-element-interactions -->
+				<div class="flex items-center justify-between gap-2">
+					<div class="flex min-w-0 items-center gap-2">
+						<div class="relative h-6 w-6 flex-shrink-0">
+							{#if !loadedImages.has(config.name)}
+								<div
+									class="absolute inset-0 animate-pulse rounded bg-neutral-200 dark:bg-neutral-700"
+								></div>
+							{/if}
+							<img
+								src={logos[config.arr_type]}
+								alt="{config.arr_type} logo"
+								class="h-6 w-6 rounded {loadedImages.has(config.name)
+									? 'opacity-100'
+									: 'opacity-0'}"
+								on:load={() => handleImageLoad(config.name)}
+							/>
+						</div>
 						<h3 class="truncate text-sm font-semibold text-neutral-900 dark:text-neutral-100">
 							{config.name}
 						</h3>
-						<div class="mt-1">
-							{#if config.rename}
-								<Label variant="success" size="sm" rounded="md">Rename Enabled</Label>
-							{:else}
-								<Label variant="secondary" size="sm" rounded="md">Rename Disabled</Label>
-							{/if}
-						</div>
 					</div>
-				</div>
-
-				<!-- svelte-ignore a11y-click-events-have-key-events a11y-no-static-element-interactions -->
-				<div class="flex items-center gap-0.5" on:click|stopPropagation|preventDefault>
-					{#if FEATURES.importExport}
+					<div class="flex items-center gap-0.5" on:click|stopPropagation|preventDefault>
+						{#if FEATURES.importExport}
+							<Button
+								icon={Download}
+								size="xs"
+								variant="ghost"
+								tooltip="Export"
+								on:click={() =>
+									dispatch('export', { name: config.name, arr_type: config.arr_type })}
+							/>
+						{/if}
 						<Button
-							icon={Download}
+							icon={Copy}
 							size="xs"
 							variant="ghost"
-							tooltip="Export"
-							on:click={() => dispatch('export', { name: config.name, arr_type: config.arr_type })}
+							tooltip="Clone"
+							on:click={() => dispatch('clone', { name: config.name, arr_type: config.arr_type })}
 						/>
-					{/if}
-					<Button
-						icon={Copy}
-						size="xs"
-						variant="ghost"
-						tooltip="Clone"
-						on:click={() => dispatch('clone', { name: config.name, arr_type: config.arr_type })}
-					/>
+					</div>
 				</div>
+			</svelte:fragment>
+
+			<div class="space-y-1">
+				<div class="flex items-center justify-between text-xs">
+					<span class="flex items-center gap-1.5 text-neutral-500 dark:text-neutral-400">
+						<Pencil size={11} />Rename
+					</span>
+					<span class="font-mono text-neutral-900 dark:text-neutral-100">
+						{config.rename ? '✓' : '✗'}
+					</span>
+				</div>
+				<div class="flex items-center justify-between text-xs">
+					<span class="flex items-center gap-1.5 text-neutral-500 dark:text-neutral-400">
+						<Ban size={11} />Illegal characters
+					</span>
+					<span class="font-mono text-neutral-900 dark:text-neutral-100">
+						{config.replace_illegal_characters ? '✓' : '✗'}
+					</span>
+				</div>
+				{#if config.replace_illegal_characters}
+					<div class="flex items-center justify-between gap-2 text-xs">
+						<span class="flex items-center gap-1.5 text-neutral-500 dark:text-neutral-400">
+							<Replace size={11} />Colon replacement
+						</span>
+						<span class="truncate font-mono text-neutral-900 dark:text-neutral-100">
+							{formatColonReplacement(config.colon_replacement_format)}
+						</span>
+					</div>
+				{/if}
+				{#if config.arr_type === 'sonarr' && config.multi_episode_style !== null}
+					<div class="flex items-center justify-between gap-2 text-xs">
+						<span class="flex items-center gap-1.5 text-neutral-500 dark:text-neutral-400">
+							<List size={11} />Multi-episode
+						</span>
+						<span class="truncate font-mono text-neutral-900 dark:text-neutral-100">
+							{getMultiEpisodeStyleLabel(config.multi_episode_style)}
+						</span>
+					</div>
+				{/if}
 			</div>
 		</Card>
 	{/each}

--- a/src/routes/media-management/[databaseId]/quality-definitions/components/QualityDefinitionsForm.svelte
+++ b/src/routes/media-management/[databaseId]/quality-definitions/components/QualityDefinitionsForm.svelte
@@ -313,7 +313,7 @@
 	}
 </script>
 
-<StickyCard position="top" {breadcrumbItems} {breadcrumbCurrent}>
+<StickyCard position="top" {breadcrumbItems} {breadcrumbCurrent} stickyBreadcrumb={false}>
 	<div slot="left">
 		<h1 class="text-xl font-semibold text-neutral-900 dark:text-neutral-50">{title}</h1>
 		<p class="text-sm text-neutral-500 dark:text-neutral-400">{description}</p>
@@ -371,7 +371,7 @@
 	</div>
 </StickyCard>
 
-<div class="mt-6 space-y-6 md:px-4">
+<div class="space-y-6 md:px-4">
 	<!-- Name input -->
 	<FormInput
 		label="Name"

--- a/src/routes/media-management/[databaseId]/quality-definitions/views/CardView.svelte
+++ b/src/routes/media-management/[databaseId]/quality-definitions/views/CardView.svelte
@@ -2,9 +2,8 @@
 	import { createEventDispatcher } from 'svelte';
 	import CardGrid from '$ui/card/CardGrid.svelte';
 	import Card from '$ui/card/Card.svelte';
-	import Label from '$ui/label/Label.svelte';
 	import Button from '$ui/button/Button.svelte';
-	import { Copy, Download } from 'lucide-svelte';
+	import { Copy, Download, Layers } from 'lucide-svelte';
 	import type { QualityDefinitionListItem } from '$shared/pcd/display.ts';
 	import radarrLogo from '$lib/client/assets/Radarr.svg';
 	import sonarrLogo from '$lib/client/assets/Sonarr.svg';
@@ -37,58 +36,61 @@
 	}
 </script>
 
-<CardGrid columns={1} flush>
+<CardGrid columns={4} flush>
 	{#each configs as config}
 		<Card href={getConfigHref(config)} hoverable>
-			<div class="flex items-center gap-4">
-				<!-- Logo + Name -->
-				<div class="flex min-w-0 flex-1 items-center gap-3">
-					<div class="relative h-10 w-10 flex-shrink-0">
-						{#if !loadedImages.has(config.name)}
-							<div
-								class="absolute inset-0 animate-pulse rounded-lg bg-neutral-200 dark:bg-neutral-700"
-							></div>
-						{/if}
-						<img
-							src={logos[config.arr_type]}
-							alt="{config.arr_type} logo"
-							class="h-10 w-10 rounded-lg {loadedImages.has(config.name)
-								? 'opacity-100'
-								: 'opacity-0'}"
-							on:load={() => handleImageLoad(config.name)}
-						/>
-					</div>
-					<div class="min-w-0">
+			<svelte:fragment slot="header">
+				<!-- svelte-ignore a11y-click-events-have-key-events a11y-no-static-element-interactions -->
+				<div class="flex items-center justify-between gap-2">
+					<div class="flex min-w-0 items-center gap-2">
+						<div class="relative h-6 w-6 flex-shrink-0">
+							{#if !loadedImages.has(config.name)}
+								<div
+									class="absolute inset-0 animate-pulse rounded bg-neutral-200 dark:bg-neutral-700"
+								></div>
+							{/if}
+							<img
+								src={logos[config.arr_type]}
+								alt="{config.arr_type} logo"
+								class="h-6 w-6 rounded {loadedImages.has(config.name)
+									? 'opacity-100'
+									: 'opacity-0'}"
+								on:load={() => handleImageLoad(config.name)}
+							/>
+						</div>
 						<h3 class="truncate text-sm font-semibold text-neutral-900 dark:text-neutral-100">
 							{config.name}
 						</h3>
-						<div class="mt-1">
-							<Label variant="secondary" size="sm" rounded="md"
-								>{config.quality_count} qualities</Label
-							>
-						</div>
 					</div>
-				</div>
-
-				<!-- svelte-ignore a11y-click-events-have-key-events a11y-no-static-element-interactions -->
-				<div class="flex items-center gap-0.5" on:click|stopPropagation|preventDefault>
-					{#if FEATURES.importExport}
+					<div class="flex items-center gap-0.5" on:click|stopPropagation|preventDefault>
+						{#if FEATURES.importExport}
+							<Button
+								icon={Download}
+								size="xs"
+								variant="ghost"
+								tooltip="Export"
+								on:click={() =>
+									dispatch('export', { name: config.name, arr_type: config.arr_type })}
+							/>
+						{/if}
 						<Button
-							icon={Download}
+							icon={Copy}
 							size="xs"
 							variant="ghost"
-							tooltip="Export"
-							on:click={() => dispatch('export', { name: config.name, arr_type: config.arr_type })}
+							tooltip="Clone"
+							on:click={() => dispatch('clone', { name: config.name, arr_type: config.arr_type })}
 						/>
-					{/if}
-					<Button
-						icon={Copy}
-						size="xs"
-						variant="ghost"
-						tooltip="Clone"
-						on:click={() => dispatch('clone', { name: config.name, arr_type: config.arr_type })}
-					/>
+					</div>
 				</div>
+			</svelte:fragment>
+
+			<div class="flex items-center justify-between text-xs">
+				<span class="flex items-center gap-1.5 text-neutral-500 dark:text-neutral-400">
+					<Layers size={11} />Qualities
+				</span>
+				<span class="font-mono text-neutral-900 dark:text-neutral-100">
+					{config.quality_count}
+				</span>
 			</div>
 		</Card>
 	{/each}


### PR DESCRIPTION
- Reworks the four media management card views (delay profiles, media settings, quality definitions, naming) into multi-column grids with a consistent header + data-row body. Naming exposes additional config (illegal chars, colon replacement, sonarr multi-episode style).
- Tidies the delay profile and naming edit forms: simpler form shells, aligned headings, consistent field sizing, inactive fields disabled.
- Fixes media management breadcrumb spacing and sticky-header collisions.