### PR TITLE
fix: prevent dropdowns from clipping near screen edges

### DIFF
--- a/src/lib/client/ui/dropdown/Dropdown.svelte
+++ b/src/lib/client/ui/dropdown/Dropdown.svelte
@@ -1,17 +1,22 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
+	import { createEventDispatcher, onMount } from 'svelte';
+
+	const dispatch = createEventDispatcher<{ placementchange: 'bottom' | 'top' }>();
 
 	export let position: 'left' | 'right' | 'middle' = 'left';
 	export let mobilePosition: 'left' | 'right' | 'middle' | null = null;
 	export let minWidth: string = '12rem';
 	export let width: string | undefined = undefined;
 	export let compact: boolean = false;
+	export let placement: 'auto' | 'bottom' | 'top' = 'auto';
 	// Fixed positioning to escape overflow containers
 	export let fixed: boolean = false;
 	export let triggerEl: HTMLElement | null = null;
 
 	let dropdownEl: HTMLElement;
 	let fixedStyle = '';
+	let resolvedPlacement: 'bottom' | 'top' = 'bottom';
+	let lastDispatchedPlacement: 'bottom' | 'top' | null = null;
 
 	const positionClasses = {
 		left: 'left-0',
@@ -33,13 +38,28 @@
 			: positionClasses[position];
 
 	$: marginClass = compact ? 'mt-1' : 'mt-3';
+	$: topMarginClass = compact ? 'mb-1' : 'mb-3';
 	$: gap = compact ? 4 : 12; // pixels gap below trigger
 	$: roundedClass = compact ? 'rounded-lg' : 'rounded-xl';
+	$: verticalClass =
+		resolvedPlacement === 'top' ? `bottom-full ${topMarginClass}` : `top-full ${marginClass}`;
+
+	function resolvePlacement(rect: DOMRect): 'bottom' | 'top' {
+		if (placement !== 'auto') return placement;
+		return rect.top + rect.height / 2 > window.innerHeight / 2 ? 'top' : 'bottom';
+	}
 
 	function updateFixedPosition() {
-		if (!fixed || !triggerEl) return;
+		if (!triggerEl) return;
 
 		const rect = triggerEl.getBoundingClientRect();
+		resolvedPlacement = resolvePlacement(rect);
+		if (resolvedPlacement !== lastDispatchedPlacement) {
+			lastDispatchedPlacement = resolvedPlacement;
+			dispatch('placementchange', resolvedPlacement);
+		}
+		if (!fixed) return;
+
 		let left = rect.left;
 
 		if (position === 'right') {
@@ -55,12 +75,19 @@
 			}
 		}
 
-		fixedStyle = `top: ${rect.bottom + gap}px; left: ${left}px;`;
+		const verticalStyle =
+			resolvedPlacement === 'top'
+				? `bottom: ${window.innerHeight - rect.top + gap}px;`
+				: `top: ${rect.bottom + gap}px;`;
+
+		fixedStyle = `${verticalStyle} left: ${left}px;`;
 	}
 
 	onMount(() => {
-		if (fixed && triggerEl) {
+		if (triggerEl) {
 			updateFixedPosition();
+		}
+		if (fixed && triggerEl) {
 			window.addEventListener('scroll', updateFixedPosition, true);
 			window.addEventListener('resize', updateFixedPosition);
 			return () => {
@@ -71,21 +98,23 @@
 		return;
 	});
 
-	$: if (fixed && triggerEl && dropdownEl) {
+	$: if (triggerEl && dropdownEl) {
 		updateFixedPosition();
 	}
 </script>
 
 <!-- Invisible hover bridge to keep dropdown open when moving mouse down -->
 {#if !fixed}
-	<div class="absolute top-full z-40 h-3 w-full"></div>
+	<div
+		class="absolute z-40 h-3 w-full {resolvedPlacement === 'top' ? 'bottom-full' : 'top-full'}"
+	></div>
 {/if}
 
 <div
 	bind:this={dropdownEl}
 	class="z-50 overflow-hidden border border-neutral-300 bg-neutral-100 shadow-xl dark:border-neutral-700/60 dark:bg-neutral-900 dark:shadow-black/25 {roundedClass} {fixed
 		? 'fixed'
-		: 'absolute top-full ' + marginClass} {positionClass}"
+		: 'absolute ' + verticalClass} {positionClass}"
 	style="min-width: {minWidth}; {width ? `width: ${width};` : ''} {fixed ? fixedStyle : ''}"
 >
 	<div class="bg-white/80 dark:bg-neutral-800/50">

--- a/src/lib/client/ui/dropdown/DropdownCombobox.svelte
+++ b/src/lib/client/ui/dropdown/DropdownCombobox.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { ComponentType } from 'svelte';
 	import { onMount, onDestroy, createEventDispatcher, tick } from 'svelte';
-	import { ChevronDown } from 'lucide-svelte';
+	import { ChevronDown, ChevronUp } from 'lucide-svelte';
 	import { clickOutside } from '$lib/client/utils/clickOutside';
 	import Button from '$ui/button/Button.svelte';
 	import Dropdown from './Dropdown.svelte';
@@ -23,6 +23,7 @@
 	export let minWidth: string = '12rem';
 	export let position: 'left' | 'right' | 'middle' = 'left';
 	export let mobilePosition: 'left' | 'right' | 'middle' | null = null;
+	export let placement: 'auto' | 'bottom' | 'top' = 'auto';
 	export let compact: boolean = false;
 	export let compactButton: boolean | undefined = undefined;
 	export let compactDropdown: boolean | undefined = undefined;
@@ -49,6 +50,7 @@
 	let isSmallScreen = false;
 	let mediaQuery: MediaQueryList | null = null;
 	let triggerWidth = 0;
+	let resolvedPlacement: 'bottom' | 'top' = 'bottom';
 
 	onMount(() => {
 		if ((responsiveButton || responsiveDropdown) && typeof window !== 'undefined') {
@@ -86,6 +88,7 @@
 	$: resolvedButtonSize = buttonSize ?? ((isCompactButton ? 'xs' : 'sm') as 'xs' | 'sm');
 	$: resolvedJustify = justify ?? 'between';
 	$: useSelectMode = isSmallScreen && (responsiveButton || responsiveDropdown);
+	$: chevronIcon = open && resolvedPlacement === 'top' ? ChevronUp : ChevronDown;
 
 	$: trimmedQuery = query.trim();
 	$: filteredOptions = !open
@@ -225,12 +228,16 @@
 					on:input={handleInput}
 					on:keydown={handleKeyDown}
 				/>
-				<ChevronDown size={chevronSize} class="shrink-0 text-neutral-500 dark:text-neutral-400" />
+				<svelte:component
+					this={chevronIcon}
+					size={chevronSize}
+					class="shrink-0 text-neutral-500 dark:text-neutral-400"
+				/>
 			</div>
 		{:else}
 			<Button
 				text={currentLabel}
-				icon={ChevronDown}
+				icon={chevronIcon}
 				iconPosition="right"
 				leadingIcon={currentIcon}
 				size={resolvedButtonSize}
@@ -245,11 +252,13 @@
 			<Dropdown
 				{position}
 				{mobilePosition}
+				{placement}
 				{minWidth}
 				width={dropdownWidth}
 				compact={isCompactDropdown}
 				{fixed}
 				{triggerEl}
+				on:placementchange={(e) => (resolvedPlacement = e.detail)}
 			>
 				<div class="overflow-y-auto" style={maxHeightStyle}>
 					{#each filteredOptions as option, i (option.value)}

--- a/src/lib/client/ui/dropdown/DropdownSelect.svelte
+++ b/src/lib/client/ui/dropdown/DropdownSelect.svelte
@@ -2,7 +2,7 @@
 	import type { ComponentType } from 'svelte';
 	import { onMount, onDestroy, createEventDispatcher } from 'svelte';
 	import { clickOutside } from '$lib/client/utils/clickOutside';
-	import { ChevronDown } from 'lucide-svelte';
+	import { ChevronDown, ChevronUp } from 'lucide-svelte';
 	import Button from '$ui/button/Button.svelte';
 	import Dropdown from './Dropdown.svelte';
 	import DropdownItem from './DropdownItem.svelte';
@@ -20,6 +20,7 @@
 	export let minWidth: string = '8rem';
 	export let position: 'left' | 'right' | 'middle' = 'left';
 	export let mobilePosition: 'left' | 'right' | 'middle' | null = null;
+	export let placement: 'auto' | 'bottom' | 'top' = 'auto';
 	// Separate compact controls - compact is shorthand for both
 	export let compact: boolean = false;
 	export let compactButton: boolean | undefined = undefined;
@@ -48,6 +49,7 @@
 	let isSmallScreen = false;
 	let mediaQuery: MediaQueryList | null = null;
 	let triggerEl: HTMLElement;
+	let resolvedPlacement: 'bottom' | 'top' = 'bottom';
 
 	onMount(() => {
 		if ((responsiveButton || responsiveDropdown) && typeof window !== 'undefined') {
@@ -84,6 +86,7 @@
 					: compact;
 	$: resolvedButtonSize = buttonSize ?? ((isCompactButton ? 'xs' : 'sm') as 'xs' | 'sm');
 	$: resolvedJustify = justify ?? (fullWidth || width ? 'between' : 'center');
+	$: chevronIcon = open && resolvedPlacement === 'top' ? ChevronUp : ChevronDown;
 	$: labelClasses = isCompactButton
 		? 'text-xs text-neutral-500 dark:text-neutral-400'
 		: 'text-sm text-neutral-500 dark:text-neutral-400';
@@ -112,7 +115,7 @@
 	>
 		<Button
 			text={currentLabel}
-			icon={ChevronDown}
+			icon={chevronIcon}
 			iconPosition="right"
 			leadingIcon={currentIcon}
 			size={resolvedButtonSize}
@@ -126,10 +129,12 @@
 			<Dropdown
 				{position}
 				{mobilePosition}
+				{placement}
 				{minWidth}
 				compact={isCompactDropdown}
 				{fixed}
 				{triggerEl}
+				on:placementchange={(e) => (resolvedPlacement = e.detail)}
 			>
 				{#each options as option}
 					<DropdownItem


### PR DESCRIPTION
Fixes #602

What:
- Adds automatic top/bottom placement to the shared dropdown primitive.
- Flips select and combobox chevrons when dropdowns open upward.

Why:
- Menus near the bottom of the viewport were opening downward and getting clipped.