### PR TITLE
fix: allow media management clone enums

### DIFF
--- a/src/lib/server/pcd/entities/validate.ts
+++ b/src/lib/server/pcd/entities/validate.ts
@@ -8,19 +8,26 @@
 import type { EntityType } from '$shared/pcd/portable.ts';
 
 const VALID_PROTOCOLS = new Set(['prefer_usenet', 'prefer_torrent', 'only_usenet', 'only_torrent']);
-const VALID_COLON_FORMATS = new Set(['delete', 'dash', 'space_dash', 'space_dash_space', 'smart']);
+const VALID_COLON_FORMATS = new Set([
+	'delete',
+	'dash',
+	'spaceDash',
+	'spaceDashSpace',
+	'smart',
+	'custom'
+]);
 const VALID_MULTI_EPISODE_STYLES = new Set([
 	'extend',
 	'duplicate',
 	'repeat',
 	'scene',
 	'range',
-	'prefixed_range'
+	'prefixedRange'
 ]);
 const VALID_PROPERS_REPACKS = new Set([
-	'do_not_prefer',
-	'prefer_and_upgrade',
-	'do_not_upgrade_automatically'
+	'doNotPrefer',
+	'preferAndUpgrade',
+	'doNotUpgradeAutomatically'
 ]);
 
 export function validatePortableData(


### PR DESCRIPTION
Fixes #668.

Updates portable import validation for media management enums to match the camelCase values exported by clone/export.