### PR TITLE
fix: extend timeout for library refreshes

### DIFF
--- a/src/lib/server/jobs/handlers/arrLibraryRefresh.ts
+++ b/src/lib/server/jobs/handlers/arrLibraryRefresh.ts
@@ -4,6 +4,7 @@ import { arrInstancesQueries } from '$db/queries/arrInstances.ts';
 import { cache } from '$cache/cache.ts';
 import { RadarrClient } from '$utils/arr/clients/radarr.ts';
 import { SonarrClient } from '$utils/arr/clients/sonarr.ts';
+import { LIBRARY_REQUEST_TIMEOUT_MS } from '$utils/arr/base.ts';
 import { getProfilarrProfileNames } from '$lib/server/sync/libraryHelpers.ts';
 import { calculateNextRunFromMinutes } from '../scheduleUtils.ts';
 import { logger } from '$logger/logger.ts';
@@ -50,10 +51,11 @@ const libraryRefreshHandler: JobHandler = async (job) => {
 	}
 
 	const profilarrProfileNames = await getProfilarrProfileNames();
+	const clientOptions = { timeout: LIBRARY_REQUEST_TIMEOUT_MS };
 	const client =
 		instance.type === 'radarr'
-			? new RadarrClient(instance.url, instance.api_key)
-			: new SonarrClient(instance.url, instance.api_key);
+			? new RadarrClient(instance.url, instance.api_key, clientOptions)
+			: new SonarrClient(instance.url, instance.api_key, clientOptions);
 
 	try {
 		const items = await client.getLibrary(profilarrProfileNames);

--- a/src/lib/server/utils/arr/base.ts
+++ b/src/lib/server/utils/arr/base.ts
@@ -30,6 +30,7 @@ export interface ArrClientOptions {
 }
 
 export const INTERACTIVE_SEARCH_TIMEOUT_MS = 120000;
+export const LIBRARY_REQUEST_TIMEOUT_MS = 300000;
 
 export class BaseArrClient extends BaseHttpClient {
 	private apiKey: string;

--- a/src/routes/arr/[id]/library/movies/+server.ts
+++ b/src/routes/arr/[id]/library/movies/+server.ts
@@ -3,6 +3,7 @@ import type { RequestHandler } from '@sveltejs/kit';
 import { arrInstancesQueries } from '$db/queries/arrInstances.ts';
 import { cache } from '$cache/cache.ts';
 import { RadarrClient } from '$utils/arr/clients/radarr.ts';
+import { LIBRARY_REQUEST_TIMEOUT_MS } from '$utils/arr/base.ts';
 import type { RadarrLibraryItem } from '$utils/arr/types.ts';
 import { getProfilarrProfileNames } from '$lib/server/sync/libraryHelpers.ts';
 import { logger } from '$logger/logger.ts';
@@ -35,7 +36,9 @@ export const GET: RequestHandler = async ({ params }) => {
 			: MANUAL_CACHE_TTL;
 
 	const profilarrProfileNames = await getProfilarrProfileNames();
-	const client = new RadarrClient(instance.url, instance.api_key);
+	const client = new RadarrClient(instance.url, instance.api_key, {
+		timeout: LIBRARY_REQUEST_TIMEOUT_MS
+	});
 	try {
 		const items = await client.getLibrary(profilarrProfileNames);
 		cache.set(cacheKey, items, ttl);

--- a/src/routes/arr/[id]/library/series/+server.ts
+++ b/src/routes/arr/[id]/library/series/+server.ts
@@ -3,6 +3,7 @@ import type { RequestHandler } from '@sveltejs/kit';
 import { arrInstancesQueries } from '$db/queries/arrInstances.ts';
 import { cache } from '$cache/cache.ts';
 import { SonarrClient } from '$utils/arr/clients/sonarr.ts';
+import { LIBRARY_REQUEST_TIMEOUT_MS } from '$utils/arr/base.ts';
 import type { SonarrLibraryItem, SonarrSeriesItem } from '$utils/arr/types.ts';
 import { getProfilarrProfileNames } from '$lib/server/sync/libraryHelpers.ts';
 import { logger } from '$logger/logger.ts';
@@ -39,7 +40,9 @@ export const GET: RequestHandler = async ({ params }) => {
 			: MANUAL_CACHE_TTL;
 
 	const profilarrProfileNames = await getProfilarrProfileNames();
-	const client = new SonarrClient(instance.url, instance.api_key);
+	const client = new SonarrClient(instance.url, instance.api_key, {
+		timeout: LIBRARY_REQUEST_TIMEOUT_MS
+	});
 	try {
 		const items = await client.getLibrary(profilarrProfileNames);
 		cache.set(cacheKey, items, ttl);


### PR DESCRIPTION
Backports hotfix tag `v2.0.3` into `develop`.

Commits:

```
fbc2b7f6 fix: extend timeout for library refreshes
```

Hotfix tag: https://github.com/Dictionarry-Hub/profilarr/releases/tag/v2.0.3
