### PR TITLE
feat(deploy): support file-based env vars via _FILE suffix

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -25,6 +25,23 @@ ARCH=$(uname -m)
 export DENO_SQLITE_PATH="/usr/lib/${ARCH}-linux-gnu/libsqlite3.so.0"
 
 # -----------------------------------------------------------------------------
+# Resolve *_FILE env vars from secret files (Docker secrets pattern)
+# -----------------------------------------------------------------------------
+# Runs before the non-root fast path so it applies in both root and non-root modes
+for var in $(printenv | grep '_FILE=' | cut -d= -f1); do
+    case "$var" in *_FILE) ;; *) continue ;; esac
+    secret_path=$(printenv "$var")
+    if [ -f "$secret_path" ]; then
+        real_var=${var%_FILE}
+        export "$real_var=$(tr -d '\n' < "$secret_path")"
+        unset "$var"
+        echo "[entrypoint] $real_var loaded from $secret_path. Your paranoia is secured- feel better?"
+    else
+        echo "[entrypoint] WARN: $var points to $secret_path which does not exist. Check your pathing."
+    fi
+done
+
+# -----------------------------------------------------------------------------
 # Non-root fast path — skip all privilege operations
 # -----------------------------------------------------------------------------
 if [ "$(id -u)" != "0" ]; then


### PR DESCRIPTION
## Why

The original issue requested file-based env vars so OIDC client secrets (and any other sensitive config) are not printed in plaintext. This pattern matches convention used by many other apps in the self-hosted space.

## How

Pure shell change in `scripts/entrypoint.sh`. No application code touched. `Deno.env.get('OIDC_CLIENT_SECRET')` reads the resolved value from the process environment without knowing or caring that it came from a file.

The block:

- Scans `printenv` output for variables ending in `_FILE`
- Reads each referenced file, strips trailing newlines (`tr -d '\n'`), exports the un-suffixed variant
- Unsets the `_FILE` variant on successful resolution
- Logs a `[entrypoint]` line for each resolved var with name and path only,  never the value
- Warns and continues (fail-soft) when the referenced file doesn't exist
- Placed before the non-root fast path so it works in both root and non-root container modes

## Testing

Verified locally with the following scenarios:

- **Happy path** - secret file mounted via Docker `secrets:` block resolves correctly and reaches the app process (verified via `/proc/1/environ`)
- **Trailing newline strip** - secret created with `echo` has its newline stripped at resolution time
- **Missing file** - entrypoint logs WARN and the container continues starting normally; `OIDC_CLIENT_SECRET` is correctly absent in the running process
- **No `_FILE` vars set** - loop is a clean no-op, `set -e` doesn't trip, nothing prints to stdout, no extraneous log clutter.
- **Precedence** - when both `VAR` and `VAR_FILE` are set, the file value wins (loop runs after Docker has set both)

## Design decisions

- **`_FILE` suffix vs `FILE__` prefix** - went with suffix to match the broader Docker ecosystem (Authentik, the database images, etc.) rather than the lscr/hotio prefix convention. Honestly, suffix is prettier.
- **Trailing newline strip** - stripping accidental newlines should alleviate user frustration diagnosing simple errors.
- **Leave `_FILE` in env on failure** - when the file is missing, the `_FILE` var stays in the environment. The WARN log scrolls past in startup output; the env var sticks around as durable evidence of the misconfiguration when a user goes looking. (if full path prints, maybe they'll notice the path has an error). On successful resolution it gets unset for env hygiene.
- **Threat model** - this protects against secrets ending up in compose files, git history, and `docker inspect` output. It does *not* protect against an attacker with `docker exec` access reading `/proc/<pid>/environ` directly- the same limitation every Docker-secrets-style feature has.

## Docs

Companion docs PR ~~will be opened against `Dictionarry-Hub/v2.dictionarry.dev` once this merges~~ is open for your perusal, adding a Docker Secret tab to the OIDC section of the Installation page (located [here](https://v2.dictionarry.dev/profilarr-setup/installation?section=authentication)) . Due to being a fairly edge case use among the standard user base, I did not think it warranted space in the repo's README.

Closes #641.