### PR TITLE
fix: skip unmonitored sonarr dry-run seasons

### DIFF
--- a/docs/backend/upgrades.md
+++ b/docs/backend/upgrades.md
@@ -198,7 +198,9 @@ cooldown across them.
 
 Dry-run mode fetches available releases for each selected item and compares
 scores without triggering actual searches. This lets users preview what the
-system would do.
+system would do. For Sonarr, dry runs only query monitored seasons that already
+have files; selected series without an eligible season are shown without a
+previewed upgrade.
 
 An in-memory exclusion cache (1-hour TTL, keyed by instance ID) tracks items
 selected in previous dry runs so the same items aren't re-picked on repeated

--- a/src/lib/server/upgrades/processor.ts
+++ b/src/lib/server/upgrades/processor.ts
@@ -308,12 +308,12 @@ function createSkippedLog(
  * Pick the best season to search for a Sonarr series (for dry-run interactive search)
  * Picks the latest monitored season that has episode files
  */
-function pickSeasonForSearch(series: SonarrSeries): number {
+function pickSeasonForSearch(series: SonarrSeries): number | undefined {
 	const monitored = series.seasons
 		.filter((s) => s.monitored && s.statistics.episodeFileCount > 0)
 		.sort((a, b) => b.seasonNumber - a.seasonNumber);
 
-	return monitored[0]?.seasonNumber ?? 1;
+	return monitored[0]?.seasonNumber;
 }
 
 /**
@@ -523,6 +523,16 @@ export async function processUpgradeConfig(
 						} else {
 							const series = item._raw as SonarrSeries;
 							searchedSeason = pickSeasonForSearch(series);
+							if (searchedSeason == null) {
+								selectionItems.push({
+									id: item.id,
+									title: item.title,
+									original,
+									upgrades: [],
+									imageUrl: getPosterUrl(item._raw)
+								});
+								continue;
+							}
 							const releases = await (client as SonarrClient).getReleases(item.id, searchedSeason);
 							bestRelease = releases.find((r) => r.approved && !r.rejected);
 						}


### PR DESCRIPTION
Stops Sonarr dry runs from querying an unmonitored fallback season when no monitored season with files is available.

Closes #583