### PR TITLE
fix(ci): use github.repository_owner for ghcr.io image push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,6 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_BASE: ghcr.io/${{ github.repository_owner }}
 
 permissions:
   contents: read
@@ -44,6 +43,9 @@ jobs:
             runner: ubuntu-24.04-arm
 
     steps:
+      - name: Set Image Base
+        run: echo "IMAGE_BASE=ghcr.io/$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+
       - uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
@@ -142,6 +144,9 @@ jobs:
         image: [profilarr, profilarr-parser]
 
     steps:
+      - name: Set Image Base
+        run: echo "IMAGE_BASE=ghcr.io/$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+
       - name: Download digests
         uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_BASE: ghcr.io/dictionarry-hub
+  IMAGE_BASE: ghcr.io/${{ github.repository_owner }}
 
 permissions:
   contents: read


### PR DESCRIPTION
This allows forks to build and push images to their own ghcr registry instead of failing due to hardcoded `dictionarry-hub` owner.