### PR TITLE
fix: rewrite restored database paths

### DIFF
--- a/src/lib/server/utils/backup/applyPending.ts
+++ b/src/lib/server/utils/backup/applyPending.ts
@@ -24,6 +24,7 @@
 
 import { config } from '$config';
 import { logger } from '$logger/logger.ts';
+import { Database } from '@jsr/db__sqlite';
 
 const SENTINEL_NAME = '.restore-pending';
 const STAGING_NAME = '.restoring';
@@ -51,6 +52,32 @@ async function readArchiveInfo(stagingDataDir: string): Promise<ArchiveInfo> {
 	} catch {
 		// Older archives don't have INFO.json. Not fatal.
 		return {};
+	}
+}
+
+function rewriteDatabaseLocalPaths(stagedDbPath: string): number {
+	const database = new Database(stagedDbPath);
+	try {
+		const table = database
+			.prepare(
+				`SELECT COUNT(*) AS count
+				 FROM sqlite_master
+				 WHERE type = 'table' AND name = 'database_instances'`
+			)
+			.get() as { count: number } | undefined;
+
+		if (!table?.count) return 0;
+
+		database
+			.prepare(
+				`UPDATE database_instances
+				 SET local_path = ? || '/' || uuid
+				 WHERE local_path != ? || '/' || uuid`
+			)
+			.run(config.paths.databases, config.paths.databases);
+		return database.changes;
+	} finally {
+		database.close();
 	}
 }
 
@@ -120,6 +147,7 @@ export async function applyPendingRestore(): Promise<void> {
 	}
 
 	const info = await readArchiveInfo(stagingDataDir);
+	const rewrittenDatabasePaths = rewriteDatabaseLocalPaths(`${stagingDataDir}/profilarr.db`);
 
 	// Wipe live data dir contents we own. Anything else (e.g. a file an
 	// operator manually placed) is left alone.
@@ -145,6 +173,6 @@ export async function applyPendingRestore(): Promise<void> {
 
 	await logger.info('Pending restore applied', {
 		source: 'applyPendingRestore',
-		meta: { archivePath, info }
+		meta: { archivePath, info, rewrittenDatabasePaths }
 	});
 }

--- a/tests/integration/backups/specs/restoreLocalPaths.test.ts
+++ b/tests/integration/backups/specs/restoreLocalPaths.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Integration test: backup restore local path normalization.
+ *
+ * Cross-host restores must not preserve absolute database repo paths from
+ * the source host. The boot restore step should repoint every restored PCD
+ * row at the current host's data/databases/{uuid} directory.
+ */
+
+import { assertEquals } from '@std/assert';
+import { Database } from '@db/sqlite';
+import { setup, teardown, test, run } from '$test-harness/runner.ts';
+import { config } from '$config';
+
+const SENTINEL_NAME = '.restore-pending';
+
+let baseDir: string;
+let applyPendingRestore: () => Promise<void>;
+
+async function createRestoreArchive(archivePath: string, uuid: string): Promise<void> {
+	const stage = await Deno.makeTempDir({ prefix: 'profilarr-restore-local-paths-' });
+	try {
+		const dataDir = `${stage}/data`;
+		await Deno.mkdir(`${dataDir}/databases/${uuid}`, { recursive: true });
+		await Deno.writeTextFile(`${dataDir}/databases/${uuid}/pcd.json`, '{}');
+
+		const database = new Database(`${dataDir}/profilarr.db`);
+		try {
+			database.exec(
+				`CREATE TABLE database_instances (
+					uuid TEXT NOT NULL,
+					name TEXT NOT NULL,
+					local_path TEXT NOT NULL
+				)`
+			);
+			database.exec(
+				`INSERT INTO database_instances (uuid, name, local_path)
+				 VALUES (?, 'Restored DB', ?)`,
+				[uuid, `/config/data/databases/${uuid}`]
+			);
+		} finally {
+			database.close();
+		}
+
+		const tar = new Deno.Command('tar', {
+			args: ['-czf', archivePath, '-C', stage, 'data'],
+			stdout: 'piped',
+			stderr: 'piped'
+		});
+		const { code, stderr } = await tar.output();
+		if (code !== 0) {
+			throw new Error(`tar create failed: ${new TextDecoder().decode(stderr)}`);
+		}
+	} finally {
+		await Deno.remove(stage, { recursive: true });
+	}
+}
+
+function readRestoredLocalPath(dbPath: string): string {
+	const database = new Database(dbPath);
+	try {
+		const row = database.prepare('SELECT local_path FROM database_instances').get() as
+			| { local_path: string }
+			| undefined;
+		if (!row) throw new Error('database_instances row missing');
+		return row.local_path;
+	} finally {
+		database.close();
+	}
+}
+
+setup(async () => {
+	baseDir = await Deno.makeTempDir({ prefix: 'profilarr-restore-local-paths-' });
+	config.setBasePath(baseDir);
+	await Deno.mkdir(config.paths.data, { recursive: true });
+	({ applyPendingRestore } = await import('$utils/backup/applyPending.ts'));
+});
+
+teardown(async () => {
+	if (baseDir) {
+		await Deno.remove(baseDir, { recursive: true });
+	}
+});
+
+test('restore rewrites database_instances.local_path for the current host', async () => {
+	const uuid = crypto.randomUUID();
+	const archivePath = `${baseDir}/backup-restore-local-paths.tar.gz`;
+	await createRestoreArchive(archivePath, uuid);
+	await Deno.writeTextFile(`${baseDir}/${SENTINEL_NAME}`, archivePath);
+
+	await applyPendingRestore();
+
+	assertEquals(readRestoredLocalPath(config.paths.database), `${config.paths.databases}/${uuid}`);
+	assertEquals(await Deno.readTextFile(`${config.paths.databases}/${uuid}/pcd.json`), '{}');
+});
+
+await run();

--- a/tests/unit/backups/applyPending.test.ts
+++ b/tests/unit/backups/applyPending.test.ts
@@ -22,23 +22,29 @@ import { BaseTest, type TestContext } from '../base/BaseTest.ts';
 import { assertEquals, assertRejects } from '@std/assert';
 import { applyPendingRestore } from '../../../src/lib/server/utils/backup/applyPending.ts';
 import { config } from '../../../src/lib/server/utils/config/config.ts';
+import { Database } from '@db/sqlite';
 
 const SENTINEL_NAME = '.restore-pending';
 const STAGING_NAME = '.restoring';
 
 /**
  * Build a valid tar.gz at `archivePath` containing `data/profilarr.db` and
- * `data/INFO.json`. The "DB" is an arbitrary byte string; applyPendingRestore
- * doesn't open it, only stat-checks it as a file.
+ * `data/INFO.json`.
  */
 async function createValidArchive(
 	workDir: string,
 	archivePath: string,
-	dbContents: string
+	marker: string
 ): Promise<void> {
 	const stage = `${workDir}/_stage`;
 	await Deno.mkdir(`${stage}/data`, { recursive: true });
-	await Deno.writeTextFile(`${stage}/data/profilarr.db`, dbContents);
+	const database = new Database(`${stage}/data/profilarr.db`);
+	try {
+		database.exec('CREATE TABLE restore_marker (value TEXT NOT NULL)');
+		database.exec('INSERT INTO restore_marker (value) VALUES (?)', [marker]);
+	} finally {
+		database.close();
+	}
 	await Deno.writeTextFile(
 		`${stage}/data/INFO.json`,
 		JSON.stringify({ appVersion: 'test', schemaVersion: 0, sanitized: false })
@@ -82,6 +88,19 @@ async function exists(path: string): Promise<boolean> {
 
 async function readText(path: string): Promise<string> {
 	return await Deno.readTextFile(path);
+}
+
+function readMarker(dbPath: string): string {
+	const database = new Database(dbPath);
+	try {
+		const row = database.prepare('SELECT value FROM restore_marker').get() as
+			| { value: string }
+			| undefined;
+		if (!row) throw new Error('restore_marker row missing');
+		return row.value;
+	} finally {
+		database.close();
+	}
 }
 
 class ApplyPendingTest extends BaseTest {
@@ -172,7 +191,7 @@ class ApplyPendingTest extends BaseTest {
 				await applyPendingRestore();
 
 				// New DB content moved into place.
-				assertEquals(await readText(`${ctx.tempDir}/data/profilarr.db`), 'restored-NEW');
+				assertEquals(readMarker(`${ctx.tempDir}/data/profilarr.db`), 'restored-NEW');
 				// Sidecars wiped (archive doesn't include them, and the live ones are removed pre-swap).
 				assertEquals(await exists(`${ctx.tempDir}/data/profilarr.db-wal`), false);
 				assertEquals(await exists(`${ctx.tempDir}/data/profilarr.db-shm`), false);
@@ -204,7 +223,7 @@ class ApplyPendingTest extends BaseTest {
 				await applyPendingRestore();
 
 				// New content applied, leftover gone, staging dir removed entirely.
-				assertEquals(await readText(`${ctx.tempDir}/data/profilarr.db`), 'restored-NEW');
+				assertEquals(readMarker(`${ctx.tempDir}/data/profilarr.db`), 'restored-NEW');
 				assertEquals(await exists(`${ctx.tempDir}/${STAGING_NAME}`), false);
 				assertEquals(await exists(`${ctx.tempDir}/${SENTINEL_NAME}`), false);
 			}


### PR DESCRIPTION
Fixes #528.

Rewrites restored PCD local paths during boot-time restore so cross-host backups point at the current data directory before live data is replaced.