### PR TITLE
fix: match arr source fallback in parser

### DIFF
--- a/docs/backend/parser.md
+++ b/docs/backend/parser.md
@@ -69,8 +69,9 @@ Each parser uses pre-compiled regexes tried in priority order. First match wins
 returns null and the endpoint uses defaults (empty lists, zeros, nulls).
 
 **QualityParser** handles edge cases like anime patterns (`bd720`, `bd1080`),
-MPEG2 detection for RawHD, and Remux fallback logic (Remux without explicit
-source assumes Bluray).
+MPEG2 detection for RawHD, Remux fallback logic (Remux without explicit source
+assumes Bluray), and Arr-style source fallback where resolution-only releases
+are treated as television source.
 
 **TitleParser** tries 8+ regex patterns sequentially for movies, handling anime
 with subgroups, German/French tracker formats, special editions, and

--- a/src/services/parser/Parsers/QualityParser.cs
+++ b/src/services/parser/Parsers/QualityParser.cs
@@ -237,11 +237,10 @@ public static class QualityParser
             return result;
         }
 
-        // Resolution only
-        if (resolution != Resolution.Unknown && isRemux)
+        // Resolution-only releases fallback to HDTV/SDTV in Sonarr/Radarr.
+        if (resolution != Resolution.Unknown)
         {
-            result.Source = QualitySource.Bluray;
-            result.Modifier = QualityModifier.Remux;
+            result.Source = QualitySource.TV;
         }
 
         return result;

--- a/src/services/parser/appsettings.json
+++ b/src/services/parser/appsettings.json
@@ -12,6 +12,6 @@
 		"MinLevel": "INFO"
 	},
 	"Parser": {
-		"Version": "1.0.0"
+		"Version": "1.0.1"
 	}
 }


### PR DESCRIPTION
Matches Sonarr/Radarr source fallback when a release has a resolution but no explicit source. Resolution-only releases now parse as television source instead of unknown, and the parser version bumps to refresh cached parse results.

Closes #814.