### PR TITLE
fix: sync referenced formats before quality profiles

### DIFF
--- a/docs/backend/sync.md
+++ b/docs/backend/sync.md
@@ -233,8 +233,9 @@ using the regex), delay profiles, naming, quality definitions, and media
 settings.
 
 Entity sync uses the same transform logic as batch sync but operates on a
-single entity. For quality profiles, the first-time path syncs referenced CFs;
-the update path reuses existing Arr CF IDs.
+single entity. For quality profiles, targeted sync first syncs the profile's
+referenced CFs before creates and updates so newly scored formats have Arr IDs
+before the profile payload is built.
 
 ## Cleanup
 

--- a/src/lib/server/sync/entitySync.ts
+++ b/src/lib/server/sync/entitySync.ts
@@ -80,24 +80,15 @@ export async function syncQualityProfile(
 		const existingProfiles = await client.getQualityProfiles();
 		const existingProfile = existingProfiles.find((p) => p.name === profileName);
 
-		let formatIdMap: Map<string, number>;
-
-		if (existingProfile) {
-			// Update path: build formatIdMap from existing arr CFs (no CF sync needed)
-			const existingFormats = await client.getCustomFormats();
-			formatIdMap = new Map(existingFormats.map((f) => [f.name, f.id!]));
-		} else {
-			// First-time path: sync referenced CFs first, then create QP
-			const referencedNames = await getCustomFormatsForProfile(cache, profileName, instanceType);
-			const pcdFormats = new Map<string, PcdCustomFormat>();
-			for (const name of referencedNames) {
-				const pcdFormat = await fetchCustomFormatFromPcd(cache, name);
-				if (pcdFormat) {
-					pcdFormats.set(name, pcdFormat);
-				}
+		const referencedNames = await getCustomFormatsForProfile(cache, profileName, instanceType);
+		const pcdFormats = new Map<string, PcdCustomFormat>();
+		for (const name of referencedNames) {
+			const pcdFormat = await fetchCustomFormatFromPcd(cache, name);
+			if (pcdFormat) {
+				pcdFormats.set(name, pcdFormat);
 			}
-			formatIdMap = await syncCustomFormats(client, instanceId, instanceType, pcdFormats);
 		}
+		const formatIdMap = await syncCustomFormats(client, instanceId, instanceType, pcdFormats);
 
 		// Get quality API mappings
 		const qualityMappings = await getQualityApiMappings(cache, instanceType);

--- a/src/routes/custom-formats/[databaseId]/[id]/conditions/components/ConditionCard.svelte
+++ b/src/routes/custom-formats/[databaseId]/[id]/conditions/components/ConditionCard.svelte
@@ -446,10 +446,10 @@
 			Flags
 		</div>
 		<div
-			class="grid grid-cols-1 gap-2 min-[900px]:grid-cols-2 wide:ml-auto wide:flex wide:shrink-0 wide:flex-wrap wide:items-center wide:gap-2"
+			class="grid grid-cols-1 gap-2 wide:ml-auto wide:flex wide:shrink-0 wide:flex-wrap wide:items-center"
 		>
 			<div
-				class="grid grid-cols-1 gap-2 min-[480px]:grid-cols-2 wide:flex wide:flex-wrap wide:items-center wide:gap-2"
+				class="grid grid-cols-1 gap-2 min-[480px]:grid-cols-2 wide:flex wide:flex-wrap wide:items-center wide:[&>*]:w-fit wide:[&>*]:justify-start"
 				data-onboarding="cf-cond-flags-modifiers"
 			>
 				<Toggle
@@ -470,7 +470,7 @@
 				/>
 			</div>
 			<div
-				class="grid grid-cols-1 gap-2 min-[480px]:grid-cols-2 wide:flex wide:flex-wrap wide:items-center wide:gap-2"
+				class="grid grid-cols-1 gap-2 min-[480px]:grid-cols-2 wide:flex wide:flex-wrap wide:items-center wide:[&>*]:w-fit wide:[&>*]:justify-start"
 				data-onboarding="cf-cond-flags-arr"
 			>
 				<Toggle


### PR DESCRIPTION
Ensures targeted quality profile sync creates or updates referenced custom formats before building the profile payload.

Also restores the condition flag layout from #686 so medium views stay full width and wide views remain compact.

Closes #659