### PR TITLE
fix: evaluate tags/genres filters as set membership

### DIFF
--- a/src/lib/shared/upgrades/filters.ts
+++ b/src/lib/shared/upgrades/filters.ts
@@ -818,6 +818,27 @@ export function isGroup(child: FilterRule | FilterGroup): child is FilterGroup {
 }
 
 /**
+ * Fields whose value is a comma-joined string of multiple values (e.g. tags,
+ * genres). For these, equality/text operators are evaluated against each
+ * individual value (set membership) instead of the whole joined string, so a
+ * rule like "Tags is not X" means "X is not among the item's tags" regardless
+ * of any other values present.
+ */
+export const multiValueFields = ['tags', 'genres'] as const;
+
+export function isMultiValueField(field: string): boolean {
+	return (multiValueFields as readonly string[]).includes(field);
+}
+
+/** Split a comma-joined multi-value field into trimmed, lowercased parts. */
+function splitMultiValue(value: unknown): string[] {
+	return String(value)
+		.split(',')
+		.map((part) => part.trim().toLowerCase())
+		.filter(Boolean);
+}
+
+/**
  * Evaluate a single filter rule against an item
  */
 export function evaluateRule(item: Record<string, unknown>, rule: FilterRule): boolean {
@@ -853,6 +874,30 @@ export function evaluateRule(item: Record<string, unknown>, rule: FilterRule): b
 			return true;
 		}
 		return false;
+	}
+
+	// Multi-value fields (tags, genres): evaluate against the set of values, so
+	// membership/negation considers each value independently rather than the
+	// whole comma-joined string.
+	if (isMultiValueField(rule.field)) {
+		const values = splitMultiValue(fieldValue);
+		const target = String(ruleValue).toLowerCase();
+		switch (rule.operator) {
+			case 'eq':
+				return values.includes(target);
+			case 'neq':
+				return !values.includes(target);
+			case 'contains':
+				return values.some((value) => value.includes(target));
+			case 'not_contains':
+				return !values.some((value) => value.includes(target));
+			case 'starts_with':
+				return values.some((value) => value.startsWith(target));
+			case 'ends_with':
+				return values.some((value) => value.endsWith(target));
+			default:
+				return false;
+		}
 	}
 
 	// Check if this field uses ordinal comparison

--- a/tests/unit/upgrades/filters.test.ts
+++ b/tests/unit/upgrades/filters.test.ts
@@ -1014,6 +1014,175 @@ class FilterEvaluationTest extends BaseTest {
 			assertEquals(matched[0].title, 'Movie 1');
 			assertEquals(matched[1].title, 'Movie 4');
 		});
+
+		// =====================
+		// Multi-value fields (tags / genres)
+		// =====================
+		// These fields arrive as a comma-joined string of many values
+		// (e.g. "no-redownload, profilarr-upgrade-all-movies"). The UI only
+		// exposes "is" (eq) / "is not" (neq) for them, and the user intent is
+		// set membership: "Tags is not X" must mean "X is not among the tags",
+		// not "the whole joined string is not equal to X".
+
+		this.test('tags: eq matches when value is one of several tags (membership)', () => {
+			const item = { tags: 'no-redownload, profilarr-upgrade-all-movies' };
+			const rule: FilterRule = {
+				type: 'rule',
+				field: 'tags',
+				operator: 'eq',
+				value: 'no-redownload'
+			};
+			assertEquals(evaluateRule(item, rule), true);
+		});
+
+		this.test('tags: eq rejects value that is not among the tags', () => {
+			const item = { tags: 'profilarr-upgrade-all-movies, hdr' };
+			const rule: FilterRule = {
+				type: 'rule',
+				field: 'tags',
+				operator: 'eq',
+				value: 'no-redownload'
+			};
+			assertEquals(evaluateRule(item, rule), false);
+		});
+
+		this.test('tags: neq excludes item that has the tag among others (the bug)', () => {
+			// Ace Ventura: tagged no-redownload PLUS several profilarr cooldown tags.
+			// "Tags is not no-redownload" must exclude it (return false), because it
+			// DOES carry no-redownload. The old whole-string compare returned true.
+			const item = {
+				tags: 'no-redownload, profilarr-filter, profilarr-upgrade-all, profilarr-upgrade-all-1080p-movies, profilarr-upgrade-all-movies'
+			};
+			const rule: FilterRule = {
+				type: 'rule',
+				field: 'tags',
+				operator: 'neq',
+				value: 'no-redownload'
+			};
+			assertEquals(evaluateRule(item, rule), false);
+		});
+
+		this.test('tags: neq matches item that lacks the tag', () => {
+			const item = { tags: 'profilarr-upgrade-all-movies, hdr' };
+			const rule: FilterRule = {
+				type: 'rule',
+				field: 'tags',
+				operator: 'neq',
+				value: 'no-redownload'
+			};
+			assertEquals(evaluateRule(item, rule), true);
+		});
+
+		this.test('tags: neq matches item with empty tag string', () => {
+			const item = { tags: '' };
+			const rule: FilterRule = {
+				type: 'rule',
+				field: 'tags',
+				operator: 'neq',
+				value: 'no-redownload'
+			};
+			assertEquals(evaluateRule(item, rule), true);
+		});
+
+		this.test('tags: eq rejects item with empty tag string', () => {
+			const item = { tags: '' };
+			const rule: FilterRule = {
+				type: 'rule',
+				field: 'tags',
+				operator: 'eq',
+				value: 'no-redownload'
+			};
+			assertEquals(evaluateRule(item, rule), false);
+		});
+
+		this.test('tags: membership is case-insensitive', () => {
+			const item = { tags: 'No-Redownload, HDR' };
+			const rule: FilterRule = {
+				type: 'rule',
+				field: 'tags',
+				operator: 'eq',
+				value: 'no-redownload'
+			};
+			assertEquals(evaluateRule(item, rule), true);
+		});
+
+		this.test('tags: single exact tag still matches eq', () => {
+			const item = { tags: 'no-redownload' };
+			const rule: FilterRule = {
+				type: 'rule',
+				field: 'tags',
+				operator: 'eq',
+				value: 'no-redownload'
+			};
+			assertEquals(evaluateRule(item, rule), true);
+		});
+
+		this.test('genres: eq matches one of several genres (membership)', () => {
+			const item = { genres: 'Action, Comedy, Crime' };
+			const rule: FilterRule = {
+				type: 'rule',
+				field: 'genres',
+				operator: 'eq',
+				value: 'comedy'
+			};
+			assertEquals(evaluateRule(item, rule), true);
+		});
+
+		this.test('genres: neq excludes item that has the genre among others', () => {
+			const item = { genres: 'Comedy, Crime, Mystery' };
+			const rule: FilterRule = {
+				type: 'rule',
+				field: 'genres',
+				operator: 'neq',
+				value: 'comedy'
+			};
+			assertEquals(evaluateRule(item, rule), false);
+		});
+
+		this.test('genres: contains matches per-element, not across the comma', () => {
+			const item = { genres: 'Science Fiction, Action' };
+			// Matches within a single value...
+			assertEquals(
+				evaluateRule(item, {
+					type: 'rule',
+					field: 'genres',
+					operator: 'contains',
+					value: 'fiction'
+				}),
+				true
+			);
+			// ...but not across the joining ", " boundary.
+			assertEquals(
+				evaluateRule(item, {
+					type: 'rule',
+					field: 'genres',
+					operator: 'contains',
+					value: 'fiction, a'
+				}),
+				false
+			);
+		});
+
+		this.test('scenario: exclude no-redownload across a mixed library', () => {
+			// Mirrors the real "Upgrade all FHD movies" filter: only items WITHOUT
+			// the no-redownload tag should pass, regardless of profilarr cooldown tags.
+			const movies = [
+				{ title: 'Keep A', tags: 'profilarr-upgrade-all-movies' },
+				{ title: 'Skip B', tags: 'no-redownload' },
+				{ title: 'Skip C', tags: 'no-redownload, profilarr-upgrade-all-1080p-movies' },
+				{ title: 'Keep D', tags: '' }
+			];
+			const group: FilterGroup = {
+				type: 'group',
+				match: 'all',
+				children: [{ type: 'rule', field: 'tags', operator: 'neq', value: 'no-redownload' }]
+			};
+
+			const matched = movies.filter((m) => evaluateGroup(m, group));
+			assertEquals(matched.length, 2);
+			assertEquals(matched[0].title, 'Keep A');
+			assertEquals(matched[1].title, 'Keep D');
+		});
 	}
 }
 


### PR DESCRIPTION
## Problem

In the Upgrades filter builder, `Tags` and `Genres` are dynamic multi-value fields. The UI only exposes **is** (`eq`) / **is not** (`neq`) for them, and each item's value reaches the evaluator as a single comma-joined string built in `normalize.ts` (e.g. `"no-redownload, profilarr-upgrade-all-movies"`).

`evaluateRule` compared the rule value against that **whole joined string**, so membership/negation broke whenever an item had more than one tag:

- A movie tagged `no-redownload` **plus** any other tag (including Profilarr's own cooldown tags like `profilarr-upgrade-all-movies`) produced the string `"no-redownload, profilarr-upgrade-all-movies"`.
- `"Tags is not no-redownload"` → `neq` compares `"no-redownload, profilarr-upgrade-all-movies" !== "no-redownload"` → **true** → the item was **not** excluded, even though it carries `no-redownload`.

The net effect: a `Tags is not X` rule silently fails to exclude items that have `X` alongside any other tag — which, because Profilarr applies its own cooldown tags over time, is most of the library. The same bug affects `Genres` (e.g. `"Genres is Comedy"` on a `"Comedy, Crime, Mystery"` movie returns false).

## Fix

Treat `tags` and `genres` as **sets**: split the comma-joined value and evaluate the operator against each element (membership) instead of the whole string.

- `eq` → value is among the items
- `neq` → value is not among the items
- `contains` / `not_contains` / `starts_with` / `ends_with` → matched per element

So `"Tags is not no-redownload"` now correctly excludes any item that carries `no-redownload`, regardless of its other tags.

## Tests

Adds 12 unit tests to `tests/unit/upgrades/filters.test.ts` covering membership, negation, empty and case-insensitive values, per-element `contains` (no matching across the `", "` boundary), and a real-world "exclude no-redownload across a mixed library" scenario.

```
deno task test unit upgrades   →  288 passed / 0 failed
```

## Note / possible follow-up

This change is scoped to `tags` and `genres` (the multi-value fields the UI restricts to is/is not). `keywords` (Radarr) is also a comma-joined multi-value field with the same shape and would have the same issue under `eq`/`neq`; it's left out of this PR since it uses the full text-operator set. Happy to fold it into `multiValueFields` if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)