### PR TITLE
fix: treat upgrade tags and genres as sets

### DIFF
--- a/docs/backend/upgrades.md
+++ b/docs/backend/upgrades.md
@@ -89,7 +89,8 @@ Fields are typed by category:
 | Category      | Operators                                              | Examples                                 |
 | ------------- | ------------------------------------------------------ | ---------------------------------------- |
 | Boolean       | is, is_not                                             | monitored, cutoff_met                    |
-| Text          | contains, not_contains, starts/ends_with, eq           | title, quality_profile, genres, tags     |
+| Text          | contains, not_contains, starts/ends_with, eq           | title, quality_profile                   |
+| Multi-value   | includes, does_not_include, is_only, has_any, has_none | genres, tags                             |
 | Number        | eq, neq, gt, gte, lt, lte                              | year, rating, size_on_disk, popularity   |
 | Date          | before, after, in_last, not_in_last                    | date_added, digital_release, first_aired |
 | Ordinal       | eq, neq, gte, lte, gt, lt                              | status, minimum_availability             |
@@ -123,7 +124,9 @@ load, so the page shell renders before heavier library/file metadata finishes
 loading.
 
 Most dynamic fields use exact string operators only: `eq` and `neq` (shown as
-"is" / "is not" in the UI). `custom_format` is dynamic but uses set operators.
+"is" / "is not" in the UI). `tags`, `genres`, and `custom_format` are dynamic
+but use set operators. Existing saved `eq` / `neq` tag and genre rules are
+treated as `includes` / `does_not_include` for compatibility.
 
 | Scope  | Fields                                                   | Source                  |
 | ------ | -------------------------------------------------------- | ----------------------- |

--- a/src/lib/server/upgrades/normalize.ts
+++ b/src/lib/server/upgrades/normalize.ts
@@ -75,9 +75,7 @@ export function normalizeRadarrItem(
 	const physicalRelease = movie.physicalRelease ?? null;
 
 	// Convert tag IDs to labels
-	const tags = (movie.tags ?? [])
-		.map((tagId) => tagMap?.get(tagId) ?? '')
-		.filter(Boolean);
+	const tags = (movie.tags ?? []).map((tagId) => tagMap?.get(tagId) ?? '').filter(Boolean);
 
 	return {
 		// Shared fields
@@ -181,9 +179,7 @@ export function normalizeSonarrItem(
 	const dateAdded = series.added ?? new Date().toISOString();
 
 	// Convert tag IDs to labels
-	const tags = (series.tags ?? [])
-		.map((tagId) => tagMap?.get(tagId) ?? '')
-		.filter(Boolean);
+	const tags = (series.tags ?? []).map((tagId) => tagMap?.get(tagId) ?? '').filter(Boolean);
 
 	return {
 		// Shared fields

--- a/src/lib/server/upgrades/normalize.ts
+++ b/src/lib/server/upgrades/normalize.ts
@@ -77,8 +77,7 @@ export function normalizeRadarrItem(
 	// Convert tag IDs to labels
 	const tags = (movie.tags ?? [])
 		.map((tagId) => tagMap?.get(tagId) ?? '')
-		.filter(Boolean)
-		.join(', ');
+		.filter(Boolean);
 
 	return {
 		// Shared fields
@@ -91,7 +90,7 @@ export function normalizeRadarrItem(
 		quality_name: movieFile?.quality?.quality?.name ?? '',
 		file_name: getFileName(movieFile?.relativePath ?? movieFile?.path),
 		original_language: movie.originalLanguage?.name ?? '',
-		genres: movie.genres?.join(', ') ?? '',
+		genres: movie.genres ?? [],
 		tags,
 		custom_formats: movieFile?.customFormats.map((cf) => cf.name) ?? [],
 		score_breakdown: movieFile
@@ -184,8 +183,7 @@ export function normalizeSonarrItem(
 	// Convert tag IDs to labels
 	const tags = (series.tags ?? [])
 		.map((tagId) => tagMap?.get(tagId) ?? '')
-		.filter(Boolean)
-		.join(', ');
+		.filter(Boolean);
 
 	return {
 		// Shared fields
@@ -198,7 +196,7 @@ export function normalizeSonarrItem(
 		quality_name: '',
 		file_name: '',
 		original_language: series.originalLanguage?.name ?? '',
-		genres: series.genres?.join(', ') ?? '',
+		genres: series.genres ?? [],
 		tags,
 		custom_formats: [],
 		score_breakdown: [],

--- a/src/lib/server/upgrades/preview.ts
+++ b/src/lib/server/upgrades/preview.ts
@@ -106,10 +106,7 @@ function toPreviewItem(
 			fileName: item.file_name,
 			customFormats: item.score_breakdown,
 			score: item.score,
-			tags: item.tags
-				.split(',')
-				.map((tag) => tag.trim())
-				.filter(Boolean),
+			tags: item.tags,
 			monitored: item.monitored,
 			dateAdded: item.date_added,
 			sizeOnDisk: item.size_on_disk,

--- a/src/lib/server/upgrades/types.ts
+++ b/src/lib/server/upgrades/types.ts
@@ -20,8 +20,8 @@ export interface UpgradeItem {
 	quality_name: string;
 	file_name: string;
 	original_language: string;
-	genres: string;
-	tags: string;
+	genres: string[];
+	tags: string[];
 	custom_formats: string[];
 	score_breakdown: ScoreBreakdownItem[];
 	rating: number;

--- a/src/lib/shared/upgrades/filters.ts
+++ b/src/lib/shared/upgrades/filters.ts
@@ -281,6 +281,114 @@ export function normalizeMultiValueOperator(operator: string): string {
 	return operator;
 }
 
+function isValuelessOperator(fieldId: string, operator: string): boolean {
+	return (
+		(fieldId === 'custom_format' && isCustomFormatUnaryOperator(operator)) ||
+		(isMultiValueFilterField(fieldId) && isMultiValueUnaryOperator(operator))
+	);
+}
+
+function getDefaultRuleValue(
+	fieldId: string,
+	field: FilterField,
+	operator: string,
+	dynamicFilterOptions?: DynamicFilterOptions
+): FilterValueType {
+	if (isValuelessOperator(fieldId, operator)) return null;
+	if (dynamicFilterOptions && fieldId in dynamicFilterOptions) {
+		return dynamicFilterOptions[fieldId]?.[0]?.value ?? null;
+	}
+	return field.values?.[0]?.value ?? null;
+}
+
+export interface NormalizeFilterRulesOptions {
+	dynamicFilterOptions?: DynamicFilterOptions;
+}
+
+export function normalizeFilterRule(
+	rule: FilterRule,
+	appType: UpgradeAppType,
+	options: NormalizeFilterRulesOptions = {}
+): boolean {
+	const field = getFilterField(rule.field, appType);
+	if (!field) return false;
+
+	if (isMultiValueFilterField(rule.field)) {
+		let changed = false;
+		const normalizedOperator = normalizeMultiValueOperator(rule.operator);
+		if (rule.operator !== normalizedOperator) {
+			rule.operator = normalizedOperator;
+			changed = true;
+		}
+		if (!field.operators.some((operator) => operator.id === rule.operator)) {
+			rule.operator = field.operators[0].id;
+			changed = true;
+		}
+		if (isMultiValueUnaryOperator(rule.operator) && rule.value !== null) {
+			rule.value = null;
+			changed = true;
+		}
+		if (!isMultiValueUnaryOperator(rule.operator) && rule.value === null) {
+			const defaultValue = getDefaultRuleValue(
+				rule.field,
+				field,
+				rule.operator,
+				options.dynamicFilterOptions
+			);
+			if (rule.value !== defaultValue) {
+				rule.value = defaultValue;
+				changed = true;
+			}
+		}
+		return changed;
+	}
+
+	if (
+		options.dynamicFilterOptions &&
+		rule.field in options.dynamicFilterOptions &&
+		rule.field !== 'custom_format' &&
+		rule.operator !== 'eq' &&
+		rule.operator !== 'neq'
+	) {
+		rule.operator = 'eq';
+		return true;
+	}
+
+	if (rule.field !== 'custom_format') return false;
+
+	let changed = false;
+	if (!field.operators.some((operator) => operator.id === rule.operator)) {
+		rule.operator = field.operators[0].id;
+		changed = true;
+	}
+	if (isCustomFormatUnaryOperator(rule.operator) && rule.value !== null) {
+		rule.value = null;
+		changed = true;
+	}
+	return changed;
+}
+
+export function normalizeFilterGroup(
+	group: FilterGroup,
+	appType: UpgradeAppType,
+	options: NormalizeFilterRulesOptions = {}
+): boolean {
+	let changed = false;
+	for (const child of group.children) {
+		if (isRule(child)) {
+			if (normalizeFilterRule(child, appType, options)) {
+				changed = true;
+			}
+			continue;
+		}
+
+		if (normalizeFilterGroup(child, appType, options)) {
+			changed = true;
+		}
+	}
+	return changed;
+}
+
 // =============================================================================
 // Ordinal mappings
 // =============================================================================

--- a/src/lib/shared/upgrades/filters.ts
+++ b/src/lib/shared/upgrades/filters.ts
@@ -1003,7 +1003,9 @@ function evaluateMultiValueRule(fieldValue: unknown, rule: FilterRule): boolean 
 		case 'does_not_include':
 			return selected.length > 0 && !normalizedValues.includes(selected);
 		case 'is_only':
-			return selected.length > 0 && normalizedValues.length === 1 && normalizedValues[0] === selected;
+			return (
+				selected.length > 0 && normalizedValues.length === 1 && normalizedValues[0] === selected
+			);
 		case 'has_any':
 			return normalizedValues.length > 0;
 		case 'has_none':

--- a/src/lib/shared/upgrades/filters.ts
+++ b/src/lib/shared/upgrades/filters.ts
@@ -147,6 +147,39 @@ const textOperators: FilterOperator[] = [
 	{ id: 'neq', label: 'does not equal', description: 'Does not equal the text' }
 ];
 
+const multiValueOperators: FilterOperator[] = [
+	{
+		id: 'includes',
+		label: 'includes',
+		shortLabel: 'has',
+		description: 'Includes this value'
+	},
+	{
+		id: 'does_not_include',
+		label: 'does not include',
+		shortLabel: 'lacks',
+		description: 'Does not include this value'
+	},
+	{
+		id: 'is_only',
+		label: 'is only',
+		shortLabel: 'only',
+		description: 'Only includes this value and no others'
+	},
+	{
+		id: 'has_any',
+		label: 'has any',
+		shortLabel: 'any',
+		description: 'Has one or more values'
+	},
+	{
+		id: 'has_none',
+		label: 'has none',
+		shortLabel: 'none',
+		description: 'Has no values'
+	}
+];
+
 const dateOperators: FilterOperator[] = [
 	{
 		id: 'before',
@@ -225,11 +258,27 @@ const customFormatOperators: FilterOperator[] = [
 ];
 
 export const customFormatUnaryOperators = ['has_any', 'has_none'] as const;
+export const multiValueFilterFieldIds = ['tags', 'genres'] as const;
+export const multiValueUnaryOperators = ['has_any', 'has_none'] as const;
 
 export function isCustomFormatUnaryOperator(operator: string): boolean {
 	return customFormatUnaryOperators.includes(
 		operator as (typeof customFormatUnaryOperators)[number]
 	);
+}
+
+export function isMultiValueFilterField(fieldId: string): boolean {
+	return multiValueFilterFieldIds.includes(fieldId as (typeof multiValueFilterFieldIds)[number]);
+}
+
+export function isMultiValueUnaryOperator(operator: string): boolean {
+	return multiValueUnaryOperators.includes(operator as (typeof multiValueUnaryOperators)[number]);
+}
+
+export function normalizeMultiValueOperator(operator: string): string {
+	if (operator === 'eq') return 'includes';
+	if (operator === 'neq') return 'does_not_include';
+	return operator;
 }
 
 // =============================================================================
@@ -318,14 +367,14 @@ const sharedFilterFields: FilterField[] = [
 		id: 'genres',
 		label: 'Genres',
 		description: 'Genres (Action, Comedy, Drama, etc.)',
-		operators: textOperators,
+		operators: multiValueOperators,
 		valueType: 'text'
 	},
 	{
 		id: 'tags',
 		label: 'Tags',
 		description: 'Tags applied to the item',
-		operators: textOperators,
+		operators: multiValueOperators,
 		valueType: 'text'
 	},
 
@@ -817,6 +866,53 @@ export function isGroup(child: FilterRule | FilterGroup): child is FilterGroup {
 	return child.type === 'group';
 }
 
+function getMultiValueItems(value: unknown): string[] {
+	if (Array.isArray(value)) {
+		return value.map((item) => String(item).trim()).filter(Boolean);
+	}
+
+	if (typeof value === 'string') {
+		return value
+			.split(',')
+			.map((item) => item.trim())
+			.filter(Boolean);
+	}
+
+	return [];
+}
+
+function evaluateMultiValueRule(fieldValue: unknown, rule: FilterRule): boolean {
+	const values = getMultiValueItems(fieldValue);
+	const normalizedValues = values.map((value) => value.toLowerCase());
+	const selected =
+		typeof rule.value === 'string' || typeof rule.value === 'number'
+			? String(rule.value).trim().toLowerCase()
+			: '';
+
+	switch (normalizeMultiValueOperator(rule.operator)) {
+		case 'includes':
+			return selected.length > 0 && normalizedValues.includes(selected);
+		case 'does_not_include':
+			return selected.length > 0 && !normalizedValues.includes(selected);
+		case 'is_only':
+			return selected.length > 0 && normalizedValues.length === 1 && normalizedValues[0] === selected;
+		case 'has_any':
+			return normalizedValues.length > 0;
+		case 'has_none':
+			return normalizedValues.length === 0;
+		case 'contains':
+			return selected.length > 0 && normalizedValues.some((value) => value.includes(selected));
+		case 'not_contains':
+			return selected.length > 0 && normalizedValues.every((value) => !value.includes(selected));
+		case 'starts_with':
+			return selected.length > 0 && normalizedValues.some((value) => value.startsWith(selected));
+		case 'ends_with':
+			return selected.length > 0 && normalizedValues.some((value) => value.endsWith(selected));
+		default:
+			return false;
+	}
+}
+
 /**
  * Evaluate a single filter rule against an item
  */
@@ -844,6 +940,10 @@ export function evaluateRule(item: Record<string, unknown>, rule: FilterRule): b
 			default:
 				return false;
 		}
+	}
+
+	if (isMultiValueFilterField(rule.field)) {
+		return evaluateMultiValueRule(fieldValue, rule);
 	}
 
 	// Handle null/undefined field values

--- a/src/routes/arr/[id]/upgrades/components/FilterGroup.svelte
+++ b/src/routes/arr/[id]/upgrades/components/FilterGroup.svelte
@@ -7,8 +7,11 @@
 		createEmptyGroup,
 		createEmptyRule,
 		isCustomFormatUnaryOperator,
+		isMultiValueFilterField,
+		isMultiValueUnaryOperator,
 		isRule,
 		isGroup,
+		normalizeMultiValueOperator,
 		type DynamicFilterOptions,
 		type FilterField,
 		type FilterGroup,
@@ -73,22 +76,35 @@
 	}
 
 	function getDefaultOperator(fieldId: string, field: FilterField) {
-		if (fieldId === 'custom_format') return field.operators[0].id;
+		if (fieldId === 'custom_format' || isMultiValueFilterField(fieldId)) {
+			return field.operators[0].id;
+		}
 		return fieldId in dynamicFilterOptions ? 'eq' : field.operators[0].id;
 	}
 
 	function getDefaultValue(fieldId: string, field: FilterField, operator: string) {
-		if (fieldId === 'custom_format' && isCustomFormatUnaryOperator(operator)) return null;
+		if (isValuelessOperator(fieldId, operator)) return null;
 		if (fieldId in dynamicFilterOptions) return dynamicFilterOptions[fieldId]?.[0]?.value ?? null;
 		return field.values?.[0]?.value ?? null;
 	}
 
 	function isDynamicStringField(fieldId: string) {
-		return fieldId in dynamicFilterOptions && fieldId !== 'custom_format';
+		return (
+			fieldId in dynamicFilterOptions &&
+			fieldId !== 'custom_format' &&
+			!isMultiValueFilterField(fieldId)
+		);
+	}
+
+	function isValuelessOperator(fieldId: string, operator: string) {
+		return (
+			(fieldId === 'custom_format' && isCustomFormatUnaryOperator(operator)) ||
+			(isMultiValueFilterField(fieldId) && isMultiValueUnaryOperator(operator))
+		);
 	}
 
 	function ruleNeedsValue(rule: FilterRule) {
-		return !(rule.field === 'custom_format' && isCustomFormatUnaryOperator(rule.operator));
+		return !isValuelessOperator(rule.field, rule.operator);
 	}
 
 	function getDynamicOptions(
@@ -109,6 +125,28 @@
 	function normalizeRule(rule: FilterRule): boolean {
 		const field = getFilterField(rule.field, appType);
 		if (!field) return false;
+
+		if (isMultiValueFilterField(rule.field)) {
+			let changed = false;
+			const normalizedOperator = normalizeMultiValueOperator(rule.operator);
+			if (rule.operator !== normalizedOperator) {
+				rule.operator = normalizedOperator;
+				changed = true;
+			}
+			if (!field.operators.some((operator) => operator.id === rule.operator)) {
+				rule.operator = field.operators[0].id;
+				changed = true;
+			}
+			if (isMultiValueUnaryOperator(rule.operator) && rule.value !== null) {
+				rule.value = null;
+				changed = true;
+			}
+			if (!isMultiValueUnaryOperator(rule.operator) && rule.value === null) {
+				rule.value = getDefaultValue(rule.field, field, rule.operator);
+				changed = true;
+			}
+			return changed;
+		}
 
 		if (isDynamicStringField(rule.field) && rule.operator !== 'eq' && rule.operator !== 'neq') {
 			rule.operator = 'eq';
@@ -168,8 +206,8 @@
 
 	function onOperatorChange(rule: FilterRule, operator: string, field: FilterField) {
 		rule.operator = operator;
-		if (rule.field === 'custom_format') {
-			rule.value = isCustomFormatUnaryOperator(operator)
+		if (rule.field === 'custom_format' || isMultiValueFilterField(rule.field)) {
+			rule.value = isValuelessOperator(rule.field, operator)
 				? null
 				: (rule.value ?? getDefaultValue(rule.field, field, operator));
 		}

--- a/src/routes/arr/[id]/upgrades/components/FilterGroup.svelte
+++ b/src/routes/arr/[id]/upgrades/components/FilterGroup.svelte
@@ -11,7 +11,7 @@
 		isMultiValueUnaryOperator,
 		isRule,
 		isGroup,
-		normalizeMultiValueOperator,
+		normalizeFilterGroup,
 		type DynamicFilterOptions,
 		type FilterField,
 		type FilterGroup,
@@ -122,66 +122,8 @@
 		return [{ value: currentValue, label: currentValue }, ...options];
 	}
 
-	function normalizeRule(rule: FilterRule): boolean {
-		const field = getFilterField(rule.field, appType);
-		if (!field) return false;
-
-		if (isMultiValueFilterField(rule.field)) {
-			let changed = false;
-			const normalizedOperator = normalizeMultiValueOperator(rule.operator);
-			if (rule.operator !== normalizedOperator) {
-				rule.operator = normalizedOperator;
-				changed = true;
-			}
-			if (!field.operators.some((operator) => operator.id === rule.operator)) {
-				rule.operator = field.operators[0].id;
-				changed = true;
-			}
-			if (isMultiValueUnaryOperator(rule.operator) && rule.value !== null) {
-				rule.value = null;
-				changed = true;
-			}
-			if (!isMultiValueUnaryOperator(rule.operator) && rule.value === null) {
-				rule.value = getDefaultValue(rule.field, field, rule.operator);
-				changed = true;
-			}
-			return changed;
-		}
-
-		if (isDynamicStringField(rule.field) && rule.operator !== 'eq' && rule.operator !== 'neq') {
-			rule.operator = 'eq';
-			return true;
-		}
-
-		if (rule.field !== 'custom_format') return false;
-
-		let changed = false;
-		if (!field.operators.some((operator) => operator.id === rule.operator)) {
-			rule.operator = field.operators[0].id;
-			changed = true;
-		}
-		if (isCustomFormatUnaryOperator(rule.operator) && rule.value !== null) {
-			rule.value = null;
-			changed = true;
-		}
-		return changed;
-	}
-
 	function normalizeDynamicOperators(targetGroup: FilterGroup): boolean {
-		let changed = false;
-		for (const child of targetGroup.children) {
-			if (isRule(child)) {
-				if (normalizeRule(child)) {
-					changed = true;
-				}
-				continue;
-			}
-
-			if (normalizeDynamicOperators(child)) {
-				changed = true;
-			}
-		}
-		return changed;
+		return normalizeFilterGroup(targetGroup, appType, { dynamicFilterOptions });
 	}
 
 	$: {

--- a/tests/unit/upgrades/filters.test.ts
+++ b/tests/unit/upgrades/filters.test.ts
@@ -10,9 +10,10 @@ import {
 	evaluateGroup,
 	getDynamicFilterFieldIds,
 	getFilterFields,
+	normalizeFilterGroup,
 	type FilterRule,
 	type FilterGroup
-} from '../../../src/lib/shared/upgrades/filters.ts';
+} from '$shared/upgrades/filters.ts';
 
 class FilterEvaluationTest extends BaseTest {
 	runTests(): void {
@@ -334,6 +335,38 @@ class FilterEvaluationTest extends BaseTest {
 				value: 'Fantasy'
 			};
 			assertEquals(evaluateRule(item, rule), false);
+		});
+
+		this.test('multi-value normalize: maps legacy tag and genre operators', () => {
+			const group: FilterGroup = {
+				type: 'group',
+				match: 'all',
+				children: [
+					{ type: 'rule', field: 'tags', operator: 'eq', value: 'no-redownload' },
+					{ type: 'rule', field: 'tags', operator: 'neq', value: 'manual-review' },
+					{ type: 'rule', field: 'genres', operator: 'eq', value: 'Action' },
+					{ type: 'rule', field: 'genres', operator: 'neq', value: 'Comedy' }
+				]
+			};
+
+			assertEquals(normalizeFilterGroup(group, 'radarr'), true);
+			const rules = group.children as FilterRule[];
+			assertEquals(rules[0].operator, 'includes');
+			assertEquals(rules[1].operator, 'does_not_include');
+			assertEquals(rules[2].operator, 'includes');
+			assertEquals(rules[3].operator, 'does_not_include');
+		});
+
+		this.test('multi-value normalize: clears values for unary operators', () => {
+			const group: FilterGroup = {
+				type: 'group',
+				match: 'all',
+				children: [{ type: 'rule', field: 'tags', operator: 'has_any', value: 'unused' }]
+			};
+
+			assertEquals(normalizeFilterGroup(group, 'radarr'), true);
+			const rule = group.children[0] as FilterRule;
+			assertEquals(rule.value, null);
 		});
 
 		// =====================

--- a/tests/unit/upgrades/filters.test.ts
+++ b/tests/unit/upgrades/filters.test.ts
@@ -245,6 +245,98 @@ class FilterEvaluationTest extends BaseTest {
 		});
 
 		// =====================
+		// Multi-Value Operators
+		// =====================
+
+		this.test('tags: includes matches exact tag in multi-tag list', () => {
+			const item = { tags: ['no-redownload', 'profilarr-upgrades'] };
+			const rule: FilterRule = {
+				type: 'rule',
+				field: 'tags',
+				operator: 'includes',
+				value: 'no-redownload'
+			};
+			assertEquals(evaluateRule(item, rule), true);
+		});
+
+		this.test('tags: does_not_include rejects exact tag in multi-tag list', () => {
+			const item = { tags: ['no-redownload', 'profilarr-upgrades'] };
+			const rule: FilterRule = {
+				type: 'rule',
+				field: 'tags',
+				operator: 'does_not_include',
+				value: 'no-redownload'
+			};
+			assertEquals(evaluateRule(item, rule), false);
+		});
+
+		this.test('tags: has_any matches non-empty tag list', () => {
+			const item = { tags: ['no-redownload'] };
+			const rule: FilterRule = {
+				type: 'rule',
+				field: 'tags',
+				operator: 'has_any',
+				value: null
+			};
+			assertEquals(evaluateRule(item, rule), true);
+		});
+
+		this.test('tags: has_none matches empty tag list', () => {
+			const item = { tags: [] };
+			const rule: FilterRule = {
+				type: 'rule',
+				field: 'tags',
+				operator: 'has_none',
+				value: null
+			};
+			assertEquals(evaluateRule(item, rule), true);
+		});
+
+		this.test('tags: legacy eq matches exact tag in multi-tag list', () => {
+			const item = { tags: ['no-redownload', 'profilarr-upgrades'] };
+			const rule: FilterRule = {
+				type: 'rule',
+				field: 'tags',
+				operator: 'eq',
+				value: 'no-redownload'
+			};
+			assertEquals(evaluateRule(item, rule), true);
+		});
+
+		this.test('tags: legacy neq rejects exact tag in multi-tag list', () => {
+			const item = { tags: ['no-redownload', 'profilarr-upgrades'] };
+			const rule: FilterRule = {
+				type: 'rule',
+				field: 'tags',
+				operator: 'neq',
+				value: 'no-redownload'
+			};
+			assertEquals(evaluateRule(item, rule), false);
+		});
+
+		this.test('genres: includes matches exact genre in multi-genre list', () => {
+			const item = { genres: ['Comedy', 'Fantasy'] };
+			const rule: FilterRule = {
+				type: 'rule',
+				field: 'genres',
+				operator: 'includes',
+				value: 'fantasy'
+			};
+			assertEquals(evaluateRule(item, rule), true);
+		});
+
+		this.test('genres: legacy neq rejects exact genre in multi-genre list', () => {
+			const item = { genres: ['Comedy', 'Fantasy'] };
+			const rule: FilterRule = {
+				type: 'rule',
+				field: 'genres',
+				operator: 'neq',
+				value: 'Fantasy'
+			};
+			assertEquals(evaluateRule(item, rule), false);
+		});
+
+		// =====================
 		// Custom Format Operators
 		// =====================
 

--- a/tests/unit/upgrades/filters.test.ts
+++ b/tests/unit/upgrades/filters.test.ts
@@ -282,6 +282,28 @@ class FilterEvaluationTest extends BaseTest {
 			assertEquals(evaluateRule(item, rule), true);
 		});
 
+		this.test('tags: is_only matches single selected tag', () => {
+			const item = { tags: ['no-redownload'] };
+			const rule: FilterRule = {
+				type: 'rule',
+				field: 'tags',
+				operator: 'is_only',
+				value: 'no-redownload'
+			};
+			assertEquals(evaluateRule(item, rule), true);
+		});
+
+		this.test('tags: is_only rejects selected tag with other tags', () => {
+			const item = { tags: ['no-redownload', 'profilarr-upgrades'] };
+			const rule: FilterRule = {
+				type: 'rule',
+				field: 'tags',
+				operator: 'is_only',
+				value: 'no-redownload'
+			};
+			assertEquals(evaluateRule(item, rule), false);
+		});
+
 		this.test('tags: has_none matches empty tag list', () => {
 			const item = { tags: [] };
 			const rule: FilterRule = {

--- a/tests/unit/upgrades/normalize.test.ts
+++ b/tests/unit/upgrades/normalize.test.ts
@@ -191,7 +191,7 @@ class NormalizeTest extends BaseTest {
 			assertEquals(result.original_language, 'Japanese');
 		});
 
-		this.test('normalizes genres as comma-separated string', () => {
+		this.test('normalizes genres as string array', () => {
 			const movie = this.createMockMovie({
 				genres: ['Comedy', 'Fantasy', 'Horror']
 			});
@@ -200,7 +200,7 @@ class NormalizeTest extends BaseTest {
 
 			const result = normalizeRadarrItem(movie, movieFile, profile, 80);
 
-			assertEquals(result.genres, 'Comedy, Fantasy, Horror');
+			assertEquals(result.genres, ['Comedy', 'Fantasy', 'Horror']);
 		});
 
 		this.test('normalizes release group from movie file', () => {
@@ -404,9 +404,15 @@ class NormalizeTest extends BaseTest {
 			const movie = this.createMockMovie({ tags: [1, 2, 3] });
 			const movieFile = this.createMockMovieFile();
 			const profile = this.createMockProfile();
+			const tagMap = new Map([
+				[1, 'no-redownload'],
+				[2, 'profilarr-upgrades'],
+				[3, 'manual-review']
+			]);
 
-			const result = normalizeRadarrItem(movie, movieFile, profile, 80);
+			const result = normalizeRadarrItem(movie, movieFile, profile, 80, tagMap);
 
+			assertEquals(result.tags, ['no-redownload', 'profilarr-upgrades', 'manual-review']);
 			assertEquals(result._tags, [1, 2, 3]);
 		});
 
@@ -487,7 +493,7 @@ class NormalizeTest extends BaseTest {
 			assertEquals(result.collection, '');
 			assertEquals(result.studio, '');
 			assertEquals(result.original_language, '');
-			assertEquals(result.genres, '');
+			assertEquals(result.genres, []);
 			assertEquals(result.release_group, '');
 			assertEquals(result.popularity, 0);
 			assertEquals(result.runtime, 0);


### PR DESCRIPTION
Fixes #801.

Changes:
- Normalize upgrade tags and genres as arrays instead of comma-separated strings.
- Evaluate tag and genre filters with set operators, including legacy eq/neq compatibility.
- Move filter rule normalization into shared helpers so old saved rules display with the new operators.
- Update upgrade filter docs and preview output for array-backed tags.