### PR TITLE
feat: add upgrades page admonitions for rate limits and usage

### DIFF
--- a/src/lib/client/ui/admonition/Admonition.svelte
+++ b/src/lib/client/ui/admonition/Admonition.svelte
@@ -1,0 +1,116 @@
+<script lang="ts">
+	import type { ComponentType } from 'svelte';
+	import { createEventDispatcher } from 'svelte';
+	import { X, Info, AlertTriangle, AlertOctagon, CheckCircle2, MessageSquare } from 'lucide-svelte';
+	import Button from '$ui/button/Button.svelte';
+	import Modal from '$ui/modal/Modal.svelte';
+
+	type Variant = 'info' | 'warning' | 'danger' | 'success' | 'note';
+
+	export let variant: Variant = 'info';
+	export let title: string | undefined = undefined;
+	export let icon: ComponentType | undefined = undefined;
+	export let dismissible: boolean = false;
+	export let confirmDismiss: boolean = false;
+	export let confirmHeader: string = 'Are you sure?';
+	export let confirmMessage: string = 'This message will be permanently hidden.';
+	export let confirmText: string = 'Dismiss';
+	export let className: string = '';
+
+	const dispatch = createEventDispatcher<{ dismiss: void }>();
+
+	const defaultIcons: Record<Variant, ComponentType> = {
+		info: Info,
+		warning: AlertTriangle,
+		danger: AlertOctagon,
+		success: CheckCircle2,
+		note: MessageSquare
+	};
+
+	const variantStyles: Record<Variant, { accent: string; surface: string; divider: string }> = {
+		info: {
+			accent: 'text-blue-700 dark:text-blue-300',
+			surface: 'border-blue-200 bg-blue-50 dark:border-blue-800/50 dark:bg-blue-950/30',
+			divider: 'border-blue-200 dark:border-blue-800/50'
+		},
+		warning: {
+			accent: 'text-amber-700 dark:text-amber-300',
+			surface: 'border-amber-200 bg-amber-50 dark:border-amber-800/50 dark:bg-amber-950/30',
+			divider: 'border-amber-200 dark:border-amber-800/50'
+		},
+		danger: {
+			accent: 'text-red-700 dark:text-red-300',
+			surface: 'border-red-200 bg-red-50 dark:border-red-800/50 dark:bg-red-950/30',
+			divider: 'border-red-200 dark:border-red-800/50'
+		},
+		success: {
+			accent: 'text-green-700 dark:text-green-300',
+			surface: 'border-green-200 bg-green-50 dark:border-green-800/50 dark:bg-green-950/30',
+			divider: 'border-green-200 dark:border-green-800/50'
+		},
+		note: {
+			accent: 'text-neutral-700 dark:text-neutral-300',
+			surface: 'border-neutral-300 bg-neutral-50 dark:border-neutral-700/60 dark:bg-neutral-900',
+			divider: 'border-neutral-300 dark:border-neutral-700/60'
+		}
+	};
+
+	let showConfirm = false;
+
+	function handleClickDismiss() {
+		if (confirmDismiss) {
+			showConfirm = true;
+		} else {
+			dispatch('dismiss');
+		}
+	}
+
+	function handleConfirm() {
+		showConfirm = false;
+		dispatch('dismiss');
+	}
+
+	function handleCancel() {
+		showConfirm = false;
+	}
+
+	$: style = variantStyles[variant];
+	$: IconCmp = icon ?? defaultIcons[variant];
+</script>
+
+<div class="overflow-hidden rounded-xl border {style.surface} {className}">
+	<div class="flex items-center gap-2 border-b px-4 py-2 {style.divider}">
+		<div class="shrink-0 {style.accent}">
+			<svelte:component this={IconCmp} size={18} />
+		</div>
+		{#if title}
+			<h3 class="flex-1 text-sm font-semibold text-neutral-900 dark:text-neutral-50">{title}</h3>
+		{:else}
+			<div class="flex-1"></div>
+		{/if}
+		{#if dismissible}
+			<Button
+				icon={X}
+				variant="ghost"
+				size="xs"
+				ariaLabel="Dismiss"
+				on:click={handleClickDismiss}
+			/>
+		{/if}
+	</div>
+	<div class="px-4 py-3 text-sm text-neutral-700 dark:text-neutral-300">
+		<slot />
+	</div>
+</div>
+
+{#if dismissible && confirmDismiss}
+	<Modal
+		open={showConfirm}
+		header={confirmHeader}
+		bodyMessage={confirmMessage}
+		{confirmText}
+		cancelText="Cancel"
+		on:confirm={handleConfirm}
+		on:cancel={handleCancel}
+	/>
+{/if}

--- a/src/routes/arr/[id]/upgrades/+page.svelte
+++ b/src/routes/arr/[id]/upgrades/+page.svelte
@@ -20,12 +20,33 @@
 	import DirtyModal from '$ui/modal/DirtyModal.svelte';
 	import StickyCard from '$ui/card/StickyCard.svelte';
 	import Button from '$ui/button/Button.svelte';
+	import Admonition from '$ui/admonition/Admonition.svelte';
 
 	export let data: PageData;
 	export let form: ActionData;
 
+	const RATE_LIMITS_KEY = 'upgrades.dismissed.rateLimits.v1';
+	const WHEN_TO_USE_KEY = 'upgrades.dismissed.whenToUse.v1';
+
+	let showRateLimitsAdmonition = true;
+	let showWhenToUseAdmonition = true;
+
+	function dismissRateLimits() {
+		localStorage.setItem(RATE_LIMITS_KEY, '1');
+		showRateLimitsAdmonition = false;
+	}
+
+	function dismissWhenToUse() {
+		localStorage.setItem(WHEN_TO_USE_KEY, '1');
+		showWhenToUseAdmonition = false;
+	}
+
 	// Initialize dirty tracking on mount (same pattern as sync page)
 	onMount(() => {
+		if (browser) {
+			showRateLimitsAdmonition = localStorage.getItem(RATE_LIMITS_KEY) !== '1';
+			showWhenToUseAdmonition = localStorage.getItem(WHEN_TO_USE_KEY) !== '1';
+		}
 		const initialFormData = {
 			enabled: data.config?.enabled ?? false,
 			cron: data.config?.cron ?? '0 */6 * * *',
@@ -200,6 +221,53 @@
 	</StickyCard>
 
 	<div class="mt-4 space-y-6">
+		{#if showRateLimitsAdmonition}
+			<div class="md:px-4">
+				<Admonition
+					variant="danger"
+					title="Indexer rate limits"
+					dismissible
+					confirmDismiss
+					confirmMessage="This warning will be permanently hidden. Make sure you have read it."
+					on:dismiss={dismissRateLimits}
+				>
+					<p>
+						Profilarr limits upgrade searches to at most one movie every 10 minutes (Radarr) and one
+						series per hour (Sonarr). These are intentionally conservative defaults, but they don't
+						override your indexer's own rules. Confirm what your indexer allows and stay within it.
+					</p>
+				</Admonition>
+			</div>
+		{/if}
+
+		{#if showWhenToUseAdmonition}
+			<div class="md:px-4">
+				<Admonition
+					variant="info"
+					title="When to use upgrades"
+					dismissible
+					confirmDismiss
+					confirmMessage="This message will be permanently hidden. Make sure you have read it."
+					on:dismiss={dismissWhenToUse}
+				>
+					<p class="mb-2">
+						Most libraries don't need upgrades running. RSS already grabs better releases as they're
+						posted; this feature only matters when your existing library has fallen behind your
+						current config. Turn it on to catch up after a change, for example:
+					</p>
+					<ul class="list-disc space-y-1 pl-5">
+						<li>You switched a library to a different quality profile</li>
+						<li>Your custom format scores changed, often after a PCD update</li>
+						<li>
+							Your Arr instance was offline for a stretch (internet outage, downtime, updates)
+						</li>
+						<li>You added a new indexer with releases you couldn't reach before</li>
+					</ul>
+					<p class="mt-2">If none of those apply, leaving it disabled is fine.</p>
+				</Admonition>
+			</div>
+		{/if}
+
 		<section class="border-b border-neutral-200 pb-5 dark:border-neutral-800">
 			<CoreSettings
 				{enabled}


### PR DESCRIPTION
## Summary
- Adds two dismissible admonitions to the top of the upgrades page: a red rate-limit warning and a blue "when to use upgrades" note.
- Introduces a reusable `Admonition` UI component (`$ui/admonition/Admonition.svelte`) with `info`, `warning`, `danger`, `success`, and `note` variants.
- Dismissals persist in `localStorage` under versioned `v1` keys, gated behind a built-in confirmation modal so the warnings cannot be lost accidentally.