### PR TITLE
docs: document runtime requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,14 @@ drifts between instances. Profilarr tries to make that easier.
 
 ## 📦 Getting Started
 
+### Requirements
+
+- Docker host with Linux kernel `3.17+`. Older kernels, including Synology DSM
+  installs on kernel `3.10`, are not supported by Profilarr v2.
+- Docker platform `linux/amd64` or `linux/arm64`
+- Sonarr `v4+`
+- Radarr `v5+`
+
 ### Production
 
 ```yaml


### PR DESCRIPTION
Document runtime requirements in the README.

Closes #650