### PR TITLE
fix: remove unsupported semver-major-days from github-actions cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,4 +41,3 @@ updates:
     open-pull-requests-limit: 10
     cooldown:
       default-days: 3
-      semver-major-days: 7


### PR DESCRIPTION
## Summary

- Remove `semver-major-days` from the github-actions ecosystem cooldown config (not supported for this ecosystem)