### PR TITLE
fix: block invalid PCD dependency drops

### DIFF
--- a/docs/backend/pcd.md
+++ b/docs/backend/pcd.md
@@ -198,6 +198,9 @@ inside the savepoint, then rolled back. If any constraint fails (foreign
 key, unique, NOT NULL, CHECK), the write is rejected with a detailed
 error before anything is persisted.
 
+Before a base draft export is pushed, the exporter also validates the
+final batch against a clean base view: schema ops, published base ops, then the proposed export SQL. This catches dependency or constraint errors that would not be visible when validating against the current draft cache.
+
 ### Metadata and Desired State
 
 Each op stores two JSON blobs alongside its SQL:
@@ -239,6 +242,15 @@ When a user deletes an entity they just created (same layer, no dependent
 ops referencing it), the writer marks the original create op as `dropped`
 instead of writing a new delete op. This avoids accumulating redundant
 create-then-delete pairs.
+
+Dependent ops include both same-entity follow-up ops and `dependsOn`
+references from other entities. For example, a quality profile scoring op
+that references a newly created custom format prevents that custom format
+create from being silently cancelled.
+
+Dropping draft creates from the Changes page also respects `dependsOn`.
+If a selected create has unselected draft dependents, the drop is blocked
+and the user is told which outstanding changes must be selected too.
 
 ### Base vs User
 

--- a/src/lib/server/pcd/ops/draftChanges.ts
+++ b/src/lib/server/pcd/ops/draftChanges.ts
@@ -156,6 +156,13 @@ export type DraftEntityChange = {
 	path?: string;
 };
 
+export type DraftDropBlocker = {
+	key: string;
+	entity: string;
+	name: string;
+	summary: string;
+};
+
 const FIELD_LABELS: Record<string, string> = {
 	quality_profile_name: 'Quality profile',
 	custom_format_name: 'Custom format',
@@ -917,4 +924,77 @@ export function listDraftEntityChanges(databaseId: number): DraftEntityChange[] 
 		return a.updatedAt < b.updatedAt ? 1 : -1;
 	});
 	return results;
+}
+
+export function findDraftDropBlockers(
+	databaseId: number,
+	selectedOpIds: Iterable<number>
+): DraftDropBlocker[] {
+	const changes = listDraftEntityChanges(databaseId);
+	const changeByKey = new Map(changes.map((change) => [change.key, change]));
+	const keyByOpId = new Map<number, string>();
+
+	for (const change of changes) {
+		for (const op of change.ops) {
+			keyByOpId.set(op.id, change.key);
+		}
+	}
+
+	const selectedKeys = new Set<string>();
+	for (const opId of selectedOpIds) {
+		const key = keyByOpId.get(opId);
+		if (key) selectedKeys.add(key);
+	}
+
+	const selectedCreateKeys = new Set<string>();
+	for (const key of selectedKeys) {
+		const change = changeByKey.get(key);
+		if (change?.operation === 'create') {
+			selectedCreateKeys.add(key);
+		}
+	}
+
+	if (selectedCreateKeys.size === 0) {
+		return [];
+	}
+
+	const dependentsByKey = new Map<string, Set<string>>();
+	for (const change of changes) {
+		for (const requirement of change.requires ?? []) {
+			const dependents = dependentsByKey.get(requirement.key) ?? new Set<string>();
+			dependents.add(change.key);
+			dependentsByKey.set(requirement.key, dependents);
+		}
+	}
+
+	const blockerKeys = new Set<string>();
+	const queue = Array.from(selectedCreateKeys);
+	while (queue.length > 0) {
+		const key = queue.shift();
+		if (!key) continue;
+		for (const dependentKey of dependentsByKey.get(key) ?? []) {
+			if (selectedKeys.has(dependentKey) || blockerKeys.has(dependentKey)) continue;
+			blockerKeys.add(dependentKey);
+			if (changeByKey.get(dependentKey)?.operation === 'create') {
+				queue.push(dependentKey);
+			}
+		}
+	}
+
+	return Array.from(blockerKeys)
+		.map((key) => {
+			const change = changeByKey.get(key);
+			if (!change) return null;
+			return {
+				key: change.key,
+				entity: change.entity,
+				name: change.name,
+				summary: change.summary
+			};
+		})
+		.filter((blocker): blocker is DraftDropBlocker => blocker !== null)
+		.sort((a, b) => {
+			if (a.entity === b.entity) return a.name.localeCompare(b.name);
+			return a.entity.localeCompare(b.entity);
+		});
 }

--- a/src/lib/server/pcd/ops/exporter.ts
+++ b/src/lib/server/pcd/ops/exporter.ts
@@ -4,6 +4,7 @@ import { pcdOpHistoryQueries } from '$db/queries/pcdOpHistory.ts';
 import { logger } from '$logger/logger.ts';
 import { stage, commit, configureIdentity } from '$utils/git/write.ts';
 import { execGit } from '$utils/git/exec.ts';
+import { Database } from '@jsr/db__sqlite';
 import { getBranch, getStatus } from '$utils/git/read.ts';
 import { compile } from '../database/compiler.ts';
 import { canWriteToBase } from './writer.ts';
@@ -12,6 +13,7 @@ import { uuid } from '$shared/utils/uuid.ts';
 import { validateFilePaths } from '$utils/paths.ts';
 import { getMaxOpNumber } from '$pcd/utils/git.ts';
 import { loadManifest } from '$pcd/manifest/manifest.ts';
+import { loadOperationsFromDir } from '$pcd/utils/operations.ts';
 
 type ExportResult =
 	| {
@@ -77,6 +79,8 @@ type ExportPreview = {
 
 type PreviewResult = { success: true; preview: ExportPreview } | { success: false; error: string };
 
+type ExportValidationResult = { valid: true } | { valid: false; error: string };
+
 type ParsedMetadata = {
 	operation?: string;
 	entity?: string;
@@ -121,6 +125,76 @@ function buildMetadataJson(message: string, opIds: number[], exportedAt: string)
 		exported_at: exportedAt,
 		op_ids: opIds
 	});
+}
+
+function formatSqlValidationError(error: unknown): string {
+	const errorStr = String(error);
+	if (errorStr.includes('FOREIGN KEY constraint failed')) {
+		return `Foreign key constraint failed. ${errorStr}`;
+	}
+	if (errorStr.includes('UNIQUE constraint failed')) {
+		return `Unique constraint failed. ${errorStr}`;
+	}
+	if (errorStr.includes('NOT NULL constraint failed')) {
+		return `Required field is missing. ${errorStr}`;
+	}
+	if (errorStr.includes('CHECK constraint failed')) {
+		return `Value validation failed. ${errorStr}`;
+	}
+	return errorStr;
+}
+
+async function validateExportPlan(
+	databaseId: number,
+	repoPath: string,
+	plan: ExportPlan
+): Promise<ExportValidationResult> {
+	const validationDb = new Database(':memory:', { int64: true });
+
+	try {
+		validationDb.exec('PRAGMA foreign_keys = ON');
+
+		const schemaOps = await loadOperationsFromDir(`${repoPath}/deps/schema/ops`, 'schema');
+		for (const op of schemaOps) {
+			try {
+				validationDb.exec(op.sql);
+			} catch (error) {
+				return {
+					valid: false,
+					error: `Existing schema operation ${op.filename} failed validation: ${formatSqlValidationError(error)}`
+				};
+			}
+		}
+
+		const baseOps = pcdOpsQueries
+			.listByDatabaseAndOrigin(databaseId, 'base', { states: ['published'] })
+			.sort((a, b) => (a.sequence ?? a.id) - (b.sequence ?? b.id));
+
+		for (const op of baseOps) {
+			const label = op.filename ?? `pcd_op_${op.id}.sql`;
+			try {
+				validationDb.exec(op.sql);
+			} catch (error) {
+				return {
+					valid: false,
+					error: `Existing base operation ${label} failed validation: ${formatSqlValidationError(error)}`
+				};
+			}
+		}
+
+		try {
+			validationDb.exec(plan.dbSql);
+		} catch (error) {
+			return {
+				valid: false,
+				error: `Export batch ${plan.filename} failed validation: ${formatSqlValidationError(error)}`
+			};
+		}
+
+		return { valid: true };
+	} finally {
+		validationDb.close();
+	}
 }
 
 function opLabel(op: { metadata?: string | null }): string | null {
@@ -397,21 +471,27 @@ async function buildExportPlan(
 	const maxOpNumber = await getMaxOpNumber(repoPath);
 	const opNumber = maxOpNumber + 1;
 	const filename = `${opNumber}.${slugify(trimmedMessage)}.sql`;
+	const plan: ExportPlan = {
+		filename,
+		filepath: `ops/${filename}`,
+		fileContent,
+		dbSql,
+		metadataJson,
+		contentHash,
+		opIds: opIdList,
+		exportedAt,
+		opNumber,
+		ops
+	};
+
+	const validation = await validateExportPlan(databaseId, repoPath, plan);
+	if (!validation.valid) {
+		return { success: false, error: validation.error };
+	}
 
 	return {
 		success: true,
-		plan: {
-			filename,
-			filepath: `ops/${filename}`,
-			fileContent,
-			dbSql,
-			metadataJson,
-			contentHash,
-			opIds: opIdList,
-			exportedAt,
-			opNumber,
-			ops
-		}
+		plan
 	};
 }
 

--- a/src/lib/server/pcd/ops/writer.ts
+++ b/src/lib/server/pcd/ops/writer.ts
@@ -81,6 +81,7 @@ async function cancelOutCreate(
 		entity?: string;
 		name?: string;
 		stable_key?: { key?: string; value?: string };
+		depends_on?: Array<{ entity?: string; key?: string; value?: string }>;
 	};
 
 	function hasDependentOps(
@@ -115,6 +116,18 @@ async function cancelOutCreate(
 				parsed.name === createdMeta.name
 			) {
 				return true;
+			}
+
+			if (createdMeta.entity && createdStableKey?.key && createdStableKey.value) {
+				for (const dependency of parsed.depends_on ?? []) {
+					if (
+						dependency.entity === createdMeta.entity &&
+						dependency.key === createdStableKey.key &&
+						dependency.value === createdStableKey.value
+					) {
+						return true;
+					}
+				}
 			}
 
 			if (createdMeta.entity === 'test_entity' && createdStableKey?.value) {

--- a/src/routes/databases/[id]/changes/+page.server.ts
+++ b/src/routes/databases/[id]/changes/+page.server.ts
@@ -7,7 +7,7 @@ import { logger } from '$logger/logger.ts';
 import { pcdManager } from '$pcd/core/manager.ts';
 import { reconcileAndNotify, reconcileFromWorkingCopy } from '$announcements/database/index.ts';
 import { compile } from '$pcd/database/compiler.ts';
-import { listDraftEntityChanges } from '$pcd/ops/draftChanges.ts';
+import { findDraftDropBlockers, listDraftEntityChanges } from '$pcd/ops/draftChanges.ts';
 import { exportDraftOps, previewDraftOps } from '$pcd/ops/exporter.ts';
 import { uuid } from '$shared/utils/uuid.ts';
 import { validateFilePaths } from '$utils/paths.ts';
@@ -97,6 +97,19 @@ export const actions: Actions = {
 					meta: { databaseId: id }
 				});
 				return { success: false, error: 'No changes selected' };
+			}
+
+			const blockers = findDraftDropBlockers(id, opIds);
+			if (blockers.length > 0) {
+				const details = blockers
+					.map(
+						(blocker) => `${formatEntity(blocker.entity)} "${blocker.name}" (${blocker.summary})`
+					)
+					.join(', ');
+				return {
+					success: false,
+					error: `Cannot drop selected changes because other outstanding changes depend on them. Select these changes too, then drop again: ${details}`
+				};
 			}
 
 			// ─── File-backed drops ──────────────────────────────────────────
@@ -336,3 +349,8 @@ export const actions: Actions = {
 		}
 	}
 };
+
+function formatEntity(entity: string): string {
+	const trimmed = entity.replace(/[_-]+/g, ' ').trim();
+	return trimmed.replace(/\b\w/g, (char) => char.toUpperCase());
+}


### PR DESCRIPTION
Block dropping draft creates while other draft changes still depend on them, and validate export batches before pushing.