### PR TITLE
ci: automate GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,3 +184,45 @@ jobs:
       - name: Inspect manifest
         run: |
           docker buildx imagetools inspect ${{ env.IMAGE_BASE }}/${{ matrix.image }}:${{ steps.meta.outputs.version }}
+
+  # ─── Publish GitHub release notes ──────────────────────────────────────
+
+  github-release:
+    name: GitHub Release
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: [manifest]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Generate release notes
+        uses: orhun/git-cliff-action@v4
+        with:
+          config: cliff.toml
+          args: --current --output RELEASE_NOTES.md
+        env:
+          GITHUB_REPO: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release edit "$TAG" \
+              --title "$TAG" \
+              --notes-file RELEASE_NOTES.md \
+              --latest
+          else
+            gh release create "$TAG" \
+              --title "$TAG" \
+              --notes-file RELEASE_NOTES.md \
+              --verify-tag \
+              --latest
+          fi

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,63 @@
+# git-cliff configuration for GitHub release notes.
+# https://git-cliff.org/docs/configuration
+
+[changelog]
+body = """
+{%- if version -%}
+## {{ version }}
+{%- else -%}
+## Unreleased
+{%- endif %}
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | striptags | trim }}
+
+{% for commit in commits -%}
+- {% if commit.scope and commit.scope != "deps" and commit.scope != "deps-dev" %}{{ commit.scope }}: {% endif %}{% if commit.breaking %}**Breaking:** {% endif %}{{ commit.message | upper_first | trim }}
+{% endfor %}
+{%- endfor -%}
+{% set first_time_contributors = github.contributors | filter(attribute="is_first_time", value=true) %}
+{% if first_time_contributors | length > 0 %}
+### 🌱 New Contributors
+
+{% for contributor in first_time_contributors -%}
+- @{{ contributor.username }} made their first contribution in #{{ contributor.pr_number }}
+{% endfor %}
+{% endif -%}
+{% if previous.version and version -%}
+**Full Changelog**: https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}/compare/{{ previous.version }}...{{ version }}
+{% endif %}
+"""
+trim = true
+render_always = true
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+require_conventional = true
+split_commits = false
+protect_breaking_commits = true
+filter_commits = true
+fail_on_unmatched_commit = true
+tag_pattern = "v[0-9]+\\.[0-9]+\\.[0-9]+"
+topo_order = false
+topo_order_commits = true
+sort_commits = "oldest"
+
+commit_parsers = [
+	{ message = "^feat", group = "<!-- 0 -->✨ Features" },
+	{ message = "^fix", group = "<!-- 1 -->🐛 Fixes" },
+	{ message = "^perf", group = "<!-- 2 -->⚡ Performance" },
+	{ message = "^security", group = "<!-- 3 -->🔒 Security" },
+	{ message = "^docs", group = "<!-- 4 -->📚 Documentation" },
+	{ message = "^refactor", group = "<!-- 5 -->♻️ Refactors" },
+	{ message = "^test", group = "<!-- 6 -->🧪 Tests" },
+	{ message = "^build", group = "<!-- 7 -->🔧 Maintenance" },
+	{ message = "^chore\\(deps.*\\)", group = "<!-- 9 -->📦 Dependencies" },
+	{ message = "^chore", group = "<!-- 7 -->🔧 Maintenance" },
+	{ message = "^style", group = "<!-- 7 -->🔧 Maintenance" },
+	{ message = "^ci", group = "<!-- 8 -->⚙️ CI" }
+]
+
+[remote.github]
+owner = "Dictionarry-Hub"
+repo = "profilarr"


### PR DESCRIPTION
Adds git-cliff release notes configuration and a tag-only GitHub Release job after Docker manifests publish. Release notes are grouped by conventional commit type, include dependency bumps and first-time contributors when present, and link the full changelog.