### PR TITLE
fix: wrap mobile table titles on word boundaries

### DIFF
--- a/src/lib/client/ui/table/ExpandableTable.svelte
+++ b/src/lib/client/ui/table/ExpandableTable.svelte
@@ -219,7 +219,7 @@
 						<!-- Primary row: first column as title + actions + chevron -->
 						<div class="flex items-start justify-between gap-3 px-4 py-3">
 							<div
-								class="min-w-0 flex-1 font-medium break-all text-neutral-900 dark:text-neutral-100"
+								class="min-w-0 flex-1 font-medium break-words text-neutral-900 dark:text-neutral-100"
 							>
 								<slot
 									name="cell"


### PR DESCRIPTION
`break-all` → `break-words` on the `ExpandableTable` mobile primary column. Wraps at word boundaries instead of mid-character.