### PR TITLE
fix: tolerate missing sonarr season statistics

### DIFF
--- a/src/lib/server/upgrades/processor.ts
+++ b/src/lib/server/upgrades/processor.ts
@@ -310,7 +310,7 @@ function createSkippedLog(
  */
 function pickSeasonForSearch(series: SonarrSeries): number | undefined {
 	const monitored = series.seasons
-		.filter((s) => s.monitored && s.statistics.episodeFileCount > 0)
+		.filter((s) => s.monitored && (s.statistics?.episodeFileCount ?? 0) > 0)
 		.sort((a, b) => b.seasonNumber - a.seasonNumber);
 
 	return monitored[0]?.seasonNumber;

--- a/src/lib/server/utils/arr/clients/sonarr.ts
+++ b/src/lib/server/utils/arr/clients/sonarr.ts
@@ -96,11 +96,11 @@ export class SonarrClient extends BaseArrClient {
 			const seasons: SonarrSeasonItem[] = series.seasons.map((s) => ({
 				seasonNumber: s.seasonNumber,
 				monitored: s.monitored,
-				episodeCount: s.statistics.episodeCount,
-				episodeFileCount: s.statistics.episodeFileCount,
-				totalEpisodeCount: s.statistics.totalEpisodeCount,
-				sizeOnDisk: s.statistics.sizeOnDisk,
-				percentOfEpisodes: s.statistics.percentOfEpisodes
+				episodeCount: s.statistics?.episodeCount ?? 0,
+				episodeFileCount: s.statistics?.episodeFileCount ?? 0,
+				totalEpisodeCount: s.statistics?.totalEpisodeCount ?? 0,
+				sizeOnDisk: s.statistics?.sizeOnDisk ?? 0,
+				percentOfEpisodes: s.statistics?.percentOfEpisodes ?? 0
 			}));
 
 			let monitoredState: 'monitored' | 'partial' | 'unmonitored';

--- a/src/lib/server/utils/arr/releaseImport.ts
+++ b/src/lib/server/utils/arr/releaseImport.ts
@@ -15,14 +15,17 @@ import type { SonarrSeries, SonarrSeason, RadarrRelease, SonarrRelease } from '.
  * A season is considered finished when episodeCount === totalEpisodeCount
  */
 export function getFinishedSeasons(series: SonarrSeries): SonarrSeason[] {
-	return series.seasons.filter((s) => s.statistics.episodeCount === s.statistics.totalEpisodeCount);
+	return series.seasons.filter((s) => isSeasonFinished(s));
 }
 
 /**
  * Check if a specific season is finished
  */
 export function isSeasonFinished(season: SonarrSeason): boolean {
-	return season.statistics.episodeCount === season.statistics.totalEpisodeCount;
+	return (
+		season.statistics !== undefined &&
+		season.statistics.episodeCount === season.statistics.totalEpisodeCount
+	);
 }
 
 // =============================================================================

--- a/src/lib/server/utils/arr/types.ts
+++ b/src/lib/server/utils/arr/types.ts
@@ -326,7 +326,7 @@ export interface SonarrSeasonStatistics {
 export interface SonarrSeason {
 	seasonNumber: number;
 	monitored: boolean;
-	statistics: SonarrSeasonStatistics;
+	statistics?: SonarrSeasonStatistics;
 }
 
 /**

--- a/tests/unit/arr/sonarrClient.test.ts
+++ b/tests/unit/arr/sonarrClient.test.ts
@@ -1,0 +1,90 @@
+import { assertEquals } from '@std/assert';
+import { BaseTest } from '../base/BaseTest.ts';
+import { SonarrClient } from '$utils/arr/clients/sonarr.ts';
+import type { ArrQualityProfile, SonarrSeries } from '$utils/arr/types.ts';
+
+class MockSonarrClient extends SonarrClient {
+	constructor(
+		private readonly series: SonarrSeries[],
+		private readonly profiles: ArrQualityProfile[]
+	) {
+		super('http://sonarr.local', 'test-api-key');
+	}
+
+	override getAllSeries(): Promise<SonarrSeries[]> {
+		return Promise.resolve(this.series);
+	}
+
+	override getQualityProfiles(): Promise<ArrQualityProfile[]> {
+		return Promise.resolve(this.profiles);
+	}
+}
+
+class SonarrClientTest extends BaseTest {
+	runTests(): void {
+		this.test('maps seasons with missing statistics to zero values', async () => {
+			const client = new MockSonarrClient(
+				[
+					{
+						id: 1,
+						title: 'Whatbox Show',
+						qualityProfileId: 10,
+						monitored: true,
+						seasons: [
+							{
+								seasonNumber: 1,
+								monitored: true
+							},
+							{
+								seasonNumber: 2,
+								monitored: true,
+								statistics: {
+									episodeCount: 8,
+									episodeFileCount: 7,
+									totalEpisodeCount: 8,
+									sizeOnDisk: 1234,
+									releaseGroups: [],
+									percentOfEpisodes: 87.5
+								}
+							}
+						]
+					}
+				],
+				[
+					{
+						id: 10,
+						name: 'HD',
+						upgradeAllowed: true,
+						cutoff: 1,
+						items: [],
+						minFormatScore: 0,
+						cutoffFormatScore: 0,
+						formatItems: []
+					}
+				]
+			);
+
+			try {
+				const library = await client.getLibrary(new Set(['HD']));
+
+				assertEquals(library[0].qualityProfileName, 'HD');
+				assertEquals(library[0].isProfilarrProfile, true);
+				assertEquals(library[0].seasons[0], {
+					seasonNumber: 1,
+					monitored: true,
+					episodeCount: 0,
+					episodeFileCount: 0,
+					totalEpisodeCount: 0,
+					sizeOnDisk: 0,
+					percentOfEpisodes: 0
+				});
+				assertEquals(library[0].seasons[1].episodeCount, 8);
+			} finally {
+				client.close();
+			}
+		});
+	}
+}
+
+const sonarrClientTest = new SonarrClientTest();
+sonarrClientTest.runTests();


### PR DESCRIPTION
Prevents Sonarr library loading from crashing when a season response omits statistics by defaulting the season counters to zero.

Closes #579