### PR TITLE
feat: support env-managed API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ services:
 | `ORIGIN`                 | -                                                                 | Public URL when running behind a reverse proxy (e.g. `https://profilarr.example.com`) |
 | `PARSER_HOST`            | `localhost`                                                       | Parser service host                                                                   |
 | `PARSER_PORT`            | `5000`                                                            | Parser service port                                                                   |
+| `PROFILARR_API_KEY`      | -                                                                 | Declaratively set the internal API key for `X-Api-Key` API authentication             |
 | `PROFILARR_BULLETIN_URL` | `https://raw.githubusercontent.com/Dictionarry-Hub/bulletin/main` | Override for the announcement feed + release manifest base URL                        |
 
 > [!NOTE]

--- a/README.md
+++ b/README.md
@@ -133,8 +133,12 @@ services:
 | `ORIGIN`                 | -                                                                 | Public URL when running behind a reverse proxy (e.g. `https://profilarr.example.com`) |
 | `PARSER_HOST`            | `localhost`                                                       | Parser service host                                                                   |
 | `PARSER_PORT`            | `5000`                                                            | Parser service port                                                                   |
-| `PROFILARR_API_KEY`      | -                                                                 | Declaratively set the internal API key for `X-Api-Key` API authentication             |
+| `PROFILARR_API_KEY`      | -                                                                 | Plaintext runtime secret for `X-Api-Key` auth                                         |
 | `PROFILARR_BULLETIN_URL` | `https://raw.githubusercontent.com/Dictionarry-Hub/bulletin/main` | Override for the announcement feed + release manifest base URL                        |
+
+`PROFILARR_API_KEY` must be at least 32 characters long. It is not persisted to
+SQLite or bcrypt-hashed; while set, it overrides the stored database key.
+Removing it reactivates the stored database key if one exists.
 
 > [!NOTE]
 > When using OIDC `ORIGIN=` _must_ be set to your Profilarr URL, and Profilarr

--- a/docs/backend/security.md
+++ b/docs/backend/security.md
@@ -172,6 +172,9 @@ session checks in the request flow.
 - `regenerateApiKey()` returns the plaintext key once for the user to copy; only
   the hash is persisted
 - Validation uses async bcrypt `verify()` against the stored hash
+- `PROFILARR_API_KEY` can declaratively set the active API key from the
+  environment. When set, it takes precedence over the database hash and
+  regeneration is disabled in Settings > Security.
 - Invalid keys are logged with a masked value (`****` + last 4 chars)
 
 ## Request Flow

--- a/docs/backend/security.md
+++ b/docs/backend/security.md
@@ -173,8 +173,10 @@ session checks in the request flow.
   the hash is persisted
 - Validation uses async bcrypt `verify()` against the stored hash
 - `PROFILARR_API_KEY` can declaratively set the active API key from the
-  environment. When set, it takes precedence over the database hash and
-  regeneration is disabled in Settings > Security.
+  environment. It must be at least 32 characters long. The value is a plaintext
+  runtime secret, is not persisted to SQLite, and is not bcrypt-hashed. When
+  set, it overrides the database hash and regeneration is disabled in Settings >
+  Security. Removing it reactivates the stored database key if one exists.
 - Invalid keys are logged with a masked value (`****` + last 4 chars)
 
 ## Request Flow

--- a/src/lib/server/db/queries/authSettings.ts
+++ b/src/lib/server/db/queries/authSettings.ts
@@ -1,6 +1,7 @@
 import { db } from '../db.ts';
 import { generateApiKey } from '$auth/apiKey.ts';
 import { hash, verify } from '@felix/bcrypt';
+import { config } from '$config';
 
 /**
  * Types for auth_settings table
@@ -17,6 +18,16 @@ export interface AuthSettings {
 export interface UpdateAuthSettingsInput {
 	sessionDurationHours?: number;
 	apiKey?: string | null;
+}
+
+export enum ApiKeySource {
+	Environment = 'environment',
+	Generated = 'generated'
+}
+
+export interface ApiKey {
+	source: ApiKeySource;
+	key: string | null;
 }
 
 /**
@@ -46,7 +57,25 @@ export const authSettingsQueries = {
 	 * Check whether an API key is configured
 	 */
 	hasApiKey(): boolean {
-		return this.get().api_key !== null;
+		return config.profilarrApiKey !== null || this.get().api_key !== null;
+	},
+
+	/**
+	 * Check whether users can regenerate the API key from the UI
+	 */
+	canRegenerateApiKey(): boolean {
+		return config.profilarrApiKey === null;
+	},
+
+	/**
+	 * Get the active API key and where it comes from.
+	 */
+	getApiKey(): ApiKey {
+		if (config.profilarrApiKey !== null) {
+			return { source: ApiKeySource.Environment, key: config.profilarrApiKey };
+		}
+
+		return { source: ApiKeySource.Generated, key: this.get().api_key };
 	},
 
 	/**
@@ -102,6 +131,10 @@ export const authSettingsQueries = {
 	 * Regenerate API key — returns the plaintext key (stored as bcrypt hash)
 	 */
 	async regenerateApiKey(): Promise<string> {
+		if (!this.canRegenerateApiKey()) {
+			throw new Error('PROFILARR_API_KEY is set; API key regeneration is disabled');
+		}
+
 		const plaintext = generateApiKey();
 		const hashed = await hash(plaintext);
 		this.update({ apiKey: hashed });
@@ -116,12 +149,17 @@ export const authSettingsQueries = {
 	},
 
 	/**
-	 * Validate an API key against the stored bcrypt hash
+	 * Validate an API key against the active source.
 	 */
 	async validateApiKey(key: string): Promise<boolean> {
-		const settings = this.get();
-		if (settings.api_key === null) return false;
+		const activeKey = this.getApiKey();
+		if (activeKey.key === null) return false;
 
-		return verify(key, settings.api_key);
+		switch (activeKey.source) {
+			case ApiKeySource.Environment:
+				return key === activeKey.key;
+			case ApiKeySource.Generated:
+				return verify(key, activeKey.key);
+		}
 	}
 };

--- a/src/lib/server/db/queries/authSettings.ts
+++ b/src/lib/server/db/queries/authSettings.ts
@@ -30,6 +30,36 @@ export interface ApiKey {
 	key: string | null;
 }
 
+const encoder = new TextEncoder();
+
+async function timingSafeStringEquals(left: string, right: string): Promise<boolean> {
+	const [leftHash, rightHash] = await Promise.all([
+		crypto.subtle.digest('SHA-256', encoder.encode(left)),
+		crypto.subtle.digest('SHA-256', encoder.encode(right))
+	]);
+
+	const leftBytes = new Uint8Array(leftHash);
+	const rightBytes = new Uint8Array(rightHash);
+	let diff = 0;
+
+	for (let i = 0; i < leftBytes.length; i++) {
+		diff |= leftBytes[i] ^ rightBytes[i];
+	}
+
+	return diff === 0;
+}
+
+async function verifyApiKey(candidate: string, activeKey: ApiKey): Promise<boolean> {
+	if (activeKey.key === null) return false;
+
+	switch (activeKey.source) {
+		case ApiKeySource.Environment:
+			return timingSafeStringEquals(candidate, activeKey.key);
+		case ApiKeySource.Generated:
+			return verify(candidate, activeKey.key);
+	}
+}
+
 /**
  * All queries for auth_settings table
  * Singleton pattern - only one settings record exists
@@ -152,14 +182,6 @@ export const authSettingsQueries = {
 	 * Validate an API key against the active source.
 	 */
 	async validateApiKey(key: string): Promise<boolean> {
-		const activeKey = this.getApiKey();
-		if (activeKey.key === null) return false;
-
-		switch (activeKey.source) {
-			case ApiKeySource.Environment:
-				return key === activeKey.key;
-			case ApiKeySource.Generated:
-				return verify(key, activeKey.key);
-		}
+		return verifyApiKey(key, this.getApiKey());
 	}
 };

--- a/src/lib/server/utils/config/config.ts
+++ b/src/lib/server/utils/config/config.ts
@@ -4,6 +4,8 @@
 
 export type AuthMode = 'on' | 'off' | 'oidc';
 
+export const PROFILARR_API_KEY_MIN_LENGTH = 32;
+
 class Config {
 	private basePath: string;
 	public readonly timezone: string;
@@ -59,7 +61,13 @@ class Config {
 		this.authMode = ['on', 'off', 'oidc'].includes(auth) ? (auth as AuthMode) : 'on';
 
 		// Optional declarative internal API key for GitOps/container deployments.
-		this.profilarrApiKey = Deno.env.get('PROFILARR_API_KEY') || null;
+		const profilarrApiKey = Deno.env.get('PROFILARR_API_KEY') || null;
+		if (profilarrApiKey !== null && profilarrApiKey.length < PROFILARR_API_KEY_MIN_LENGTH) {
+			throw new Error(
+				`PROFILARR_API_KEY must be at least ${PROFILARR_API_KEY_MIN_LENGTH} characters long`
+			);
+		}
+		this.profilarrApiKey = profilarrApiKey;
 
 		// OIDC configuration (only used when AUTH=oidc)
 		this.oidc = {

--- a/src/lib/server/utils/config/config.ts
+++ b/src/lib/server/utils/config/config.ts
@@ -12,6 +12,7 @@ class Config {
 	public readonly host: string;
 	public readonly origin: string;
 	public readonly authMode: AuthMode;
+	public readonly profilarrApiKey: string | null;
 	public readonly oidc: {
 		discoveryUrl: string | null;
 		clientId: string | null;
@@ -56,6 +57,9 @@ class Config {
 		// Note: AUTH=local is no longer an env var — use the local bypass toggle in Settings > Security
 		const auth = (Deno.env.get('AUTH') || 'on').toLowerCase();
 		this.authMode = ['on', 'off', 'oidc'].includes(auth) ? (auth as AuthMode) : 'on';
+
+		// Optional declarative internal API key for GitOps/container deployments.
+		this.profilarrApiKey = Deno.env.get('PROFILARR_API_KEY') || null;
 
 		// OIDC configuration (only used when AUTH=oidc)
 		this.oidc = {

--- a/src/routes/settings/security/+page.server.ts
+++ b/src/routes/settings/security/+page.server.ts
@@ -11,11 +11,18 @@ export const load: ServerLoad = async ({ cookies }) => {
 	const user = usersQueries.getByUsername('admin') ?? usersQueries.getById(1);
 
 	if (!user) {
-		return { sessions: [], hasApiKey: false, currentSessionId: null };
+		return {
+			sessions: [],
+			hasApiKey: false,
+			canRegenerateApiKey: true,
+			currentSessionId: null,
+			localBypassEnabled: false
+		};
 	}
 
 	const sessions = sessionsQueries.getByUserId(user.id);
 	const hasApiKey = authSettingsQueries.hasApiKey();
+	const canRegenerateApiKey = authSettingsQueries.canRegenerateApiKey();
 	const localBypassEnabled = authSettingsQueries.isLocalBypassEnabled();
 
 	return {
@@ -31,6 +38,7 @@ export const load: ServerLoad = async ({ cookies }) => {
 			isCurrent: s.id === currentSessionId
 		})),
 		hasApiKey,
+		canRegenerateApiKey,
 		currentSessionId,
 		localBypassEnabled
 	};
@@ -90,6 +98,12 @@ export const actions: Actions = {
 	},
 
 	regenerateApiKey: async () => {
+		if (!authSettingsQueries.canRegenerateApiKey()) {
+			return fail(400, {
+				apiKeyError: 'API key is managed by PROFILARR_API_KEY and cannot be regenerated'
+			});
+		}
+
 		const newKey = await authSettingsQueries.regenerateApiKey();
 
 		await logger.info('API key regenerated', {

--- a/src/routes/settings/security/+page.svelte
+++ b/src/routes/settings/security/+page.svelte
@@ -51,6 +51,9 @@
 	$: if (form?.apiKeyRegenerated) {
 		alertStore.add('success', 'API key regenerated');
 	}
+	$: if (form?.apiKeyError) {
+		alertStore.add('error', form.apiKeyError);
+	}
 	$: if (form?.sessionRevoked) {
 		alertStore.add('success', 'Session revoked');
 	}
@@ -65,6 +68,10 @@
 	}
 
 	$: apiKey = form?.apiKey ?? null;
+	$: apiKeyRegenerationDisabled = regeneratingKey || !data.canRegenerateApiKey;
+	$: apiKeyRegenerationTooltip = data.canRegenerateApiKey
+		? ''
+		: 'API key is managed by PROFILARR_API_KEY';
 
 	async function copyApiKey() {
 		if (apiKey) {
@@ -296,7 +303,8 @@
 								size="sm"
 								icon={RefreshCw}
 								text={regeneratingKey ? 'Regenerating...' : 'Regenerate'}
-								disabled={regeneratingKey}
+								disabled={apiKeyRegenerationDisabled}
+								tooltip={apiKeyRegenerationTooltip}
 							/>
 						</form>
 					</div>
@@ -304,8 +312,12 @@
 					<!-- Key exists but can't be displayed -->
 					<div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
 						<p class="text-sm text-neutral-500 dark:text-neutral-400">
-							Your API key is hashed and cannot be displayed. Regenerating will replace the current
-							key.
+							{#if data.canRegenerateApiKey}
+								Your API key is hashed and cannot be displayed. Regenerating will replace the
+								current key.
+							{:else}
+								Your API key is managed by the PROFILARR_API_KEY environment variable.
+							{/if}
 						</p>
 						<form
 							method="POST"
@@ -325,7 +337,8 @@
 								icon={RefreshCw}
 								iconColor="text-emerald-500"
 								text={regeneratingKey ? 'Regenerating...' : 'Regenerate'}
-								disabled={regeneratingKey}
+								disabled={apiKeyRegenerationDisabled}
+								tooltip={apiKeyRegenerationTooltip}
 							/>
 						</form>
 					</div>

--- a/tests/integration/auth/specs/apiKey.test.ts
+++ b/tests/integration/auth/specs/apiKey.test.ts
@@ -8,26 +8,28 @@
  * 4. API key in query param → 401 (only header accepted)
  * 5. API key rejected for browser pages (scoped to /api/ only)
  * 6. API key rejected for form actions (scoped to /api/ only)
+ * 7. PROFILARR_API_KEY overrides the database API key
  */
 
 import { assertEquals } from '@std/assert';
 import { TestClient } from '$test-harness/client.ts';
 import { startServer, stopServer, getDbPath } from '$test-harness/server.ts';
-import { createUser, setApiKey } from '$test-harness/setup.ts';
+import { createUser, login, setApiKey } from '$test-harness/setup.ts';
 import { setup, teardown, test, run } from '$test-harness/runner.ts';
 import { PORTS } from '$test-harness/ports.ts';
 
 const PORT = PORTS.auth.apiKey;
 const ORIGIN = `http://localhost:${PORT}`;
 const API_KEY = 'test-api-key-valid-12345';
+const DB_API_KEY = 'test-db-api-key-valid-12345';
 
 let client: TestClient;
 
 setup(async () => {
-	await startServer(PORT, { AUTH: 'on', ORIGIN }, 'preview');
+	await startServer(PORT, { AUTH: 'on', ORIGIN, PROFILARR_API_KEY: API_KEY }, 'preview');
 	client = new TestClient(ORIGIN);
 	await createUser(client, 'admin', 'password123', ORIGIN);
-	await setApiKey(getDbPath(PORT), API_KEY);
+	await setApiKey(getDbPath(PORT), DB_API_KEY);
 });
 
 teardown(async () => {
@@ -40,6 +42,15 @@ test('valid API key returns 200', async () => {
 		headers: { 'X-Api-Key': API_KEY }
 	});
 	assertEquals(res.status, 200);
+});
+
+test('database API key returns 401 when PROFILARR_API_KEY is set', async () => {
+	// PROFILARR_API_KEY is the active key when configured; the stored hash is ignored.
+	const c = new TestClient(ORIGIN);
+	const res = await c.get('/api/v1/status', {
+		headers: { 'X-Api-Key': DB_API_KEY }
+	});
+	assertEquals(res.status, 401, `Expected DB-backed key to be ignored, got ${res.status}`);
 });
 
 test('invalid API key returns 401', async () => {
@@ -84,6 +95,23 @@ test('API key rejected for form actions', async () => {
 		{ headers: { Origin: ORIGIN, 'X-Api-Key': API_KEY } }
 	);
 	assertEquals(res.status, 403, `Expected 403 for form action with API key, got ${res.status}`);
+});
+
+test('session user cannot regenerate API key when PROFILARR_API_KEY is set', async () => {
+	// A logged-in admin should not be able to rotate an env-managed key from the UI.
+	const res = await login(client, 'admin', 'password123', ORIGIN);
+	assertEquals(res.status, 303);
+
+	const regen = await client.postForm(
+		'/settings/security?/regenerateApiKey',
+		{},
+		{ headers: { Origin: ORIGIN } }
+	);
+	assertEquals(
+		regen.status,
+		400,
+		`Expected 400 for env-managed key regeneration, got ${regen.status}`
+	);
 });
 
 await run();

--- a/tests/integration/auth/specs/apiKey.test.ts
+++ b/tests/integration/auth/specs/apiKey.test.ts
@@ -8,28 +8,26 @@
  * 4. API key in query param → 401 (only header accepted)
  * 5. API key rejected for browser pages (scoped to /api/ only)
  * 6. API key rejected for form actions (scoped to /api/ only)
- * 7. PROFILARR_API_KEY overrides the database API key
  */
 
 import { assertEquals } from '@std/assert';
 import { TestClient } from '$test-harness/client.ts';
 import { startServer, stopServer, getDbPath } from '$test-harness/server.ts';
-import { createUser, login, setApiKey } from '$test-harness/setup.ts';
+import { createUser, setApiKey } from '$test-harness/setup.ts';
 import { setup, teardown, test, run } from '$test-harness/runner.ts';
 import { PORTS } from '$test-harness/ports.ts';
 
 const PORT = PORTS.auth.apiKey;
 const ORIGIN = `http://localhost:${PORT}`;
 const API_KEY = 'test-api-key-valid-12345';
-const DB_API_KEY = 'test-db-api-key-valid-12345';
 
 let client: TestClient;
 
 setup(async () => {
-	await startServer(PORT, { AUTH: 'on', ORIGIN, PROFILARR_API_KEY: API_KEY }, 'preview');
+	await startServer(PORT, { AUTH: 'on', ORIGIN }, 'preview');
 	client = new TestClient(ORIGIN);
 	await createUser(client, 'admin', 'password123', ORIGIN);
-	await setApiKey(getDbPath(PORT), DB_API_KEY);
+	await setApiKey(getDbPath(PORT), API_KEY);
 });
 
 teardown(async () => {
@@ -42,15 +40,6 @@ test('valid API key returns 200', async () => {
 		headers: { 'X-Api-Key': API_KEY }
 	});
 	assertEquals(res.status, 200);
-});
-
-test('database API key returns 401 when PROFILARR_API_KEY is set', async () => {
-	// PROFILARR_API_KEY is the active key when configured; the stored hash is ignored.
-	const c = new TestClient(ORIGIN);
-	const res = await c.get('/api/v1/status', {
-		headers: { 'X-Api-Key': DB_API_KEY }
-	});
-	assertEquals(res.status, 401, `Expected DB-backed key to be ignored, got ${res.status}`);
 });
 
 test('invalid API key returns 401', async () => {
@@ -95,23 +84,6 @@ test('API key rejected for form actions', async () => {
 		{ headers: { Origin: ORIGIN, 'X-Api-Key': API_KEY } }
 	);
 	assertEquals(res.status, 403, `Expected 403 for form action with API key, got ${res.status}`);
-});
-
-test('session user cannot regenerate API key when PROFILARR_API_KEY is set', async () => {
-	// A logged-in admin should not be able to rotate an env-managed key from the UI.
-	const res = await login(client, 'admin', 'password123', ORIGIN);
-	assertEquals(res.status, 303);
-
-	const regen = await client.postForm(
-		'/settings/security?/regenerateApiKey',
-		{},
-		{ headers: { Origin: ORIGIN } }
-	);
-	assertEquals(
-		regen.status,
-		400,
-		`Expected 400 for env-managed key regeneration, got ${regen.status}`
-	);
 });
 
 await run();

--- a/tests/integration/auth/specs/envApiKey.test.ts
+++ b/tests/integration/auth/specs/envApiKey.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Integration tests: environment-managed API key authentication
+ *
+ * Tests:
+ * 1. PROFILARR_API_KEY authenticates API requests
+ * 2. Stored database API key is ignored while PROFILARR_API_KEY is set
+ * 3. Session user cannot regenerate an env-managed API key
+ */
+
+import { assertEquals } from '@std/assert';
+import { TestClient } from '$test-harness/client.ts';
+import { startServer, stopServer, getDbPath } from '$test-harness/server.ts';
+import { createUser, login, setApiKey } from '$test-harness/setup.ts';
+import { setup, teardown, test, run } from '$test-harness/runner.ts';
+import { PORTS } from '$test-harness/ports.ts';
+
+const PORT = PORTS.auth.envApiKey;
+const ORIGIN = `http://localhost:${PORT}`;
+const API_KEY = 'test-env-api-key-valid-1234567890';
+const DB_API_KEY = 'test-db-api-key-valid-1234567890';
+
+let client: TestClient;
+
+setup(async () => {
+	await startServer(PORT, { AUTH: 'on', ORIGIN, PROFILARR_API_KEY: API_KEY }, 'preview');
+	client = new TestClient(ORIGIN);
+	await createUser(client, 'admin', 'password123', ORIGIN);
+	await setApiKey(getDbPath(PORT), DB_API_KEY);
+});
+
+teardown(async () => {
+	await stopServer(PORT);
+});
+
+test('PROFILARR_API_KEY returns 200', async () => {
+	const c = new TestClient(ORIGIN);
+	const res = await c.get('/api/v1/status', {
+		headers: { 'X-Api-Key': API_KEY }
+	});
+	assertEquals(res.status, 200);
+});
+
+test('database API key returns 401 when PROFILARR_API_KEY is set', async () => {
+	// PROFILARR_API_KEY is the active key when configured; the stored hash is ignored.
+	const c = new TestClient(ORIGIN);
+	const res = await c.get('/api/v1/status', {
+		headers: { 'X-Api-Key': DB_API_KEY }
+	});
+	assertEquals(res.status, 401, `Expected DB-backed key to be ignored, got ${res.status}`);
+});
+
+test('session user cannot regenerate API key when PROFILARR_API_KEY is set', async () => {
+	// A logged-in admin should not be able to rotate an env-managed key from the UI.
+	const res = await login(client, 'admin', 'password123', ORIGIN);
+	assertEquals(res.status, 200);
+
+	const regen = await client.postForm(
+		'/settings/security?/regenerateApiKey',
+		{},
+		{ headers: { Origin: ORIGIN } }
+	);
+	const body = await regen.text();
+	assertEquals(regen.status, 200);
+	assertEquals(
+		body.includes('"status":400'),
+		true,
+		`Expected form failure status 400 for env-managed key regeneration, got ${body}`
+	);
+});
+
+await run();

--- a/tests/integration/harness/ports.ts
+++ b/tests/integration/harness/ports.ts
@@ -42,7 +42,8 @@ export const PORTS = {
 		reverseProxy502Manual: 7014,
 		secretExposure: 7015,
 		session: 7016,
-		xForwardedFor: 7017
+		xForwardedFor: 7017,
+		envApiKey: 7018
 	},
 	api: {
 		arr: 7100,

--- a/tests/unit/auth/profilarrApiKeyConfig.test.ts
+++ b/tests/unit/auth/profilarrApiKeyConfig.test.ts
@@ -1,0 +1,16 @@
+import { assertEquals, assertStringIncludes } from '@std/assert';
+
+Deno.test('PROFILARR_API_KEY shorter than 32 characters fails config import', async () => {
+	const result = await new Deno.Command('deno', {
+		args: ['eval', "await import('./src/lib/server/utils/config/config.ts');"],
+		env: { ...Deno.env.toObject(), PROFILARR_API_KEY: 'too-short' },
+		stdout: 'piped',
+		stderr: 'piped'
+	}).output();
+
+	assertEquals(result.code, 1);
+	assertStringIncludes(
+		new TextDecoder().decode(result.stderr),
+		'PROFILARR_API_KEY must be at least 32 characters long'
+	);
+});


### PR DESCRIPTION
## Summary

- Add `PROFILARR_API_KEY` as an optional env-managed internal API key
- Prefer the env-managed key over the stored DB key when authenticating `X-Api-Key`
- Disable API key regeneration when the key is managed by environment config
- Document the new env var and add integration coverage to the existing API key auth spec

## Notes

`PROFILARR_API_KEY` is treated as runtime secret configuration and does not mutate `auth_settings.api_key`. Generated UI keys remain stored as bcrypt hashes in SQLite.

## Testing

- `deno task check`
- `deno task build`

Addresses: #796