### PR TITLE
fix: preserve queued named schedules

### DIFF
--- a/docs/backend/jobs.md
+++ b/docs/backend/jobs.md
@@ -169,6 +169,11 @@ fixed times:
 | `weekly`  | 7 days from now at midnight   |
 | `monthly` | 1st of next month at midnight |
 
+Schedule rebuild preserves an existing queued run time for named schedules.
+Startup and unrelated settings saves do not move the next run. A fresh run time
+is calculated when the job is missing, cancelled, re-enabled, or the backup
+cadence changes.
+
 ### Manual Triggers
 
 Any job can be triggered manually via "Run now" in the settings UI or via API.

--- a/src/lib/server/jobs/schedule.ts
+++ b/src/lib/server/jobs/schedule.ts
@@ -18,6 +18,12 @@ function notify(runAt: string | null): void {
 	jobDispatcher.notifyJobEnqueued(runAt);
 }
 
+function preservedQueuedRunAt(dedupeKey: string, force: boolean = false): string | null {
+	if (force) return null;
+	const existing = jobQueueQueries.getByDedupeKey(dedupeKey);
+	return existing?.status === 'queued' ? existing.runAt : null;
+}
+
 export function scheduleArrSyncForInstance(instanceId: number): void {
 	const status = arrSyncQueries.getSyncConfigStatus(instanceId);
 
@@ -214,7 +220,12 @@ export function schedulePcdSyncForDatabase(databaseId: number): void {
 	notify(job.runAt);
 }
 
-export function scheduleBackupJobs(): void {
+interface ScheduleBackupJobsOptions {
+	forceBackup?: boolean;
+	forceCleanup?: boolean;
+}
+
+export function scheduleBackupJobs(options: ScheduleBackupJobsOptions = {}): void {
 	const settings = backupSettingsQueries.get();
 	if (!settings || settings.enabled !== 1) {
 		jobQueueQueries.cancelByDedupeKey('backup.create');
@@ -222,8 +233,12 @@ export function scheduleBackupJobs(): void {
 		return;
 	}
 
-	const backupRunAt = calculateNextRunFromSchedule(settings.schedule);
-	const cleanupRunAt = calculateNextRunFromSchedule('daily');
+	const backupRunAt =
+		preservedQueuedRunAt('backup.create', options.forceBackup) ??
+		calculateNextRunFromSchedule(settings.schedule);
+	const cleanupRunAt =
+		preservedQueuedRunAt('backup.cleanup', options.forceCleanup) ??
+		calculateNextRunFromSchedule('daily');
 
 	const backupJob = jobQueueQueries.upsertScheduled({
 		jobType: 'backup.create',
@@ -245,14 +260,19 @@ export function scheduleBackupJobs(): void {
 	notify(cleanupJob.runAt);
 }
 
-export function scheduleLogCleanup(): void {
+interface ScheduleLogCleanupOptions {
+	force?: boolean;
+}
+
+export function scheduleLogCleanup(options: ScheduleLogCleanupOptions = {}): void {
 	const settings = logSettingsQueries.get();
 	if (!settings || settings.file_logging !== 1) {
 		jobQueueQueries.cancelByDedupeKey('logs.cleanup');
 		return;
 	}
 
-	const runAt = calculateNextRunFromSchedule('daily');
+	const runAt =
+		preservedQueuedRunAt('logs.cleanup', options.force) ?? calculateNextRunFromSchedule('daily');
 	const job = jobQueueQueries.upsertScheduled({
 		jobType: 'logs.cleanup',
 		runAt,

--- a/src/routes/api/v1/backups/settings/+server.ts
+++ b/src/routes/api/v1/backups/settings/+server.ts
@@ -70,6 +70,13 @@ export const PATCH: RequestHandler = async ({ request }) => {
 		return json(error, { status: 400 });
 	}
 
+	const current = backupSettingsQueries.get();
+	if (!current) {
+		const error: ErrorResponse = { error: 'Backup settings not found' };
+		return json(error, { status: 500 });
+	}
+	const scheduleChanged = schedule !== undefined && schedule !== current.schedule;
+
 	// Build update input
 	const updateInput: {
 		schedule?: string;
@@ -82,7 +89,7 @@ export const PATCH: RequestHandler = async ({ request }) => {
 	if (enabled !== undefined) updateInput.enabled = enabled;
 
 	backupSettingsQueries.update(updateInput);
-	await scheduleBackupJobs();
+	await scheduleBackupJobs({ forceBackup: scheduleChanged });
 
 	// Return updated settings
 	const updated = backupSettingsQueries.get()!;

--- a/src/routes/settings/general/+page.server.ts
+++ b/src/routes/settings/general/+page.server.ts
@@ -107,6 +107,12 @@ export const actions: Actions = {
 			return fail(400, { error: 'Backup retention days must be between 1 and 365' });
 		}
 
+		const currentBackupSettings = backupSettingsQueries.get();
+		if (!currentBackupSettings) {
+			return fail(500, { error: 'Backup settings not found' });
+		}
+		const backupScheduleChanged = currentBackupSettings.schedule !== backupSchedule;
+
 		// --- AI settings (feature-flagged) ---
 		let aiEnabled = false;
 		let aiApiUrl = '';
@@ -216,7 +222,7 @@ export const actions: Actions = {
 		// --- Side effects ---
 		logSettings.reload();
 		scheduleLogCleanup();
-		scheduleBackupJobs();
+		scheduleBackupJobs({ forceBackup: backupScheduleChanged });
 
 		await logger.info('General settings saved', {
 			source: 'settings/general',

--- a/tests/integration/backups/specs/settings.test.ts
+++ b/tests/integration/backups/specs/settings.test.ts
@@ -10,6 +10,7 @@ import { PORTS } from '$test-harness/ports.ts';
 import { startServer, stopServer, getDbPath } from '$test-harness/server.ts';
 import { TestClient } from '$test-harness/client.ts';
 import { createUser, login, setApiKey } from '$test-harness/setup.ts';
+import { openDb } from '$test-harness/db.ts';
 
 const PORT = PORTS.backups.settings;
 const ORIGIN = `http://localhost:${PORT}`;
@@ -18,6 +19,105 @@ const API_KEY = 'test-api-key-backups-settings-123';
 let client: TestClient;
 let unauthClient: TestClient;
 let apiKeyClient: TestClient;
+
+function setBackupSettings(
+	dbPath: string,
+	settings: { schedule?: string; retentionDays?: number; enabled?: boolean }
+): void {
+	const db = openDb(dbPath);
+	try {
+		const updates: string[] = [];
+		const params: (string | number)[] = [];
+		if (settings.schedule !== undefined) {
+			updates.push('schedule = ?');
+			params.push(settings.schedule);
+		}
+		if (settings.retentionDays !== undefined) {
+			updates.push('retention_days = ?');
+			params.push(settings.retentionDays);
+		}
+		if (settings.enabled !== undefined) {
+			updates.push('enabled = ?');
+			params.push(settings.enabled ? 1 : 0);
+		}
+		if (updates.length === 0) return;
+		db.exec(`UPDATE backup_settings SET ${updates.join(', ')} WHERE id = 1`, params);
+	} finally {
+		db.close();
+	}
+}
+
+function setQueuedScheduledJob(dbPath: string, dedupeKey: string, jobType: string, runAt: string): void {
+	const db = openDb(dbPath);
+	try {
+		const existing = db
+			.prepare('SELECT id FROM job_queue WHERE dedupe_key = ?')
+			.get(dedupeKey) as { id: number } | undefined;
+		if (existing) {
+			db.exec(
+				`UPDATE job_queue
+				 SET job_type = ?, status = 'queued', run_at = ?, payload = '{}', source = 'schedule'
+				 WHERE id = ?`,
+				[jobType, runAt, existing.id]
+			);
+			return;
+		}
+
+		db.exec(
+			`INSERT INTO job_queue (job_type, status, run_at, payload, source, dedupe_key)
+			 VALUES (?, 'queued', ?, '{}', 'schedule', ?)`,
+			[jobType, runAt, dedupeKey]
+		);
+	} finally {
+		db.close();
+	}
+}
+
+function getScheduledRunAt(dbPath: string, dedupeKey: string): string | null {
+	const db = openDb(dbPath);
+	try {
+		const row = db
+			.prepare('SELECT run_at FROM job_queue WHERE dedupe_key = ?')
+			.get(dedupeKey) as { run_at: string } | undefined;
+		return row?.run_at ?? null;
+	} finally {
+		db.close();
+	}
+}
+
+function setScheduleFixture(dbPath: string): { backupRunAt: string; cleanupRunAt: string } {
+	const backupRunAt = '2035-01-02T03:04:05.000Z';
+	const cleanupRunAt = '2035-01-03T03:04:05.000Z';
+	setBackupSettings(dbPath, { schedule: 'weekly', retentionDays: 30, enabled: true });
+	setQueuedScheduledJob(dbPath, 'backup.create', 'backup.create', backupRunAt);
+	setQueuedScheduledJob(dbPath, 'backup.cleanup', 'backup.cleanup', cleanupRunAt);
+	setQueuedScheduledJob(dbPath, 'logs.cleanup', 'logs.cleanup', cleanupRunAt);
+	return { backupRunAt, cleanupRunAt };
+}
+
+async function saveGeneralSettings(fields: {
+	backupSchedule: string;
+	backupRetentionDays: number;
+	logRetentionDays: number;
+}): Promise<Response> {
+	return client.postForm(
+		'/settings/general?/save',
+		{
+			date_format: 'auto',
+			arr_apply_default_delay_profiles: 'on',
+			backup_enabled: 'on',
+			backup_schedule: fields.backupSchedule,
+			backup_retention_days: String(fields.backupRetentionDays),
+			log_enabled: 'on',
+			log_file_logging: 'on',
+			log_console_logging: 'on',
+			log_retention_days: String(fields.logRetentionDays),
+			log_min_level: 'INFO',
+			tmdb_api_key: ''
+		},
+		{ headers: { Origin: ORIGIN } }
+	);
+}
 
 setup(async () => {
 	await startServer(PORT, { AUTH: 'on', ORIGIN }, 'preview');
@@ -97,6 +197,47 @@ test('PATCH updates enabled toggle', async () => {
 
 	// Restore
 	await client.patch('/api/v1/backups/settings', { enabled: true });
+});
+
+// ─── Scheduled jobs ─────────────────────────────────────────────────────────
+
+test('PATCH retentionDays preserves queued backup job run times', async () => {
+	const dbPath = getDbPath(PORT);
+	const { backupRunAt, cleanupRunAt } = setScheduleFixture(dbPath);
+
+	const res = await client.patch('/api/v1/backups/settings', { retentionDays: 14 });
+	assertEquals(res.status, 200);
+
+	assertEquals(getScheduledRunAt(dbPath, 'backup.create'), backupRunAt);
+	assertEquals(getScheduledRunAt(dbPath, 'backup.cleanup'), cleanupRunAt);
+});
+
+test('PATCH schedule recalculates backup job but preserves cleanup job run time', async () => {
+	const dbPath = getDbPath(PORT);
+	const { backupRunAt, cleanupRunAt } = setScheduleFixture(dbPath);
+
+	const res = await client.patch('/api/v1/backups/settings', { schedule: 'daily' });
+	assertEquals(res.status, 200);
+
+	const nextBackupRunAt = getScheduledRunAt(dbPath, 'backup.create');
+	assertEquals(nextBackupRunAt === backupRunAt, false);
+	assertEquals(getScheduledRunAt(dbPath, 'backup.cleanup'), cleanupRunAt);
+});
+
+test('general settings save preserves queued named schedule run times', async () => {
+	const dbPath = getDbPath(PORT);
+	const { backupRunAt, cleanupRunAt } = setScheduleFixture(dbPath);
+
+	const res = await saveGeneralSettings({
+		backupSchedule: 'weekly',
+		backupRetentionDays: 21,
+		logRetentionDays: 21
+	});
+	assertEquals(res.status, 200);
+
+	assertEquals(getScheduledRunAt(dbPath, 'backup.create'), backupRunAt);
+	assertEquals(getScheduledRunAt(dbPath, 'backup.cleanup'), cleanupRunAt);
+	assertEquals(getScheduledRunAt(dbPath, 'logs.cleanup'), cleanupRunAt);
 });
 
 // ─── PATCH: Validation ───────────────────────────────────────────────────────

--- a/tests/integration/backups/specs/settings.test.ts
+++ b/tests/integration/backups/specs/settings.test.ts
@@ -47,12 +47,17 @@ function setBackupSettings(
 	}
 }
 
-function setQueuedScheduledJob(dbPath: string, dedupeKey: string, jobType: string, runAt: string): void {
+function setQueuedScheduledJob(
+	dbPath: string,
+	dedupeKey: string,
+	jobType: string,
+	runAt: string
+): void {
 	const db = openDb(dbPath);
 	try {
-		const existing = db
-			.prepare('SELECT id FROM job_queue WHERE dedupe_key = ?')
-			.get(dedupeKey) as { id: number } | undefined;
+		const existing = db.prepare('SELECT id FROM job_queue WHERE dedupe_key = ?').get(dedupeKey) as
+			| { id: number }
+			| undefined;
 		if (existing) {
 			db.exec(
 				`UPDATE job_queue
@@ -76,9 +81,9 @@ function setQueuedScheduledJob(dbPath: string, dedupeKey: string, jobType: strin
 function getScheduledRunAt(dbPath: string, dedupeKey: string): string | null {
 	const db = openDb(dbPath);
 	try {
-		const row = db
-			.prepare('SELECT run_at FROM job_queue WHERE dedupe_key = ?')
-			.get(dedupeKey) as { run_at: string } | undefined;
+		const row = db.prepare('SELECT run_at FROM job_queue WHERE dedupe_key = ?').get(dedupeKey) as
+			| { run_at: string }
+			| undefined;
 		return row?.run_at ?? null;
 	} finally {
 		db.close();


### PR DESCRIPTION
Preserves existing queued run times when named schedules are rebuilt during startup or unrelated settings saves.

Recalculates backup creation only when the backup cadence changes, while backup cleanup and log cleanup keep their queued run times unless the job is missing, cancelled, or re-enabled.

Adds integration coverage for backup settings and general settings saves so regressions fail against the old behavior.