### PR TITLE
fix: parse markdown descriptions as block content for CFs and regex

### DIFF
--- a/src/lib/client/ui/display/Markdown.svelte
+++ b/src/lib/client/ui/display/Markdown.svelte
@@ -52,4 +52,34 @@
 	:global(.dark) .markdown :global(a) {
 		color: rgb(var(--color-accent-400));
 	}
+
+	.markdown :global(ul),
+	.markdown :global(ol) {
+		padding-left: 1.5rem;
+		margin: 0.5rem 0;
+	}
+
+	.markdown :global(ul) {
+		list-style-type: disc;
+	}
+
+	.markdown :global(ol) {
+		list-style-type: decimal;
+	}
+
+	.markdown :global(li) {
+		margin: 0.25rem 0;
+	}
+
+	.markdown :global(p) {
+		margin: 0.25rem 0;
+	}
+
+	.markdown :global(p:first-child) {
+		margin-top: 0;
+	}
+
+	.markdown :global(p:last-child) {
+		margin-bottom: 0;
+	}
 </style>

--- a/src/routes/custom-formats/[databaseId]/views/CardView.svelte
+++ b/src/routes/custom-formats/[databaseId]/views/CardView.svelte
@@ -89,7 +89,7 @@
 
 				<!-- Description -->
 				{#if format.description}
-					<div class="prose-inline line-clamp-2 text-xs text-neutral-600 dark:text-neutral-400">
+					<div class="prose-inline line-clamp-3 text-xs text-neutral-600 dark:text-neutral-400">
 						{@html parseMarkdown(format.description)}<!-- nosemgrep: profilarr.xss.at-html-usage -->
 					</div>
 				{:else}

--- a/src/routes/custom-formats/[databaseId]/views/CardView.svelte
+++ b/src/routes/custom-formats/[databaseId]/views/CardView.svelte
@@ -26,7 +26,7 @@
 
 	function parseMarkdown(text: string | null): string {
 		if (!text) return '';
-		return sanitizeHtml(marked.parseInline(text) as string); // nosemgrep: profilarr.xss.marked-unsanitized
+		return sanitizeHtml(marked.parse(text) as string); // nosemgrep: profilarr.xss.marked-unsanitized
 	}
 
 	function getConditionVariant(
@@ -113,30 +113,3 @@
 	{/each}
 </CardGrid>
 <div use:sentinel></div>
-
-<style>
-	:global(.prose-inline code) {
-		background-color: rgb(229 231 235);
-		padding: 0.125rem 0.25rem;
-		border-radius: 0.25rem;
-		font-size: 0.75rem;
-		font-family: var(--font-mono);
-	}
-
-	:global(.dark .prose-inline code) {
-		background-color: rgb(38 38 38);
-	}
-
-	:global(.prose-inline strong) {
-		font-weight: 600;
-	}
-
-	:global(.prose-inline a) {
-		color: rgb(var(--color-accent-600));
-		text-decoration: underline;
-	}
-
-	:global(.dark .prose-inline a) {
-		color: rgb(var(--color-accent-400));
-	}
-</style>

--- a/src/routes/custom-formats/[databaseId]/views/TableView.svelte
+++ b/src/routes/custom-formats/[databaseId]/views/TableView.svelte
@@ -32,7 +32,7 @@
 
 	function parseMarkdown(text: string | null): string {
 		if (!text) return '';
-		return sanitizeHtml(marked.parseInline(text) as string); // nosemgrep: profilarr.xss.marked-unsanitized
+		return sanitizeHtml(marked.parse(text) as string); // nosemgrep: profilarr.xss.marked-unsanitized
 	}
 
 	const columns: Column<CustomFormatTableRow>[] = [
@@ -162,31 +162,3 @@
 		</div>
 	</svelte:fragment>
 </Table>
-
-<style>
-	/* Inline prose styles for markdown content */
-	:global(.prose-inline code) {
-		background-color: rgb(229 231 235);
-		padding: 0.125rem 0.25rem;
-		border-radius: 0.25rem;
-		font-size: 0.75rem;
-		font-family: var(--font-mono);
-	}
-
-	:global(.dark .prose-inline code) {
-		background-color: rgb(38 38 38);
-	}
-
-	:global(.prose-inline strong) {
-		font-weight: 600;
-	}
-
-	:global(.prose-inline a) {
-		color: rgb(var(--color-accent-600));
-		text-decoration: underline;
-	}
-
-	:global(.dark .prose-inline a) {
-		color: rgb(var(--color-accent-400));
-	}
-</style>

--- a/src/routes/regular-expressions/[databaseId]/views/CardView.svelte
+++ b/src/routes/regular-expressions/[databaseId]/views/CardView.svelte
@@ -72,7 +72,7 @@
 			<div class="space-y-3">
 				<CodeBlock code={expression.pattern} />
 				{#if expression.description}
-					<Markdown content={expression.description} inline={false} />
+					<Markdown content={expression.description} inline={false} maxLines={3} />
 				{/if}
 			</div>
 		</Card>

--- a/src/routes/regular-expressions/[databaseId]/views/CardView.svelte
+++ b/src/routes/regular-expressions/[databaseId]/views/CardView.svelte
@@ -72,7 +72,7 @@
 			<div class="space-y-3">
 				<CodeBlock code={expression.pattern} />
 				{#if expression.description}
-					<Markdown content={expression.description} />
+					<Markdown content={expression.description} inline={false} />
 				{/if}
 			</div>
 		</Card>

--- a/src/routes/regular-expressions/[databaseId]/views/TableView.svelte
+++ b/src/routes/regular-expressions/[databaseId]/views/TableView.svelte
@@ -31,7 +31,7 @@
 
 	function parseMarkdown(text: string | null): string {
 		if (!text) return '';
-		return sanitizeHtml(marked.parseInline(text) as string); // nosemgrep: profilarr.xss.marked-unsanitized
+		return sanitizeHtml(marked.parse(text) as string); // nosemgrep: profilarr.xss.marked-unsanitized
 	}
 
 	const columns: Column<RegularExpressionWithTags>[] = [
@@ -136,31 +136,3 @@
 		</div>
 	</svelte:fragment>
 </Table>
-
-<style>
-	/* Inline prose styles for markdown content */
-	:global(.prose-inline code) {
-		background-color: rgb(229 231 235);
-		padding: 0.125rem 0.25rem;
-		border-radius: 0.25rem;
-		font-size: 0.75rem;
-		font-family: var(--font-mono);
-	}
-
-	:global(.dark .prose-inline code) {
-		background-color: rgb(38 38 38);
-	}
-
-	:global(.prose-inline strong) {
-		font-weight: 600;
-	}
-
-	:global(.prose-inline a) {
-		color: rgb(var(--color-accent-600));
-		text-decoration: underline;
-	}
-
-	:global(.dark .prose-inline a) {
-		color: rgb(var(--color-accent-400));
-	}
-</style>

--- a/src/styles/prose.css
+++ b/src/styles/prose.css
@@ -231,6 +231,62 @@
 	margin-bottom: 1.25em;
 }
 
+/* Compact prose for inline markdown (card descriptions, table cells) */
+.prose-inline code {
+	background-color: rgb(229 231 235);
+	padding: 0.125rem 0.25rem;
+	border-radius: 0.25rem;
+	font-size: 0.75rem;
+	font-family: var(--font-mono);
+}
+
+.dark .prose-inline code {
+	background-color: rgb(38 38 38);
+}
+
+.prose-inline strong {
+	font-weight: 600;
+}
+
+.prose-inline a {
+	color: rgb(var(--color-accent-600));
+	text-decoration: underline;
+}
+
+.dark .prose-inline a {
+	color: rgb(var(--color-accent-400));
+}
+
+.prose-inline ul,
+.prose-inline ol {
+	padding-left: 1.5rem;
+	margin: 0.5rem 0;
+}
+
+.prose-inline ul {
+	list-style-type: disc;
+}
+
+.prose-inline ol {
+	list-style-type: decimal;
+}
+
+.prose-inline li {
+	margin: 0.25rem 0;
+}
+
+.prose-inline p {
+	margin: 0.25rem 0;
+}
+
+.prose-inline p:first-child {
+	margin-top: 0;
+}
+
+.prose-inline p:last-child {
+	margin-bottom: 0;
+}
+
 .prose-sm {
 	font-size: 0.875rem;
 }


### PR DESCRIPTION
Switches custom format and regex description rendering from `marked.parseInline()` to `marked.parse()` so block-level markdown (lists, paragraphs) renders properly. Consolidates the duplicated `.prose-inline` CSS into `prose.css` and adds list styles. Standardizes card description clamp to 3 lines for both entity types.

Closes #721