### PR TITLE
feat: add optional Basic Auth support to Sonarr and Radarr

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,9 +128,9 @@ services:
 | `PROFILARR_BULLETIN_URL` | `https://raw.githubusercontent.com/Dictionarry-Hub/bulletin/main` | Override for the announcement feed + release manifest base URL                        |
 
 > [!NOTE]
-> When using OIDC `ORIGIN=` *must* be set to your Profilarr URL, and Profilarr
-> expects `{ORIGIN}/auth/oidc/callback` for the redirect URL 
-> (e.g. `https://profilarr.example.com/auth/oidc/callback`). Many 
+> When using OIDC `ORIGIN=` _must_ be set to your Profilarr URL, and Profilarr
+> expects `{ORIGIN}/auth/oidc/callback` for the redirect URL
+> (e.g. `https://profilarr.example.com/auth/oidc/callback`). Many
 > IdPs will infer this automatically.
 
 See the [documentation](https://dictionarry.dev/) for full setup and

--- a/docs/api/v1/paths/arr.yaml
+++ b/docs/api/v1/paths/arr.yaml
@@ -12,7 +12,7 @@ instances:
 
       **Behavior:**
       - Returns an empty array if no instances are connected
-      - The `api_key` field is never included
+      - The `api_key`, `basic_auth_username`, and `basic_auth_password` fields are never included
     tags:
       - Arr
     responses:

--- a/src/lib/api/v1.d.ts
+++ b/src/lib/api/v1.d.ts
@@ -22,7 +22,7 @@ export interface paths {
 		 *
 		 *     **Behavior:**
 		 *     - Returns an empty array if no instances are connected
-		 *     - The `api_key` field is never included
+		 *     - The `api_key`, `basic_auth_username`, and `basic_auth_password` fields are never included
 		 */
 		get: operations['listArrInstances'];
 		put?: never;

--- a/src/lib/api/v1.openapi.json
+++ b/src/lib/api/v1.openapi.json
@@ -58,7 +58,7 @@
 			"get": {
 				"operationId": "listArrInstances",
 				"summary": "List Arr Instances",
-				"description": "Returns all Arr instances (Radarr/Sonarr) with secrets stripped.\n\n**Use cases:**\n- Dashboard widgets showing connected instances\n- Automation scripts checking instance state\n- Prerequisite checks (e.g. onboarding)\n\n**Behavior:**\n- Returns an empty array if no instances are connected\n- The `api_key` field is never included\n",
+				"description": "Returns all Arr instances (Radarr/Sonarr) with secrets stripped.\n\n**Use cases:**\n- Dashboard widgets showing connected instances\n- Automation scripts checking instance state\n- Prerequisite checks (e.g. onboarding)\n\n**Behavior:**\n- Returns an empty array if no instances are connected\n- The `api_key`, `basic_auth_username`, and `basic_auth_password` fields are never included\n",
 				"tags": ["Arr"],
 				"responses": {
 					"200": {

--- a/src/lib/server/db/migrations.ts
+++ b/src/lib/server/db/migrations.ts
@@ -69,6 +69,7 @@ import { migration as migration064 } from './migrations/064_add_fail_on_referenc
 import { migration as migration065 } from './migrations/065_create_arr_drift_tables.ts';
 import { migration as migration066 } from './migrations/066_add_date_format_setting.ts';
 import { migration as migration067 } from './migrations/067_enable_all_arr_instances.ts';
+import { migration as migration068 } from './migrations/068_add_basic_auth_to_arr_instances.ts';
 
 export interface Migration {
 	version: number;
@@ -356,7 +357,8 @@ export function loadMigrations(): Migration[] {
 		migration064,
 		migration065,
 		migration066,
-		migration067
+		migration067,
+		migration068
 	];
 
 	// Sort by version number

--- a/src/lib/server/db/migrations/068_add_basic_auth_to_arr_instances.ts
+++ b/src/lib/server/db/migrations/068_add_basic_auth_to_arr_instances.ts
@@ -1,0 +1,20 @@
+import type { Migration } from '../migrations.ts';
+
+/**
+ * Migration 068: Add optional Basic Auth credentials to Arr instances
+ */
+
+export const migration: Migration = {
+	version: 68,
+	name: 'Add Basic Auth credentials to Arr instances',
+
+	up: `
+		ALTER TABLE arr_instances ADD COLUMN basic_auth_username TEXT;
+		ALTER TABLE arr_instances ADD COLUMN basic_auth_password TEXT;
+	`,
+
+	down: `
+		ALTER TABLE arr_instances DROP COLUMN basic_auth_username;
+		ALTER TABLE arr_instances DROP COLUMN basic_auth_password;
+	`
+};

--- a/src/lib/server/db/queries/arrInstances.ts
+++ b/src/lib/server/db/queries/arrInstances.ts
@@ -11,6 +11,8 @@ export interface ArrInstance {
 	url: string;
 	external_url: string | null;
 	api_key: string;
+	basic_auth_username: string | null;
+	basic_auth_password: string | null;
 	tags: string | null;
 	enabled: number;
 	library_refresh_interval: number;
@@ -19,7 +21,26 @@ export interface ArrInstance {
 	updated_at: string;
 }
 
-export type ArrInstancePublic = Omit<ArrInstance, 'api_key'>;
+export type ArrInstancePublic = Omit<
+	ArrInstance,
+	'api_key' | 'basic_auth_username' | 'basic_auth_password'
+>;
+
+export function toPublicArrInstance(instance: ArrInstance): ArrInstancePublic {
+	return {
+		id: instance.id,
+		name: instance.name,
+		type: instance.type,
+		url: instance.url,
+		external_url: instance.external_url,
+		tags: instance.tags,
+		enabled: instance.enabled,
+		library_refresh_interval: instance.library_refresh_interval,
+		library_last_refreshed_at: instance.library_last_refreshed_at,
+		created_at: instance.created_at,
+		updated_at: instance.updated_at
+	};
+}
 
 export interface CreateArrInstanceInput {
 	name: string;
@@ -27,6 +48,8 @@ export interface CreateArrInstanceInput {
 	url: string;
 	externalUrl?: string | null;
 	apiKey: string;
+	basicAuthUsername?: string | null;
+	basicAuthPassword?: string | null;
 	tags?: string[];
 }
 
@@ -36,6 +59,8 @@ export interface UpdateArrInstanceInput {
 	url?: string;
 	externalUrl?: string | null;
 	apiKey?: string;
+	basicAuthUsername?: string | null;
+	basicAuthPassword?: string | null;
 	tags?: string[];
 	libraryRefreshInterval?: number;
 }
@@ -51,13 +76,17 @@ export const arrInstancesQueries = {
 		const tagsJson = input.tags && input.tags.length > 0 ? JSON.stringify(input.tags) : null;
 
 		db.execute(
-			`INSERT INTO arr_instances (name, type, url, external_url, api_key, tags, enabled)
-       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			`INSERT INTO arr_instances (
+				name, type, url, external_url, api_key, basic_auth_username, basic_auth_password, tags, enabled
+			)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 			input.name,
 			input.type,
 			input.url,
 			input.externalUrl ?? null,
 			input.apiKey,
+			input.basicAuthUsername ?? null,
+			input.basicAuthPassword ?? null,
 			tagsJson,
 			1
 		);
@@ -123,6 +152,14 @@ export const arrInstancesQueries = {
 		if (input.apiKey !== undefined) {
 			updates.push('api_key = ?');
 			params.push(input.apiKey);
+		}
+		if (input.basicAuthUsername !== undefined) {
+			updates.push('basic_auth_username = ?');
+			params.push(input.basicAuthUsername);
+		}
+		if (input.basicAuthPassword !== undefined) {
+			updates.push('basic_auth_password = ?');
+			params.push(input.basicAuthPassword);
 		}
 		if (input.tags !== undefined) {
 			updates.push('tags = ?');

--- a/src/lib/server/db/schema.sql
+++ b/src/lib/server/db/schema.sql
@@ -18,7 +18,7 @@ CREATE TABLE IF NOT EXISTS migrations (
 -- ==============================================================================
 -- TABLE: arr_instances
 -- Purpose: Store configuration for *arr application instances (Radarr, Sonarr, etc.)
--- Migration: 001_create_arr_instances.ts, 053_add_library_refresh_to_arr_instances.ts, 059_add_external_url_to_arr_instances.ts, 067_enable_all_arr_instances.ts
+-- Migration: 001_create_arr_instances.ts, 053_add_library_refresh_to_arr_instances.ts, 059_add_external_url_to_arr_instances.ts, 067_enable_all_arr_instances.ts, 068_add_basic_auth_to_arr_instances.ts
 -- ==============================================================================
 
 CREATE TABLE arr_instances (
@@ -32,6 +32,8 @@ CREATE TABLE arr_instances (
     url TEXT NOT NULL,                      -- Base URL used by Profilarr's backend (e.g., "http://localhost:7878")
     external_url TEXT,                      -- Optional browser-facing URL for UI links (Migration 059); falls back to url when NULL
     api_key TEXT NOT NULL,                  -- API key for authentication
+    basic_auth_username TEXT,               -- Optional Basic Auth username for reverse proxies
+    basic_auth_password TEXT,               -- Optional Basic Auth password for reverse proxies
 
     -- Configuration
     tags TEXT,                              -- JSON array of tags (e.g., '["movies","4k"]')

--- a/src/lib/server/jobs/handlers/arrCleanup.ts
+++ b/src/lib/server/jobs/handlers/arrCleanup.ts
@@ -2,7 +2,7 @@ import { jobQueueRegistry } from '../queueRegistry.ts';
 import type { JobHandler } from '../queueTypes.ts';
 import { arrCleanupSettingsQueries } from '$db/queries/arrCleanupSettings.ts';
 import { arrInstancesQueries } from '$db/queries/arrInstances.ts';
-import { createArrClient } from '$utils/arr/factory.ts';
+import { arrClientOptionsFromInstance, createArrClient } from '$utils/arr/factory.ts';
 import type { ArrType } from '$utils/arr/types.ts';
 import {
 	scanForStaleItems,
@@ -73,9 +73,12 @@ const cleanupHandler: JobHandler = async (job) => {
 
 	const instanceType = instance.type as 'radarr' | 'sonarr';
 
-	const client = createArrClient(instance.type as ArrType, instance.url, instance.api_key, {
-		retries: 0
-	});
+	const client = createArrClient(
+		instance.type as ArrType,
+		instance.url,
+		instance.api_key,
+		arrClientOptionsFromInstance(instance, { retries: 0 })
+	);
 
 	try {
 		const preScanned = extractPreScanned(job.payload);

--- a/src/lib/server/jobs/handlers/arrDrift.ts
+++ b/src/lib/server/jobs/handlers/arrDrift.ts
@@ -5,7 +5,7 @@ import { arrDriftStatusQueries } from '$db/queries/arrDriftStatus.ts';
 import { arrInstancesQueries } from '$db/queries/arrInstances.ts';
 import { FEATURES } from '$shared/features.ts';
 import { calculateNextRun } from '../scheduleUtils.ts';
-import { createArrClient } from '$arr/factory.ts';
+import { arrClientOptionsFromInstance, createArrClient } from '$arr/factory.ts';
 import type { ArrType } from '$arr/types.ts';
 import { checkArrDrift } from '$drift/check.ts';
 import { buildDriftDisplayEntities } from '$drift/display.ts';
@@ -41,9 +41,12 @@ const driftHandler: JobHandler = async (job) => {
 	const nextRunAt = calculateNextRun(settings.cron);
 	if (nextRunAt) arrDriftSettingsQueries.updateNextRunAt(instanceId, nextRunAt);
 
-	const client = createArrClient(instance.type as ArrType, instance.url, instance.api_key, {
-		retries: 0
-	});
+	const client = createArrClient(
+		instance.type as ArrType,
+		instance.url,
+		instance.api_key,
+		arrClientOptionsFromInstance(instance, { retries: 0 })
+	);
 	const previousStatus = arrDriftStatusQueries.getByInstanceId(instanceId);
 
 	try {

--- a/src/lib/server/jobs/handlers/arrLibraryRefresh.ts
+++ b/src/lib/server/jobs/handlers/arrLibraryRefresh.ts
@@ -4,6 +4,7 @@ import { arrInstancesQueries } from '$db/queries/arrInstances.ts';
 import { cache } from '$cache/cache.ts';
 import { RadarrClient } from '$utils/arr/clients/radarr.ts';
 import { SonarrClient } from '$utils/arr/clients/sonarr.ts';
+import { arrClientOptionsFromInstance } from '$utils/arr/factory.ts';
 import { LIBRARY_REQUEST_TIMEOUT_MS } from '$utils/arr/base.ts';
 import { getProfilarrProfileNames } from '$lib/server/sync/libraryHelpers.ts';
 import { calculateNextRunFromMinutes } from '../scheduleUtils.ts';
@@ -51,7 +52,9 @@ const libraryRefreshHandler: JobHandler = async (job) => {
 	}
 
 	const profilarrProfileNames = await getProfilarrProfileNames();
-	const clientOptions = { timeout: LIBRARY_REQUEST_TIMEOUT_MS };
+	const clientOptions = arrClientOptionsFromInstance(instance, {
+		timeout: LIBRARY_REQUEST_TIMEOUT_MS
+	});
 	const client =
 		instance.type === 'radarr'
 			? new RadarrClient(instance.url, instance.api_key, clientOptions)

--- a/src/lib/server/jobs/handlers/arrSync.ts
+++ b/src/lib/server/jobs/handlers/arrSync.ts
@@ -3,7 +3,7 @@ import type { JobHandler, JobType } from '../queueTypes.ts';
 import { arrInstancesQueries } from '$db/queries/arrInstances.ts';
 import { arrSyncQueries } from '$db/queries/arrSync.ts';
 import { arrDriftSettingsQueries } from '$db/queries/arrDriftSettings.ts';
-import { createArrClient } from '$arr/factory.ts';
+import { arrClientOptionsFromInstance, createArrClient } from '$arr/factory.ts';
 import type { ArrType } from '$arr/types.ts';
 import { calculateNextRun } from '$lib/server/sync/utils.ts';
 import type { SectionType } from '$lib/server/sync/types.ts';
@@ -72,7 +72,12 @@ const arrSyncHandler: JobHandler = async (job) => {
 		return { status: 'skipped', output: 'No sync sections specified' };
 	}
 
-	const client = createArrClient(instance.type as ArrType, instance.url, instance.api_key);
+	const client = createArrClient(
+		instance.type as ArrType,
+		instance.url,
+		instance.api_key,
+		arrClientOptionsFromInstance(instance)
+	);
 	const results: string[] = [];
 	const sectionResults: ArrSyncSectionResult[] = [];
 	let failures = 0;

--- a/src/lib/server/rename/processor.ts
+++ b/src/lib/server/rename/processor.ts
@@ -8,7 +8,7 @@
  * This file wires it together with client creation, logging, and notifications.
  */
 
-import { createArrClient } from '$lib/server/utils/arr/factory.ts';
+import { arrClientOptionsFromInstance, createArrClient } from '$lib/server/utils/arr/factory.ts';
 import type { RadarrClient } from '$lib/server/utils/arr/clients/radarr.ts';
 import type { SonarrClient } from '$lib/server/utils/arr/clients/sonarr.ts';
 import type { RenameSettings } from '$db/queries/arrRenameSettings.ts';
@@ -254,7 +254,8 @@ export async function processRenameConfig(
 		const client = createArrClient(
 			instance.type as 'radarr' | 'sonarr',
 			instance.url,
-			instance.api_key
+			instance.api_key,
+			arrClientOptionsFromInstance(instance)
 		);
 
 		let adapter: RenameAdapter;

--- a/src/lib/server/sync/entitySync.ts
+++ b/src/lib/server/sync/entitySync.ts
@@ -5,7 +5,7 @@
 
 import { arrInstancesQueries } from '$db/queries/arrInstances.ts';
 import { arrSyncQueries } from '$db/queries/arrSync.ts';
-import { createArrClient } from '$utils/arr/factory.ts';
+import { arrClientOptionsFromInstance, createArrClient } from '$utils/arr/factory.ts';
 import { getCache } from '$pcd/index.ts';
 import { logger } from '$logger/logger.ts';
 import type { ArrType } from '$utils/arr/types.ts';
@@ -67,7 +67,12 @@ export async function syncQualityProfile(
 	if (!cache) return { success: false, error: `PCD cache not found for database ${databaseId}` };
 
 	const instanceType = instance.type as SyncArrType;
-	const client = createArrClient(instance.type as ArrType, instance.url, instance.api_key);
+	const client = createArrClient(
+		instance.type as ArrType,
+		instance.url,
+		instance.api_key,
+		arrClientOptionsFromInstance(instance)
+	);
 
 	try {
 		// Fetch the QP from PCD
@@ -157,7 +162,12 @@ export async function syncCustomFormat(
 	if (!cache) return { success: false, error: `PCD cache not found for database ${databaseId}` };
 
 	const instanceType = instance.type as SyncArrType;
-	const client = createArrClient(instance.type as ArrType, instance.url, instance.api_key);
+	const client = createArrClient(
+		instance.type as ArrType,
+		instance.url,
+		instance.api_key,
+		arrClientOptionsFromInstance(instance)
+	);
 
 	try {
 		const pcdFormat = await fetchCustomFormatFromPcd(cache, formatName);
@@ -216,7 +226,12 @@ export async function syncRegularExpression(
 	if (!cache) return { success: false, error: `PCD cache not found for database ${databaseId}` };
 
 	const instanceType = instance.type as SyncArrType;
-	const client = createArrClient(instance.type as ArrType, instance.url, instance.api_key);
+	const client = createArrClient(
+		instance.type as ArrType,
+		instance.url,
+		instance.api_key,
+		arrClientOptionsFromInstance(instance)
+	);
 
 	try {
 		// Find all CFs that use this regex
@@ -280,7 +295,12 @@ export async function syncDelayProfile(
 	const cache = getCache(databaseId);
 	if (!cache) return { success: false, error: `PCD cache not found for database ${databaseId}` };
 
-	const client = createArrClient(instance.type as ArrType, instance.url, instance.api_key);
+	const client = createArrClient(
+		instance.type as ArrType,
+		instance.url,
+		instance.api_key,
+		arrClientOptionsFromInstance(instance)
+	);
 
 	try {
 		const profile = await getDelayProfileByName(cache, profileName);
@@ -326,7 +346,12 @@ export async function syncNaming(
 	const cache = getCache(databaseId);
 	if (!cache) return { success: false, error: `PCD cache not found for database ${databaseId}` };
 
-	const client = createArrClient(instance.type as ArrType, instance.url, instance.api_key);
+	const client = createArrClient(
+		instance.type as ArrType,
+		instance.url,
+		instance.api_key,
+		arrClientOptionsFromInstance(instance)
+	);
 
 	try {
 		if (instance.type === 'radarr') {
@@ -387,7 +412,12 @@ export async function syncQualityDefinitions(
 	if (!cache) return { success: false, error: `PCD cache not found for database ${databaseId}` };
 
 	const instanceType = instance.type as SyncArrType;
-	const client = createArrClient(instance.type as ArrType, instance.url, instance.api_key);
+	const client = createArrClient(
+		instance.type as ArrType,
+		instance.url,
+		instance.api_key,
+		arrClientOptionsFromInstance(instance)
+	);
 
 	try {
 		const getByName = instanceType === 'radarr' ? getRadarrQualityDefs : getSonarrQualityDefs;
@@ -458,7 +488,12 @@ export async function syncMediaSettings(
 	const cache = getCache(databaseId);
 	if (!cache) return { success: false, error: `PCD cache not found for database ${databaseId}` };
 
-	const client = createArrClient(instance.type as ArrType, instance.url, instance.api_key);
+	const client = createArrClient(
+		instance.type as ArrType,
+		instance.url,
+		instance.api_key,
+		arrClientOptionsFromInstance(instance)
+	);
 
 	try {
 		const getByName = instance.type === 'radarr' ? getRadarrMediaSettings : getSonarrMediaSettings;

--- a/src/lib/server/sync/processor.ts
+++ b/src/lib/server/sync/processor.ts
@@ -10,7 +10,7 @@
 import { arrInstancesQueries, type ArrInstance } from '$db/queries/arrInstances.ts';
 import { arrSyncQueries } from '$db/queries/arrSync.ts';
 import { calculateNextRun } from './utils.ts';
-import { createArrClient } from '$arr/factory.ts';
+import { arrClientOptionsFromInstance, createArrClient } from '$arr/factory.ts';
 import type { ArrType } from '$arr/types.ts';
 import { logger } from '$logger/logger.ts';
 import { upsertScheduledJob } from '$lib/server/jobs/queueService.ts';
@@ -131,7 +131,12 @@ async function processInstanceSections(
 		instanceName: instance.name
 	};
 
-	const client = createArrClient(instance.type as ArrType, instance.url, instance.api_key);
+	const client = createArrClient(
+		instance.type as ArrType,
+		instance.url,
+		instance.api_key,
+		arrClientOptionsFromInstance(instance)
+	);
 
 	// Process sections sequentially (quality profiles depend on custom formats being synced first)
 	for (const sectionType of sectionTypes) {
@@ -280,7 +285,12 @@ export async function syncInstance(instanceId: number): Promise<InstanceSyncResu
 		meta: { instanceId }
 	});
 
-	const client = createArrClient(instance.type as ArrType, instance.url, instance.api_key);
+	const client = createArrClient(
+		instance.type as ArrType,
+		instance.url,
+		instance.api_key,
+		arrClientOptionsFromInstance(instance)
+	);
 	const result: InstanceSyncResult = {
 		instanceId,
 		instanceName: instance.name

--- a/src/lib/server/upgrades/dynamicOptions.ts
+++ b/src/lib/server/upgrades/dynamicOptions.ts
@@ -1,6 +1,7 @@
 import type { ArrInstance } from '$lib/server/db/queries/arrInstances.ts';
 import { RadarrClient } from '$lib/server/utils/arr/clients/radarr.ts';
 import { SonarrClient } from '$lib/server/utils/arr/clients/sonarr.ts';
+import { arrClientOptionsFromInstance } from '$lib/server/utils/arr/factory.ts';
 import type {
 	ArrCustomFormat,
 	ArrQualityProfile,
@@ -42,8 +43,8 @@ export async function loadDynamicFilterOptions(
 	const options = createEmptyDynamicFilterOptions(instance.type);
 	const isRadarr = instance.type === 'radarr';
 	const client = isRadarr
-		? new RadarrClient(instance.url, instance.api_key)
-		: new SonarrClient(instance.url, instance.api_key);
+		? new RadarrClient(instance.url, instance.api_key, arrClientOptionsFromInstance(instance))
+		: new SonarrClient(instance.url, instance.api_key, arrClientOptionsFromInstance(instance));
 
 	const [profiles, tags, libraryItems, customFormats] = await Promise.all([
 		loadOptional<ArrQualityProfile[]>(() => client.getQualityProfiles()),

--- a/src/lib/server/upgrades/processor.ts
+++ b/src/lib/server/upgrades/processor.ts
@@ -5,6 +5,7 @@
 
 import { RadarrClient } from '$lib/server/utils/arr/clients/radarr.ts';
 import { SonarrClient } from '$lib/server/utils/arr/clients/sonarr.ts';
+import { arrClientOptionsFromInstance } from '$lib/server/utils/arr/factory.ts';
 import type { ArrInstance } from '$lib/server/db/queries/arrInstances.ts';
 import type { UpgradeConfig, FilterConfig } from '$shared/upgrades/filters.ts';
 import { evaluateGroup } from '$shared/upgrades/filters.ts';
@@ -233,7 +234,7 @@ export async function processUpgradeConfig(
 
 	// Create client based on instance type
 	const isRadarr = instance.type === 'radarr';
-	const clientOpts = { timeout: 120000 };
+	const clientOpts = arrClientOptionsFromInstance(instance, { timeout: 120000 });
 	const client = isRadarr
 		? new RadarrClient(instance.url, instance.api_key, clientOpts)
 		: new SonarrClient(instance.url, instance.api_key, clientOpts);

--- a/src/lib/server/utils/arr/base.ts
+++ b/src/lib/server/utils/arr/base.ts
@@ -27,6 +27,8 @@ import { logger } from '$logger/logger.ts';
 export interface ArrClientOptions {
 	timeout?: number;
 	retries?: number;
+	basicAuthUsername?: string | null;
+	basicAuthPassword?: string | null;
 }
 
 export const INTERACTIVE_SEARCH_TIMEOUT_MS = 120000;
@@ -37,10 +39,17 @@ export class BaseArrClient extends BaseHttpClient {
 	protected apiVersion: string = 'v3'; // Default to v3, can be overridden by subclasses
 
 	constructor(url: string, apiKey: string, options?: ArrClientOptions) {
+		const headers: Record<string, string> = {
+			'X-Api-Key': apiKey
+		};
+		if (options?.basicAuthUsername) {
+			headers.Authorization = `Basic ${btoa(
+				`${options.basicAuthUsername}:${options.basicAuthPassword ?? ''}`
+			)}`;
+		}
+
 		super(url, {
-			headers: {
-				'X-Api-Key': apiKey
-			},
+			headers,
 			timeout: options?.timeout,
 			retries: options?.retries
 		});

--- a/src/lib/server/utils/arr/factory.ts
+++ b/src/lib/server/utils/arr/factory.ts
@@ -4,6 +4,7 @@ import { RadarrClient } from './clients/radarr.ts';
 import { SonarrClient } from './clients/sonarr.ts';
 import { LidarrClient } from './clients/lidarr.ts';
 import { ChaptarrClient } from './clients/chaptarr.ts';
+import type { ArrInstance } from '$db/queries/arrInstances.ts';
 
 /**
  * Factory function to create an arr client instance
@@ -31,4 +32,15 @@ export function createArrClient(
 		default:
 			throw new Error(`Unknown arr type: ${type}`);
 	}
+}
+
+export function arrClientOptionsFromInstance(
+	instance: Pick<ArrInstance, 'basic_auth_username' | 'basic_auth_password'>,
+	options?: ArrClientOptions
+): ArrClientOptions {
+	return {
+		...options,
+		basicAuthUsername: instance.basic_auth_username,
+		basicAuthPassword: instance.basic_auth_password
+	};
 }

--- a/src/routes/api/v1/arr/+server.ts
+++ b/src/routes/api/v1/arr/+server.ts
@@ -1,13 +1,11 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from '@sveltejs/kit';
 import type { components } from '$api/v1';
-import { arrInstancesQueries } from '$db/queries/arrInstances.ts';
+import { arrInstancesQueries, toPublicArrInstance } from '$db/queries/arrInstances.ts';
 
 type ArrInstance = components['schemas']['ArrInstance'];
 
 export const GET: RequestHandler = async () => {
-	const instances = arrInstancesQueries
-		.getAll()
-		.map(({ api_key, ...safe }) => safe) as ArrInstance[];
+	const instances = arrInstancesQueries.getAll().map(toPublicArrInstance) as ArrInstance[];
 	return json(instances);
 };

--- a/src/routes/arr/+page.server.ts
+++ b/src/routes/arr/+page.server.ts
@@ -1,6 +1,6 @@
 import { fail, redirect } from '@sveltejs/kit';
 import type { Actions, ServerLoad } from '@sveltejs/kit';
-import { arrInstancesQueries } from '$db/queries/arrInstances.ts';
+import { arrInstancesQueries, toPublicArrInstance } from '$db/queries/arrInstances.ts';
 import type { ArrInstancePublic } from '$db/queries/arrInstances.ts';
 import { arrSyncQueries } from '$db/queries/arrSync.ts';
 import { upgradeConfigsQueries } from '$db/queries/upgradeConfigs.ts';
@@ -33,7 +33,8 @@ function computeCompositeSyncStatus(statuses: string[]): CompositeSyncStatus {
 export const load: ServerLoad = () => {
 	const instances = arrInstancesQueries.getAll();
 
-	const summaries: ArrInstanceSummary[] = instances.map(({ api_key, ...safe }) => {
+	const summaries: ArrInstanceSummary[] = instances.map((instance) => {
+		const safe = toPublicArrInstance(instance);
 		const syncStatus = arrSyncQueries.getSyncConfigStatus(safe.id);
 		const qpSync = arrSyncQueries.getQualityProfilesSync(safe.id);
 		const dpSync = arrSyncQueries.getDelayProfilesSync(safe.id);

--- a/src/routes/arr/[id]/+layout.server.ts
+++ b/src/routes/arr/[id]/+layout.server.ts
@@ -1,6 +1,6 @@
 import { error } from '@sveltejs/kit';
 import type { LayoutServerLoad } from './$types';
-import { arrInstancesQueries } from '$db/queries/arrInstances.ts';
+import { arrInstancesQueries, toPublicArrInstance } from '$db/queries/arrInstances.ts';
 import { arrSyncQueries } from '$db/queries/arrSync.ts';
 import { arrDriftStatusQueries } from '$db/queries/arrDriftStatus.ts';
 
@@ -17,7 +17,7 @@ export const load: LayoutServerLoad = ({ params }) => {
 		error(404, `Instance not found: ${id}`);
 	}
 
-	const { api_key, ...safe } = instance;
+	const safe = toPublicArrInstance(instance);
 
 	const sync = arrSyncQueries.getFullSyncData(id);
 	const hasSyncConfig =

--- a/src/routes/arr/[id]/drift/+page.server.ts
+++ b/src/routes/arr/[id]/drift/+page.server.ts
@@ -2,7 +2,7 @@ import { error, fail } from '@sveltejs/kit';
 import type { Actions, ServerLoad } from '@sveltejs/kit';
 import { arrDriftSettingsQueries } from '$db/queries/arrDriftSettings.ts';
 import { arrDriftStatusQueries } from '$db/queries/arrDriftStatus.ts';
-import { arrInstancesQueries } from '$db/queries/arrInstances.ts';
+import { arrInstancesQueries, toPublicArrInstance } from '$db/queries/arrInstances.ts';
 import { logger } from '$logger/logger.ts';
 import { scheduleDriftForInstance } from '$lib/server/jobs/init.ts';
 import { enqueueJob } from '$lib/server/jobs/queueService.ts';
@@ -25,7 +25,7 @@ export const load: ServerLoad = ({ params }) => {
 
 	const driftSettings = arrDriftSettingsQueries.getByInstanceId(id);
 	const driftStatus = arrDriftStatusQueries.getByInstanceId(id);
-	const { api_key: _, ...safeInstance } = instance;
+	const safeInstance = toPublicArrInstance(instance);
 	const diff = driftStatus?.diff ?? {};
 
 	return {

--- a/src/routes/arr/[id]/library/movies/+server.ts
+++ b/src/routes/arr/[id]/library/movies/+server.ts
@@ -3,6 +3,7 @@ import type { RequestHandler } from '@sveltejs/kit';
 import { arrInstancesQueries } from '$db/queries/arrInstances.ts';
 import { cache } from '$cache/cache.ts';
 import { RadarrClient } from '$utils/arr/clients/radarr.ts';
+import { arrClientOptionsFromInstance } from '$utils/arr/factory.ts';
 import { LIBRARY_REQUEST_TIMEOUT_MS } from '$utils/arr/base.ts';
 import type { RadarrLibraryItem } from '$utils/arr/types.ts';
 import { getProfilarrProfileNames } from '$lib/server/sync/libraryHelpers.ts';
@@ -36,9 +37,13 @@ export const GET: RequestHandler = async ({ params }) => {
 			: MANUAL_CACHE_TTL;
 
 	const profilarrProfileNames = await getProfilarrProfileNames();
-	const client = new RadarrClient(instance.url, instance.api_key, {
-		timeout: LIBRARY_REQUEST_TIMEOUT_MS
-	});
+	const client = new RadarrClient(
+		instance.url,
+		instance.api_key,
+		arrClientOptionsFromInstance(instance, {
+			timeout: LIBRARY_REQUEST_TIMEOUT_MS
+		})
+	);
 	try {
 		const items = await client.getLibrary(profilarrProfileNames);
 		cache.set(cacheKey, items, ttl);

--- a/src/routes/arr/[id]/library/movies/[movieId]/releases/+server.ts
+++ b/src/routes/arr/[id]/library/movies/[movieId]/releases/+server.ts
@@ -2,6 +2,7 @@ import { json } from '@sveltejs/kit';
 import type { RequestHandler } from '@sveltejs/kit';
 import { arrInstancesQueries } from '$db/queries/arrInstances.ts';
 import { RadarrClient } from '$utils/arr/clients/radarr.ts';
+import { arrClientOptionsFromInstance } from '$utils/arr/factory.ts';
 import { groupRadarrReleases } from '$utils/arr/releaseImport.ts';
 import { logger } from '$logger/logger.ts';
 
@@ -25,7 +26,11 @@ export const GET: RequestHandler = async ({ params }) => {
 		);
 	}
 
-	const client = new RadarrClient(instance.url, instance.api_key);
+	const client = new RadarrClient(
+		instance.url,
+		instance.api_key,
+		arrClientOptionsFromInstance(instance)
+	);
 	try {
 		const releases = await client.getReleases(movieId);
 		const grouped = groupRadarrReleases(releases);

--- a/src/routes/arr/[id]/library/series/+server.ts
+++ b/src/routes/arr/[id]/library/series/+server.ts
@@ -3,6 +3,7 @@ import type { RequestHandler } from '@sveltejs/kit';
 import { arrInstancesQueries } from '$db/queries/arrInstances.ts';
 import { cache } from '$cache/cache.ts';
 import { SonarrClient } from '$utils/arr/clients/sonarr.ts';
+import { arrClientOptionsFromInstance } from '$utils/arr/factory.ts';
 import { LIBRARY_REQUEST_TIMEOUT_MS } from '$utils/arr/base.ts';
 import type { SonarrLibraryItem, SonarrSeriesItem } from '$utils/arr/types.ts';
 import { getProfilarrProfileNames } from '$lib/server/sync/libraryHelpers.ts';
@@ -40,9 +41,13 @@ export const GET: RequestHandler = async ({ params }) => {
 			: MANUAL_CACHE_TTL;
 
 	const profilarrProfileNames = await getProfilarrProfileNames();
-	const client = new SonarrClient(instance.url, instance.api_key, {
-		timeout: LIBRARY_REQUEST_TIMEOUT_MS
-	});
+	const client = new SonarrClient(
+		instance.url,
+		instance.api_key,
+		arrClientOptionsFromInstance(instance, {
+			timeout: LIBRARY_REQUEST_TIMEOUT_MS
+		})
+	);
 	try {
 		const items = await client.getLibrary(profilarrProfileNames);
 		cache.set(cacheKey, items, ttl);

--- a/src/routes/arr/[id]/library/series/[seriesId]/seasons/+server.ts
+++ b/src/routes/arr/[id]/library/series/[seriesId]/seasons/+server.ts
@@ -3,6 +3,7 @@ import type { RequestHandler } from '@sveltejs/kit';
 import { arrInstancesQueries } from '$db/queries/arrInstances.ts';
 import { cache } from '$cache/cache.ts';
 import { SonarrClient } from '$utils/arr/clients/sonarr.ts';
+import { arrClientOptionsFromInstance } from '$utils/arr/factory.ts';
 import type { SonarrLibraryItem } from '$utils/arr/types.ts';
 import { getProfilarrProfileNames } from '$lib/server/sync/libraryHelpers.ts';
 import { logger } from '$logger/logger.ts';
@@ -23,7 +24,11 @@ async function getLibraryCached(instanceId: number): Promise<SonarrLibraryItem[]
 			: MANUAL_CACHE_TTL;
 
 	const profilarrProfileNames = await getProfilarrProfileNames();
-	const client = new SonarrClient(instance.url, instance.api_key);
+	const client = new SonarrClient(
+		instance.url,
+		instance.api_key,
+		arrClientOptionsFromInstance(instance)
+	);
 	try {
 		const items = await client.getLibrary(profilarrProfileNames);
 		cache.set(cacheKey, items, ttl);

--- a/src/routes/arr/[id]/library/series/[seriesId]/seasons/[seasonNumber]/episodes/+server.ts
+++ b/src/routes/arr/[id]/library/series/[seriesId]/seasons/[seasonNumber]/episodes/+server.ts
@@ -3,20 +3,29 @@ import type { RequestHandler } from '@sveltejs/kit';
 import { arrInstancesQueries } from '$db/queries/arrInstances.ts';
 import { cache } from '$cache/cache.ts';
 import { SonarrClient } from '$utils/arr/clients/sonarr.ts';
+import { arrClientOptionsFromInstance } from '$utils/arr/factory.ts';
+import type { ArrInstance } from '$db/queries/arrInstances.ts';
 import type { SonarrEpisodeItem } from '$utils/arr/types.ts';
 import { logger } from '$logger/logger.ts';
 
 const EPISODE_CACHE_TTL = 300;
 
 async function getSeriesEpisodesCached(
-	instance: { id: number; url: string; api_key: string },
+	instance: Pick<
+		ArrInstance,
+		'id' | 'url' | 'api_key' | 'basic_auth_username' | 'basic_auth_password'
+	>,
 	seriesId: number
 ): Promise<SonarrEpisodeItem[]> {
 	const cacheKey = `library-episodes:${instance.id}:${seriesId}`;
 	const cached = cache.get<SonarrEpisodeItem[]>(cacheKey);
 	if (cached) return cached;
 
-	const client = new SonarrClient(instance.url, instance.api_key);
+	const client = new SonarrClient(
+		instance.url,
+		instance.api_key,
+		arrClientOptionsFromInstance(instance)
+	);
 	try {
 		const profiles = await client.getQualityProfiles();
 		const series = await client.getSeries(seriesId);

--- a/src/routes/arr/[id]/library/series/[seriesId]/seasons/[seasonNumber]/releases/+server.ts
+++ b/src/routes/arr/[id]/library/series/[seriesId]/seasons/[seasonNumber]/releases/+server.ts
@@ -2,6 +2,7 @@ import { json } from '@sveltejs/kit';
 import type { RequestHandler } from '@sveltejs/kit';
 import { arrInstancesQueries } from '$db/queries/arrInstances.ts';
 import { SonarrClient } from '$utils/arr/clients/sonarr.ts';
+import { arrClientOptionsFromInstance } from '$utils/arr/factory.ts';
 import { groupSonarrReleases } from '$utils/arr/releaseImport.ts';
 import { logger } from '$logger/logger.ts';
 
@@ -28,7 +29,11 @@ export const GET: RequestHandler = async ({ params }) => {
 		);
 	}
 
-	const client = new SonarrClient(instance.url, instance.api_key);
+	const client = new SonarrClient(
+		instance.url,
+		instance.api_key,
+		arrClientOptionsFromInstance(instance)
+	);
 	try {
 		const releases = await client.getSeasonPackReleases(seriesId, seasonNumber);
 		const grouped = groupSonarrReleases(releases);

--- a/src/routes/arr/[id]/logs/+page.server.ts
+++ b/src/routes/arr/[id]/logs/+page.server.ts
@@ -1,7 +1,7 @@
 import { error } from '@sveltejs/kit';
 import type { ServerLoad } from '@sveltejs/kit';
-import { arrInstancesQueries } from '$db/queries/arrInstances.ts';
-import { createArrClient } from '$arr/factory.ts';
+import { arrInstancesQueries, toPublicArrInstance } from '$db/queries/arrInstances.ts';
+import { arrClientOptionsFromInstance, createArrClient } from '$arr/factory.ts';
 import type { ArrType } from '$arr/types.ts';
 
 export const load: ServerLoad = async ({ params, url }) => {
@@ -22,7 +22,12 @@ export const load: ServerLoad = async ({ params, url }) => {
 	const pageSize = parseInt(url.searchParams.get('pageSize') || '50', 10);
 	const level = url.searchParams.get('level') || undefined;
 
-	const client = createArrClient(instance.type as ArrType, instance.url, instance.api_key);
+	const client = createArrClient(
+		instance.type as ArrType,
+		instance.url,
+		instance.api_key,
+		arrClientOptionsFromInstance(instance)
+	);
 
 	try {
 		const logs = await client.getLogs({
@@ -33,7 +38,7 @@ export const load: ServerLoad = async ({ params, url }) => {
 			level: level as 'Trace' | 'Debug' | 'Info' | 'Warn' | 'Error' | 'Fatal' | undefined
 		});
 
-		const { api_key: _, ...safeInstance } = instance;
+		const safeInstance = toPublicArrInstance(instance);
 
 		return {
 			instance: safeInstance,

--- a/src/routes/arr/[id]/rename/+page.server.ts
+++ b/src/routes/arr/[id]/rename/+page.server.ts
@@ -1,6 +1,6 @@
 import { error, fail } from '@sveltejs/kit';
 import type { Actions, ServerLoad } from '@sveltejs/kit';
-import { arrInstancesQueries } from '$db/queries/arrInstances.ts';
+import { arrInstancesQueries, toPublicArrInstance } from '$db/queries/arrInstances.ts';
 import { arrRenameSettingsQueries } from '$db/queries/arrRenameSettings.ts';
 import { renameRunsQueries } from '$db/queries/renameRuns.ts';
 import { logger } from '$logger/logger.ts';
@@ -25,7 +25,7 @@ export const load: ServerLoad = ({ params }) => {
 	const settings = arrRenameSettingsQueries.getByInstanceId(id);
 	const renameRuns = renameRunsQueries.getByInstanceId(id);
 
-	const { api_key: _, ...safeInstance } = instance;
+	const safeInstance = toPublicArrInstance(instance);
 
 	return {
 		instance: safeInstance,

--- a/src/routes/arr/[id]/settings/+page.server.ts
+++ b/src/routes/arr/[id]/settings/+page.server.ts
@@ -39,6 +39,24 @@ export const actions: Actions = {
 		const externalUrlRaw = formData.get('external_url')?.toString().trim() ?? '';
 		const externalUrl = externalUrlRaw === '' ? null : externalUrlRaw;
 		const apiKey = formData.get('api_key')?.toString().trim() || instance.api_key;
+		const basicAuthUsernameRaw = formData.get('basic_auth_username')?.toString().trim();
+		const basicAuthPasswordRaw = formData.get('basic_auth_password')?.toString();
+		const basicAuthUsernameTouched =
+			formData.get('basic_auth_username_touched')?.toString() === '1';
+		const basicAuthPasswordTouched =
+			formData.get('basic_auth_password_touched')?.toString() === '1';
+		const basicAuthUsername =
+			basicAuthUsernameTouched && basicAuthUsernameRaw !== undefined
+				? basicAuthUsernameRaw === ''
+					? null
+					: basicAuthUsernameRaw
+				: instance.basic_auth_username;
+		const basicAuthPassword =
+			basicAuthPasswordTouched && basicAuthPasswordRaw !== undefined
+				? basicAuthPasswordRaw === ''
+					? null
+					: basicAuthPasswordRaw
+				: instance.basic_auth_password;
 		const tagsJson = formData.get('tags')?.toString() || '';
 		const libraryRefreshInterval =
 			parseInt(formData.get('library_refresh_interval')?.toString() || '0', 10) || 0;
@@ -78,6 +96,8 @@ export const actions: Actions = {
 				url,
 				externalUrl,
 				apiKey,
+				basicAuthUsername,
+				basicAuthPassword,
 				tags,
 				libraryRefreshInterval
 			});

--- a/src/routes/arr/[id]/settings/cleanup/preview/+server.ts
+++ b/src/routes/arr/[id]/settings/cleanup/preview/+server.ts
@@ -1,7 +1,7 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from '@sveltejs/kit';
 import { arrInstancesQueries } from '$db/queries/arrInstances.ts';
-import { createArrClient } from '$utils/arr/factory.ts';
+import { arrClientOptionsFromInstance, createArrClient } from '$utils/arr/factory.ts';
 import { scanForStaleItems, type CleanupScanResult } from '$lib/server/sync/cleanup.ts';
 import { scanForRemovedEntities, type EntityScanResult } from '$lib/server/sync/entityCleanup.ts';
 import type { ArrType } from '$utils/arr/types.ts';
@@ -39,9 +39,12 @@ export const GET: RequestHandler = async ({ params }) => {
 	}
 
 	const instanceType = instance.type as 'radarr' | 'sonarr';
-	const client = createArrClient(instance.type as ArrType, instance.url, instance.api_key, {
-		retries: 0
-	});
+	const client = createArrClient(
+		instance.type as ArrType,
+		instance.url,
+		instance.api_key,
+		arrClientOptionsFromInstance(instance, { retries: 0 })
+	);
 
 	try {
 		const [configs, entities] = await Promise.all([

--- a/src/routes/arr/[id]/sync/+page.server.ts
+++ b/src/routes/arr/[id]/sync/+page.server.ts
@@ -1,6 +1,6 @@
 import { error, fail } from '@sveltejs/kit';
 import type { ServerLoad, Actions } from '@sveltejs/kit';
-import { arrInstancesQueries } from '$db/queries/arrInstances.ts';
+import { arrInstancesQueries, toPublicArrInstance } from '$db/queries/arrInstances.ts';
 import { arrSyncQueries, type SyncTrigger, type ProfileSelection } from '$db/queries/arrSync.ts';
 import { arrDriftStatusQueries } from '$db/queries/arrDriftStatus.ts';
 import { arrDriftSettingsQueries } from '$db/queries/arrDriftSettings.ts';
@@ -306,7 +306,7 @@ export const load: ServerLoad = async ({ params }) => {
 	const syncData = arrSyncQueries.getFullSyncData(id);
 	const driftProgress = await loadDriftProgress(id, arrType);
 
-	const { api_key: _, ...safeInstance } = instance;
+	const safeInstance = toPublicArrInstance(instance);
 
 	return {
 		instance: safeInstance,

--- a/src/routes/arr/[id]/upgrades/+page.server.ts
+++ b/src/routes/arr/[id]/upgrades/+page.server.ts
@@ -1,6 +1,6 @@
 import { error, fail } from '@sveltejs/kit';
 import type { Actions, ServerLoad } from '@sveltejs/kit';
-import { arrInstancesQueries } from '$db/queries/arrInstances.ts';
+import { arrInstancesQueries, toPublicArrInstance } from '$db/queries/arrInstances.ts';
 import { upgradeConfigsQueries } from '$db/queries/upgradeConfigs.ts';
 import { upgradeRunsQueries } from '$db/queries/upgradeRuns.ts';
 import { logger } from '$logger/logger.ts';
@@ -37,7 +37,7 @@ export const load: ServerLoad = async ({ params }) => {
 	const upgradeRuns = upgradeRunsQueries.getByInstanceId(id);
 	const dynamicFilterOptions = loadDynamicFilterOptions(instance);
 
-	const { api_key: _, ...safeInstance } = instance;
+	const safeInstance = toPublicArrInstance(instance);
 
 	return {
 		instance: safeInstance,

--- a/src/routes/arr/components/InstanceForm.svelte
+++ b/src/routes/arr/components/InstanceForm.svelte
@@ -47,6 +47,8 @@
 				url: instance.url,
 				externalUrl: instance.external_url ?? '',
 				apiKey: '', // Never pre-populate for security
+				basicAuthUsername: '',
+				basicAuthPassword: '',
 				tags: JSON.stringify(parseTags(instance.tags)),
 				libraryRefreshInterval: String(instance.library_refresh_interval ?? 0),
 				cleanupEnabled: cleanupSettings?.enabled ?? false,
@@ -59,6 +61,8 @@
 				url: '',
 				externalUrl: '',
 				apiKey: '',
+				basicAuthUsername: '',
+				basicAuthPassword: '',
 				tags: '[]',
 				libraryRefreshInterval: '0',
 				cleanupEnabled: false,
@@ -74,6 +78,8 @@
 	$: url = ($current.url ?? '') as string;
 	$: externalUrl = ($current.externalUrl ?? '') as string;
 	$: apiKey = ($current.apiKey ?? '') as string;
+	$: basicAuthUsername = ($current.basicAuthUsername ?? '') as string;
+	$: basicAuthPassword = ($current.basicAuthPassword ?? '') as string;
 	$: tags = JSON.parse(($current.tags ?? '[]') as string) as string[];
 	$: libraryRefreshInterval = ($current.libraryRefreshInterval ?? '0') as string;
 	$: cleanupEnabled = ($current.cleanupEnabled ?? false) as boolean;
@@ -92,6 +98,8 @@
 	let deleting = false;
 	let showDeleteModal = false;
 	let showCleanupModal = false;
+	let basicAuthUsernameTouched = false;
+	let basicAuthPasswordTouched = false;
 
 	// Options for dropdowns
 	const typeOptions = [
@@ -122,7 +130,13 @@
 			const response = await fetch('/arr/validate', {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({ type, url, apiKey })
+				body: JSON.stringify({
+					type,
+					url,
+					apiKey,
+					basicAuthUsername,
+					basicAuthPassword
+				})
 			});
 
 			const result = await response.json();
@@ -159,7 +173,13 @@
 				const response = await fetch('/arr/validate', {
 					method: 'POST',
 					headers: { 'Content-Type': 'application/json' },
-					body: JSON.stringify({ type, url, apiKey })
+					body: JSON.stringify({
+						type,
+						url,
+						apiKey,
+						basicAuthUsername,
+						basicAuthPassword
+					})
 				});
 
 				const result = await response.json();
@@ -195,11 +215,15 @@
 				url,
 				externalUrl,
 				apiKey: '',
+				basicAuthUsername: '',
+				basicAuthPassword: '',
 				tags: JSON.stringify(tags),
 				libraryRefreshInterval,
 				cleanupEnabled,
 				cleanupCron
 			});
+			basicAuthUsernameTouched = false;
+			basicAuthPasswordTouched = false;
 		}
 		if (form.error) {
 			alertStore.add('error', form.error);
@@ -370,6 +394,35 @@
 					on:click={testConnection}
 				/>
 			</div>
+			<div class="space-y-2">
+				<p class="text-xs text-neutral-600 dark:text-neutral-400">
+					Optional. Use when a reverse proxy protects this Arr instance with Basic Auth.
+					{#if mode === 'edit'}Leave blank to keep existing credentials.{/if}
+				</p>
+				<div class="grid gap-4 md:grid-cols-2">
+					<FormInput
+						label="Basic Auth Username"
+						name="basic_auth_username"
+						value={basicAuthUsername}
+						placeholder={mode === 'edit' ? 'Leave blank to keep existing username' : 'Optional'}
+						on:input={(e) => {
+							basicAuthUsernameTouched = true;
+							update('basicAuthUsername', e.detail);
+						}}
+					/>
+					<FormInput
+						label="Basic Auth Password"
+						name="basic_auth_password"
+						value={basicAuthPassword}
+						placeholder={mode === 'edit' ? '••••••••••••••••' : 'Optional'}
+						private_
+						on:input={(e) => {
+							basicAuthPasswordTouched = true;
+							update('basicAuthPassword', e.detail);
+						}}
+					/>
+				</div>
+			</div>
 		</div>
 		<!-- Tags Row -->
 		<div class="space-y-2">
@@ -507,6 +560,18 @@
 	<input type="hidden" name="url" value={url} />
 	<input type="hidden" name="external_url" value={externalUrl} />
 	<input type="hidden" name="api_key" value={apiKey} />
+	<input type="hidden" name="basic_auth_username" value={basicAuthUsername} />
+	<input type="hidden" name="basic_auth_password" value={basicAuthPassword} />
+	<input
+		type="hidden"
+		name="basic_auth_username_touched"
+		value={basicAuthUsernameTouched ? '1' : '0'}
+	/>
+	<input
+		type="hidden"
+		name="basic_auth_password_touched"
+		value={basicAuthPasswordTouched ? '1' : '0'}
+	/>
 	<input type="hidden" name="tags" value={JSON.stringify(tags)} />
 	<input type="hidden" name="library_refresh_interval" value={libraryRefreshInterval} />
 </form>

--- a/src/routes/arr/new/+page.server.ts
+++ b/src/routes/arr/new/+page.server.ts
@@ -19,6 +19,10 @@ export const actions = {
 		const externalUrlRaw = formData.get('external_url')?.toString().trim() ?? '';
 		const externalUrl = externalUrlRaw === '' ? null : externalUrlRaw;
 		const apiKey = formData.get('api_key')?.toString().trim();
+		const basicAuthUsernameRaw = formData.get('basic_auth_username')?.toString().trim() ?? '';
+		const basicAuthPasswordRaw = formData.get('basic_auth_password')?.toString() ?? '';
+		const basicAuthUsername = basicAuthUsernameRaw === '' ? null : basicAuthUsernameRaw;
+		const basicAuthPassword = basicAuthPasswordRaw === '' ? null : basicAuthPasswordRaw;
 		const tagsJson = formData.get('tags')?.toString().trim();
 
 		// Validation
@@ -97,6 +101,8 @@ export const actions = {
 				url,
 				externalUrl,
 				apiKey,
+				basicAuthUsername,
+				basicAuthPassword,
 				tags
 			});
 
@@ -111,7 +117,10 @@ export const actions = {
 				generalSettingsQueries.shouldApplyDefaultDelayProfiles()
 			) {
 				try {
-					const client = createArrClient(type as ArrType, url, apiKey);
+					const client = createArrClient(type as ArrType, url, apiKey, {
+						basicAuthUsername,
+						basicAuthPassword
+					});
 					const defaultProfile = getDefaultDelayProfile(type);
 
 					// Update the default delay profile (id=1)

--- a/src/routes/arr/validate/+server.ts
+++ b/src/routes/arr/validate/+server.ts
@@ -7,7 +7,7 @@ const VALID_TYPES = ['radarr', 'sonarr'];
 
 export const POST: RequestHandler = async ({ request }) => {
 	try {
-		const { type, url, apiKey } = await request.json();
+		const { type, url, apiKey, basicAuthUsername, basicAuthPassword } = await request.json();
 
 		// Validation
 		if (!type || !url || !apiKey) {
@@ -19,7 +19,12 @@ export const POST: RequestHandler = async ({ request }) => {
 		}
 
 		// Create client and test connection (3 second timeout, no retries for quick feedback)
-		const client = createArrClient(type as ArrType, url, apiKey, { timeout: 3000, retries: 0 });
+		const client = createArrClient(type as ArrType, url, apiKey, {
+			timeout: 3000,
+			retries: 0,
+			basicAuthUsername,
+			basicAuthPassword
+		});
 		const isConnected = await client.testConnection();
 		client.close();
 

--- a/tests/integration/api/specs/arr.test.ts
+++ b/tests/integration/api/specs/arr.test.ts
@@ -5,7 +5,7 @@
  * 1. Returns 401 without auth
  * 2. Returns 200 with empty array when no instances exist
  * 3. Returns populated array after seeding an instance
- * 4. Response does not contain api_key
+ * 4. Response does not contain stored credentials
  */
 
 import { assertEquals, assertExists } from '@std/assert';
@@ -26,8 +26,18 @@ function seedArrInstance(dbPath: string): void {
 	const db = openDb(dbPath);
 	try {
 		db.exec(
-			`INSERT INTO arr_instances (name, type, url, api_key, enabled)
-			 VALUES ('Test Radarr', 'radarr', 'http://localhost:7878', 'secret-arr-api-key', 1)`
+			`INSERT INTO arr_instances (
+				name, type, url, api_key, basic_auth_username, basic_auth_password, enabled
+			)
+			 VALUES (
+				'Test Radarr',
+				'radarr',
+				'http://localhost:7878',
+				'secret-arr-api-key',
+				'proxy-user',
+				'proxy-pass',
+				1
+			)`
 		);
 	} finally {
 		db.close();
@@ -76,13 +86,15 @@ test('GET /api/v1/arr returns seeded instance', async () => {
 	assertExists(body[0].enabled);
 });
 
-test('response does not contain api_key', async () => {
+test('response does not contain stored credentials', async () => {
 	const res = await client.get('/api/v1/arr', {
 		headers: { 'X-Api-Key': API_KEY }
 	});
 	const body = await res.json();
 	assertEquals(body.length, 1);
 	assertEquals(body[0].api_key, undefined);
+	assertEquals(body[0].basic_auth_username, undefined);
+	assertEquals(body[0].basic_auth_password, undefined);
 });
 
 await run();

--- a/tests/integration/auth/specs/secretExposure.test.ts
+++ b/tests/integration/auth/specs/secretExposure.test.ts
@@ -25,10 +25,10 @@
  *   delay-profiles, regular-expressions, media-management, arr/[id]/sync)
  *
  * Tests:
- * 1. /arr list does not expose arr API keys
- * 2. /arr/[id]/upgrades does not expose arr API key
- * 3. /arr/[id]/rename does not expose arr API key
- * 4. /arr/[id]/sync does not expose arr API key
+ * 1. /arr list does not expose arr credentials
+ * 2. /arr/[id]/upgrades does not expose arr credentials
+ * 3. /arr/[id]/rename does not expose arr credentials
+ * 4. /arr/[id]/sync does not expose arr credentials
  * 5. /databases list does not expose PATs
  * 6. /databases/[id]/tweaks does not expose PAT
  * 7. /quality-profiles/[databaseId] list does not expose PATs
@@ -57,6 +57,8 @@ const ORIGIN = `http://localhost:${PORT}`;
 
 // Known secrets — we insert these and check they don't appear in responses
 const ARR_API_KEY = 'sonarr-secret-key-abc123def456';
+const ARR_BASIC_AUTH_USERNAME = 'arr-basic-auth-user';
+const ARR_BASIC_AUTH_PASSWORD = 'arr-basic-auth-pass';
 const DB_PAT = 'ghp-secret-pat-token-uvw567xyz890';
 const TMDB_API_KEY = 'tmdb-secret-key-xyz789ghi012';
 const AI_API_KEY = 'sk-ai-secret-key-jkl345mno678';
@@ -71,11 +73,13 @@ let notificationServiceId: string;
 async function seedSecrets(dbPath: string) {
 	const db = openDb(dbPath);
 	try {
-		// Arr instance with known API key
+		// Arr instance with known credentials
 		db.exec(
-			`INSERT INTO arr_instances (name, type, url, api_key, enabled)
-			 VALUES ('Test Sonarr', 'sonarr', 'http://localhost:8989', ?, 1)`,
-			[ARR_API_KEY]
+			`INSERT INTO arr_instances (
+				name, type, url, api_key, basic_auth_username, basic_auth_password, enabled
+			)
+			 VALUES ('Test Sonarr', 'sonarr', 'http://localhost:8989', ?, ?, ?, 1)`,
+			[ARR_API_KEY, ARR_BASIC_AUTH_USERNAME, ARR_BASIC_AUTH_PASSWORD]
 		);
 		const arrRow = db.prepare('SELECT id FROM arr_instances WHERE name = ?').get('Test Sonarr') as {
 			id: number;
@@ -159,26 +163,32 @@ teardown(async () => {
 	await stopServer(PORT);
 });
 
-// --- Arr API keys ---
+// --- Arr credentials ---
 
-test('/arr list does not expose arr API keys', async () => {
+function assertArrCredentialsNotExposed(body: string) {
+	assertNotExposed(body, ARR_API_KEY, 'arr API key');
+	assertNotExposed(body, ARR_BASIC_AUTH_USERNAME, 'arr Basic Auth username');
+	assertNotExposed(body, ARR_BASIC_AUTH_PASSWORD, 'arr Basic Auth password');
+}
+
+test('/arr list does not expose arr credentials', async () => {
 	const body = await fetchPage('/arr');
-	assertNotExposed(body, ARR_API_KEY, 'arr API key');
+	assertArrCredentialsNotExposed(body);
 });
 
-test('/arr/[id]/upgrades does not expose arr API key', async () => {
+test('/arr/[id]/upgrades does not expose arr credentials', async () => {
 	const body = await fetchPage(`/arr/${arrInstanceId}/upgrades`);
-	assertNotExposed(body, ARR_API_KEY, 'arr API key');
+	assertArrCredentialsNotExposed(body);
 });
 
-test('/arr/[id]/rename does not expose arr API key', async () => {
+test('/arr/[id]/rename does not expose arr credentials', async () => {
 	const body = await fetchPage(`/arr/${arrInstanceId}/rename`);
-	assertNotExposed(body, ARR_API_KEY, 'arr API key');
+	assertArrCredentialsNotExposed(body);
 });
 
-test('/arr/[id]/sync does not expose arr API key', async () => {
+test('/arr/[id]/sync does not expose arr credentials', async () => {
 	const body = await fetchPage(`/arr/${arrInstanceId}/sync`);
-	assertNotExposed(body, ARR_API_KEY, 'arr API key');
+	assertArrCredentialsNotExposed(body);
 });
 
 // --- Database PATs ---

--- a/tests/unit/rename/processor.test.ts
+++ b/tests/unit/rename/processor.test.ts
@@ -177,6 +177,8 @@ function makeInstance(overrides: Partial<ArrInstance> = {}): ArrInstance {
 		url: 'http://localhost:7878',
 		external_url: null,
 		api_key: 'test-key',
+		basic_auth_username: null,
+		basic_auth_password: null,
 		tags: null,
 		enabled: 1,
 		library_refresh_interval: 60,


### PR DESCRIPTION
What:
* Add optional Basic Auth support to Sonarr and Radarr

Why:
It's common to run ARRs behind reverse proxies with Basic Auth. If Profilarr and ARRs are on different servers then Profilarr needs to be able to connect to remote ARRs.

The simple and lazy solution would be to support Basic Auth in the url like `http://user:pass@host.dev` but that has drawbacks over separate fields that then set it as a `Authorization` header on the requests.

I've tested this with both Sonarr and Radarr and it works as expected.