### PR TITLE
chore: ignore kysely minor updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,10 @@ updates:
     ignore:
       - dependency-name: '@sveltejs/vite-plugin-svelte'
         update-types: ['version-update:semver-major']
+      - dependency-name: 'kysely'
+        update-types:
+          - 'version-update:semver-minor'
+          - 'version-update:semver-major'
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
Blocks Dependabot from opening Kysely minor or major update PRs for now, while still allowing patch updates on the current 0.27 line.

Kysely 0.29 changes the CompiledQuery shape in a way that affects the PCD writer, so that update should be handled separately with PCD-specific review.