### PR TITLE
fix: stack name and type fields on narrow screens

### DIFF
--- a/src/routes/arr/components/InstanceForm.svelte
+++ b/src/routes/arr/components/InstanceForm.svelte
@@ -287,45 +287,40 @@
 	>
 		<!-- Name, URL, API Key -->
 		<div data-onboarding="arr-connection" class="space-y-4">
-			<div class="space-y-2">
-				<div class="flex items-center gap-4">
-					<div class="min-w-0 flex-[12] text-sm font-medium text-neutral-900 dark:text-neutral-100">
+			<div class="flex flex-col gap-4 2xl:flex-row">
+				<div class="min-w-0 space-y-2 2xl:flex-[3]">
+					<div class="text-sm font-medium text-neutral-900 dark:text-neutral-100">
 						Name<span class="text-red-500">*</span>
 					</div>
-					<div class="flex-1 text-right text-sm font-medium text-neutral-900 dark:text-neutral-100">
-						Type{#if mode === 'create'}<span class="text-red-500">*</span>{/if}
-					</div>
-				</div>
-				<div class="flex items-center gap-4">
-					<p class="min-w-0 flex-1 text-xs text-neutral-600 dark:text-neutral-400">
+					<p class="text-xs text-neutral-600 dark:text-neutral-400">
 						The display name for this Arr instance
 					</p>
-					<p class="flex-1 text-right text-xs text-neutral-600 dark:text-neutral-400">
+					<FormInput
+						label="Name"
+						name="name"
+						value={name}
+						placeholder="e.g., Main Radarr, 4K Sonarr"
+						required
+						hideLabel
+						on:input={(e) => update('name', e.detail)}
+					/>
+				</div>
+				<div class="min-w-0 space-y-2 2xl:flex-1" data-onboarding="arr-type">
+					<div class="text-sm font-medium text-neutral-900 dark:text-neutral-100">
+						Type{#if mode === 'create'}<span class="text-red-500">*</span>{/if}
+					</div>
+					<p class="text-xs text-neutral-600 dark:text-neutral-400">
 						Type cannot be changed after creation
 					</p>
-				</div>
-				<div class="flex items-end gap-4">
-					<div class="min-w-0 flex-[12]">
-						<FormInput
-							label="Name"
-							name="name"
-							value={name}
-							placeholder="e.g., Main Radarr, 4K Sonarr"
-							required
-							hideLabel
-							on:input={(e) => update('name', e.detail)}
-						/>
-					</div>
-					<div class="min-w-0 flex-1" data-onboarding="arr-type">
-						<DropdownSelect
-							value={type}
-							options={typeOptions}
-							placeholder="Select type..."
-							disabled={mode === 'edit'}
-							fullWidth
-							on:change={(e) => update('type', e.detail)}
-						/>
-					</div>
+					<DropdownSelect
+						value={type}
+						options={typeOptions}
+						placeholder="Select type..."
+						disabled={mode === 'edit'}
+						fullWidth
+						position="right"
+						on:change={(e) => update('type', e.detail)}
+					/>
 				</div>
 			</div>
 			<!-- URL Row -->


### PR DESCRIPTION
Restructures the Name/Type row on the Arr instance form so the two fields stack vertically below the `2xl` breakpoint (1536px) instead of staying side-by-side and overflowing.

On wide screens the layout is 3:1 (Name:Type) with the dropdown right-aligned.

<img width="2664" height="1620" alt="image" src="https://github.com/user-attachments/assets/ba9bbd03-746f-42d3-aeb2-2741df0edd98" />

<img width="618" height="1372" alt="image" src="https://github.com/user-attachments/assets/d7850a8e-6745-4c55-85e4-d2b5c96b79c5" />

Closes #707