### PR TITLE
fix: clarify dry runs do not preview folder renames

### DIFF
--- a/src/routes/arr/[id]/rename/+page.svelte
+++ b/src/routes/arr/[id]/rename/+page.svelte
@@ -93,7 +93,7 @@
 				icon={FlaskConical}
 				iconColor="text-amber-600 dark:text-amber-400"
 				disabled={isNewConfig || !enabled || running || saving || $isDirty}
-				tooltip="Preview which files would be renamed without making changes"
+				tooltip="Preview which files would be renamed without making changes. Folder renames cannot be previewed."
 				tooltipPosition="bottom"
 				tooltipAlign="right"
 				on:click={() => {

--- a/src/routes/arr/[id]/rename/components/RenameInfoModal.svelte
+++ b/src/routes/arr/[id]/rename/components/RenameInfoModal.svelte
@@ -34,8 +34,9 @@
 				<div>
 					<dt class="font-medium text-neutral-900 dark:text-neutral-100">Dry Run</dt>
 					<dd class="text-neutral-600 dark:text-neutral-400">
-						Shows what would be renamed without making changes. Use this to preview before
-						committing.
+						Shows what files would be renamed without making changes. Use this to preview before
+						committing. Folder renames cannot be previewed because the Arr API does not support it,
+						so a live run may also rename folders not shown here.
 					</dd>
 				</div>
 				<div>

--- a/src/routes/arr/[id]/rename/components/RenameRunHistory.svelte
+++ b/src/routes/arr/[id]/rename/components/RenameRunHistory.svelte
@@ -295,6 +295,11 @@
 					<span class="text-sm text-neutral-900 dark:text-neutral-100">
 						{#if row.config.dryRun}
 							<span class="font-mono">{row.results.filesNeedingRename}</span> files would be renamed
+							{#if row.config.renameFolders}
+								<div class="mt-1 text-xs text-neutral-500 dark:text-neutral-400">
+									Folder renames are not included in dry run previews.
+								</div>
+							{/if}
 						{:else}
 							<span class="font-mono">{row.results.filesRenamed}</span> file{row.results
 								.filesRenamed !== 1


### PR DESCRIPTION
Adds notes to the dry run tooltip, info modal, and run history explaining that folder renames are not included in dry run previews because the Arr API does not support it.

Closes #706