### PR TITLE
fix: improve number input behavior

### DIFF
--- a/docs/frontend/ui.md
+++ b/docs/frontend/ui.md
@@ -136,6 +136,8 @@ flush with surrounding content when `label` is omitted.
 **`$ui/form/NumberInput.svelte`** wraps `<input type="number">` and adds
 increment/decrement buttons, min/max validation, and a `compact` mode for
 dense form grids. Typical use: retention days, timeouts, thresholds.
+Use `validateOn="blur"` when the field should allow free typing and only
+commit min/max validation after focus leaves the input.
 
 ```svelte
 <!-- src/routes/settings/general/+page.svelte:472 -->

--- a/docs/frontend/ui.md
+++ b/docs/frontend/ui.md
@@ -134,8 +134,9 @@ flush with surrounding content when `label` is omitted.
 #### NumberInput
 
 **`$ui/form/NumberInput.svelte`** wraps `<input type="number">` and adds
-increment/decrement buttons, min/max validation, and a `compact` mode for
-dense form grids. Typical use: retention days, timeouts, thresholds.
+increment/decrement buttons with press-and-hold repeat, min/max validation,
+and a `compact` mode for dense form grids. Typical use: retention days,
+timeouts, thresholds.
 Use `validateOn="blur"` when the field should allow free typing and only
 commit min/max validation after focus leaves the input.
 

--- a/src/lib/client/ui/form/NumberInput.svelte
+++ b/src/lib/client/ui/form/NumberInput.svelte
@@ -208,8 +208,7 @@
 		const progress = Math.min(1, elapsedMs / repeatRampDurationMs);
 		const easedProgress = progress * progress * (3 - 2 * progress);
 		return Math.round(
-			repeatInitialIntervalMs -
-				(repeatInitialIntervalMs - repeatMinIntervalMs) * easedProgress
+			repeatInitialIntervalMs - (repeatInitialIntervalMs - repeatMinIntervalMs) * easedProgress
 		);
 	}
 

--- a/src/lib/client/ui/form/NumberInput.svelte
+++ b/src/lib/client/ui/form/NumberInput.svelte
@@ -4,6 +4,7 @@
 	import Tooltip from '$ui/tooltip/Tooltip.svelte';
 
 	type CorrectionReason = 'min' | 'max';
+	type StepDirection = 'increment' | 'decrement';
 
 	const dispatch = createEventDispatcher<{
 		change: number | undefined;
@@ -31,10 +32,21 @@
 	export let onMinBlocked: (() => void) | undefined = undefined;
 	export let onMaxBlocked: (() => void) | undefined = undefined;
 
+	const repeatDelayMs = 350;
+	const repeatInitialIntervalMs = 100;
+	const repeatMinIntervalMs = 1;
+	const repeatRampDurationMs = 5000;
+	const ignoreClickResetDelayMs = 100;
+
 	let inputValue = value === undefined || value === null ? '' : String(value);
 	let isFocused = false;
 	let isSmallScreen = false;
 	let mediaQuery: MediaQueryList | null = null;
+	let repeatTimeout: ReturnType<typeof setTimeout> | null = null;
+	let ignoreClickResetTimeout: ReturnType<typeof setTimeout> | null = null;
+	let repeatingDirection: StepDirection | null = null;
+	let repeatStartedAt = 0;
+	let ignoreNextClick = false;
 
 	onMount(() => {
 		if (responsive && typeof window !== 'undefined') {
@@ -48,6 +60,8 @@
 		if (mediaQuery) {
 			mediaQuery.removeEventListener('change', handleMediaChange);
 		}
+		clearStepRepeat();
+		clearIgnoredClickReset();
 	});
 
 	function handleMediaChange(e: MediaQueryListEvent) {
@@ -131,7 +145,7 @@
 			onMaxBlocked?.();
 			return;
 		}
-		updateValue(currentValue + step);
+		updateValue(max === undefined ? currentValue + step : Math.min(max, currentValue + step));
 	}
 
 	function decrement() {
@@ -140,7 +154,105 @@
 			onMinBlocked?.();
 			return;
 		}
-		updateValue(currentValue - step);
+		updateValue(min === undefined ? currentValue - step : Math.max(min, currentValue - step));
+	}
+
+	function canStep(direction: StepDirection): boolean {
+		return direction === 'increment' ? !incrementDisabled : !decrementDisabled;
+	}
+
+	function stepValue(direction: StepDirection) {
+		if (direction === 'increment') {
+			increment();
+		} else {
+			decrement();
+		}
+	}
+
+	function commitFocusedValue() {
+		if (isFocused && validateOn === 'blur') {
+			handleBlur();
+		}
+	}
+
+	function clearIgnoredClickReset() {
+		if (ignoreClickResetTimeout) {
+			clearTimeout(ignoreClickResetTimeout);
+			ignoreClickResetTimeout = null;
+		}
+	}
+
+	function clearStepRepeat() {
+		if (repeatTimeout) {
+			clearTimeout(repeatTimeout);
+			repeatTimeout = null;
+		}
+		repeatingDirection = null;
+		repeatStartedAt = 0;
+
+		if (typeof window !== 'undefined') {
+			window.removeEventListener('pointerup', clearStepRepeat);
+			window.removeEventListener('blur', clearStepRepeat);
+		}
+
+		if (ignoreNextClick && !ignoreClickResetTimeout) {
+			ignoreClickResetTimeout = setTimeout(() => {
+				ignoreNextClick = false;
+				ignoreClickResetTimeout = null;
+			}, ignoreClickResetDelayMs);
+		}
+	}
+
+	function getRepeatInterval(): number {
+		const elapsedMs = Date.now() - repeatStartedAt;
+		const progress = Math.min(1, elapsedMs / repeatRampDurationMs);
+		const easedProgress = progress * progress * (3 - 2 * progress);
+		return Math.round(
+			repeatInitialIntervalMs -
+				(repeatInitialIntervalMs - repeatMinIntervalMs) * easedProgress
+		);
+	}
+
+	function repeatStep() {
+		if (!repeatingDirection || !canStep(repeatingDirection)) {
+			clearStepRepeat();
+			return;
+		}
+
+		stepValue(repeatingDirection);
+		repeatTimeout = setTimeout(repeatStep, getRepeatInterval());
+	}
+
+	function startStepRepeat(direction: StepDirection, event: PointerEvent) {
+		if (!canStep(direction)) {
+			return;
+		}
+
+		clearStepRepeat();
+		clearIgnoredClickReset();
+		event.preventDefault();
+		ignoreNextClick = true;
+		commitFocusedValue();
+		stepValue(direction);
+		repeatingDirection = direction;
+		repeatStartedAt = Date.now();
+
+		if (typeof window !== 'undefined') {
+			window.addEventListener('pointerup', clearStepRepeat);
+			window.addEventListener('blur', clearStepRepeat);
+		}
+
+		repeatTimeout = setTimeout(repeatStep, repeatDelayMs);
+	}
+
+	function handleStepClick(direction: StepDirection) {
+		if (ignoreNextClick) {
+			ignoreNextClick = false;
+			clearIgnoredClickReset();
+			return;
+		}
+
+		stepValue(direction);
 	}
 
 	// Validate on input
@@ -169,6 +281,7 @@
 	}
 
 	function handleBlur() {
+		if (!isFocused) return;
 		isFocused = false;
 		if (inputValue === '' || inputValue === '-' || inputValue === '.' || inputValue === '-.') {
 			value = undefined;
@@ -198,9 +311,9 @@
 		{id}
 		{name}
 		bind:value={inputValue}
-		on:input={handleInput}
-		on:focus={handleFocus}
-		on:blur={handleBlur}
+		oninput={handleInput}
+		onfocus={handleFocus}
+		onblur={handleBlur}
 		{min}
 		{max}
 		{step}
@@ -226,7 +339,9 @@
 		<div class="absolute top-0 right-0 bottom-0 flex flex-col">
 			<button
 				type="button"
-				on:click={increment}
+				onclick={() => handleStepClick('increment')}
+				onpointerdown={(event) => startStepRepeat('increment', event)}
+				onpointerleave={clearStepRepeat}
 				disabled={incrementDisabled}
 				class="flex flex-1 {buttonWidthClass} items-center justify-center {buttonTopRadius} border border-neutral-300 bg-white text-neutral-600 transition-colors hover:bg-neutral-50 disabled:cursor-not-allowed disabled:opacity-40 dark:border-neutral-700/60 dark:bg-neutral-800/50 dark:text-neutral-300 dark:hover:bg-neutral-800"
 			>
@@ -234,7 +349,9 @@
 			</button>
 			<button
 				type="button"
-				on:click={decrement}
+				onclick={() => handleStepClick('decrement')}
+				onpointerdown={(event) => startStepRepeat('decrement', event)}
+				onpointerleave={clearStepRepeat}
 				disabled={decrementDisabled}
 				class="flex flex-1 {buttonWidthClass} items-center justify-center {buttonBottomRadius} border border-t-0 border-neutral-300 bg-white text-neutral-600 transition-colors hover:bg-neutral-50 disabled:cursor-not-allowed disabled:opacity-40 dark:border-neutral-700/60 dark:bg-neutral-800/50 dark:text-neutral-300 dark:hover:bg-neutral-800"
 			>

--- a/src/lib/client/ui/form/NumberInput.svelte
+++ b/src/lib/client/ui/form/NumberInput.svelte
@@ -3,7 +3,12 @@
 	import { ChevronUp, ChevronDown, CircleAlert } from 'lucide-svelte';
 	import Tooltip from '$ui/tooltip/Tooltip.svelte';
 
-	const dispatch = createEventDispatcher<{ change: number | undefined }>();
+	type CorrectionReason = 'min' | 'max';
+
+	const dispatch = createEventDispatcher<{
+		change: number | undefined;
+		correction: { inputValue: number; value: number; reason: CorrectionReason };
+	}>();
 
 	// Props
 	export let name: string;
@@ -18,6 +23,7 @@
 	export let placeholder: string = '';
 	export let font: 'mono' | 'sans' | undefined = undefined;
 	export let compact: boolean = false;
+	export let validateOn: 'input' | 'blur' = 'input';
 	// Responsive: auto-switch to compact on smaller screens (< 1280px)
 	export let responsive: boolean = false;
 	export let autoWidth: boolean = false;
@@ -87,11 +93,31 @@
 		inputValue = value === undefined || value === null ? '' : String(value);
 	}
 
-	function updateValue(newValue: number) {
+	function clampValue(rawValue: number): { value: number; reason: CorrectionReason | undefined } {
+		let newValue = rawValue;
+		let reason: CorrectionReason | undefined = undefined;
+
+		if (min !== undefined && newValue < min) {
+			newValue = min;
+			reason = 'min';
+		}
+
+		if (max !== undefined && newValue > max) {
+			newValue = max;
+			reason = 'max';
+		}
+
+		return { value: newValue, reason };
+	}
+
+	function updateValue(newValue: number, rawValue: number = newValue, reason?: CorrectionReason) {
 		value = newValue;
 		inputValue = String(newValue);
 		onchange?.(newValue);
 		dispatch('change', newValue);
+		if (reason && rawValue !== newValue) {
+			dispatch('correction', { inputValue: rawValue, value: newValue, reason });
+		}
 	}
 
 	// Increment/decrement handlers
@@ -124,21 +150,18 @@
 			return;
 		}
 
-		let newValue = Number(inputValue);
+		const rawValue = Number(inputValue);
 
-		if (Number.isNaN(newValue)) {
+		if (Number.isNaN(rawValue)) {
 			return;
 		}
 
-		if (min !== undefined && newValue < min) {
-			newValue = min;
+		if (validateOn === 'blur') {
+			return;
 		}
 
-		if (max !== undefined && newValue > max) {
-			newValue = max;
-		}
-
-		updateValue(newValue);
+		const result = clampValue(rawValue);
+		updateValue(result.value, rawValue, result.reason);
 	}
 
 	function handleBlur() {
@@ -150,21 +173,14 @@
 			return;
 		}
 
-		let newValue = Number(inputValue);
-		if (Number.isNaN(newValue)) {
+		const rawValue = Number(inputValue);
+		if (Number.isNaN(rawValue)) {
 			inputValue = value === undefined || value === null ? '' : String(value);
 			return;
 		}
 
-		if (min !== undefined && newValue < min) {
-			newValue = min;
-		}
-
-		if (max !== undefined && newValue > max) {
-			newValue = max;
-		}
-
-		updateValue(newValue);
+		const result = clampValue(rawValue);
+		updateValue(result.value, rawValue, result.reason);
 	}
 
 	function handleFocus() {

--- a/src/lib/client/ui/form/NumberInput.svelte
+++ b/src/lib/client/ui/form/NumberInput.svelte
@@ -88,6 +88,10 @@
 	$: autoWidthStyle = effectiveAutoWidth
 		? `width: calc(${autoWidthCharacters}ch + ${autoWidthPadding});`
 		: undefined;
+	$: canIncrement = max === undefined || value === undefined || value < max;
+	$: canDecrement = min === undefined || value === undefined || value > min;
+	$: incrementDisabled = disabled || !canIncrement;
+	$: decrementDisabled = disabled || !canDecrement;
 
 	$: if (!isFocused) {
 		inputValue = value === undefined || value === null ? '' : String(value);
@@ -223,7 +227,7 @@
 			<button
 				type="button"
 				on:click={increment}
-				{disabled}
+				disabled={incrementDisabled}
 				class="flex flex-1 {buttonWidthClass} items-center justify-center {buttonTopRadius} border border-neutral-300 bg-white text-neutral-600 transition-colors hover:bg-neutral-50 disabled:cursor-not-allowed disabled:opacity-40 dark:border-neutral-700/60 dark:bg-neutral-800/50 dark:text-neutral-300 dark:hover:bg-neutral-800"
 			>
 				<ChevronUp size={iconSize} />
@@ -231,7 +235,7 @@
 			<button
 				type="button"
 				on:click={decrement}
-				{disabled}
+				disabled={decrementDisabled}
 				class="flex flex-1 {buttonWidthClass} items-center justify-center {buttonBottomRadius} border border-t-0 border-neutral-300 bg-white text-neutral-600 transition-colors hover:bg-neutral-50 disabled:cursor-not-allowed disabled:opacity-40 dark:border-neutral-700/60 dark:bg-neutral-800/50 dark:text-neutral-300 dark:hover:bg-neutral-800"
 			>
 				<ChevronDown size={iconSize} />

--- a/src/lib/client/ui/form/NumberInput.svelte
+++ b/src/lib/client/ui/form/NumberInput.svelte
@@ -343,7 +343,7 @@
 				onpointerdown={(event) => startStepRepeat('increment', event)}
 				onpointerleave={clearStepRepeat}
 				disabled={incrementDisabled}
-				class="flex flex-1 {buttonWidthClass} items-center justify-center {buttonTopRadius} border border-neutral-300 bg-white text-neutral-600 transition-colors hover:bg-neutral-50 disabled:cursor-not-allowed disabled:opacity-40 dark:border-neutral-700/60 dark:bg-neutral-800/50 dark:text-neutral-300 dark:hover:bg-neutral-800"
+				class="flex flex-1 {buttonWidthClass} cursor-pointer items-center justify-center {buttonTopRadius} border border-neutral-300 bg-white text-neutral-600 transition-colors hover:bg-neutral-50 disabled:cursor-not-allowed disabled:opacity-40 dark:border-neutral-700/60 dark:bg-neutral-800/50 dark:text-neutral-300 dark:hover:bg-neutral-800"
 			>
 				<ChevronUp size={iconSize} />
 			</button>
@@ -353,7 +353,7 @@
 				onpointerdown={(event) => startStepRepeat('decrement', event)}
 				onpointerleave={clearStepRepeat}
 				disabled={decrementDisabled}
-				class="flex flex-1 {buttonWidthClass} items-center justify-center {buttonBottomRadius} border border-t-0 border-neutral-300 bg-white text-neutral-600 transition-colors hover:bg-neutral-50 disabled:cursor-not-allowed disabled:opacity-40 dark:border-neutral-700/60 dark:bg-neutral-800/50 dark:text-neutral-300 dark:hover:bg-neutral-800"
+				class="flex flex-1 {buttonWidthClass} cursor-pointer items-center justify-center {buttonBottomRadius} border border-t-0 border-neutral-300 bg-white text-neutral-600 transition-colors hover:bg-neutral-50 disabled:cursor-not-allowed disabled:opacity-40 dark:border-neutral-700/60 dark:bg-neutral-800/50 dark:text-neutral-300 dark:hover:bg-neutral-800"
 			>
 				<ChevronDown size={iconSize} />
 			</button>

--- a/src/routes/media-management/[databaseId]/quality-definitions/components/QualityDefinitionsForm.svelte
+++ b/src/routes/media-management/[databaseId]/quality-definitions/components/QualityDefinitionsForm.svelte
@@ -29,6 +29,13 @@
 
 	// Resolution grouping for quality definitions UI
 	type ResolutionGroup = 'SD' | '720p' | '1080p' | '2160p' | 'Prereleases' | 'Other';
+	type QualitySizeField = 'min' | 'preferred' | 'max';
+
+	interface NumberCorrectionDetail {
+		inputValue: number;
+		value: number;
+		reason: 'min' | 'max';
+	}
 
 	const RESOLUTION_GROUP_ORDER: ResolutionGroup[] = [
 		'2160p',
@@ -279,6 +286,23 @@
 		}
 	}
 
+	function formatCorrectedSize(field: QualitySizeField, value: number): string {
+		if ((field === 'preferred' || field === 'max') && value >= baseScaleMax) {
+			return `${baseScaleMax} MB/m (unlimited)`;
+		}
+
+		return `${value} MB/m`;
+	}
+
+	function handleSizeCorrection(field: QualitySizeField, detail: NumberCorrectionDetail) {
+		const label = field === 'min' ? 'Min' : field === 'preferred' ? 'Preferred' : 'Max';
+		const action = detail.reason === 'min' ? 'raised' : 'lowered';
+		alertStore.add(
+			'warning',
+			`${label} was ${action} to ${formatCorrectedSize(field, detail.value)}.`
+		);
+	}
+
 	// Note: API uses 0 for "unlimited", so convert baseScaleMax → 0 on save
 	$: entriesForSubmit = JSON.stringify(
 		entries.map((e) => ({
@@ -458,7 +482,9 @@
 										max={markers[1].value}
 										step={1}
 										responsive
+										validateOn="blur"
 										onchange={() => syncToEntry(entry.quality_name)}
+										on:correction={(event) => handleSizeCorrection('min', event.detail)}
 									/>
 								</div>
 
@@ -476,7 +502,9 @@
 										max={markers[2].value}
 										step={1}
 										responsive
+										validateOn="blur"
 										onchange={() => syncToEntry(entry.quality_name)}
+										on:correction={(event) => handleSizeCorrection('preferred', event.detail)}
 									/>
 								</div>
 
@@ -494,7 +522,9 @@
 										max={baseScaleMax}
 										step={1}
 										responsive
+										validateOn="blur"
 										onchange={() => syncToEntry(entry.quality_name)}
+										on:correction={(event) => handleSizeCorrection('max', event.detail)}
 									/>
 								</div>
 							</div>


### PR DESCRIPTION
Updates the shared number input so direct editing can defer validation until blur, which lets quality definition sizes be typed normally before clamping and warning on correction.

Also improves the stepper controls by disabling bounded buttons, supporting press-and-hold repeat, and showing a pointer cursor when they can be clicked.

Closes #712.