### PR TITLE
chore: add release helper tasks

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -55,6 +55,8 @@
 		"check:server": "deno check --quiet src/lib/server/**/*.ts",
 		"check:client": "NODE_ENV=development npx svelte-check --tsconfig ./tsconfig.json",
 		"test": "deno run -A tests/runner.ts",
+		"release:dry": "deno run --allow-run=git-cliff scripts/release.ts dry",
+		"release": "deno run --allow-run=git scripts/release.ts tag",
 		"generate:api-json": "deno run --allow-read=docs/api/v1 --allow-write=src/lib/api/v1.openapi.json scripts/generate-openapi-json.ts",
 		"generate:api-types": "deno task generate:api-json && npx openapi-typescript docs/api/v1/openapi.yaml -o src/lib/api/v1.d.ts && prettier --write src/lib/api/v1.d.ts src/lib/api/v1.openapi.json",
 		"generate:pcd-types": "deno run -A scripts/generate-pcd-types.ts",

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -1,0 +1,58 @@
+const mode = Deno.args[0];
+const version = Deno.args[1];
+const versionPattern = /^v\d+\.\d+\.\d+$/;
+
+function usage(): never {
+	console.error('Usage:');
+	console.error('  deno task release:dry v2.6.0');
+	console.error('  deno task release v2.6.0');
+	Deno.exit(1);
+}
+
+function assertVersion(value: string | undefined): string {
+	if (!value || !versionPattern.test(value)) {
+		console.error('Version must look like v2.6.0.');
+		usage();
+	}
+
+	return value;
+}
+
+async function run(command: string, args: string[]) {
+	try {
+		const status = await new Deno.Command(command, {
+			args,
+			stdout: 'inherit',
+			stderr: 'inherit'
+		}).output();
+
+		if (!status.success) {
+			Deno.exit(status.code);
+		}
+	} catch (error) {
+		if (error instanceof Deno.errors.NotFound) {
+			console.error(`${command} was not found on PATH.`);
+			Deno.exit(127);
+		}
+
+		throw error;
+	}
+}
+
+const tag = assertVersion(version);
+
+if (mode === 'dry') {
+	await run('git-cliff', ['--config', 'cliff.toml', '--unreleased', '--tag', tag]);
+} else if (mode === 'tag') {
+	const answer = prompt(`Create and push release tag ${tag}? Type ${tag} to confirm:`);
+
+	if (answer !== tag) {
+		console.error('Release cancelled.');
+		Deno.exit(1);
+	}
+
+	await run('git', ['tag', tag]);
+	await run('git', ['push', 'origin', tag]);
+} else {
+	usage();
+}


### PR DESCRIPTION
Adds Deno tasks to preview git-cliff release notes for a supplied version and to create/push a confirmed release tag.