### PR TITLE
feat: add drift count badge to drift tab

### DIFF
--- a/src/lib/client/ui/navigation/tabs/Tabs.svelte
+++ b/src/lib/client/ui/navigation/tabs/Tabs.svelte
@@ -14,7 +14,11 @@
 		active?: boolean;
 		icon?: ComponentType;
 		onboarding?: string;
+		badge?: number;
 	}
+
+	const badgeClass =
+		'inline-flex min-w-5 items-center justify-center rounded-full bg-blue-100 px-1.5 text-xs font-semibold text-blue-700 dark:bg-blue-900/40 dark:text-blue-300';
 
 	interface BackButton {
 		label: string;
@@ -100,6 +104,9 @@
 							<svelte:component this={activeTab.icon} size={16} class="shrink-0 text-accent-500" />
 						{/if}
 						<span class="truncate">{activeTab?.label ?? 'Select...'}</span>
+						{#if activeTab?.badge && activeTab.badge > 0}
+							<span class={badgeClass}>{activeTab.badge}</span>
+						{/if}
 					</span>
 					<ChevronDown
 						size={16}
@@ -113,9 +120,17 @@
 							<DropdownItem
 								icon={tab.icon}
 								label={tab.label}
+								customContent
 								selected={tab.active}
 								on:click={() => handleTabSelect(tab.href)}
-							/>
+							>
+								<span class="flex items-center gap-2">
+									<span>{tab.label}</span>
+									{#if tab.badge && tab.badge > 0}
+										<span class={badgeClass}>{tab.badge}</span>
+									{/if}
+								</span>
+							</DropdownItem>
 						{/each}
 					</Dropdown>
 				{/if}
@@ -150,6 +165,9 @@
 							<svelte:component this={tab.icon} size={16} />
 						{/if}
 						{tab.label}
+						{#if tab.badge && tab.badge > 0}
+							<span class={badgeClass}>{tab.badge}</span>
+						{/if}
 					</button>
 				{/each}
 

--- a/src/routes/arr/[id]/+layout.server.ts
+++ b/src/routes/arr/[id]/+layout.server.ts
@@ -2,6 +2,7 @@ import { error } from '@sveltejs/kit';
 import type { LayoutServerLoad } from './$types';
 import { arrInstancesQueries } from '$db/queries/arrInstances.ts';
 import { arrSyncQueries } from '$db/queries/arrSync.ts';
+import { arrDriftStatusQueries } from '$db/queries/arrDriftStatus.ts';
 
 export const load: LayoutServerLoad = ({ params }) => {
 	const id = parseInt(params.id || '', 10);
@@ -26,8 +27,15 @@ export const load: LayoutServerLoad = ({ params }) => {
 		!!sync.mediaManagement.qualityDefinitionsDatabaseId ||
 		!!sync.mediaManagement.mediaSettingsDatabaseId;
 
+	const driftStatus = arrDriftStatusQueries.getByInstanceId(id);
+	const driftCount =
+		driftStatus?.status === 'drift_detected'
+			? Object.values(driftStatus.counts).reduce((sum, n) => sum + (n ?? 0), 0)
+			: 0;
+
 	return {
 		instance: safe,
-		hasSyncConfig
+		hasSyncConfig,
+		driftCount
 	};
 };

--- a/src/routes/arr/[id]/+layout.svelte
+++ b/src/routes/arr/[id]/+layout.svelte
@@ -38,7 +38,8 @@
 		href: `/arr/${instanceId}/drift`,
 		active: currentPath.includes('/drift'),
 		icon: ArrowLeftRight,
-		onboarding: 'arr-tab-drift'
+		onboarding: 'arr-tab-drift',
+		badge: data.driftCount
 	};
 
 	$: otherTabs = [


### PR DESCRIPTION
## Summary
- Show a blue count badge on the Drift tab when an instance has `drift_detected` status, sourced from `arr_drift_status.counts_json` summed across sections.
- Extend the `Tabs` component with an optional `badge?: number` field on the `Tab` interface. Renders in the desktop tab bar, the mobile trigger, and mobile dropdown items via `DropdownItem`'s `customContent` slot.