### PR TITLE
fix: improve custom format scoring toggles

### DIFF
--- a/src/lib/client/ui/form/IconCheckbox.svelte
+++ b/src/lib/client/ui/form/IconCheckbox.svelte
@@ -37,7 +37,7 @@
 	$: iconSize = compact ? 9 : 14;
 	const baseClass = 'flex items-center justify-center border transition-colors';
 	const uncheckedClass =
-		'border-neutral-300 bg-white hover:border-neutral-400 hover:bg-neutral-50 dark:border-neutral-700/60 dark:bg-neutral-800/50 dark:hover:border-neutral-600 dark:hover:bg-neutral-800';
+		'border-2 border-neutral-400 bg-white hover:border-neutral-600 hover:bg-neutral-50 dark:border-neutral-500 dark:bg-neutral-800/50 dark:hover:border-neutral-300 dark:hover:bg-neutral-800';
 	const disabledClass = 'cursor-not-allowed opacity-50';
 	const enabledClass = 'cursor-pointer focus:outline-none';
 

--- a/src/routes/quality-profiles/[databaseId]/[id]/scoring/components/ScoringTableDesktop.svelte
+++ b/src/routes/quality-profiles/[databaseId]/[id]/scoring/components/ScoringTableDesktop.svelte
@@ -29,33 +29,22 @@
 		enabledChange: { formatName: string; arrType: string; enabled: boolean };
 	}>();
 
-	function isRowDisabled(format: any): boolean {
-		return arrTypes.every((arrType) => !customFormatEnabled[format.name]?.[arrType]);
-	}
+	$: columns = ((activeArrTypes) =>
+		[
+			{
+				key: 'name',
+				header: 'Custom Format',
+				tdClass: 'sticky left-0 z-[1] bg-white font-medium dark:bg-neutral-900'
+			},
+			...activeArrTypes.map((arrType) => ({
+				key: arrType,
+				header: arrType.charAt(0).toUpperCase() + arrType.slice(1),
+				align: 'center' as const,
+				width: 'w-64'
+			}))
+		] as Column<any>[])(arrTypes);
 
-	$: columns = [
-		{
-			key: 'name',
-			header: 'Custom Format',
-			tdClass: (row: any) => {
-				const disabled = isRowDisabled(row);
-				return `sticky left-0 z-[1] font-medium ${disabled ? 'bg-neutral-100 dark:bg-neutral-800' : 'bg-white dark:bg-neutral-900'}`;
-			}
-		},
-		...arrTypes.map((arrType) => ({
-			key: arrType,
-			header: arrType.charAt(0).toUpperCase() + arrType.slice(1),
-			align: 'center' as const,
-			width: 'w-64'
-		}))
-	] as Column<any>[];
-
-	function rowClass(row: any): string {
-		const disabled = isRowDisabled(row);
-		return disabled
-			? 'bg-neutral-100 opacity-60 dark:bg-neutral-800'
-			: 'transition-colors hover:bg-neutral-50 dark:hover:bg-neutral-900';
-	}
+	const rowClass = () => 'transition-colors hover:bg-neutral-50 dark:hover:bg-neutral-900';
 
 	function rowAttributes(_: any, i: number): Record<string, string> {
 		return i === 0 && firstRowOnboarding ? { 'data-onboarding': firstRowOnboarding } : {};

--- a/src/routes/quality-profiles/[databaseId]/[id]/scoring/components/ScoringTableMobile.svelte
+++ b/src/routes/quality-profiles/[databaseId]/[id]/scoring/components/ScoringTableMobile.svelte
@@ -68,20 +68,13 @@
 			<div style="height: {topHeight}px;"></div>
 		{/if}
 		{#each visibleFormats as format, i (format.name)}
-			{@const rowDisabled = arrTypes.every(
-				(arrType) => !customFormatEnabled[format.name]?.[arrType]
-			)}
 			<div
-				class="rounded-lg border border-neutral-200 bg-white dark:border-neutral-800 dark:bg-neutral-900 {rowDisabled
-					? 'opacity-60'
-					: ''}"
+				class="rounded-lg border border-neutral-200 bg-white dark:border-neutral-800 dark:bg-neutral-900"
 				data-onboarding={start + i === 0 ? firstRowOnboarding : undefined}
 			>
 				<!-- Format name -->
 				<div
-					class="border-b border-neutral-200 px-4 py-2.5 text-sm font-medium dark:border-neutral-800 {rowDisabled
-						? 'text-neutral-500 dark:text-neutral-500'
-						: 'text-neutral-900 dark:text-neutral-100'}"
+					class="border-b border-neutral-200 px-4 py-2.5 text-sm font-medium text-neutral-900 dark:border-neutral-800 dark:text-neutral-100"
 				>
 					<InlineLink
 						href="/custom-formats/{databaseId}/{format.id}/general"


### PR DESCRIPTION
Closes #747

Improves unchecked icon checkbox contrast with a neutral thicker border so scoring toggles read as interactive.

Removes the muted disabled-row styling from quality profile scoring rows and mobile cards so custom formats no longer look locked when both Arr scores are off.