### PR TITLE
fix: support quality profile upgrades allowed

### DIFF
--- a/docs/backend/pcd-entities.md
+++ b/docs/backend/pcd-entities.md
@@ -133,7 +133,8 @@ Quality profiles tie everything together: an ordered list of acceptable
 qualities, custom format scores that influence selection, language
 preferences, and upgrade thresholds.
 
-**Fields:** name, description, tags, language
+**Fields:** name, description, tags, language, upgrades_allowed,
+minimum_custom_format_score, upgrade_until_score, upgrade_score_increment
 
 **Create** inserts the profile with defaults (`upgrades_allowed = 1`,
 scores at 0, increment at 1), then seeds all available qualities as
@@ -164,7 +165,7 @@ name without conflict.
 ### Scoring
 
 **Source:** `entities/qualityProfiles/scoring/`
-**Tables:** quality_profile_custom_formats
+**Tables:** quality_profiles, quality_profile_custom_formats
 
 Each profile assigns scores to custom formats, optionally per `arr_type`
 (`all`, `radarr`, `sonarr`). When a score set to `all` is modified for a
@@ -173,9 +174,9 @@ change only affects the targeted type.
 
 Score operations are per-CF: insert (new score), update (changed score,
 guarded on old value), or delete (score removed). Profile-level settings
-(`minimum_custom_format_score`, `upgrade_until_score`,
-`upgrade_score_increment`) are updated in separate ops with their own
-guards.
+(`upgrades_allowed`, `minimum_custom_format_score`,
+`upgrade_until_score`, `upgrade_score_increment`) are updated in separate
+ops with their own guards.
 
 ### Entity Testing
 

--- a/src/lib/server/pcd/entities/deserialize.ts
+++ b/src/lib/server/pcd/entities/deserialize.ts
@@ -164,6 +164,7 @@ export async function deserializeQualityProfile(
 		layer,
 		profileName: portable.name,
 		input: {
+			upgradesAllowed: portable.upgradesAllowed ?? true,
 			minimumScore: portable.minimumScore,
 			upgradeUntilScore: portable.upgradeUntilScore,
 			upgradeScoreIncrement: portable.upgradeScoreIncrement,

--- a/src/lib/server/pcd/entities/qualityProfiles/override/index.ts
+++ b/src/lib/server/pcd/entities/qualityProfiles/override/index.ts
@@ -26,12 +26,14 @@ function hasScoringChanges(
 	desiredState: StoredDesiredState | null
 ): boolean {
 	if (metadata?.changed_fields?.includes('minimum_custom_format_score')) return true;
+	if (metadata?.changed_fields?.includes('upgrades_allowed')) return true;
 	if (metadata?.changed_fields?.includes('upgrade_until_score')) return true;
 	if (metadata?.changed_fields?.includes('upgrade_score_increment')) return true;
 	if (metadata?.changed_fields?.includes('custom_format_scores')) return true;
 	if (metadata?.changed_fields?.some((field) => field.startsWith('custom_format_score:')))
 		return true;
 	if (desiredState?.custom_format_scores) return true;
+	if (desiredState?.upgrades_allowed) return true;
 	if (desiredState?.minimum_custom_format_score) return true;
 	if (desiredState?.upgrade_until_score) return true;
 	if (desiredState?.upgrade_score_increment) return true;

--- a/src/lib/server/pcd/entities/qualityProfiles/override/scoring.ts
+++ b/src/lib/server/pcd/entities/qualityProfiles/override/scoring.ts
@@ -59,6 +59,26 @@ export async function overrideScoring(
 	const nextDesiredState: StoredDesiredState = {};
 	const changedFields: string[] = [];
 
+	const desiredUpgradesAllowed = getDesiredTo<boolean>(desiredState.upgrades_allowed);
+	if (
+		desiredUpgradesAllowed !== undefined &&
+		!valuesEqual(desiredUpgradesAllowed, currentScoring.upgrades_allowed)
+	) {
+		queries.push({
+			sql: `UPDATE quality_profiles
+SET upgrades_allowed = ${desiredUpgradesAllowed ? 1 : 0}
+WHERE name = '${esc(profileName)}'
+  AND upgrades_allowed = ${currentScoring.upgrades_allowed ? 1 : 0}`,
+			parameters: [],
+			query: {} as never
+		});
+		nextDesiredState.upgrades_allowed = {
+			from: currentScoring.upgrades_allowed,
+			to: desiredUpgradesAllowed
+		};
+		changedFields.push('upgrades_allowed');
+	}
+
 	const desiredMinimum = getDesiredTo<number>(desiredState.minimum_custom_format_score);
 	if (
 		desiredMinimum !== undefined &&

--- a/src/lib/server/pcd/entities/qualityProfiles/scoring/read.ts
+++ b/src/lib/server/pcd/entities/qualityProfiles/scoring/read.ts
@@ -24,7 +24,12 @@ export async function scoring(
 	// 1. Get profile settings
 	const profile = await db
 		.selectFrom('quality_profiles')
-		.select(['minimum_custom_format_score', 'upgrade_until_score', 'upgrade_score_increment'])
+		.select([
+			'upgrades_allowed',
+			'minimum_custom_format_score',
+			'upgrade_until_score',
+			'upgrade_score_increment'
+		])
 		.where('name', '=', profileName)
 		.executeTakeFirst();
 
@@ -101,6 +106,7 @@ export async function scoring(
 		databaseId,
 		arrTypes,
 		customFormats: customFormatScoring,
+		upgrades_allowed: profile.upgrades_allowed === 1,
 		minimum_custom_format_score: profile.minimum_custom_format_score,
 		upgrade_until_score: profile.upgrade_until_score,
 		upgrade_score_increment: profile.upgrade_score_increment

--- a/src/lib/server/pcd/entities/qualityProfiles/scoring/update.ts
+++ b/src/lib/server/pcd/entities/qualityProfiles/scoring/update.ts
@@ -23,6 +23,7 @@ interface CustomFormatScore {
 }
 
 interface UpdateScoringInput {
+	upgradesAllowed: boolean;
 	minimumScore: number;
 	upgradeUntilScore: number;
 	upgradeScoreIncrement: number;
@@ -64,7 +65,12 @@ export async function updateScoring(options: UpdateScoringOptions) {
 
 	const currentProfile = await db
 		.selectFrom('quality_profiles')
-		.select(['minimum_custom_format_score', 'upgrade_until_score', 'upgrade_score_increment'])
+		.select([
+			'upgrades_allowed',
+			'minimum_custom_format_score',
+			'upgrade_until_score',
+			'upgrade_score_increment'
+		])
 		.where('name', '=', profileName)
 		.executeTakeFirst();
 
@@ -84,6 +90,30 @@ export async function updateScoring(options: UpdateScoringOptions) {
 	}
 
 	const ops: ScoringOp[] = [];
+	const currentUpgradesAllowed = currentProfile.upgrades_allowed === 1;
+
+	if (currentUpgradesAllowed !== input.upgradesAllowed) {
+		const query = db
+			.updateTable('quality_profiles')
+			.set({ upgrades_allowed: input.upgradesAllowed ? 1 : 0 })
+			.where('name', '=', profileName)
+			.where('upgrades_allowed', '=', currentProfile.upgrades_allowed)
+			.compile();
+
+		ops.push({
+			description: `update-quality-profile-upgrades-allowed-${profileName}`,
+			queries: [query],
+			desiredState: {
+				upgrades_allowed: {
+					from: currentUpgradesAllowed,
+					to: input.upgradesAllowed
+				}
+			},
+			changedFields: ['upgrades_allowed'],
+			summary: 'Update quality profile upgrades allowed',
+			title: `Update upgrades allowed for quality profile "${profileName}"`
+		});
+	}
 
 	// Expand 'all' rows into per-arr-type rows for any CFs being modified.
 	// This prevents ghost fallbacks when a specific arr_type score is deleted

--- a/src/lib/server/pcd/entities/serialize.ts
+++ b/src/lib/server/pcd/entities/serialize.ts
@@ -139,6 +139,7 @@ export async function serializeQualityProfile(
 		.select([
 			'name',
 			'description',
+			'upgrades_allowed',
 			'minimum_custom_format_score',
 			'upgrade_until_score',
 			'upgrade_score_increment'
@@ -177,6 +178,7 @@ export async function serializeQualityProfile(
 		tags: tags.map((t) => t.name),
 		language: languageRow?.language_name ?? null,
 		orderedItems: qualitiesData.orderedItems,
+		upgradesAllowed: profile.upgrades_allowed === 1,
 		minimumScore: profile.minimum_custom_format_score,
 		upgradeUntilScore: profile.upgrade_until_score,
 		upgradeScoreIncrement: profile.upgrade_score_increment,

--- a/src/lib/server/pcd/entities/validate.ts
+++ b/src/lib/server/pcd/entities/validate.ts
@@ -143,6 +143,9 @@ function validateQualityProfile(data: Record<string, unknown>): string | null {
 	if (!Array.isArray(data.orderedItems)) {
 		return 'data.orderedItems must be an array';
 	}
+	if (data.upgradesAllowed !== undefined && typeof data.upgradesAllowed !== 'boolean') {
+		return 'data.upgradesAllowed must be a boolean';
+	}
 	if (typeof data.minimumScore !== 'number') {
 		return 'data.minimumScore must be a number';
 	}

--- a/src/lib/shared/pcd/display.ts
+++ b/src/lib/shared/pcd/display.ts
@@ -386,6 +386,7 @@ export interface QualityProfileScoring {
 	databaseId: number;
 	arrTypes: string[];
 	customFormats: CustomFormatScoring[];
+	upgrades_allowed: boolean;
 	minimum_custom_format_score: number;
 	upgrade_until_score: number;
 	upgrade_score_increment: number;

--- a/src/lib/shared/pcd/portable.ts
+++ b/src/lib/shared/pcd/portable.ts
@@ -93,6 +93,7 @@ export interface PortableQualityProfile {
 	tags: string[];
 	language: string | null;
 	orderedItems: OrderedItem[];
+	upgradesAllowed?: boolean;
 	minimumScore: number;
 	upgradeUntilScore: number;
 	upgradeScoreIncrement: number;

--- a/src/routes/quality-profiles/[databaseId]/[id]/scoring/+page.server.ts
+++ b/src/routes/quality-profiles/[databaseId]/[id]/scoring/+page.server.ts
@@ -78,6 +78,7 @@ export const actions: Actions = {
 		const formData = await request.formData();
 
 		// Parse form data
+		const upgradesAllowed = formData.get('upgradesAllowed') !== 'false';
 		const minimumScore = parseInt(formData.get('minimumScore') as string, 10) || 0;
 		const upgradeUntilScore = parseInt(formData.get('upgradeUntilScore') as string, 10) || 0;
 		const upgradeScoreIncrement =
@@ -127,6 +128,7 @@ export const actions: Actions = {
 				layer,
 				profileName: profile.name,
 				input: {
+					upgradesAllowed,
 					minimumScore,
 					upgradeUntilScore,
 					upgradeScoreIncrement,

--- a/src/routes/quality-profiles/[databaseId]/[id]/scoring/+page.svelte
+++ b/src/routes/quality-profiles/[databaseId]/[id]/scoring/+page.svelte
@@ -986,7 +986,6 @@
 								{customFormatScores}
 								{customFormatEnabled}
 								{getArrTypeColor}
-								disabled={!upgradesAllowed}
 								title={group.name}
 								firstRowOnboarding={groupIndex === 0 ? 'qp-scoring-row' : undefined}
 								on:scoreChange={handleScoreChange}

--- a/src/routes/quality-profiles/[databaseId]/[id]/scoring/+page.svelte
+++ b/src/routes/quality-profiles/[databaseId]/[id]/scoring/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import FormInput from '$ui/form/FormInput.svelte';
 	import NumberInput from '$ui/form/NumberInput.svelte';
+	import Toggle from '$ui/toggle/Toggle.svelte';
 	import {
 		Info,
 		ArrowUpDown,
@@ -57,6 +58,7 @@
 
 	// Scoring data shape
 	interface ScoringFormData {
+		upgradesAllowed: boolean;
 		minimumScore: number;
 		upgradeUntilScore: number;
 		upgradeScoreIncrement: number;
@@ -71,6 +73,7 @@
 	function buildInitialData(scoring: typeof data.scoring): ScoringFormData {
 		if (!scoring) {
 			return {
+				upgradesAllowed: true,
 				minimumScore: 0,
 				upgradeUntilScore: 0,
 				upgradeScoreIncrement: 1,
@@ -91,6 +94,7 @@
 		});
 
 		return {
+			upgradesAllowed: scoring.upgrades_allowed,
 			minimumScore: scoring.minimum_custom_format_score,
 			upgradeUntilScore: scoring.upgrade_until_score,
 			upgradeScoreIncrement: scoring.upgrade_score_increment,
@@ -103,6 +107,7 @@
 	$: initEdit(initialData);
 
 	// Reactive getters for current values
+	$: upgradesAllowed = ($current.upgradesAllowed ?? true) as boolean;
 	$: minimumScore = ($current.minimumScore ?? 0) as number;
 	$: upgradeUntilScore = ($current.upgradeUntilScore ?? 0) as number;
 	$: upgradeScoreIncrement = ($current.upgradeScoreIncrement ?? 1) as number;
@@ -672,6 +677,7 @@
 			};
 		}}
 	>
+		<input type="hidden" name="upgradesAllowed" value={upgradesAllowed ? 'true' : 'false'} />
 		<input type="hidden" name="minimumScore" value={minimumScore} />
 		<input type="hidden" name="upgradeUntilScore" value={upgradeUntilScore} />
 		<input type="hidden" name="upgradeScoreIncrement" value={upgradeScoreIncrement} />
@@ -681,7 +687,26 @@
 
 	<div class="mt-6 space-y-6 md:px-4">
 		<!-- Profile-level Score Settings -->
-		<div class="grid grid-cols-1 gap-6 md:grid-cols-3">
+		<div class="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-4">
+			<div class="space-y-2" data-onboarding="qp-scoring-upgrades-allowed">
+				<label
+					for="upgradesAllowed"
+					class="block text-sm font-medium text-neutral-900 dark:text-neutral-100"
+				>
+					Upgrades Allowed
+				</label>
+				<p class="text-xs text-neutral-600 dark:text-neutral-400">
+					Allow this profile to upgrade existing media
+				</p>
+				<Toggle
+					checked={upgradesAllowed}
+					label={upgradesAllowed ? 'Enabled' : 'Disabled'}
+					ariaLabel="Upgrades allowed"
+					fullWidth
+					on:change={(event) => update('upgradesAllowed', event.detail)}
+				/>
+			</div>
+
 			<div class="space-y-2" data-onboarding="qp-scoring-minimum">
 				<label
 					for="minimumScore"
@@ -717,6 +742,7 @@
 					onchange={(v) => update('upgradeUntilScore', v)}
 					step={1}
 					font="mono"
+					disabled={!upgradesAllowed}
 				/>
 			</div>
 
@@ -736,6 +762,7 @@
 					onchange={(v) => update('upgradeScoreIncrement', v)}
 					step={1}
 					font="mono"
+					disabled={!upgradesAllowed}
 				/>
 			</div>
 		</div>
@@ -959,6 +986,7 @@
 								{customFormatScores}
 								{customFormatEnabled}
 								{getArrTypeColor}
+								disabled={!upgradesAllowed}
 								title={group.name}
 								firstRowOnboarding={groupIndex === 0 ? 'qp-scoring-row' : undefined}
 								on:scoreChange={handleScoreChange}

--- a/src/routes/quality-profiles/[databaseId]/[id]/scoring/components/ScoringTable.svelte
+++ b/src/routes/quality-profiles/[databaseId]/[id]/scoring/components/ScoringTable.svelte
@@ -6,6 +6,7 @@
 	export let arrTypes: string[];
 	export let customFormatScores: Record<string, Record<string, number | null>>;
 	export let customFormatEnabled: Record<string, Record<string, boolean>>;
+	export let disabled: boolean = false;
 	type IconCheckboxColor =
 		| 'accent'
 		| 'blue'
@@ -56,6 +57,7 @@
 		{arrTypes}
 		{customFormatScores}
 		{customFormatEnabled}
+		{disabled}
 		{getArrTypeColor}
 		{firstRowOnboarding}
 		on:scoreChange
@@ -68,6 +70,7 @@
 		{arrTypes}
 		{customFormatScores}
 		{customFormatEnabled}
+		{disabled}
 		{getArrTypeColor}
 		{firstRowOnboarding}
 		on:scoreChange

--- a/src/routes/quality-profiles/[databaseId]/[id]/scoring/components/ScoringTableDesktop.svelte
+++ b/src/routes/quality-profiles/[databaseId]/[id]/scoring/components/ScoringTableDesktop.svelte
@@ -12,6 +12,7 @@
 	export let arrTypes: string[];
 	export let customFormatScores: Record<string, Record<string, number | null>>;
 	export let customFormatEnabled: Record<string, Record<string, boolean>>;
+	export let disabled: boolean = false;
 	type IconCheckboxColor =
 		| 'accent'
 		| 'blue'
@@ -61,10 +62,12 @@
 	}
 
 	function handleScoreChange(formatName: string, arrType: string, score: number | null) {
+		if (disabled) return;
 		dispatch('scoreChange', { formatName, arrType, score });
 	}
 
 	function handleToggleEnabled(formatName: string, arrType: string) {
+		if (disabled) return;
 		const isEnabled = customFormatEnabled[formatName]?.[arrType] ?? false;
 		if (isEnabled) {
 			dispatch('scoreChange', { formatName, arrType, score: null });
@@ -97,6 +100,7 @@
 					icon={Check}
 					color={getArrTypeColor(arrType)}
 					shape="circle"
+					{disabled}
 					on:click={() => handleToggleEnabled(row.name, arrType)}
 				/>
 				{#if customFormatScores[row.name]}
@@ -106,7 +110,7 @@
 							value={customFormatScores[row.name][arrType] ?? 0}
 							onchange={(newValue) => handleScoreChange(row.name, arrType, newValue)}
 							step={1}
-							disabled={!customFormatEnabled[row.name]?.[arrType]}
+							disabled={disabled || !customFormatEnabled[row.name]?.[arrType]}
 							font="mono"
 						/>
 					</div>

--- a/src/routes/quality-profiles/[databaseId]/[id]/scoring/components/ScoringTableMobile.svelte
+++ b/src/routes/quality-profiles/[databaseId]/[id]/scoring/components/ScoringTableMobile.svelte
@@ -11,6 +11,7 @@
 	export let arrTypes: string[];
 	export let customFormatScores: Record<string, Record<string, number | null>>;
 	export let customFormatEnabled: Record<string, Record<string, boolean>>;
+	export let disabled: boolean = false;
 	type IconCheckboxColor =
 		| 'accent'
 		| 'blue'
@@ -37,10 +38,12 @@
 	$: visibleFormats = formats.slice(start, end);
 
 	function handleScoreChange(formatName: string, arrType: string, score: number | null) {
+		if (disabled) return;
 		dispatch('scoreChange', { formatName, arrType, score });
 	}
 
 	function handleToggleEnabled(formatName: string, arrType: string) {
+		if (disabled) return;
 		const isEnabled = customFormatEnabled[formatName]?.[arrType] ?? false;
 		if (isEnabled) {
 			dispatch('scoreChange', { formatName, arrType, score: null });
@@ -97,6 +100,7 @@
 									icon={Check}
 									color={getArrTypeColor(arrType)}
 									shape="circle"
+									{disabled}
 									on:click={() => handleToggleEnabled(format.name, arrType)}
 								/>
 								<span class="text-xs font-medium text-neutral-600 capitalize dark:text-neutral-400">
@@ -110,7 +114,7 @@
 										value={customFormatScores[format.name][arrType] ?? 0}
 										onchange={(newValue) => handleScoreChange(format.name, arrType, newValue)}
 										step={1}
-										disabled={!customFormatEnabled[format.name]?.[arrType]}
+										disabled={disabled || !customFormatEnabled[format.name]?.[arrType]}
 										responsive={true}
 										font="mono"
 									/>

--- a/tests/integration/harness/ports.ts
+++ b/tests/integration/harness/ports.ts
@@ -103,6 +103,7 @@ export const PORTS = {
 		writeQualityDefinitionsSonarrDelete: 7627,
 		writeQualityProfilesGeneralUpdate: 7628,
 		writeCustomFormatConditions: 7629,
+		writeQualityProfilesScoringUpdate: 7630,
 		conflictsDelayProfiles: 7700,
 		conflictsRegex: 7701,
 		conflictsMediaSettings: 7702,

--- a/tests/integration/pcd/conflicts/quality-profiles-scoring.test.ts
+++ b/tests/integration/pcd/conflicts/quality-profiles-scoring.test.ts
@@ -38,6 +38,7 @@ type LatestHistory = {
 type QualityProfileScoringRow = {
 	name: string;
 	description: string | null;
+	upgrades_allowed: number;
 	minimum_custom_format_score: number;
 	upgrade_until_score: number;
 	upgrade_score_increment: number;
@@ -266,6 +267,37 @@ test('matching upstream upgrade score increment auto-aligns user op', async () =
 	}
 });
 
+test('matching upstream upgrades allowed auto-aligns user op', async () => {
+	for (const strategy of STRATEGIES) {
+		const ctx = await seededScenario(strategy, 'upgrades-allowed-auto-align', [
+			base.qualityProfile({
+				name: PROFILE_NAME
+			})
+		]);
+		const checkpoint = opCheckpoint(ctx);
+
+		await write.qualityProfile.updateScoring(ctx, 1, {
+			upgradesAllowed: false
+		});
+
+		seedUpstream(
+			ctx,
+			upstreamProfileScoringUpdate(PROFILE_NAME, {
+				upgrades_allowed: { from: true, to: false }
+			})
+		);
+		await compilePcd(ctx);
+
+		const op = firstOpForChangedFields(opsSince(ctx, checkpoint), ['upgrades_allowed']);
+		assertEquals(op.state, 'dropped');
+		assertLatestHistory(ctx, op, 'dropped', 'aligned');
+		assertNoPendingConflicts(ctx);
+
+		const row = assertQualityProfileScoring(ctx, PROFILE_NAME);
+		assertEquals(row.upgrades_allowed, 0);
+	}
+});
+
 /**
  * Migrates old 2.14.
  *
@@ -456,6 +488,31 @@ test('minimum score update after upstream rename resolves by strategy', async ()
 
 		const row = assertQualityProfileScoring(ctx, 'Scoring Profile Upstream');
 		assertEquals(row.minimum_custom_format_score, strategy === 'override' ? 7 : 0);
+		assertNoQualityProfileScoring(ctx, PROFILE_NAME);
+	}
+});
+
+test('upgrades allowed update after upstream rename resolves by strategy', async () => {
+	for (const strategy of STRATEGIES) {
+		const ctx = await seededScenario(strategy, 'upgrades-allowed-upstream-rename', [
+			base.qualityProfile({
+				name: PROFILE_NAME
+			})
+		]);
+		const checkpoint = opCheckpoint(ctx);
+
+		await write.qualityProfile.updateScoring(ctx, 1, {
+			upgradesAllowed: false
+		});
+
+		seedUpstream(ctx, upstreamRename(PROFILE_NAME, 'Scoring Profile Upstream'));
+		await compilePcd(ctx);
+
+		const op = firstOpForChangedFields(opsSince(ctx, checkpoint), ['upgrades_allowed']);
+		assertStrategyOutcome(ctx, op, strategy, 'guard_mismatch');
+
+		const row = assertQualityProfileScoring(ctx, 'Scoring Profile Upstream');
+		assertEquals(row.upgrades_allowed, strategy === 'override' ? 0 : 1);
 		assertNoQualityProfileScoring(ctx, PROFILE_NAME);
 	}
 });
@@ -1270,6 +1327,7 @@ function compiledQualityProfileState(ctx: PcdTestContext): {
 			.prepare(
 				`SELECT name,
 				        description,
+				        upgrades_allowed,
 				        minimum_custom_format_score,
 				        upgrade_until_score,
 				        upgrade_score_increment

--- a/tests/integration/pcd/harness/fixtures.ts
+++ b/tests/integration/pcd/harness/fixtures.ts
@@ -126,6 +126,7 @@ export const base = {
 		description?: string | null;
 		tags?: string[];
 		language?: string | null;
+		upgradesAllowed?: boolean;
 		minimumScore?: number;
 		upgradeUntilScore?: number;
 		upgradeScoreIncrement?: number;
@@ -176,7 +177,7 @@ export const base = {
 			      VALUES (
 				       ${sqlValue(input.name)},
 				       ${sqlValue(description)},
-				       1,
+				       ${input.upgradesAllowed === false ? 0 : 1},
 				       ${sqlNumber(input.minimumScore ?? 0)},
 				       ${sqlNumber(input.upgradeUntilScore ?? 0)},
 				       ${sqlNumber(input.upgradeScoreIncrement ?? 1)}

--- a/tests/integration/pcd/harness/write.ts
+++ b/tests/integration/pcd/harness/write.ts
@@ -43,6 +43,7 @@ export interface QualityProfileQualityItemInput {
 }
 
 export interface QualityProfileScoringFormInput {
+	upgradesAllowed?: boolean;
 	minimumScore?: number;
 	upgradeUntilScore?: number;
 	upgradeScoreIncrement?: number;
@@ -574,6 +575,7 @@ function qualityProfileScoringFields(
 	input: QualityProfileScoringFormInput
 ): Record<string, string> {
 	return {
+		upgradesAllowed: String(input.upgradesAllowed ?? true),
 		minimumScore: String(input.minimumScore ?? 0),
 		upgradeUntilScore: String(input.upgradeUntilScore ?? 0),
 		upgradeScoreIncrement: String(input.upgradeScoreIncrement ?? 1),

--- a/tests/integration/pcd/write/quality-profiles/scoring-update.test.ts
+++ b/tests/integration/pcd/write/quality-profiles/scoring-update.test.ts
@@ -1,0 +1,137 @@
+/**
+ * PCD write tests: quality profile scoring update.
+ */
+
+import { assert, assertEquals, assertExists } from '@std/assert';
+import { startServer, stopServer } from '$test-harness/server.ts';
+import { openDb } from '$test-harness/db.ts';
+import { run, setup, teardown, test } from '$test-harness/runner.ts';
+import { PORTS } from '$test-harness/ports.ts';
+import { base } from '../../harness/fixtures.ts';
+import {
+	normalizeSql,
+	opCheckpoint,
+	parseDesiredState,
+	type OpRow,
+	type PcdTestContext
+} from '../../harness/pcd.ts';
+import { write } from '../../harness/write.ts';
+import { createScenarioFactory, opForChangedField, userOpsSince } from './helpers.ts';
+
+const PORT = PORTS.pcd.writeQualityProfilesScoringUpdate;
+const ORIGIN = `http://localhost:${PORT}`;
+
+const { seededPcd } = createScenarioFactory(PORT, 'pcd-write-quality-profile-scoring-update');
+
+setup(async () => {
+	await startServer(PORT, { AUTH: 'off', ORIGIN }, 'preview');
+});
+
+teardown(async () => {
+	await stopServer(PORT);
+});
+
+test('upgrades allowed disable emits guarded op', async () => {
+	const ctx = await seededPcd('upgrades-allowed-disable', [
+		base.qualityProfile({
+			name: 'Upgrade Toggle Profile'
+		})
+	]);
+	const checkpoint = opCheckpoint(ctx);
+
+	await write.qualityProfile.updateScoring(ctx, 1, {
+		upgradesAllowed: false
+	});
+
+	const ops = userOpsSince(ctx, checkpoint);
+	assertEquals(ops.length, 1);
+	const op = opForChangedField(ops, 'upgrades_allowed');
+	assertEquals(parseDesiredState(op).upgrades_allowed, {
+		from: true,
+		to: false
+	});
+
+	const sql = normalizeSql(op.sql).toLowerCase();
+	assert(sql.includes('upgrades_allowed" = 0'), `Expected disabled value, got ${sql}`);
+	assert(sql.includes('upgrades_allowed" = 1'), `Expected current value guard, got ${sql}`);
+});
+
+test('upgrades allowed enable applies cleanly', async () => {
+	const ctx = await seededPcd('upgrades-allowed-enable', [
+		base.qualityProfile({
+			name: 'Upgrade Toggle Profile',
+			upgradesAllowed: false
+		})
+	]);
+	const checkpoint = opCheckpoint(ctx);
+
+	await write.qualityProfile.updateScoring(ctx, 1, {
+		upgradesAllowed: true
+	});
+
+	const op = opForChangedField(userOpsSince(ctx, checkpoint), 'upgrades_allowed');
+	assertEquals(parseDesiredState(op).upgrades_allowed, {
+		from: false,
+		to: true
+	});
+	assertEquals(compiledUpgradesAllowed(ctx, 'Upgrade Toggle Profile'), 1);
+});
+
+function compiledUpgradesAllowed(ctx: PcdTestContext, name: string): number {
+	const source = openDb(ctx.dbPath);
+	const replay = openDb(':memory:');
+
+	try {
+		replay.exec('PRAGMA foreign_keys = ON');
+		replay.exec(Deno.readTextFileSync('docs/backend/0.schema.sql'));
+
+		const ops = source
+			.prepare(
+				`SELECT *
+				 FROM pcd_ops
+				 WHERE database_id = ?
+				   AND (
+				       (origin = 'base' AND state = 'published')
+				       OR (origin = 'user' AND state = 'published')
+				   )
+				 ORDER BY
+				   CASE origin WHEN 'base' THEN 0 ELSE 1 END,
+				   COALESCE(sequence, id),
+				   id`
+			)
+			.all(ctx.dbId) as OpRow[];
+		const histories = latestHistories(source, ctx.dbId);
+
+		for (const op of ops) {
+			if (op.origin === 'user' && histories.get(op.id) !== 'applied') continue;
+			replay.exec(op.sql);
+		}
+
+		const row = replay
+			.prepare('SELECT upgrades_allowed FROM quality_profiles WHERE name = ?')
+			.get(name) as { upgrades_allowed: number } | undefined;
+		assertExists(row, `Expected quality profile ${name}`);
+		return row.upgrades_allowed;
+	} finally {
+		replay.close();
+		source.close();
+	}
+}
+
+function latestHistories(db: ReturnType<typeof openDb>, databaseId: number): Map<number, string> {
+	const rows = db
+		.prepare(
+			`SELECT op_id, status
+			 FROM pcd_op_history
+			 WHERE database_id = ?
+			 ORDER BY applied_at ASC, id ASC`
+		)
+		.all(databaseId) as Array<{ op_id: number; status: string }>;
+	const latest = new Map<number, string>();
+	for (const row of rows) {
+		latest.set(row.op_id, row.status);
+	}
+	return latest;
+}
+
+run();


### PR DESCRIPTION
Adds an Upgrades Allowed control for quality profiles and persists it through PCD scoring ops, including conflict override handling.

Closes #589