### PR TITLE
fix: fetch arr logs client-side to avoid blocking tab navigation

### DIFF
--- a/src/routes/arr/[id]/logs/+page.server.ts
+++ b/src/routes/arr/[id]/logs/+page.server.ts
@@ -4,7 +4,7 @@ import { arrInstancesQueries } from '$db/queries/arrInstances.ts';
 import { createArrClient } from '$arr/factory.ts';
 import type { ArrType } from '$arr/types.ts';
 
-export const load: ServerLoad = async ({ params, url }) => {
+export const load: ServerLoad = ({ params, url }) => {
 	const id = parseInt(params.id || '', 10);
 
 	if (isNaN(id)) {
@@ -24,29 +24,26 @@ export const load: ServerLoad = async ({ params, url }) => {
 
 	const client = createArrClient(instance.type as ArrType, instance.url, instance.api_key);
 
-	try {
-		const logs = await client.getLogs({
+	// Stream the logs promise so navigation isn't blocked by the arr HTTP call
+	const logs = client
+		.getLogs({
 			page,
 			pageSize,
 			sortKey: 'time',
 			sortDirection: 'descending',
 			level: level as 'Trace' | 'Debug' | 'Info' | 'Warn' | 'Error' | 'Fatal' | undefined
-		});
+		})
+		.finally(() => client.close());
 
-		const { api_key: _, ...safeInstance } = instance;
+	const { api_key: _, ...safeInstance } = instance;
 
-		return {
-			instance: safeInstance,
-			logs,
-			filters: {
-				page,
-				pageSize,
-				level
-			}
-		};
-	} catch (err) {
-		error(500, `Failed to fetch logs: ${err instanceof Error ? err.message : 'Unknown error'}`);
-	} finally {
-		client.close();
-	}
+	return {
+		instance: safeInstance,
+		logs,
+		filters: {
+			page,
+			pageSize,
+			level
+		}
+	};
 };

--- a/src/routes/arr/[id]/logs/+page.server.ts
+++ b/src/routes/arr/[id]/logs/+page.server.ts
@@ -1,8 +1,6 @@
 import { error } from '@sveltejs/kit';
 import type { ServerLoad } from '@sveltejs/kit';
 import { arrInstancesQueries } from '$db/queries/arrInstances.ts';
-import { createArrClient } from '$arr/factory.ts';
-import type { ArrType } from '$arr/types.ts';
 
 export const load: ServerLoad = ({ params, url }) => {
 	const id = parseInt(params.id || '', 10);
@@ -17,33 +15,14 @@ export const load: ServerLoad = ({ params, url }) => {
 		error(404, `Instance not found: ${id}`);
 	}
 
-	// Parse query params for pagination/filtering
-	const page = parseInt(url.searchParams.get('page') || '1', 10);
-	const pageSize = parseInt(url.searchParams.get('pageSize') || '50', 10);
-	const level = url.searchParams.get('level') || undefined;
-
-	const client = createArrClient(instance.type as ArrType, instance.url, instance.api_key);
-
-	// Stream the logs promise so navigation isn't blocked by the arr HTTP call
-	const logs = client
-		.getLogs({
-			page,
-			pageSize,
-			sortKey: 'time',
-			sortDirection: 'descending',
-			level: level as 'Trace' | 'Debug' | 'Info' | 'Warn' | 'Error' | 'Fatal' | undefined
-		})
-		.finally(() => client.close());
-
 	const { api_key: _, ...safeInstance } = instance;
 
 	return {
 		instance: safeInstance,
-		logs,
 		filters: {
-			page,
-			pageSize,
-			level
+			page: parseInt(url.searchParams.get('page') || '1', 10),
+			pageSize: parseInt(url.searchParams.get('pageSize') || '50', 10),
+			level: url.searchParams.get('level') || undefined
 		}
 	};
 };

--- a/src/routes/arr/[id]/logs/+page.svelte
+++ b/src/routes/arr/[id]/logs/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
 	import { page } from '$app/stores';
-	import { Copy, RefreshCw, Filter, Rows3 } from 'lucide-svelte';
+	import { Copy, RefreshCw, Filter, Rows3, Loader2, AlertTriangle } from 'lucide-svelte';
 	import { alertStore } from '$alerts/store';
 	import Table from '$ui/table/Table.svelte';
 	import Button from '$ui/button/Button.svelte';
@@ -150,24 +150,21 @@
 	}
 
 	// Client-side search filter
-	$: filteredLogs = data.logs.records.filter((log) => {
-		if (selectedLevel !== 'ALL' && normalizeLevel(log.level) !== normalizeLevel(selectedLevel)) {
-			return false;
-		}
+	function filterLogs(records: LogEntry[], query: string): LogEntry[] {
+		return records.filter((log) => {
+			if (selectedLevel !== 'ALL' && normalizeLevel(log.level) !== normalizeLevel(selectedLevel)) {
+				return false;
+			}
 
-		const query = $searchStore.query;
-		if (!query) return true;
+			if (!query) return true;
 
-		const searchLower = query.toLowerCase();
-		return (
-			log.message.toLowerCase().includes(searchLower) ||
-			log.logger.toLowerCase().includes(searchLower)
-		);
-	});
-
-	// Pagination info
-	$: totalPages = Math.ceil(data.logs.totalRecords / data.logs.pageSize);
-	$: currentPage = data.logs.page;
+			const searchLower = query.toLowerCase();
+			return (
+				log.message.toLowerCase().includes(searchLower) ||
+				log.logger.toLowerCase().includes(searchLower)
+			);
+		});
+	}
 </script>
 
 <svelte:head>
@@ -235,50 +232,74 @@
 		</ActionButton>
 	</ActionsBar>
 
-	<!-- Stats -->
-	<div
-		class="mt-6 mb-4 flex items-center justify-between text-sm text-neutral-600 dark:text-neutral-400"
-	>
-		<span>
-			Showing {filteredLogs.length} of {data.logs.totalRecords} logs
-			{#if selectedLevel !== 'ALL'}
-				(filtered by {selectedLevel})
-			{/if}
-		</span>
-
-		<!-- Pagination -->
-		{#if totalPages > 1}
-			<Pagination {currentPage} {totalPages} onPageChange={goToPage} />
-		{/if}
-	</div>
-
-	<!-- Log Table -->
-	<Table
-		data={filteredLogs}
-		{columns}
-		emptyMessage="No logs found"
-		hoverable={true}
-		compact={true}
-		responsive
-	>
-		<svelte:fragment slot="actions" let:row>
-			<div class="flex items-center justify-end gap-1">
-				<Button
-					icon={Copy}
-					size="xs"
-					variant="secondary"
-					title="Copy log entry"
-					ariaLabel="Copy log entry"
-					on:click={() => copyLog(row)}
-				/>
-			</div>
-		</svelte:fragment>
-	</Table>
-
-	<!-- Bottom Pagination -->
-	{#if totalPages > 1}
-		<div class="mt-4 flex justify-center">
-			<Pagination {currentPage} {totalPages} onPageChange={goToPage} />
+	{#await data.logs}
+		<!-- Loading state -->
+		<div
+			class="mt-12 flex flex-col items-center justify-center gap-3 text-neutral-500 dark:text-neutral-400"
+		>
+			<Loader2 size={24} class="animate-spin" />
+			<span class="text-sm">Loading logs...</span>
 		</div>
-	{/if}
+	{:then logs}
+		{@const filteredLogs = filterLogs(logs.records, $searchStore.query)}
+		{@const totalPages = Math.ceil(logs.totalRecords / logs.pageSize)}
+		{@const currentPage = logs.page}
+
+		<!-- Stats -->
+		<div
+			class="mt-6 mb-4 flex items-center justify-between text-sm text-neutral-600 dark:text-neutral-400"
+		>
+			<span>
+				Showing {filteredLogs.length} of {logs.totalRecords} logs
+				{#if selectedLevel !== 'ALL'}
+					(filtered by {selectedLevel})
+				{/if}
+			</span>
+
+			<!-- Pagination -->
+			{#if totalPages > 1}
+				<Pagination {currentPage} {totalPages} onPageChange={goToPage} />
+			{/if}
+		</div>
+
+		<!-- Log Table -->
+		<Table
+			data={filteredLogs}
+			{columns}
+			emptyMessage="No logs found"
+			hoverable={true}
+			compact={true}
+			responsive
+		>
+			<svelte:fragment slot="actions" let:row>
+				<div class="flex items-center justify-end gap-1">
+					<Button
+						icon={Copy}
+						size="xs"
+						variant="secondary"
+						title="Copy log entry"
+						ariaLabel="Copy log entry"
+						on:click={() => copyLog(row)}
+					/>
+				</div>
+			</svelte:fragment>
+		</Table>
+
+		<!-- Bottom Pagination -->
+		{#if totalPages > 1}
+			<div class="mt-4 flex justify-center">
+				<Pagination {currentPage} {totalPages} onPageChange={goToPage} />
+			</div>
+		{/if}
+	{:catch err}
+		<!-- Error state -->
+		<div
+			class="mt-12 flex flex-col items-center justify-center gap-3 text-neutral-500 dark:text-neutral-400"
+		>
+			<AlertTriangle size={24} class="text-yellow-500 dark:text-yellow-400" />
+			<span class="text-sm">Failed to load logs from this instance.</span>
+			<span class="text-xs">{err instanceof Error ? err.message : String(err)}</span>
+			<Button variant="secondary" size="sm" on:click={refreshLogs}>Retry</Button>
+		</div>
+	{/await}
 </div>

--- a/src/routes/arr/[id]/logs/+page.svelte
+++ b/src/routes/arr/[id]/logs/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
 	import { page } from '$app/stores';
+	import { browser } from '$app/environment';
 	import { Copy, RefreshCw, Filter, Rows3, Loader2, AlertTriangle } from 'lucide-svelte';
 	import { alertStore } from '$alerts/store';
 	import Table from '$ui/table/Table.svelte';
@@ -33,6 +34,62 @@
 		exception?: string | null;
 	}
 
+	interface LogResponse {
+		page: number;
+		pageSize: number;
+		totalRecords: number;
+		records: LogEntry[];
+	}
+
+	// Client-side log fetching — avoids blocking tab navigation with a
+	// server-streamed promise. The page load returns instantly; logs are
+	// fetched separately via the colocated +server.ts endpoint.
+	let logs: LogResponse | null = null;
+	let logsLoading = true;
+	let logsError: string | null = null;
+	let fetchController: AbortController | null = null;
+
+	function buildLogsUrl(filters: { page: number; pageSize: number; level?: string }): string {
+		const params = new URLSearchParams();
+		params.set('page', String(filters.page));
+		params.set('pageSize', String(filters.pageSize));
+		if (filters.level) params.set('level', filters.level);
+		return `/arr/${$page.params.id}/logs?${params}`;
+	}
+
+	async function fetchLogs(filters: { page: number; pageSize: number; level?: string }) {
+		// Abort any in-flight request
+		fetchController?.abort();
+		fetchController = new AbortController();
+		const { signal } = fetchController;
+
+		logs = null;
+		logsLoading = true;
+		logsError = null;
+
+		try {
+			const res = await fetch(buildLogsUrl(filters), {
+				signal,
+				headers: { Accept: 'application/json' }
+			});
+			if (!res.ok) {
+				const body = await res.json().catch(() => null);
+				throw new Error(body?.message || `HTTP ${res.status}`);
+			}
+			logs = await res.json();
+		} catch (err) {
+			if ((err as Error).name === 'AbortError') return;
+			logsError = err instanceof Error ? err.message : String(err);
+		} finally {
+			logsLoading = false;
+		}
+	}
+
+	// Fetch logs on mount and whenever filters change via navigation
+	$: if (browser) {
+		fetchLogs(data.filters);
+	}
+
 	// Initialize search store
 	let searchStore: SearchStore;
 	$: searchStore = getPersistentSearchStore(`arrLogsSearch:${$page.params.id}`, {
@@ -42,7 +99,6 @@
 	// Filter state
 	let selectedLevel: string = data.filters.level || 'ALL';
 	let pageSize: number = data.filters.pageSize;
-	let isRefreshing = false;
 
 	const logLevels = ['ALL', 'Trace', 'Debug', 'Info', 'Warn', 'Error', 'Fatal'] as const;
 
@@ -112,7 +168,8 @@
 		}
 	}
 
-	// Navigate with updated params
+	// Navigate with updated params — triggers server load which updates
+	// data.filters, which triggers the reactive fetchLogs call above.
 	function updateParams(params: Record<string, string | number | undefined>) {
 		const url = new URL($page.url);
 		for (const [key, value] of Object.entries(params)) {
@@ -126,10 +183,8 @@
 	}
 
 	// Refresh logs
-	async function refreshLogs() {
-		isRefreshing = true;
-		await goto($page.url.toString(), { invalidateAll: true });
-		isRefreshing = false;
+	function refreshLogs() {
+		fetchLogs(data.filters);
 	}
 
 	// Change level filter
@@ -150,21 +205,29 @@
 	}
 
 	// Client-side search filter
-	function filterLogs(records: LogEntry[], query: string): LogEntry[] {
-		return records.filter((log) => {
-			if (selectedLevel !== 'ALL' && normalizeLevel(log.level) !== normalizeLevel(selectedLevel)) {
-				return false;
-			}
+	$: filteredLogs = logs
+		? logs.records.filter((log) => {
+				if (
+					selectedLevel !== 'ALL' &&
+					normalizeLevel(log.level) !== normalizeLevel(selectedLevel)
+				) {
+					return false;
+				}
 
-			if (!query) return true;
+				const query = $searchStore.query;
+				if (!query) return true;
 
-			const searchLower = query.toLowerCase();
-			return (
-				log.message.toLowerCase().includes(searchLower) ||
-				log.logger.toLowerCase().includes(searchLower)
-			);
-		});
-	}
+				const searchLower = query.toLowerCase();
+				return (
+					log.message.toLowerCase().includes(searchLower) ||
+					log.logger.toLowerCase().includes(searchLower)
+				);
+			})
+		: [];
+
+	// Pagination info
+	$: totalPages = logs ? Math.ceil(logs.totalRecords / logs.pageSize) : 0;
+	$: currentPage = logs?.page ?? 1;
 </script>
 
 <svelte:head>
@@ -181,7 +244,7 @@
 			<ActionButton on:click={refreshLogs}>
 				<RefreshCw
 					size={20}
-					class="text-neutral-700 dark:text-neutral-300 {isRefreshing ? 'animate-spin' : ''}"
+					class="text-neutral-700 dark:text-neutral-300 {logsLoading ? 'animate-spin' : ''}"
 				/>
 			</ActionButton>
 		</Tooltip>
@@ -232,7 +295,7 @@
 		</ActionButton>
 	</ActionsBar>
 
-	{#await data.logs}
+	{#if logsLoading}
 		<!-- Loading state -->
 		<div
 			class="mt-12 flex flex-col items-center justify-center gap-3 text-neutral-500 dark:text-neutral-400"
@@ -240,11 +303,17 @@
 			<Loader2 size={24} class="animate-spin" />
 			<span class="text-sm">Loading logs...</span>
 		</div>
-	{:then logs}
-		{@const filteredLogs = filterLogs(logs.records, $searchStore.query)}
-		{@const totalPages = Math.ceil(logs.totalRecords / logs.pageSize)}
-		{@const currentPage = logs.page}
-
+	{:else if logsError}
+		<!-- Error state -->
+		<div
+			class="mt-12 flex flex-col items-center justify-center gap-3 text-neutral-500 dark:text-neutral-400"
+		>
+			<AlertTriangle size={24} class="text-yellow-500 dark:text-yellow-400" />
+			<span class="text-sm">Failed to load logs from this instance.</span>
+			<span class="text-xs">{logsError}</span>
+			<Button variant="secondary" size="sm" on:click={refreshLogs}>Retry</Button>
+		</div>
+	{:else if logs}
 		<!-- Stats -->
 		<div
 			class="mt-6 mb-4 flex items-center justify-between text-sm text-neutral-600 dark:text-neutral-400"
@@ -291,15 +360,5 @@
 				<Pagination {currentPage} {totalPages} onPageChange={goToPage} />
 			</div>
 		{/if}
-	{:catch err}
-		<!-- Error state -->
-		<div
-			class="mt-12 flex flex-col items-center justify-center gap-3 text-neutral-500 dark:text-neutral-400"
-		>
-			<AlertTriangle size={24} class="text-yellow-500 dark:text-yellow-400" />
-			<span class="text-sm">Failed to load logs from this instance.</span>
-			<span class="text-xs">{err instanceof Error ? err.message : String(err)}</span>
-			<Button variant="secondary" size="sm" on:click={refreshLogs}>Retry</Button>
-		</div>
-	{/await}
+	{/if}
 </div>

--- a/src/routes/arr/[id]/logs/+server.ts
+++ b/src/routes/arr/[id]/logs/+server.ts
@@ -1,0 +1,41 @@
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from '@sveltejs/kit';
+import { arrInstancesQueries } from '$db/queries/arrInstances.ts';
+import { createArrClient } from '$arr/factory.ts';
+import type { ArrType } from '$arr/types.ts';
+
+export const GET: RequestHandler = async ({ params, url }) => {
+	const id = parseInt(params.id || '', 10);
+
+	if (isNaN(id)) {
+		error(400, 'Invalid instance ID');
+	}
+
+	const instance = arrInstancesQueries.getById(id);
+
+	if (!instance) {
+		error(404, 'Instance not found');
+	}
+
+	const page = parseInt(url.searchParams.get('page') || '1', 10);
+	const pageSize = parseInt(url.searchParams.get('pageSize') || '50', 10);
+	const level = url.searchParams.get('level') || undefined;
+
+	const client = createArrClient(instance.type as ArrType, instance.url, instance.api_key);
+
+	try {
+		const logs = await client.getLogs({
+			page,
+			pageSize,
+			sortKey: 'time',
+			sortDirection: 'descending',
+			level: level as 'Trace' | 'Debug' | 'Info' | 'Warn' | 'Error' | 'Fatal' | undefined
+		});
+
+		return json(logs);
+	} catch (err) {
+		error(502, `Failed to fetch logs: ${err instanceof Error ? err.message : 'Unknown error'}`);
+	} finally {
+		client.close();
+	}
+};


### PR DESCRIPTION
Moves arr log fetching from the server load into a client-side fetch against a colocated `+server.ts` endpoint. The server load now returns instantly, so navigating to the Logs tab never blocks on an external HTTP call to the arr.

Uses `AbortController` to cancel in-flight requests on navigation or filter changes.

Related: #704