### PR TITLE
fix: monitor upgrade queue during search commands

### DIFF
--- a/docs/backend/upgrades.md
+++ b/docs/backend/upgrades.md
@@ -48,6 +48,13 @@ flowchart TD
     BATCH --> LOG
 ```
 
+Live searches watch the Arr queue as soon as the search command is created.
+Queue entries are accumulated every 3 seconds while the command runs. After
+the command completes, the processor parses Arr's downloaded report count from
+the command message and keeps watching for up to 3 minutes if fewer queue
+entries were observed. If Arr reports zero downloads, the run finishes
+immediately after command completion.
+
 ### Status
 
 | Status    | Meaning                                       |
@@ -210,7 +217,11 @@ Every run produces an `UpgradeJobLog` that captures the full funnel:
   details (title, current score/formats, upgrade releases with scores)
 - **Results** -- searches triggered, successful, failed, errors
 
-Three logging functions in `logger.ts`:
+If Arr reports more downloaded releases than Profilarr observed in the queue,
+the run still records the upgrades it saw and logs a warning with the reported
+and observed counts.
+
+Core logging functions in `logger.ts`:
 
 - `logUpgradeRun(log)` -- persists the full log to the `upgrade_runs` table
   and writes a summary to the [logger](./logger.md) with source
@@ -218,6 +229,8 @@ Three logging functions in `logger.ts`:
   failed.
 - `logUpgradeSkipped(instanceId, name, reason)` -- DEBUG-level.
 - `logUpgradeError(instanceId, name, error)` -- ERROR-level.
+- `logUpgradeQueueDetectionMismatch(details)` -- WARN-level diagnostic when
+  Arr reports more downloads than the queue monitor observed.
 
 ## Notifications
 

--- a/src/lib/server/upgrades/commandMessages.ts
+++ b/src/lib/server/upgrades/commandMessages.ts
@@ -1,0 +1,8 @@
+export function parseDownloadedReportCount(message: string | null | undefined): number | null {
+	if (!message) return null;
+
+	const match = message.match(/\b(\d+)\s+reports?\s+downloaded\b/i);
+	if (!match) return null;
+
+	return Number.parseInt(match[1], 10);
+}

--- a/src/lib/server/upgrades/logger.ts
+++ b/src/lib/server/upgrades/logger.ts
@@ -115,6 +115,40 @@ export async function logUpgradeError(
 	});
 }
 
+export async function logUpgradeQueueDetectionMismatch(details: {
+	instanceId: number;
+	instanceName: string;
+	app: 'Radarr' | 'Sonarr';
+	filterName: string;
+	commandId: number;
+	reportedDownloads: number;
+	observedDownloads: number;
+	graceElapsedMs: number;
+	commandMessage?: string;
+}): Promise<void> {
+	await logger.warn(
+		`Upgrade detection under-reported ${details.app} grabs: command reported ${details.reportedDownloads}, queue observation saw ${details.observedDownloads}`,
+		{
+			source: SOURCE,
+			meta: details
+		}
+	);
+}
+
+export async function logUpgradeCommandCompleted(details: {
+	commandId: number;
+	status: string;
+	elapsedMs: number;
+	commandMessage?: string;
+	reportedDownloads: number | null;
+	observedDownloads: number;
+}): Promise<void> {
+	await logger.debug(`Upgrade command ${details.commandId} completed`, {
+		source: SOURCE,
+		meta: details
+	});
+}
+
 /**
  * Log when dry run cache is cleared
  */

--- a/src/lib/server/upgrades/processor.ts
+++ b/src/lib/server/upgrades/processor.ts
@@ -20,7 +20,10 @@ import type {
 	RadarrMovie,
 	RadarrMovieFile,
 	SonarrSeries,
-	ArrTag
+	ArrTag,
+	ArrCommand,
+	RadarrQueueItem,
+	SonarrQueueItem
 } from '$lib/server/utils/arr/types.ts';
 import { normalizeRadarrItems, normalizeSonarrItems } from './normalize.ts';
 import {
@@ -31,7 +34,14 @@ import {
 	isFilterExhausted,
 	resetFilterCooldown
 } from './cooldown.ts';
-import { logUpgradeRun, logUpgradeError, logUpgradeSkipped } from './logger.ts';
+import {
+	logUpgradeRun,
+	logUpgradeError,
+	logUpgradeSkipped,
+	logUpgradeQueueDetectionMismatch,
+	logUpgradeCommandCompleted
+} from './logger.ts';
+import { parseDownloadedReportCount } from './commandMessages.ts';
 import { notifications } from '$notifications/definitions/index.ts';
 import { notificationManager } from '$notifications/NotificationManager.ts';
 
@@ -42,6 +52,9 @@ import { notificationManager } from '$notifications/NotificationManager.ts';
  */
 const dryRunExclusions = new Map<number, { items: Set<number>; timestamp: number }>();
 const DRY_RUN_EXCLUSION_TTL_MS = 60 * 60 * 1000; // 1 hour
+const UPGRADE_QUEUE_POLL_INTERVAL_MS = 3000;
+const UPGRADE_QUEUE_GRACE_MS = 3 * 60 * 1000;
+const UPGRADE_COMMAND_TIMEOUT_MS = 60 * 60 * 1000;
 
 /**
  * Extract poster URL from arr API image data
@@ -89,32 +102,127 @@ export function clearDryRunExclusions(instanceId: number): number[] {
 	return clearedIds;
 }
 
-/**
- * Poll a queue function until results stabilize (no new items between polls)
- * Waits intervalMs between attempts, up to maxAttempts
- */
-async function pollQueue<T>(
-	fetch: () => Promise<T[]>,
-	maxAttempts = 5,
-	intervalMs = 3000
-): Promise<T[]> {
-	let lastCount = 0;
-	let stableResult: T[] = [];
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
-	for (let i = 0; i < maxAttempts; i++) {
-		await new Promise((r) => setTimeout(r, intervalMs));
-		const result = await fetch();
+function isCommandComplete(command: ArrCommand): boolean {
+	return command.status === 'completed';
+}
 
-		if (result.length > 0 && result.length === lastCount) {
-			// Queue stabilized — same count as last poll
-			return result;
+function isCommandFailed(command: ArrCommand): boolean {
+	return command.status === 'failed';
+}
+
+async function monitorQueueDuringCommand<T>(options: {
+	commandId: number;
+	getCommand: (commandId: number) => Promise<ArrCommand>;
+	getQueue: () => Promise<T[]>;
+	mergeQueueItem: (item: T) => void;
+	getObservedCount: () => number;
+	onCommandComplete: (details: {
+		command: ArrCommand;
+		elapsedMs: number;
+		reportedDownloads: number | null;
+		observedDownloads: number;
+	}) => Promise<void>;
+	onMismatch: (details: {
+		command: ArrCommand;
+		reportedDownloads: number;
+		observedDownloads: number;
+		graceElapsedMs: number;
+	}) => Promise<void>;
+}): Promise<ArrCommand> {
+	const startTime = Date.now();
+	let command: ArrCommand | null = null;
+	let completedAt: number | null = null;
+	let reportedDownloads: number | null = null;
+	let completionLogged = false;
+	let mismatchLogged = false;
+
+	while (true) {
+		const elapsedMs = Date.now() - startTime;
+		if (elapsedMs >= UPGRADE_COMMAND_TIMEOUT_MS) {
+			throw new Error(`Command ${options.commandId} timed out after 60 minutes`);
 		}
 
-		stableResult = result;
-		lastCount = result.length;
+		command = await options.getCommand(options.commandId);
+
+		if (isCommandFailed(command)) {
+			throw new Error(`Command ${options.commandId} failed: ${command.message || 'Unknown error'}`);
+		}
+
+		const queue = await options.getQueue();
+		for (const item of queue) {
+			options.mergeQueueItem(item);
+		}
+
+		if (isCommandComplete(command)) {
+			if (completedAt === null) {
+				completedAt = Date.now();
+			}
+			if (reportedDownloads === null) {
+				reportedDownloads = parseDownloadedReportCount(command.message);
+			}
+
+			if (!completionLogged) {
+				await options.onCommandComplete({
+					command,
+					elapsedMs: Date.now() - startTime,
+					reportedDownloads,
+					observedDownloads: options.getObservedCount()
+				});
+				completionLogged = true;
+			}
+
+			if (reportedDownloads === 0) {
+				return command;
+			}
+
+			if (reportedDownloads === null) {
+				return command;
+			}
+
+			if (options.getObservedCount() >= reportedDownloads) {
+				return command;
+			}
+
+			const graceElapsedMs = Date.now() - completedAt;
+			if (graceElapsedMs >= UPGRADE_QUEUE_GRACE_MS) {
+				if (options.getObservedCount() < reportedDownloads && !mismatchLogged) {
+					await options.onMismatch({
+						command,
+						reportedDownloads,
+						observedDownloads: options.getObservedCount(),
+						graceElapsedMs
+					});
+					mismatchLogged = true;
+				}
+
+				return command;
+			}
+		}
+
+		await sleep(UPGRADE_QUEUE_POLL_INTERVAL_MS);
+	}
+}
+
+function mergeSonarrQueueItem(
+	queueMap: Map<number, SonarrQueueItem[]>,
+	queueItem: SonarrQueueItem
+): void {
+	const existing = queueMap.get(queueItem.seriesId) ?? [];
+	const alreadySeen = existing.some((item) =>
+		queueItem.downloadId
+			? item.downloadId === queueItem.downloadId
+			: item.title === queueItem.title
+	);
+
+	if (!alreadySeen) {
+		existing.push(queueItem);
 	}
 
-	return stableResult;
+	queueMap.set(queueItem.seriesId, existing);
 }
 
 /**
@@ -462,7 +570,7 @@ export async function processUpgradeConfig(
 					}
 				}
 			} else {
-				// Live mode - trigger search, wait, check queue
+				// Live mode - trigger search and monitor queue while Arr processes it
 				try {
 					const itemIds = selectedItems.map((item) => item.id);
 
@@ -470,12 +578,39 @@ export async function processUpgradeConfig(
 						// Radarr: batch search
 						const radarr = client as RadarrClient;
 						const searchCommand = await radarr.searchMovies(itemIds);
-						await radarr.waitForCommand(searchCommand.id);
 						searchesTriggered = itemIds.length;
 
-						// Poll queue until results stabilize
-						const queue = await pollQueue(() => radarr.getQueue(itemIds));
-						const queueMap = new Map(queue.map((q) => [q.movieId, q]));
+						const queueMap = new Map<number, RadarrQueueItem>();
+						await monitorQueueDuringCommand({
+							commandId: searchCommand.id,
+							getCommand: (commandId) => radarr.getCommand(commandId),
+							getQueue: () => radarr.getQueue(itemIds),
+							mergeQueueItem: (item) => {
+								queueMap.set(item.movieId, item);
+							},
+							getObservedCount: () => queueMap.size,
+							onCommandComplete: (details) =>
+								logUpgradeCommandCompleted({
+									commandId: searchCommand.id,
+									status: details.command.status,
+									elapsedMs: details.elapsedMs,
+									commandMessage: details.command.message,
+									reportedDownloads: details.reportedDownloads,
+									observedDownloads: details.observedDownloads
+								}),
+							onMismatch: (details) =>
+								logUpgradeQueueDetectionMismatch({
+									instanceId: instance.id,
+									instanceName: instance.name,
+									app: 'Radarr',
+									filterName: filter.name,
+									commandId: searchCommand.id,
+									reportedDownloads: details.reportedDownloads,
+									observedDownloads: details.observedDownloads,
+									graceElapsedMs: details.graceElapsedMs,
+									commandMessage: details.command.message
+								})
+						});
 
 						for (const item of selectedItems) {
 							const original = getOriginalFile(item);
@@ -518,23 +653,41 @@ export async function processUpgradeConfig(
 					} else {
 						// Sonarr: search one series at a time
 						const sonarr = client as SonarrClient;
+						const queueMap = new Map<number, SonarrQueueItem[]>();
 
 						for (const item of selectedItems) {
 							const cmd = await sonarr.searchSeries(item.id);
-							await sonarr.waitForCommand(cmd.id);
+							await monitorQueueDuringCommand({
+								commandId: cmd.id,
+								getCommand: (commandId) => sonarr.getCommand(commandId),
+								getQueue: () => sonarr.getQueue([item.id]),
+								mergeQueueItem: (queueItem) => {
+									mergeSonarrQueueItem(queueMap, queueItem);
+								},
+								getObservedCount: () => queueMap.get(item.id)?.length ?? 0,
+								onCommandComplete: (details) =>
+									logUpgradeCommandCompleted({
+										commandId: cmd.id,
+										status: details.command.status,
+										elapsedMs: details.elapsedMs,
+										commandMessage: details.command.message,
+										reportedDownloads: details.reportedDownloads,
+										observedDownloads: details.observedDownloads
+									}),
+								onMismatch: (details) =>
+									logUpgradeQueueDetectionMismatch({
+										instanceId: instance.id,
+										instanceName: instance.name,
+										app: 'Sonarr',
+										filterName: filter.name,
+										commandId: cmd.id,
+										reportedDownloads: details.reportedDownloads,
+										observedDownloads: details.observedDownloads,
+										graceElapsedMs: details.graceElapsedMs,
+										commandMessage: details.command.message
+									})
+							});
 							searchesTriggered++;
-						}
-
-						// Poll queue until results stabilize
-						const queue = await pollQueue(() => sonarr.getQueue(itemIds));
-						// Group queue items by seriesId, deduplicate by release title
-						const queueMap = new Map<number, typeof queue>();
-						for (const q of queue) {
-							const existing = queueMap.get(q.seriesId) ?? [];
-							if (!existing.some((e) => e.title === q.title)) {
-								existing.push(q);
-							}
-							queueMap.set(q.seriesId, existing);
 						}
 
 						for (const item of selectedItems) {

--- a/src/lib/server/upgrades/processor.ts
+++ b/src/lib/server/upgrades/processor.ts
@@ -213,9 +213,7 @@ function mergeSonarrQueueItem(
 ): void {
 	const existing = queueMap.get(queueItem.seriesId) ?? [];
 	const alreadySeen = existing.some((item) =>
-		queueItem.downloadId
-			? item.downloadId === queueItem.downloadId
-			: item.title === queueItem.title
+		queueItem.downloadId ? item.downloadId === queueItem.downloadId : item.title === queueItem.title
 	);
 
 	if (!alreadySeen) {

--- a/tests/unit/upgrades/commandMessages.test.ts
+++ b/tests/unit/upgrades/commandMessages.test.ts
@@ -1,0 +1,40 @@
+import { assertEquals } from '@std/assert';
+import { BaseTest } from '../base/BaseTest.ts';
+import { parseDownloadedReportCount } from '$lib/server/upgrades/commandMessages.ts';
+
+class CommandMessagesTest extends BaseTest {
+	runTests(): void {
+		this.test('parses plural downloaded report count', () => {
+			assertEquals(
+				parseDownloadedReportCount('Completed search for 10 movies. 4 reports downloaded.'),
+				4
+			);
+		});
+
+		this.test('parses singular downloaded report count', () => {
+			assertEquals(
+				parseDownloadedReportCount('Completed search for 10 movies. 1 report downloaded.'),
+				1
+			);
+		});
+
+		this.test('parses zero downloaded report count', () => {
+			assertEquals(
+				parseDownloadedReportCount('Completed search for 10 movies. 0 reports downloaded.'),
+				0
+			);
+		});
+
+		this.test('returns null for missing message', () => {
+			assertEquals(parseDownloadedReportCount(undefined), null);
+			assertEquals(parseDownloadedReportCount(null), null);
+		});
+
+		this.test('returns null for unrecognized message', () => {
+			assertEquals(parseDownloadedReportCount('Completed search for 10 movies.'), null);
+		});
+	}
+}
+
+const commandMessagesTest = new CommandMessagesTest();
+commandMessagesTest.runTests();


### PR DESCRIPTION
Reworks live upgrade detection so Profilarr starts observing the Arr queue as soon as a search command is created, instead of waiting for the command to finish first.

Queue snapshots are accumulated while the command runs, then the completed command message is parsed for Arr's reported download count. If Arr reports downloads that have not appeared in the queue yet, Profilarr keeps polling for up to 3 minutes and logs a warning if observations still fall short.

Adds focused parser unit coverage and updates the upgrade docs.

Closes #662