### PR TITLE
fix(onboarding): clarify recommended default illegal characters setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,9 +128,9 @@ services:
 | `PROFILARR_BULLETIN_URL` | `https://raw.githubusercontent.com/Dictionarry-Hub/bulletin/main` | Override for the announcement feed + release manifest base URL                        |
 
 > [!NOTE]
-> When using OIDC `ORIGIN=` *must* be set to your Profilarr URL, and Profilarr
-> expects `{ORIGIN}/auth/oidc/callback` for the redirect URL 
-> (e.g. `https://profilarr.example.com/auth/oidc/callback`). Many 
+> When using OIDC `ORIGIN=` _must_ be set to your Profilarr URL, and Profilarr
+> expects `{ORIGIN}/auth/oidc/callback` for the redirect URL
+> (e.g. `https://profilarr.example.com/auth/oidc/callback`). Many
 > IdPs will infer this automatically.
 
 See the [documentation](https://dictionarry.dev/) for full setup and

--- a/src/lib/client/cutscene/definitions/stages/media-management/naming.ts
+++ b/src/lib/client/cutscene/definitions/stages/media-management/naming.ts
@@ -32,7 +32,7 @@ export const mediaNamingStage: Stage = {
 			id: 'media-naming-character-replacement',
 			target: 'media-naming-character-replacement',
 			title: 'Character Replacement',
-			body: 'Filesystems reject characters like : ? * < > | on most operating systems, so Radarr and Sonarr can rewrite them before they hit disk. "Replace Illegal Characters" is the master toggle; when it is on, the colon replacement dropdown decides how colons specifically are handled (delete, replace with space, dash, etc.). Sonarr also lets you pick a custom replacement string. Leave this enabled unless you are on a filesystem that tolerates the original characters and you want names preserved exactly.',
+			body: 'Filesystems reject characters like : ? * < > | on most operating systems, so Radarr and Sonarr can rewrite them before they hit disk. "Replace Illegal Characters" is the master toggle; when it is on, the colon replacement dropdown decides how colons specifically are handled (delete, replace with space, dash, etc.). Sonarr also lets you pick a custom replacement string. Leaving this disabled instructs Sonarr to simply remove the illegal character instead. Leave this disabled unless you have a very specific reason not to.',
 			position: 'above',
 			freeInteract: true,
 			completion: { type: 'manual' }


### PR DESCRIPTION
Previously erroneously recommended enabling despite Dictionarry actual default setting.

Closes #635 