### PR TITLE
fix: disable cleanup Run Now when settings have unsaved changes

### DIFF
--- a/src/routes/arr/components/InstanceForm.svelte
+++ b/src/routes/arr/components/InstanceForm.svelte
@@ -465,6 +465,7 @@
 								text="Run Now"
 								icon={Eraser}
 								iconColor="text-amber-600 dark:text-amber-400"
+								disabled={$isDirty || saving}
 								on:click={() => (showCleanupModal = true)}
 							/>
 						</div>


### PR DESCRIPTION
Adds dirty and saving guards to the cleanup Run Now button, matching the pattern used by upgrades and rename.

Closes #705