### PR TITLE
fix: keep personalize onboarding visible

### DIFF
--- a/src/lib/client/cutscene/definitions/stages/getting-started/personalize.ts
+++ b/src/lib/client/cutscene/definitions/stages/getting-started/personalize.ts
@@ -10,7 +10,7 @@ export const personalizeStage: Stage = {
 			target: 'theme-toggle',
 			title: 'Theme',
 			body: 'Click this to toggle between light and dark mode. Try it out, then continue.',
-			position: 'below',
+			position: 'center',
 			completion: { type: 'manual' }
 		},
 		{
@@ -18,7 +18,7 @@ export const personalizeStage: Stage = {
 			target: 'accent-picker',
 			title: 'Accent Color',
 			body: 'Pick a color that suits you. Click to open the picker, then choose one you like.',
-			position: 'below-right',
+			position: 'center',
 			freeInteract: true,
 			completion: { type: 'manual' }
 		}

--- a/src/lib/client/ui/navigation/navbar/accentPicker.svelte
+++ b/src/lib/client/ui/navigation/navbar/accentPicker.svelte
@@ -3,6 +3,8 @@
 	import Dropdown from '$ui/dropdown/Dropdown.svelte';
 	import { Check } from 'lucide-svelte';
 
+	export let onboarding: string | undefined = undefined;
+
 	let open = false;
 	let triggerEl: HTMLElement;
 
@@ -23,7 +25,7 @@
 
 <svelte:window on:click={handleClickOutside} />
 
-<div class="accent-picker relative" data-onboarding="accent-picker">
+<div class="accent-picker relative" data-onboarding={onboarding}>
 	<button
 		bind:this={triggerEl}
 		on:click|stopPropagation={() => (open = !open)}

--- a/src/lib/client/ui/navigation/navbar/navbar.svelte
+++ b/src/lib/client/ui/navigation/navbar/navbar.svelte
@@ -103,8 +103,8 @@
 			<div class="text-xl font-bold text-neutral-900 dark:text-neutral-100">profilarr</div>
 		</div>
 		<div class="flex items-center justify-end gap-1">
-			<AccentPicker />
-			<ThemeToggle />
+			<AccentPicker onboarding="accent-picker" />
+			<ThemeToggle onboarding="theme-toggle" />
 			<HelpButton variant="navbar" />
 			{#if !cutsceneActive}
 				<button

--- a/src/lib/client/ui/navigation/navbar/themeToggle.svelte
+++ b/src/lib/client/ui/navigation/navbar/themeToggle.svelte
@@ -2,11 +2,13 @@
 	import { themeStore } from '$stores/theme.ts';
 	import { MoonStar, Sun } from 'lucide-svelte';
 
+	export let onboarding: string | undefined = undefined;
+
 	$: isDark = $themeStore === 'dark';
 </script>
 
 <button
-	data-onboarding="theme-toggle"
+	data-onboarding={onboarding}
 	on:click={() => themeStore.toggle()}
 	class="relative flex h-9 w-9 items-center justify-center rounded-md transition-colors hover:bg-neutral-200 dark:hover:bg-neutral-800"
 	aria-label="Toggle theme"


### PR DESCRIPTION
Centers the Personalize onboarding cards and ensures the desktop navbar buttons are the only theme/accent controls exposed as onboarding targets.

Closes #664