### PR TITLE
fix: default naming character replacement off

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -1535,7 +1535,7 @@
         "npm:prettier@3.8.3",
         "npm:simple-icons@^16.20.0",
         "npm:svelte-check@^4.4.8",
-        "npm:svelte@^5.55.8",
+        "npm:svelte@^5.55.9",
         "npm:tailwindcss@^4.1.13",
         "npm:typescript@^6.0.3",
         "npm:vite@^8.0.13",

--- a/src/routes/media-management/[databaseId]/naming/components/RadarrNamingForm.svelte
+++ b/src/routes/media-management/[databaseId]/naming/components/RadarrNamingForm.svelte
@@ -48,7 +48,7 @@
 		rename: true,
 		movieFormat: '{Movie Title} ({Release Year}) {Quality Full}',
 		movieFolderFormat: '{Movie Title} ({Release Year})',
-		replaceIllegalCharacters: true,
+		replaceIllegalCharacters: false,
 		colonReplacementFormat: 'delete'
 	};
 

--- a/src/routes/media-management/[databaseId]/naming/components/SonarrNamingForm.svelte
+++ b/src/routes/media-management/[databaseId]/naming/components/SonarrNamingForm.svelte
@@ -60,7 +60,7 @@
 			'{Series Title} - S{season:00}E{episode:00} - {Episode Title} {Quality Full}',
 		seriesFolderFormat: '{Series Title}',
 		seasonFolderFormat: 'Season {season}',
-		replaceIllegalCharacters: true,
+		replaceIllegalCharacters: false,
 		colonReplacementFormat: 'delete',
 		customColonReplacementFormat: '',
 		multiEpisodeStyle: 'extend'


### PR DESCRIPTION
Default new Radarr and Sonarr naming configs to leave illegal character replacement disabled, matching the intended default and onboarding guidance.