### PR TITLE
fix: strip backup git remote credentials

### DIFF
--- a/docs/backend/security.md
+++ b/docs/backend/security.md
@@ -378,11 +378,13 @@ Secrets are stripped at two levels:
   history), and empties `users`, `sessions`, and `login_attempts`. Personal
   access tokens on `database_instances`, AI keys on `ai_settings`, and TMDB
   keys on `tmdb_settings` are nulled but the rows are kept (PCD repos remain
-  linked, schedules and other settings preserved). `auth_settings.api_key`
-  is left in place because it is a bcrypt hash of a high-entropy random key,
-  computationally infeasible to brute-force from the hash alone. The local
-  archive on disk and the production database are never modified. See
-  `src/lib/server/utils/backup/sanitize.ts` for the exact policy.
+  linked, schedules and other settings preserved). Embedded HTTP(S)
+  credentials are also stripped from cloned PCD repository `.git/config`
+  remote URLs. `auth_settings.api_key` is left in place because it is a
+  bcrypt hash of a high-entropy random key, computationally infeasible to
+  brute-force from the hash alone. The local archive on disk and the production
+  database are never modified. See `src/lib/server/utils/backup/sanitize.ts`
+  for the exact policy.
 
 ### XSS via Markdown / {@html}
 

--- a/src/lib/server/utils/backup/sanitize.ts
+++ b/src/lib/server/utils/backup/sanitize.ts
@@ -18,6 +18,8 @@
  *   emails for OIDC users.
  * - database_instances PATs are nulled but the rows stay (PCD repos remain
  *   linked to the user post-restore).
+ * - Git remote URLs in cloned PCD repos are kept, but any embedded HTTP(S)
+ *   credentials are removed from `.git/config`.
  * - ai_settings / tmdb_settings api keys nulled (rows stay).
  * - auth_settings.api_key NOT touched; it's bcrypt-hashed of a high-entropy
  *   random key, so the hash is computationally infeasible to brute-force.
@@ -54,8 +56,57 @@ export const SANITIZED_CATEGORIES = [
 	'Notification services (webhook URLs, tokens, history)',
 	'User accounts and active sessions',
 	'Personal access tokens for linked databases',
+	'Credentials embedded in cloned database Git remote URLs',
 	'AI and TMDB API keys'
 ];
+
+function sanitizeGitConfigContent(content: string): string {
+	return content.replace(/^(\s*url\s*=\s*)(\S+)(.*)$/gm, (match, prefix, rawUrl, suffix) => {
+		try {
+			const url = new URL(rawUrl);
+			if (url.protocol !== 'http:' && url.protocol !== 'https:') return match;
+			if (!url.username && !url.password) return match;
+
+			url.username = '';
+			url.password = '';
+			return `${prefix}${url.toString()}${suffix}`;
+		} catch {
+			return match;
+		}
+	});
+}
+
+async function sanitizeGitConfigs(rootDir: string): Promise<void> {
+	async function walk(dir: string): Promise<void> {
+		for await (const entry of Deno.readDir(dir)) {
+			const path = `${dir}/${entry.name}`;
+
+			if (entry.isDirectory) {
+				if (entry.name === '.git') {
+					const configPath = `${path}/config`;
+					try {
+						const content = await Deno.readTextFile(configPath);
+						const sanitized = sanitizeGitConfigContent(content);
+						if (sanitized !== content) {
+							await Deno.writeTextFile(configPath, sanitized);
+						}
+					} catch (err) {
+						if (!(err instanceof Deno.errors.NotFound)) throw err;
+					}
+					continue;
+				}
+
+				await walk(path);
+			}
+		}
+	}
+
+	try {
+		await walk(rootDir);
+	} catch (err) {
+		if (!(err instanceof Deno.errors.NotFound)) throw err;
+	}
+}
 
 /**
  * Apply the sanitize SQL to an open SQLite database handle.
@@ -118,6 +169,8 @@ export async function buildSanitizedArchive(archivePath: string): Promise<Uint8A
 				dest.close();
 			}
 		}
+
+		await sanitizeGitConfigs(`${dataDir}/databases`);
 
 		// Flip INFO.json's sanitized flag.
 		const infoPath = `${dataDir}/INFO.json`;

--- a/src/routes/settings/backups/+page.svelte
+++ b/src/routes/settings/backups/+page.svelte
@@ -356,8 +356,9 @@
 >
 	<div slot="body" class="space-y-3 text-sm text-neutral-600 dark:text-neutral-400">
 		<p>
-			The local copy on this server is full-fidelity. The downloaded file is sanitized so it's safer
-			to share. The following will be removed before download:
+			The local copy on this server includes everything needed for restore, including secrets. The
+			downloaded file is sanitized so it's safer to share. The following will be removed before
+			download:
 		</p>
 		<ul class="list-disc space-y-1 pl-5">
 			{#each data.sanitizedCategories as category}

--- a/tests/integration/backups/specs/backupSecrets.test.ts
+++ b/tests/integration/backups/specs/backupSecrets.test.ts
@@ -13,6 +13,7 @@
  * - DELETE notification_services (cascades to history)
  * - DELETE users, sessions, login_attempts
  * - NULL database_instances.personal_access_token (rows preserved)
+ * - Strip credentials from cloned repository .git/config remote URLs
  * - Empty ai_settings.api_key, tmdb_settings.api_key
  * - auth_settings.api_key intentionally untouched (bcrypt hash of a
  *   high-entropy random key, computationally safe to share)
@@ -38,6 +39,8 @@ const BACKUPS_DIR = `./dist/integration-${PORT}/backups`;
 // Known secrets seeded into the live DB
 const ARR_API_KEY = 'sonarr-backup-test-key-abc123';
 const DB_PAT = 'ghp-backup-test-pat-xyz789';
+const GIT_REMOTE_PAT = 'ghp-backup-test-git-remote-pat-uvw123';
+const DEP_GIT_REMOTE_PAT = 'ghp-backup-test-dep-git-remote-pat-mno345';
 const TMDB_API_KEY = 'tmdb-backup-test-key-def456';
 const AI_API_KEY = 'sk-backup-test-ai-key-ghi012';
 const PROFILARR_API_KEY = 'profilarr-backup-test-key-jkl345';
@@ -49,6 +52,7 @@ let extractDir: string;
 let onDiskBytesBefore: Uint8Array;
 let onDiskBytesAfter: Uint8Array;
 let liveProfilarrApiKeyHash: string;
+let databaseUuid: string;
 
 async function seedSecrets(dbPath: string) {
 	const db = openDb(dbPath);
@@ -62,10 +66,35 @@ async function seedSecrets(dbPath: string) {
 
 		// Database instance
 		const uuid = crypto.randomUUID();
+		databaseUuid = uuid;
 		db.exec(
 			`INSERT INTO database_instances (uuid, name, repository_url, personal_access_token, local_path, enabled)
 			 VALUES (?, 'Backup Test DB', 'https://github.com/test/repo', ?, ?, 1)`,
 			[uuid, DB_PAT, `./data/databases/${uuid}`]
+		);
+
+		const repoPath = `./dist/integration-${PORT}/data/databases/${uuid}`;
+		await Deno.mkdir(`${repoPath}/.git`, { recursive: true });
+		await Deno.writeTextFile(
+			`${repoPath}/.git/config`,
+			`[core]
+\trepositoryformatversion = 0
+\tfilemode = true
+[remote "origin"]
+\turl = https://${GIT_REMOTE_PAT}@github.com/test/repo.git
+\tfetch = +refs/heads/*:refs/remotes/origin/*
+`
+		);
+		await Deno.mkdir(`${repoPath}/deps/schema/.git`, { recursive: true });
+		await Deno.writeTextFile(
+			`${repoPath}/deps/schema/.git/config`,
+			`[core]
+\trepositoryformatversion = 0
+\tfilemode = true
+[remote "origin"]
+\turl = https://x-access-token:${DEP_GIT_REMOTE_PAT}@github.com/test/schema.git
+\tfetch = +refs/heads/*:refs/remotes/origin/*
+`
 		);
 
 		// TMDB API key
@@ -280,6 +309,28 @@ test('downloaded archive: database_instances rows preserved with PAT nulled', ()
 	} finally {
 		db.close();
 	}
+});
+
+test('downloaded archive: cloned repository git remotes have credentials stripped', async () => {
+	const repoConfig = await Deno.readTextFile(
+		`${extractDir}/data/databases/${databaseUuid}/.git/config`
+	);
+	const depConfig = await Deno.readTextFile(
+		`${extractDir}/data/databases/${databaseUuid}/deps/schema/.git/config`
+	);
+
+	assertEquals(
+		repoConfig.includes(GIT_REMOTE_PAT),
+		false,
+		'Repository remote PAT should be removed from .git/config'
+	);
+	assertEquals(
+		depConfig.includes(DEP_GIT_REMOTE_PAT),
+		false,
+		'Dependency remote PAT should be removed from .git/config'
+	);
+	assertEquals(repoConfig.includes('url = https://github.com/test/repo.git'), true);
+	assertEquals(depConfig.includes('url = https://github.com/test/schema.git'), true);
 });
 
 test('downloaded archive: AI api_key is blanked', () => {


### PR DESCRIPTION
## Summary

- Strip embedded HTTP(S) credentials from cloned database Git remote URLs when downloading sanitized backups
- Update the backup download warning copy and sanitized categories so users can see what is removed
- Document the backup secret stripping policy for Git remotes

Closes #692