### PR TITLE
fix: smart filter matching and keyboard highlight

### DIFF
--- a/src/lib/client/ui/filter/SmartFilterBar.svelte
+++ b/src/lib/client/ui/filter/SmartFilterBar.svelte
@@ -160,6 +160,21 @@
 
 	let remainingValueCount = 0;
 
+	function rankSuggestions(all: string[], q: string): string[] {
+		if (!q) return all;
+		const ql = q.toLowerCase();
+		const exact: string[] = [];
+		const prefix: string[] = [];
+		const sub: string[] = [];
+		for (const s of all) {
+			const sl = s.toLowerCase();
+			if (sl === ql) exact.push(s);
+			else if (sl.startsWith(ql)) prefix.push(s);
+			else if (sl.includes(ql)) sub.push(s);
+		}
+		return [...exact, ...prefix, ...sub];
+	}
+
 	$: valueSuggestions = (() => {
 		if (phase !== 'value' || !activeFieldDef) {
 			remainingValueCount = 0;
@@ -170,9 +185,7 @@
 			return [];
 		}
 		const allSuggestions = activeFieldDef.suggestions?.(items) ?? [];
-		const matched = valueInputValue
-			? allSuggestions.filter((s) => s.toLowerCase().includes(valueInputValue.toLowerCase()))
-			: allSuggestions;
+		const matched = rankSuggestions(allSuggestions, valueInputValue);
 		remainingValueCount = Math.max(0, matched.length - 5);
 		return matched.slice(0, 5);
 	})();
@@ -198,10 +211,20 @@
 		onchange?.(newTags);
 	}
 
-	function addTag(field: string, value: string) {
+	function addTag(field: string, value: string, exact?: boolean) {
 		const trimmed = value.trim();
 		if (!trimmed) return;
-		updateTags([...tags, { id: uuid(), field, value: trimmed, negated: false }]);
+		let resolvedExact = exact;
+		if (resolvedExact === undefined) {
+			const fieldDef = fieldMap.get(field);
+			const fieldSuggestions = fieldDef?.suggestions?.(items) ?? [];
+			const trimmedLower = trimmed.toLowerCase();
+			resolvedExact = fieldSuggestions.some((s) => s.toLowerCase() === trimmedLower);
+		}
+		updateTags([
+			...tags,
+			{ id: uuid(), field, value: trimmed, negated: false, exact: resolvedExact }
+		]);
 		inputValue = '';
 		valueInputValue = '';
 		activeFieldDef = null;
@@ -278,7 +301,7 @@
 			}
 		} else if (phase === 'value' && activeFieldDef) {
 			if (highlightedIndex >= 0 && highlightedIndex < suggestions.length) {
-				addTag(activeFieldDef.key, suggestions[highlightedIndex].value);
+				addTag(activeFieldDef.key, suggestions[highlightedIndex].value, true);
 			} else if (valueInputValue.trim()) {
 				addTag(activeFieldDef.key, valueInputValue);
 			}
@@ -291,7 +314,7 @@
 			const field = fieldMap.get(selected.value);
 			if (field) selectField(field);
 		} else if (phase === 'value' && activeFieldDef) {
-			addTag(activeFieldDef.key, suggestions[index].value);
+			addTag(activeFieldDef.key, suggestions[index].value, true);
 		}
 	}
 
@@ -404,7 +427,7 @@
 			{#each suggestions as suggestion, i}
 				<DropdownItem
 					label={suggestion.label}
-					selected={false}
+					highlighted={i === highlightedIndex}
 					on:click={() => handleSuggestionClick(i)}
 				/>
 			{/each}

--- a/src/lib/client/ui/filter/match.ts
+++ b/src/lib/client/ui/filter/match.ts
@@ -81,6 +81,10 @@ export function applySmartFilters<T>(
 				const tagLower = tag.value.toLowerCase();
 				if (rawValue == null) {
 					matches = false;
+				} else if (tag.exact) {
+					matches = Array.isArray(rawValue)
+						? rawValue.some((v) => v.toLowerCase() === tagLower)
+						: String(rawValue).toLowerCase() === tagLower;
 				} else if (Array.isArray(rawValue)) {
 					matches = rawValue.some((v) => v.toLowerCase().includes(tagLower));
 				} else {

--- a/src/lib/client/ui/filter/types.ts
+++ b/src/lib/client/ui/filter/types.ts
@@ -15,6 +15,7 @@ export interface FilterTag {
 	field: string;
 	value: string;
 	negated: boolean;
+	exact?: boolean;
 }
 
 export type SerializedFilterTag = Omit<FilterTag, 'id'>;


### PR DESCRIPTION
- Picking a suggestion (or typing a value that exactly matches one) now stores `exact: true` on the tag, so the applied filter does case-insensitive equality instead of substring. Free-typed values without a matching suggestion keep substring behaviour. Fixes the case where a CF named `iT` could not be filtered alone, since `Bit-Bucket`, `HDR10`, etc. always matched too.
- Suggestion dropdown ranks results: exact, then prefix, then substring (alphabetical within each tier), so the literal `iT` surfaces above `Bit-Bucket` when typing `iT`.
- Arrow-key navigation visibly highlights the current dropdown item (was tracked but rendered with `selected={false}`). Enter to pick was already wired.