### PR TITLE
feat: surface expires column on announcements page

### DIFF
--- a/src/routes/announcements/+page.svelte
+++ b/src/routes/announcements/+page.svelte
@@ -130,9 +130,10 @@
 	})();
 
 	const columns: Column<Row>[] = [
-		{ key: 'title', header: 'Title' },
 		{ key: 'severity', header: 'Severity', width: 'w-32' },
+		{ key: 'title', header: 'Title' },
 		{ key: 'publishedAt', header: 'Published', width: 'w-40' },
+		{ key: 'expiresAt', header: 'Expires', width: 'w-40' },
 		{ key: 'source', header: 'Source', width: 'w-44' }
 	];
 
@@ -319,6 +320,12 @@
 				{:else if column.key === 'publishedAt'}
 					<span class="text-xs text-neutral-500 dark:text-neutral-500">
 						<DateTime value={row.publishedAt} date />
+					</span>
+				{:else if column.key === 'expiresAt'}
+					<span class="text-xs text-neutral-500 dark:text-neutral-500">
+						{#if row.expiresAt}
+							<DateTime value={row.expiresAt} date />
+						{/if}
 					</span>
 				{/if}
 			</svelte:fragment>


### PR DESCRIPTION
## Summary
- Reorder the announcements table columns so severity sits before the title.
- Add a new Expires column after Published, rendered with `<DateTime>` (per the `no-raw-dates` lint rule). Cell is blank when the announcement has no expiry.