### PR TITLE
fix: default list pages to card view

### DIFF
--- a/docs/frontend/ui.md
+++ b/docs/frontend/ui.md
@@ -658,7 +658,10 @@ top of a list page:
 - **`SearchModeToggle.svelte`**: toggle between search modes (e.g.,
   "fuzzy" vs. "exact").
 - **`ViewToggle.svelte`**: list / grid view switcher used on pages that
-  support both layouts.
+  support both layouts. Persist view state with `createViewModeStore` from
+  `$lib/client/stores/dataPage`; saved preferences win, mobile falls back to
+  cards, and the default no-preference view is cards unless the page opts into
+  `defaultView: 'table'`.
 
 ### Arr-Specific
 

--- a/src/lib/client/stores/dataPage.ts
+++ b/src/lib/client/stores/dataPage.ts
@@ -9,6 +9,15 @@ import { createSearchStore, getPersistentSearchStore, type SearchStore } from '.
 
 export type ViewMode = 'table' | 'cards';
 
+export interface ViewModeConfig {
+	/** Key for localStorage persistence */
+	storageKey: string;
+	/** Default view mode when no saved preference exists */
+	defaultView?: ViewMode;
+	/** Mobile breakpoint in px, below which cards always win */
+	mobileBreakpoint?: number;
+}
+
 export interface DataPageConfig<T> {
 	/** Key for localStorage persistence */
 	storageKey: string;
@@ -40,6 +49,38 @@ export interface DataPageStore<T> {
 	setItems: (items: T[]) => void;
 }
 
+export function createViewModeStore(config: ViewModeConfig) {
+	const { storageKey, defaultView = 'cards', mobileBreakpoint = 768 } = config;
+	let initialView: ViewMode = defaultView;
+
+	if (browser) {
+		try {
+			const stored = localStorage.getItem(storageKey);
+			if (stored === 'cards' || stored === 'table') {
+				initialView = stored;
+			} else if (window.innerWidth < mobileBreakpoint) {
+				initialView = 'cards';
+			}
+		} catch {
+			if (window.innerWidth < mobileBreakpoint) {
+				initialView = 'cards';
+			}
+		}
+	}
+
+	const view = writable<ViewMode>(initialView);
+
+	if (browser) {
+		view.subscribe((value) => {
+			try {
+				localStorage.setItem(storageKey, value);
+			} catch {}
+		});
+	}
+
+	return view;
+}
+
 /**
  * Create a data page store for managing list pages
  *
@@ -65,18 +106,7 @@ export function createDataPageStore<T>(
 			? getPersistentSearchStore(config.searchKey, { debounceMs })
 			: createSearchStore({ debounceMs }));
 
-	// Determine initial view: localStorage > mobile detection > defaultView
-	const storedView = browser ? (localStorage.getItem(storageKey) as ViewMode | null) : null;
-	const isMobile = browser ? window.innerWidth < 768 : false;
-	const initialView = storedView ?? (isMobile ? 'cards' : defaultView);
-	const view = writable<ViewMode>(initialView);
-
-	// Persist view changes to localStorage
-	if (browser) {
-		view.subscribe((value) => {
-			localStorage.setItem(storageKey, value);
-		});
-	}
+	const view = createViewModeStore({ storageKey, defaultView });
 
 	// Filtered items derived from search
 	const filtered = derived([items, search.debouncedQuery], ([$items, $query]) => {

--- a/src/lib/client/stores/dataPage.ts
+++ b/src/lib/client/stores/dataPage.ts
@@ -74,7 +74,9 @@ export function createViewModeStore(config: ViewModeConfig) {
 		view.subscribe((value) => {
 			try {
 				localStorage.setItem(storageKey, value);
-			} catch {}
+			} catch {
+				// Some browsers can deny storage access.
+			}
 		});
 	}
 

--- a/src/lib/client/ui/actions/ViewToggle.svelte
+++ b/src/lib/client/ui/actions/ViewToggle.svelte
@@ -6,7 +6,7 @@
 	import { Eye, LayoutGrid, Table } from 'lucide-svelte';
 	import type { ViewMode } from '$lib/client/stores/dataPage';
 
-	export let value: ViewMode = 'table';
+	export let value: ViewMode = 'cards';
 	export let position: 'left' | 'right' | 'middle' = 'right';
 </script>
 

--- a/src/routes/arr/[id]/library/+page.svelte
+++ b/src/routes/arr/[id]/library/+page.svelte
@@ -9,7 +9,7 @@
 	import { getPersistentSearchStore } from '$stores/search';
 	import type { FilterFieldDef, FilterTag } from '$ui/filter/types';
 	import { applySmartFilters } from '$ui/filter/match';
-	import type { ViewMode } from '$lib/client/stores/dataPage';
+	import { createViewModeStore } from '$lib/client/stores/dataPage';
 	import { createProgressiveList } from '$lib/client/utils/progressiveList';
 	import { getDisplayUrl } from '$lib/client/utils/arrDisplayUrl.ts';
 	import InfoModal from '$ui/modal/InfoModal.svelte';
@@ -176,21 +176,7 @@
 	// View Mode
 	// ==========================================================================
 
-	const VIEW_STORAGE_KEY = 'profilarr-library-view';
-	function loadViewMode(): ViewMode {
-		if (!browser) return 'table';
-		try {
-			const stored = localStorage.getItem(VIEW_STORAGE_KEY);
-			if (stored === 'cards' || stored === 'table') return stored;
-		} catch {}
-		return window.innerWidth < 768 ? 'cards' : 'table';
-	}
-
-	let viewMode: ViewMode = loadViewMode();
-
-	$: if (browser) {
-		localStorage.setItem(VIEW_STORAGE_KEY, viewMode);
-	}
+	const viewMode = createViewModeStore({ storageKey: 'profilarr-library-view' });
 
 	// ==========================================================================
 	// Expand All
@@ -702,7 +688,7 @@
 			onRefresh={handleRefresh}
 			onOpen={handleOpen}
 			instanceType={data.instance.type}
-			bind:viewMode
+			bind:viewMode={$viewMode}
 			{expandAll}
 			onToggleExpandAll={toggleExpandAll}
 			sortKey={cardSortKey}
@@ -715,7 +701,7 @@
 			onFilterInfo={() => (showFilterInfo = true)}
 		/>
 
-		{#if viewMode === 'table'}
+		{#if $viewMode === 'table'}
 			{#if isRadarr}
 				{#if allMoviesWithFiles.length === 0 && !loading && !refreshing}
 					<div

--- a/src/routes/arr/[id]/library/components/LibraryActionBar.svelte
+++ b/src/routes/arr/[id]/library/components/LibraryActionBar.svelte
@@ -46,7 +46,7 @@
 	export let onRefresh: () => void;
 	export let onOpen: () => void;
 	export let instanceType: string = 'radarr';
-	export let viewMode: ViewMode = 'table';
+	export let viewMode: ViewMode = 'cards';
 	export let expandAll: boolean = false;
 	export let onToggleExpandAll: () => void = () => {};
 	export let sortKey: string = 'title';

--- a/src/routes/custom-formats/[databaseId]/+page.svelte
+++ b/src/routes/custom-formats/[databaseId]/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { onMount, onDestroy } from 'svelte';
-	import { browser } from '$app/environment';
 	import Tabs from '$ui/navigation/tabs/Tabs.svelte';
 	import ActionsBar from '$ui/actions/ActionsBar.svelte';
 	import ActionButton from '$ui/actions/ActionButton.svelte';
@@ -17,7 +16,7 @@
 	import { filterMode } from '$stores/filterMode';
 	import type { FilterFieldDef, FilterTag } from '$ui/filter/types';
 	import { applySmartFilters } from '$ui/filter/match';
-	import type { ViewMode } from '$lib/client/stores/dataPage';
+	import { createViewModeStore } from '$lib/client/stores/dataPage';
 	import { Info, Plus } from 'lucide-svelte';
 	import { goto } from '$app/navigation';
 	import { alertStore } from '$alerts/store';
@@ -151,22 +150,7 @@
 	// View Mode
 	// ======================================================================
 
-	const VIEW_STORAGE_KEY = 'customFormatsView';
-
-	function loadViewMode(): ViewMode {
-		if (!browser) return 'table';
-		try {
-			const stored = localStorage.getItem(VIEW_STORAGE_KEY);
-			if (stored === 'cards' || stored === 'table') return stored;
-		} catch {}
-		return window.innerWidth < 768 ? 'cards' : 'table';
-	}
-
-	let viewMode: ViewMode = loadViewMode();
-
-	$: if (browser) {
-		localStorage.setItem(VIEW_STORAGE_KEY, viewMode);
-	}
+	const viewMode = createViewModeStore({ storageKey: 'customFormatsView' });
 
 	// ======================================================================
 	// Filtering
@@ -223,7 +207,7 @@
 		{#if !isMobile}
 			<FilterModeToggle bind:value={$filterMode} />
 		{/if}
-		<ViewToggle bind:value={viewMode} />
+		<ViewToggle bind:value={$viewMode} />
 		<ActionButton icon={Info} on:click={() => (infoModalOpen = true)} />
 	</ActionsBar>
 
@@ -245,7 +229,7 @@
 					No custom formats match the current filters
 				</p>
 			</div>
-		{:else if viewMode === 'table'}
+		{:else if $viewMode === 'table'}
 			<TableView formats={filtered} on:clone={handleClone} on:export={handleExport} />
 		{:else}
 			<CardView formats={filtered} on:clone={handleClone} on:export={handleExport} />

--- a/src/routes/quality-profiles/[databaseId]/+page.svelte
+++ b/src/routes/quality-profiles/[databaseId]/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { onMount, onDestroy } from 'svelte';
-	import { browser } from '$app/environment';
 	import { goto } from '$app/navigation';
 	import { Plus } from 'lucide-svelte';
 	import Tabs from '$ui/navigation/tabs/Tabs.svelte';
@@ -18,7 +17,7 @@
 	import { filterMode } from '$stores/filterMode';
 	import type { FilterFieldDef, FilterTag } from '$ui/filter/types';
 	import { applySmartFilters } from '$ui/filter/match';
-	import type { ViewMode } from '$lib/client/stores/dataPage';
+	import { createViewModeStore } from '$lib/client/stores/dataPage';
 	import { alertStore } from '$alerts/store';
 	import type { QualityProfileTableRow } from '$shared/pcd/display';
 	import { copyToClipboard } from '$lib/client/utils/clipboard';
@@ -149,22 +148,7 @@
 	// View Mode
 	// ======================================================================
 
-	const VIEW_STORAGE_KEY = 'qualityProfilesView';
-
-	function loadViewMode(): ViewMode {
-		if (!browser) return 'table';
-		try {
-			const stored = localStorage.getItem(VIEW_STORAGE_KEY);
-			if (stored === 'cards' || stored === 'table') return stored;
-		} catch {}
-		return window.innerWidth < 768 ? 'cards' : 'table';
-	}
-
-	let viewMode: ViewMode = loadViewMode();
-
-	$: if (browser) {
-		localStorage.setItem(VIEW_STORAGE_KEY, viewMode);
-	}
+	const viewMode = createViewModeStore({ storageKey: 'qualityProfilesView' });
 
 	// ======================================================================
 	// Filtering
@@ -221,7 +205,7 @@
 		{#if !isMobile}
 			<FilterModeToggle bind:value={$filterMode} />
 		{/if}
-		<ViewToggle bind:value={viewMode} />
+		<ViewToggle bind:value={$viewMode} />
 	</ActionsBar>
 
 	<!-- Quality Profiles Content -->
@@ -242,7 +226,7 @@
 					No quality profiles match the current filters
 				</p>
 			</div>
-		{:else if viewMode === 'table'}
+		{:else if $viewMode === 'table'}
 			<TableView
 				profiles={filtered}
 				databaseId={data.currentDatabase.id}

--- a/src/routes/regular-expressions/[databaseId]/+page.svelte
+++ b/src/routes/regular-expressions/[databaseId]/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { onMount, onDestroy } from 'svelte';
-	import { browser } from '$app/environment';
 	import Tabs from '$ui/navigation/tabs/Tabs.svelte';
 	import ActionsBar from '$ui/actions/ActionsBar.svelte';
 	import ActionButton from '$ui/actions/ActionButton.svelte';
@@ -19,7 +18,7 @@
 	import { filterMode } from '$stores/filterMode';
 	import type { FilterFieldDef, FilterTag } from '$ui/filter/types';
 	import { applySmartFilters } from '$ui/filter/match';
-	import type { ViewMode } from '$lib/client/stores/dataPage';
+	import { createViewModeStore } from '$lib/client/stores/dataPage';
 	import { Info, Plus, FileText, Users } from 'lucide-svelte';
 	import { goto } from '$app/navigation';
 	import { alertStore } from '$alerts/store';
@@ -151,22 +150,7 @@
 	// View Mode
 	// ======================================================================
 
-	const VIEW_STORAGE_KEY = 'regularExpressionsView';
-
-	function loadViewMode(): ViewMode {
-		if (!browser) return 'table';
-		try {
-			const stored = localStorage.getItem(VIEW_STORAGE_KEY);
-			if (stored === 'cards' || stored === 'table') return stored;
-		} catch {}
-		return window.innerWidth < 768 ? 'cards' : 'table';
-	}
-
-	let viewMode: ViewMode = loadViewMode();
-
-	$: if (browser) {
-		localStorage.setItem(VIEW_STORAGE_KEY, viewMode);
-	}
+	const viewMode = createViewModeStore({ storageKey: 'regularExpressionsView' });
 
 	// ======================================================================
 	// Filtering
@@ -235,7 +219,7 @@
 		{#if !isMobile}
 			<FilterModeToggle bind:value={$filterMode} />
 		{/if}
-		<ViewToggle bind:value={viewMode} />
+		<ViewToggle bind:value={$viewMode} />
 		<ActionButton icon={Info} on:click={() => (infoModalOpen = true)} />
 	</ActionsBar>
 
@@ -257,7 +241,7 @@
 					No regular expressions match the current filters
 				</p>
 			</div>
-		{:else if viewMode === 'table'}
+		{:else if $viewMode === 'table'}
 			<TableView expressions={filtered} on:clone={handleClone} on:export={handleExport} />
 		{:else}
 			<CardView expressions={filtered} on:clone={handleClone} on:export={handleExport} />


### PR DESCRIPTION
Centralizes persisted view-mode handling so fresh users land on card view while saved preferences still win.

Closes #677.