### PR TITLE
docs: document OIDC environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,9 @@ services:
 | `PORT`                   | `6868`                                                            | Web UI port                                                                           |
 | `HOST`                   | `0.0.0.0`                                                         | Bind address                                                                          |
 | `AUTH`                   | `on`                                                              | Auth mode (`on`, `oidc`, `off`)                                                       |
+| `OIDC_CLIENT_SECRET`     |                                                                   | Needed for oidc                                                                       |
+| `OIDC_CLIENT_ID`         |                                                                   | Needed for oidc                                                                       |
+| `OIDC_DISCVOERY_URL`     |                                                                   | Needed for oidc                                                                       |
 | `ORIGIN`                 | -                                                                 | Public URL when running behind a reverse proxy (e.g. `https://profilarr.example.com`) |
 | `PARSER_HOST`            | `localhost`                                                       | Parser service host                                                                   |
 | `PARSER_PORT`            | `5000`                                                            | Parser service port                                                                   |


### PR DESCRIPTION
This is my first PR to any project, so apologies if this is not the correct format. This request adds OIDC_CLIENT_SECRET, OIDC_CLIENT_ID, and OIDC_DISCOVERY_URL environment variables to the README. I didn't see these documented in the docs or README but they were revealed in an error page after I set the AUTH variable to oidc. This could save some time for new users who set auth type to oidc. 

I also received an error because callback url was not set in PocketID but it looks like that ended up being set automatically in my oidc client. I'm not sure if other clients will do that on their own and it would be helpful to show that here as well but since I can't confirm the redirect (only that the one set works for me) I did not include it in this PR. 

