### PR TITLE
fix: clarify Sonarr upgrade dry runs only search one season

### DIFF
--- a/src/lib/server/upgrades/processor.ts
+++ b/src/lib/server/upgrades/processor.ts
@@ -550,7 +550,8 @@ export async function processUpgradeConfig(
 										...(searchedSeason != null ? { seasonNumber: searchedSeason } : {})
 									}
 								],
-								imageUrl: getPosterUrl(item._raw)
+								imageUrl: getPosterUrl(item._raw),
+								...(searchedSeason != null ? { searchedSeasonNumber: searchedSeason } : {})
 							});
 							successful++;
 						} else {
@@ -559,7 +560,8 @@ export async function processUpgradeConfig(
 								title: item.title,
 								original,
 								upgrades: [],
-								imageUrl: getPosterUrl(item._raw)
+								imageUrl: getPosterUrl(item._raw),
+								...(searchedSeason != null ? { searchedSeasonNumber: searchedSeason } : {})
 							});
 						}
 						searchesTriggered++;
@@ -569,7 +571,8 @@ export async function processUpgradeConfig(
 							title: item.title,
 							original,
 							upgrades: [],
-							imageUrl: getPosterUrl(item._raw)
+							imageUrl: getPosterUrl(item._raw),
+							...(searchedSeason != null ? { searchedSeasonNumber: searchedSeason } : {})
 						});
 						failed++;
 						errors.push(

--- a/src/lib/server/upgrades/processor.ts
+++ b/src/lib/server/upgrades/processor.ts
@@ -511,11 +511,11 @@ export async function processUpgradeConfig(
 
 				for (const item of selectedItems) {
 					const original = getOriginalFile(item);
+					let searchedSeason: number | undefined;
 					try {
 						let bestRelease:
 							| { title: string; customFormats: { name: string }[]; customFormatScore: number }
 							| undefined;
-						let searchedSeason: number | undefined;
 
 						if (isRadarr) {
 							const releases = await (client as RadarrClient).getReleases(item.id);

--- a/src/lib/server/upgrades/types.ts
+++ b/src/lib/server/upgrades/types.ts
@@ -104,6 +104,7 @@ export interface UpgradeSelectionItem {
 	original: UpgradeOriginal;
 	upgrades: UpgradeNewRelease[];
 	imageUrl?: string;
+	searchedSeasonNumber?: number;
 }
 
 /**

--- a/src/routes/arr/[id]/upgrades/+page.svelte
+++ b/src/routes/arr/[id]/upgrades/+page.svelte
@@ -93,6 +93,7 @@
 	$: cron = ($current.cron ?? '0 */6 * * *') as string;
 	$: filterMode = ($current.filterMode ?? 'round_robin') as FilterMode;
 	$: filters = JSON.parse(($current.filters ?? '[]') as string) as FilterConfig[];
+	$: hasEnabledFilter = filters.some((f) => f.enabled);
 
 	// Derive runs per hour for dynamic count limits
 	$: runsPerHour = getRunsPerHour(cron) ?? 1;
@@ -158,8 +159,10 @@
 			<Button
 				text={clearing ? 'Clearing...' : 'Reset Cache'}
 				icon={RotateCcw}
-				disabled={isNewConfig || !enabled || clearing || running || saving}
-				tooltip="Clear dry run exclusion cache so items can be re-selected"
+				disabled={isNewConfig || !enabled || !hasEnabledFilter || clearing || running || saving}
+				tooltip={!hasEnabledFilter
+					? 'Add and enable at least one filter before running'
+					: 'Clear dry run exclusion cache so items can be re-selected'}
 				tooltipPosition="bottom"
 				tooltipAlign="right"
 				on:click={() => {
@@ -171,10 +174,18 @@
 				text={running ? 'Running...' : 'Dry Run'}
 				icon={FlaskConical}
 				iconColor="text-amber-600 dark:text-amber-400"
-				disabled={isNewConfig || !enabled || running || saving || clearing || $isDirty}
-				tooltip={data.instance.type === 'sonarr'
-					? 'Search indexers without downloading. Only searches the latest monitored season per series (limited to once every 10 min)'
-					: 'Search indexers without downloading (limited to once every 10 min)'}
+				disabled={isNewConfig ||
+					!enabled ||
+					!hasEnabledFilter ||
+					running ||
+					saving ||
+					clearing ||
+					$isDirty}
+				tooltip={!hasEnabledFilter
+					? 'Add and enable at least one filter before running'
+					: data.instance.type === 'sonarr'
+						? 'Search indexers without downloading. Only searches the latest monitored season per series (limited to once every 10 min)'
+						: 'Search indexers without downloading (limited to once every 10 min)'}
 				tooltipPosition="bottom"
 				tooltipAlign="right"
 				on:click={() => {
@@ -193,8 +204,10 @@
 					text={running ? 'Running...' : 'Live Run'}
 					icon={Play}
 					iconColor="text-red-600 dark:text-red-400"
-					disabled={isNewConfig || !enabled || running || saving || $isDirty}
-					tooltip="Run a live search that will download upgrades"
+					disabled={isNewConfig || !enabled || !hasEnabledFilter || running || saving || $isDirty}
+					tooltip={!hasEnabledFilter
+						? 'Add and enable at least one filter before running'
+						: 'Run a live search that will download upgrades'}
 					tooltipPosition="bottom"
 					tooltipAlign="right"
 					on:click={() => {

--- a/src/routes/arr/[id]/upgrades/+page.svelte
+++ b/src/routes/arr/[id]/upgrades/+page.svelte
@@ -172,7 +172,9 @@
 				icon={FlaskConical}
 				iconColor="text-amber-600 dark:text-amber-400"
 				disabled={isNewConfig || !enabled || running || saving || clearing || $isDirty}
-				tooltip="Search indexers without downloading (limited to once every 10 min)"
+				tooltip={data.instance.type === 'sonarr'
+					? 'Search indexers without downloading. Only searches the latest monitored season per series (limited to once every 10 min)'
+					: 'Search indexers without downloading (limited to once every 10 min)'}
 				tooltipPosition="bottom"
 				tooltipAlign="right"
 				on:click={() => {

--- a/src/routes/arr/[id]/upgrades/components/RunHistory.svelte
+++ b/src/routes/arr/[id]/upgrades/components/RunHistory.svelte
@@ -220,6 +220,8 @@
 			}
 
 			for (const season of [...allSeasons].sort((a, b) => a - b)) {
+				const wasSearched =
+					item.searchedSeasonNumber == null || season === item.searchedSeasonNumber;
 				result.push({
 					id: item.id * 1000 + season,
 					title: `${item.title} - Season ${season}`,
@@ -228,7 +230,8 @@
 						title: item.title,
 						episodes: seasonEpisodes.get(season) ?? []
 					},
-					upgrades: seasonUpgrades.get(season) ?? []
+					upgrades: seasonUpgrades.get(season) ?? [],
+					searchedSeasonNumber: wasSearched ? season : -1
 				});
 			}
 		}
@@ -515,6 +518,8 @@
 										{:else}
 											<Badge variant="neutral" size="sm">No formats</Badge>
 										{/if}
+									{:else if item.searchedSeasonNumber === -1}
+										<Badge variant="neutral" size="sm">Not searched</Badge>
 									{:else}
 										<Badge variant="neutral" size="sm">No upgrade</Badge>
 									{/if}
@@ -571,6 +576,10 @@
 												</span>
 											</div>
 										{/each}
+									{:else if item.searchedSeasonNumber === -1}
+										<div class="text-xs text-neutral-500 italic dark:text-neutral-400">
+											Not searched (dry run only searches latest monitored season)
+										</div>
 									{:else}
 										<div class="text-xs text-neutral-500 italic dark:text-neutral-400">
 											No upgrade available


### PR DESCRIPTION
- Dry Run tooltip for Sonarr now explains that only the latest monitored season is searched
- Run/Reset buttons disabled with explanatory tooltip when no filter is enabled
- Processor records which season was searched on each selection item
- Run history shows "Not searched" badge for seasons that were skipped during dry runs, distinguishing them from "No upgrade" (searched but nothing found)

Backwards-compatible: old logs without the field render as before.

<img width="3786" height="1880" alt="image" src="https://github.com/user-attachments/assets/95a54d9e-a839-4fd4-be0c-8e91ca62ffeb" />

<img width="3840" height="1918" alt="image" src="https://github.com/user-attachments/assets/3ab948a6-5285-454f-9101-4afacc2f571f" />

Closes #708