### PR TITLE
ci: notify on release tags

### DIFF
--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -1,10 +1,10 @@
 name: Notify
 on:
   push:
-    branches:
-      - develop
+    tags:
+      - 'v*.*.*'
 jobs:
-  call-notify-commit:
-    uses: Dictionarry-Hub/parrot/.github/workflows/notify-commit.yml@v1
+  call-notify-release:
+    uses: Dictionarry-Hub/parrot/.github/workflows/notify-release.yml@v1
     secrets:
       PARROT_URL: ${{ secrets.PARROT_URL }}


### PR DESCRIPTION
## What
- Change Profilarr notifications to run on stable version tags.
- Call Parrot's reusable release notification workflow instead of commit notifications.

## Why
- Stable announcements should happen on releases, not every develop push.

Closes #610