### PR TITLE
fix: default first-party database links to v2

### DIFF
--- a/src/lib/server/pcd/core/validate.ts
+++ b/src/lib/server/pcd/core/validate.ts
@@ -17,6 +17,39 @@ type UpdateValidationResult =
 	| { ok: false; error: string };
 
 const VALID_CONFLICT_STRATEGIES = ['override', 'align', 'ask'] as const;
+const FIRST_PARTY_DATABASE_BRANCH = 'v2';
+const FIRST_PARTY_DATABASE_REPO = 'github.com/dictionarry-hub/database';
+
+function normalizeGitHubRepoUrl(repositoryUrl: string): string | null {
+	const trimmed = repositoryUrl.trim();
+	const withoutGitSuffix = trimmed.endsWith('.git') ? trimmed.slice(0, -4) : trimmed;
+
+	if (withoutGitSuffix.startsWith('git@github.com:')) {
+		return `github.com/${withoutGitSuffix.slice('git@github.com:'.length)}`.toLowerCase();
+	}
+
+	const withScheme = /^https?:\/\//i.test(withoutGitSuffix)
+		? withoutGitSuffix
+		: `https://${withoutGitSuffix}`;
+
+	try {
+		const url = new URL(withScheme);
+		const pathname = url.pathname.replace(/^\/+|\/+$/g, '');
+		return `${url.hostname}/${pathname}`.toLowerCase();
+	} catch {
+		return null;
+	}
+}
+
+function defaultBranchForRepository(
+	repositoryUrl: string,
+	branch: string | undefined
+): string | undefined {
+	if (branch) return branch;
+	return normalizeGitHubRepoUrl(repositoryUrl) === FIRST_PARTY_DATABASE_REPO
+		? FIRST_PARTY_DATABASE_BRANCH
+		: undefined;
+}
 
 /**
  * Validate and coerce link input from either API JSON or form data.
@@ -30,8 +63,9 @@ export function validateLinkInput(body: Record<string, unknown>): ValidationResu
 		return { ok: false, error: 'Name and repository URL are required' };
 	}
 
-	const branch =
+	const rawBranch =
 		typeof body.branch === 'string' && body.branch.trim() ? body.branch.trim() : undefined;
+	const branch = defaultBranchForRepository(repositoryUrl, rawBranch);
 	const personalAccessToken =
 		typeof body.personal_access_token === 'string' && body.personal_access_token.trim()
 			? body.personal_access_token.trim()

--- a/tests/runner.ts
+++ b/tests/runner.ts
@@ -105,6 +105,7 @@ const UNIT_ALIASES: Record<string, string> = {
 	sanitize: 'tests/unit/sanitize',
 	backups: 'tests/unit/backups',
 	announcements: 'tests/unit/announcements',
+	pcd: 'tests/unit/pcd',
 	// Individual files
 	filters: 'tests/unit/upgrades/filters.test.ts',
 	normalize: 'tests/unit/upgrades/normalize.test.ts',

--- a/tests/unit/pcd/validate.test.ts
+++ b/tests/unit/pcd/validate.test.ts
@@ -1,0 +1,37 @@
+import { assertEquals } from '@std/assert';
+import { validateLinkInput } from '$pcd/core/validate.ts';
+
+function branchFor(repositoryUrl: string, branch?: string): string | undefined {
+	const result = validateLinkInput({
+		name: 'Dictionarry',
+		repository_url: repositoryUrl,
+		branch
+	});
+
+	if (!result.ok) {
+		throw new Error(result.error);
+	}
+
+	return result.input.branch;
+}
+
+Deno.test('validateLinkInput defaults first-party database links to v2', () => {
+	const urls = [
+		'https://github.com/Dictionarry-Hub/database',
+		'https://github.com/Dictionarry-Hub/database.git',
+		'git@github.com:Dictionarry-Hub/database.git',
+		'github.com/Dictionarry-Hub/database'
+	];
+
+	for (const url of urls) {
+		assertEquals(branchFor(url), 'v2', url);
+	}
+});
+
+Deno.test('validateLinkInput keeps explicit branch for first-party database links', () => {
+	assertEquals(branchFor('https://github.com/Dictionarry-Hub/database', 'main'), 'main');
+});
+
+Deno.test('validateLinkInput does not default other database links', () => {
+	assertEquals(branchFor('https://github.com/TRaSH-Guides/Guides'), undefined);
+});


### PR DESCRIPTION
Backports hotfix tag `v2.0.2` into `develop`.

Commits:

```
42fae6ae fix: default first-party database links to v2
```

Hotfix tag: https://github.com/Dictionarry-Hub/profilarr/releases/tag/v2.0.2
