### PR TITLE
feat: gate upgrades and rename pages when disabled

### DIFF
--- a/src/routes/arr/[id]/rename/+page.svelte
+++ b/src/routes/arr/[id]/rename/+page.svelte
@@ -160,9 +160,19 @@
 			/>
 		</section>
 
-		<section class="md:px-4">
-			<RenameRunHistory runs={data.renameRuns} />
-		</section>
+		{#if enabled}
+			<section class="md:px-4">
+				<RenameRunHistory runs={data.renameRuns} />
+			</section>
+		{:else}
+			<section class="md:px-4">
+				<div class="rounded-xl border border-neutral-300 dark:border-neutral-700/60">
+					<p class="px-4 py-4 text-center text-sm text-neutral-600 dark:text-neutral-400">
+						Enable rename to view run history.
+					</p>
+				</div>
+			</section>
+		{/if}
 	</div>
 
 	<!-- Hidden forms -->

--- a/src/routes/arr/[id]/upgrades/+page.svelte
+++ b/src/routes/arr/[id]/upgrades/+page.svelte
@@ -283,21 +283,31 @@
 			/>
 		</section>
 
-		<section class="md:px-4" data-onboarding="upgrades-filters">
-			<FilterSettings
-				{filters}
-				appType={data.instance.type}
-				{runsPerHour}
-				{dynamicFilterOptions}
-				{dynamicFilterOptionsLoading}
-				{dynamicFilterOptionsVersion}
-				onFiltersChange={(v) => update('filters', JSON.stringify(v))}
-			/>
-		</section>
+		{#if enabled}
+			<section class="md:px-4" data-onboarding="upgrades-filters">
+				<FilterSettings
+					{filters}
+					appType={data.instance.type}
+					{runsPerHour}
+					{dynamicFilterOptions}
+					{dynamicFilterOptionsLoading}
+					{dynamicFilterOptionsVersion}
+					onFiltersChange={(v) => update('filters', JSON.stringify(v))}
+				/>
+			</section>
 
-		<section class="md:px-4">
-			<RunHistory runs={data.upgradeRuns} />
-		</section>
+			<section class="md:px-4">
+				<RunHistory runs={data.upgradeRuns} />
+			</section>
+		{:else}
+			<section class="md:px-4">
+				<div class="rounded-xl border border-neutral-300 dark:border-neutral-700/60">
+					<p class="px-4 py-4 text-center text-sm text-neutral-600 dark:text-neutral-400">
+						Enable upgrades to configure filters and view run history.
+					</p>
+				</div>
+			</section>
+		{/if}
 	</div>
 
 	<!-- Hidden forms -->

--- a/src/routes/arr/[id]/upgrades/components/CoreSettings.svelte
+++ b/src/routes/arr/[id]/upgrades/components/CoreSettings.svelte
@@ -79,7 +79,12 @@
 		/>
 	</div>
 
-	<div data-onboarding="upgrades-schedule">
+	<div
+		data-onboarding="upgrades-schedule"
+		class:pointer-events-none={!enabled}
+		class:opacity-50={!enabled}
+		aria-disabled={!enabled}
+	>
 		<span
 			class="mb-1 block text-[10px] font-medium tracking-wider text-neutral-400 uppercase dark:text-neutral-500"
 		>
@@ -88,7 +93,12 @@
 		<CronInput bind:value={cronValue} {minIntervalMinutes} {onWarning} />
 	</div>
 
-	<div data-onboarding="upgrades-filter-mode">
+	<div
+		data-onboarding="upgrades-filter-mode"
+		class:pointer-events-none={!enabled}
+		class:opacity-50={!enabled}
+		aria-disabled={!enabled}
+	>
 		<span
 			class="mb-1 block text-[10px] font-medium tracking-wider text-neutral-400 uppercase dark:text-neutral-500"
 		>


### PR DESCRIPTION
## Summary
- On the upgrades page, hide the filters and run history sections when status is disabled, replacing them with a small ghost card prompting the user to enable. Cron and filter mode controls in CoreSettings are dimmed and unclickable in the same state.
- On the rename page, hide the run history section under the same disabled state with a matching ghost card. The settings inputs were already individually gated via native `disabled` props.