### PR TITLE
fix: support decimal custom format sizes

### DIFF
--- a/docs/backend/sync.md
+++ b/docs/backend/sync.md
@@ -234,6 +234,8 @@ Key behaviors:
 - Enum conditions (`source`, `resolution`, `indexer_flag`, etc.) resolve PCD
   string names to Arr integer IDs via `mappings.ts`. Radarr and Sonarr use
   different integer values for the same concept.
+- Size condition bounds are stored as bytes and rounded to two decimal GB
+  values before syncing to Arr.
 - `syncCustomFormats()` returns a `Map<name, arrId>` covering every CF on the
   instance (not just synced ones). Quality profiles need this because the Arr API
   requires every CF to appear in profile `formatItems`.

--- a/docs/frontend/ui.md
+++ b/docs/frontend/ui.md
@@ -133,12 +133,17 @@ flush with surrounding content when `label` is omitted.
 
 #### NumberInput
 
-**`$ui/form/NumberInput.svelte`** wraps `<input type="number">` and adds
+**`$ui/form/NumberInput.svelte`** wraps a numeric text input and adds
 increment/decrement buttons with press-and-hold repeat, min/max validation,
-and a `compact` mode for dense form grids. Typical use: retention days,
-timeouts, thresholds.
+optional decimal precision, and a `compact` mode for dense form grids.
+Typical use: retention days, timeouts, thresholds. The visible value is draft
+text while focused, so decimal fields can accept in-progress values like `.`,
+`0.`, and `0.0` before they become final numbers.
+
 Use `validateOn="blur"` when the field should allow free typing and only
-commit min/max validation after focus leaves the input.
+commit min/max validation after focus leaves the input. Use decimal `step`
+values and `maxDecimals` for float inputs; button clicks increment by `step`,
+and blur normalizes the draft back to the allowed precision and range.
 
 ```svelte
 <!-- src/routes/settings/general/+page.svelte:472 -->

--- a/docs/frontend/ui.md
+++ b/docs/frontend/ui.md
@@ -143,7 +143,9 @@ text while focused, so decimal fields can accept in-progress values like `.`,
 Use `validateOn="blur"` when the field should allow free typing and only
 commit min/max validation after focus leaves the input. Use decimal `step`
 values and `maxDecimals` for float inputs; button clicks increment by `step`,
-and blur normalizes the draft back to the allowed precision and range.
+and blur normalizes the draft back to the allowed precision and range. Use
+`emptyStepValue` when an empty input needs a domain-specific first step, such
+as seeding an empty range bound from its paired value.
 
 ```svelte
 <!-- src/routes/settings/general/+page.svelte:472 -->

--- a/src/lib/client/ui/form/NumberInput.svelte
+++ b/src/lib/client/ui/form/NumberInput.svelte
@@ -48,6 +48,7 @@
 	let repeatingDirection: StepDirection | null = null;
 	let repeatStartedAt = 0;
 	let ignoreNextClick = false;
+	let inputMode: 'decimal' | 'numeric' = 'numeric';
 
 	onMount(() => {
 		if (responsive && typeof window !== 'undefined') {

--- a/src/lib/client/ui/form/NumberInput.svelte
+++ b/src/lib/client/ui/form/NumberInput.svelte
@@ -18,6 +18,7 @@
 	export let max: number | undefined = undefined;
 	export let step: number = 1;
 	export let maxDecimals: number | undefined = undefined;
+	export let emptyStepValue: number | undefined = undefined;
 	export let required: boolean = false;
 	export let disabled: boolean = false;
 	export let warningTooltip: string = '';
@@ -226,7 +227,19 @@
 		}
 	}
 
+	function seedFromEmptyValue(): boolean {
+		if (value !== undefined || emptyStepValue === undefined || !Number.isFinite(emptyStepValue)) {
+			return false;
+		}
+
+		const result = normalizeValue(emptyStepValue);
+		updateValue(result.value, emptyStepValue, result.reason);
+		return true;
+	}
+
 	function increment() {
+		if (seedFromEmptyValue()) return;
+
 		const currentValue = value ?? min ?? 0;
 		if (max !== undefined && currentValue >= max) {
 			onMaxBlocked?.();
@@ -237,6 +250,8 @@
 	}
 
 	function decrement() {
+		if (seedFromEmptyValue()) return;
+
 		const currentValue = value ?? min ?? 0;
 		if (min !== undefined && currentValue <= min) {
 			onMinBlocked?.();

--- a/src/lib/client/ui/form/NumberInput.svelte
+++ b/src/lib/client/ui/form/NumberInput.svelte
@@ -11,13 +11,13 @@
 		correction: { inputValue: number; value: number; reason: CorrectionReason };
 	}>();
 
-	// Props
 	export let name: string;
 	export let id: string = name;
 	export let value: number | undefined = undefined;
 	export let min: number | undefined = undefined;
 	export let max: number | undefined = undefined;
 	export let step: number = 1;
+	export let maxDecimals: number | undefined = undefined;
 	export let required: boolean = false;
 	export let disabled: boolean = false;
 	export let warningTooltip: string = '';
@@ -68,6 +68,21 @@
 		isSmallScreen = e.matches;
 	}
 
+	function getDecimalPlaces(number: number): number {
+		if (!Number.isFinite(number)) return 0;
+		const text = String(number);
+		if (text.includes('e-')) {
+			const [, exponent] = text.split('e-');
+			return Number(exponent) || 0;
+		}
+		return text.split('.')[1]?.length ?? 0;
+	}
+
+	function normalizeMaxDecimals(value: number | undefined): number | undefined {
+		if (value === undefined || !Number.isFinite(value)) return undefined;
+		return Math.max(0, Math.floor(value));
+	}
+
 	$: isCompact = compact || (responsive && isSmallScreen);
 	$: hideButtons = responsive && isSmallScreen;
 	$: effectiveAutoWidth = autoWidth && (!responsive || isSmallScreen);
@@ -102,13 +117,79 @@
 	$: autoWidthStyle = effectiveAutoWidth
 		? `width: calc(${autoWidthCharacters}ch + ${autoWidthPadding});`
 		: undefined;
+	$: stepDecimals = getDecimalPlaces(step);
+	$: normalizedMaxDecimals = normalizeMaxDecimals(maxDecimals);
+	$: effectiveMaxDecimals = normalizedMaxDecimals ?? stepDecimals;
+	$: allowDecimals = effectiveMaxDecimals > 0;
+	$: inputMode = allowDecimals ? 'decimal' : 'numeric';
+	$: draftState = getDraftState(inputValue);
+	$: hasInvalidDraft =
+		isFocused &&
+		(draftState.status === 'invalid' ||
+			(draftState.status === 'valid' && isOutsideRange(draftState.value)));
+	$: inputStateClass = hasInvalidDraft
+		? 'border-red-500 bg-white focus:border-red-500 dark:border-red-500/70 dark:bg-neutral-800/50 dark:focus:border-red-400'
+		: 'border-neutral-300 bg-white focus:border-neutral-400 dark:border-neutral-700/60 dark:bg-neutral-800/50 dark:focus:border-neutral-600';
 	$: canIncrement = max === undefined || value === undefined || value < max;
 	$: canDecrement = min === undefined || value === undefined || value > min;
 	$: incrementDisabled = disabled || !canIncrement;
 	$: decrementDisabled = disabled || !canDecrement;
 
 	$: if (!isFocused) {
-		inputValue = value === undefined || value === null ? '' : String(value);
+		inputValue = formatValue(value);
+	}
+
+	function formatValue(nextValue: number | undefined | null): string {
+		if (nextValue === undefined || nextValue === null) return '';
+		if (normalizedMaxDecimals !== undefined || stepDecimals > 0) {
+			return String(roundToDecimals(nextValue, effectiveMaxDecimals));
+		}
+		return String(nextValue);
+	}
+
+	function roundToDecimals(rawValue: number, decimals: number): number {
+		if (decimals <= 0) return Math.round(rawValue);
+		const factor = 10 ** decimals;
+		return Math.round((rawValue + Number.EPSILON) * factor) / factor;
+	}
+
+	function normalizeValue(rawValue: number): { value: number; reason: CorrectionReason | undefined } {
+		return clampValue(roundToDecimals(rawValue, effectiveMaxDecimals));
+	}
+
+	function getDecimalLength(text: string): number {
+		const [, decimals = ''] = text.split('.');
+		return decimals.length;
+	}
+
+	function isEmptyDraft(text: string): boolean {
+		return text === '' || text === '-' || text === '.' || text === '-.';
+	}
+
+	function isIncompleteDecimal(text: string): boolean {
+		return allowDecimals && /^-?\d+\.$/.test(text);
+	}
+
+	function isOutsideRange(rawValue: number): boolean {
+		return (min !== undefined && rawValue < min) || (max !== undefined && rawValue > max);
+	}
+
+	function getDraftState(
+		text: string
+	): { status: 'empty' | 'partial' | 'invalid' } | { status: 'valid'; value: number } {
+		if (text === '') return { status: 'empty' };
+		if (isEmptyDraft(text) || isIncompleteDecimal(text)) return { status: 'partial' };
+
+		const pattern = allowDecimals ? /^-?(?:\d+|\d+\.\d+|\.\d+)$/ : /^-?\d+$/;
+		if (!pattern.test(text)) return { status: 'invalid' };
+
+		if (allowDecimals && getDecimalLength(text) > effectiveMaxDecimals) {
+			return { status: 'invalid' };
+		}
+
+		const rawValue = Number(text);
+		if (!Number.isFinite(rawValue)) return { status: 'invalid' };
+		return { status: 'valid', value: rawValue };
 	}
 
 	function clampValue(rawValue: number): { value: number; reason: CorrectionReason | undefined } {
@@ -128,9 +209,16 @@
 		return { value: newValue, reason };
 	}
 
-	function updateValue(newValue: number, rawValue: number = newValue, reason?: CorrectionReason) {
+	function updateValue(
+		newValue: number,
+		rawValue: number = newValue,
+		reason?: CorrectionReason,
+		syncInput = true
+	) {
 		value = newValue;
-		inputValue = String(newValue);
+		if (syncInput) {
+			inputValue = formatValue(newValue);
+		}
 		onchange?.(newValue);
 		dispatch('change', newValue);
 		if (reason && rawValue !== newValue) {
@@ -138,14 +226,14 @@
 		}
 	}
 
-	// Increment/decrement handlers
 	function increment() {
 		const currentValue = value ?? min ?? 0;
 		if (max !== undefined && currentValue >= max) {
 			onMaxBlocked?.();
 			return;
 		}
-		updateValue(max === undefined ? currentValue + step : Math.min(max, currentValue + step));
+		const result = normalizeValue(currentValue + step);
+		updateValue(result.value, currentValue + step, result.reason);
 	}
 
 	function decrement() {
@@ -154,7 +242,8 @@
 			onMinBlocked?.();
 			return;
 		}
-		updateValue(min === undefined ? currentValue - step : Math.max(min, currentValue - step));
+		const result = normalizeValue(currentValue - step);
+		updateValue(result.value, currentValue - step, result.reason);
 	}
 
 	function canStep(direction: StepDirection): boolean {
@@ -169,10 +258,33 @@
 		}
 	}
 
-	function commitFocusedValue() {
-		if (isFocused && validateOn === 'blur') {
-			handleBlur();
+	function commitInputValue() {
+		if (isEmptyDraft(inputValue)) {
+			value = undefined;
+			dispatch('change', undefined);
+			inputValue = '';
+			return;
 		}
+
+		if (!/^-?(?:\d+\.?\d*|\.\d+)$/.test(inputValue)) {
+			inputValue = formatValue(value);
+			return;
+		}
+
+		const rawValue = Number(inputValue);
+		if (!Number.isFinite(rawValue)) {
+			inputValue = formatValue(value);
+			return;
+		}
+
+		const result = normalizeValue(rawValue);
+		updateValue(result.value, rawValue, result.reason);
+	}
+
+	function commitFocusedValue() {
+		if (!isFocused) return;
+		isFocused = false;
+		commitInputValue();
 	}
 
 	function clearIgnoredClickReset() {
@@ -223,9 +335,7 @@
 	}
 
 	function startStepRepeat(direction: StepDirection, event: PointerEvent) {
-		if (!canStep(direction)) {
-			return;
-		}
+		if (!canStep(direction)) return;
 
 		clearStepRepeat();
 		clearIgnoredClickReset();
@@ -254,73 +364,59 @@
 		stepValue(direction);
 	}
 
-	// Validate on input
 	function handleInput(event: Event) {
 		const target = event.target as HTMLInputElement;
-
 		inputValue = target.value;
 
-		// Allow partial input states (e.g., "-", ".", "-.")
-		if (inputValue === '' || inputValue === '-' || inputValue === '.' || inputValue === '-.') {
-			return;
-		}
+		const state = getDraftState(inputValue);
+		if (state.status !== 'valid' || validateOn === 'blur') return;
 
-		const rawValue = Number(inputValue);
-
-		if (Number.isNaN(rawValue)) {
-			return;
-		}
-
-		if (validateOn === 'blur') {
-			return;
-		}
-
-		const result = clampValue(rawValue);
-		updateValue(result.value, rawValue, result.reason);
+		updateValue(state.value, state.value, undefined, false);
 	}
 
 	function handleBlur() {
 		if (!isFocused) return;
 		isFocused = false;
-		if (inputValue === '' || inputValue === '-' || inputValue === '.' || inputValue === '-.') {
-			value = undefined;
-			dispatch('change', undefined);
-			inputValue = '';
-			return;
-		}
-
-		const rawValue = Number(inputValue);
-		if (Number.isNaN(rawValue)) {
-			inputValue = value === undefined || value === null ? '' : String(value);
-			return;
-		}
-
-		const result = clampValue(rawValue);
-		updateValue(result.value, rawValue, result.reason);
+		commitInputValue();
 	}
 
 	function handleFocus() {
 		isFocused = true;
 	}
+
+	function handleKeydown(event: KeyboardEvent) {
+		if (disabled || (event.key !== 'ArrowUp' && event.key !== 'ArrowDown')) return;
+
+		event.preventDefault();
+		if (isFocused) {
+			commitInputValue();
+			isFocused = true;
+		}
+		stepValue(event.key === 'ArrowUp' ? 'increment' : 'decrement');
+	}
 </script>
 
 <div class="relative">
 	<input
-		type="number"
+		type="text"
 		{id}
 		{name}
+		inputmode={inputMode}
+		role="spinbutton"
+		aria-valuemin={min}
+		aria-valuemax={max}
+		aria-valuenow={value}
+		aria-invalid={hasInvalidDraft ? 'true' : undefined}
 		bind:value={inputValue}
 		oninput={handleInput}
 		onfocus={handleFocus}
 		onblur={handleBlur}
-		{min}
-		{max}
-		{step}
+		onkeydown={handleKeydown}
 		{required}
 		{disabled}
 		{placeholder}
 		style={autoWidthStyle}
-		class="block {widthClass} [appearance:textfield] border border-neutral-300 bg-white text-neutral-900 placeholder-neutral-400 transition-colors focus:border-neutral-400 focus:outline-none disabled:cursor-not-allowed disabled:bg-neutral-100 disabled:text-neutral-500 dark:border-neutral-700/60 dark:bg-neutral-800/50 dark:text-neutral-50 dark:placeholder-neutral-500 dark:focus:border-neutral-600 dark:disabled:bg-neutral-800/40 dark:disabled:text-neutral-500 [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none {inputSizeClasses} {fontClass}"
+		class="block {widthClass} border text-neutral-900 placeholder-neutral-400 transition-colors focus:outline-none disabled:cursor-not-allowed disabled:bg-neutral-100 disabled:text-neutral-500 dark:text-neutral-50 dark:placeholder-neutral-500 dark:disabled:bg-neutral-800/40 dark:disabled:text-neutral-500 {inputSizeClasses} {fontClass} {inputStateClass}"
 	/>
 
 	{#if warningTooltip}
@@ -333,7 +429,6 @@
 		</div>
 	{/if}
 
-	<!-- Custom increment/decrement buttons (hidden on mobile when responsive) -->
 	{#if !hideButtons}
 		<div class="absolute top-0 right-0 bottom-0 flex flex-col">
 			<button

--- a/src/lib/client/ui/form/NumberInput.svelte
+++ b/src/lib/client/ui/form/NumberInput.svelte
@@ -155,7 +155,10 @@
 		return Math.round((rawValue + Number.EPSILON) * factor) / factor;
 	}
 
-	function normalizeValue(rawValue: number): { value: number; reason: CorrectionReason | undefined } {
+	function normalizeValue(rawValue: number): {
+		value: number;
+		reason: CorrectionReason | undefined;
+	} {
 		return clampValue(roundToDecimals(rawValue, effectiveMaxDecimals));
 	}
 

--- a/src/lib/server/sync/customFormats/transformer.ts
+++ b/src/lib/server/sync/customFormats/transformer.ts
@@ -16,9 +16,12 @@ import {
 import { sortConditions } from '$shared/pcd/conditions.ts';
 
 const BYTES_PER_GB = 1024 * 1024 * 1024;
+const SIZE_GB_DECIMALS = 2;
 
 function bytesToGb(value: number | null): number {
-	return value == null ? 0 : value / BYTES_PER_GB;
+	if (value == null) return 0;
+	const factor = 10 ** SIZE_GB_DECIMALS;
+	return Math.round((value / BYTES_PER_GB + Number.EPSILON) * factor) / factor;
 }
 
 // =============================================================================

--- a/src/routes/custom-formats/[databaseId]/[id]/conditions/components/ConditionCard.svelte
+++ b/src/routes/custom-formats/[databaseId]/[id]/conditions/components/ConditionCard.svelte
@@ -204,14 +204,11 @@
 		return Math.round((bytes / BYTES_PER_GB + Number.EPSILON) * factor) / factor;
 	}
 
-	$: minSizeGB = condition.size?.minBytes != null
-		? bytesToDisplayGb(condition.size.minBytes)
-		: undefined;
-	$: maxSizeGB = condition.size?.maxBytes != null
-		? bytesToDisplayGb(condition.size.maxBytes)
-		: undefined;
-	$: minSizeEmptyStepValue =
-		maxSizeGB == null ? undefined : Math.max(0, maxSizeGB - SIZE_STEP_GB);
+	$: minSizeGB =
+		condition.size?.minBytes != null ? bytesToDisplayGb(condition.size.minBytes) : undefined;
+	$: maxSizeGB =
+		condition.size?.maxBytes != null ? bytesToDisplayGb(condition.size.maxBytes) : undefined;
+	$: minSizeEmptyStepValue = maxSizeGB == null ? undefined : Math.max(0, maxSizeGB - SIZE_STEP_GB);
 	$: maxSizeEmptyStepValue = minSizeGB == null ? undefined : minSizeGB + SIZE_STEP_GB;
 	$: hasInvalidSizeRange =
 		condition.size?.minBytes != null &&

--- a/src/routes/custom-formats/[databaseId]/[id]/conditions/components/ConditionCard.svelte
+++ b/src/routes/custom-formats/[databaseId]/[id]/conditions/components/ConditionCard.svelte
@@ -199,11 +199,16 @@
 	$: typeOptions = filteredConditionTypes.map((t) => ({ value: t.value, label: t.label }));
 
 	// Size helpers (convert between bytes and GB for display)
+	function bytesToDisplayGb(bytes: number): number {
+		const factor = 10 ** SIZE_MAX_DECIMALS;
+		return Math.round((bytes / BYTES_PER_GB + Number.EPSILON) * factor) / factor;
+	}
+
 	$: minSizeGB = condition.size?.minBytes != null
-		? condition.size.minBytes / BYTES_PER_GB
+		? bytesToDisplayGb(condition.size.minBytes)
 		: undefined;
 	$: maxSizeGB = condition.size?.maxBytes != null
-		? condition.size.maxBytes / BYTES_PER_GB
+		? bytesToDisplayGb(condition.size.maxBytes)
 		: undefined;
 	$: minSizeEmptyStepValue =
 		maxSizeGB == null ? undefined : Math.max(0, maxSizeGB - SIZE_STEP_GB);

--- a/src/routes/custom-formats/[databaseId]/[id]/conditions/components/ConditionCard.svelte
+++ b/src/routes/custom-formats/[databaseId]/[id]/conditions/components/ConditionCard.svelte
@@ -35,6 +35,10 @@
 	export let availablePatterns: { id: number; name: string; pattern: string }[] = [];
 	export let availableLanguages: { name: string; radarr: boolean; sonarr: boolean }[] = [];
 
+	const BYTES_PER_GB = 1024 * 1024 * 1024;
+	const SIZE_STEP_GB = 0.01;
+	const SIZE_MAX_DECIMALS = 2;
+
 	// Computed states based on mode
 	let lastEditedSizeField: 'min' | 'max' | null = null;
 	$: isDraft = mode === 'draft';
@@ -195,12 +199,15 @@
 	$: typeOptions = filteredConditionTypes.map((t) => ({ value: t.value, label: t.label }));
 
 	// Size helpers (convert between bytes and GB for display)
-	$: minSizeGB = condition.size?.minBytes
-		? condition.size.minBytes / 1024 / 1024 / 1024
+	$: minSizeGB = condition.size?.minBytes != null
+		? condition.size.minBytes / BYTES_PER_GB
 		: undefined;
-	$: maxSizeGB = condition.size?.maxBytes
-		? condition.size.maxBytes / 1024 / 1024 / 1024
+	$: maxSizeGB = condition.size?.maxBytes != null
+		? condition.size.maxBytes / BYTES_PER_GB
 		: undefined;
+	$: minSizeEmptyStepValue =
+		maxSizeGB == null ? undefined : Math.max(0, maxSizeGB - SIZE_STEP_GB);
+	$: maxSizeEmptyStepValue = minSizeGB == null ? undefined : minSizeGB + SIZE_STEP_GB;
 	$: hasInvalidSizeRange =
 		condition.size?.minBytes != null &&
 		condition.size?.maxBytes != null &&
@@ -217,7 +224,7 @@
 		emitChange({
 			size: {
 				...currentSize,
-				minBytes: value == null ? null : Math.round(value * 1024 * 1024 * 1024)
+				minBytes: value == null ? null : Math.round(value * BYTES_PER_GB)
 			}
 		});
 	}
@@ -228,7 +235,7 @@
 		emitChange({
 			size: {
 				...currentSize,
-				maxBytes: value == null ? null : Math.round(value * 1024 * 1024 * 1024)
+				maxBytes: value == null ? null : Math.round(value * BYTES_PER_GB)
 			}
 		});
 	}
@@ -367,8 +374,9 @@
 								name="minSize"
 								value={minSizeGB}
 								min={0}
-								step={0.01}
-								maxDecimals={2}
+								step={SIZE_STEP_GB}
+								maxDecimals={SIZE_MAX_DECIMALS}
+								emptyStepValue={minSizeEmptyStepValue}
 								warningTooltip={minSizeWarning}
 								font="mono"
 								responsive
@@ -382,8 +390,9 @@
 								name="maxSize"
 								value={maxSizeGB}
 								min={0}
-								step={0.01}
-								maxDecimals={2}
+								step={SIZE_STEP_GB}
+								maxDecimals={SIZE_MAX_DECIMALS}
+								emptyStepValue={maxSizeEmptyStepValue}
 								warningTooltip={maxSizeWarning}
 								font="mono"
 								responsive

--- a/src/routes/custom-formats/[databaseId]/[id]/conditions/components/ConditionCard.svelte
+++ b/src/routes/custom-formats/[databaseId]/[id]/conditions/components/ConditionCard.svelte
@@ -367,7 +367,8 @@
 								name="minSize"
 								value={minSizeGB}
 								min={0}
-								step={1}
+								step={0.01}
+								maxDecimals={2}
 								warningTooltip={minSizeWarning}
 								font="mono"
 								responsive
@@ -381,7 +382,8 @@
 								name="maxSize"
 								value={maxSizeGB}
 								min={0}
-								step={1}
+								step={0.01}
+								maxDecimals={2}
 								warningTooltip={maxSizeWarning}
 								font="mono"
 								responsive


### PR DESCRIPTION
Fixes #734.

Allows custom format size conditions to accept decimal GB values. The UI now supports decimal draft input, stores size bounds as bytes without exposing float artifacts on reload, and sends rounded GB values during sync.