### PR TITLE
ci: harden supply chain configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,7 @@ updates:
       timezone: 'Australia/Adelaide'
     open-pull-requests-limit: 10
     cooldown:
-      default-days: 3
-      semver-major-days: 7
+      default-days: 7
     ignore:
       # @db/sqlite is pinned to the npm-compat package at 0.12.0; 0.13.0's
       # npm.jsr.io tarball has a broken checksum, so any bump fails CI.
@@ -35,4 +34,4 @@ updates:
       timezone: 'Australia/Adelaide'
     open-pull-requests-limit: 10
     cooldown:
-      default-days: 3
+      default-days: 7

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v3
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
 
       - id: filter
         if: github.event_name == 'pull_request'
-        uses: dorny/paths-filter@v4
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         with:
           predicate-quantifier: every
           filters: |
@@ -60,14 +60,14 @@ jobs:
     if: ${{ needs.ci-scope.outputs.full_ci == 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: denoland/setup-deno@v2
+      - uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
         with:
           deno-version-file: .tool-versions
 
       - name: Cache deps
-        uses: actions/cache@v6.1.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.cache/deno
@@ -81,7 +81,7 @@ jobs:
         run: deno task build
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: profilarr-build
           path: |
@@ -98,14 +98,14 @@ jobs:
     if: ${{ needs.ci-scope.outputs.full_ci == 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: denoland/setup-deno@v2
+      - uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
         with:
           deno-version-file: .tool-versions
 
       - name: Cache deps
-        uses: actions/cache@v6.1.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.cache/deno
@@ -124,18 +124,18 @@ jobs:
     if: ${{ needs.ci-scope.outputs.full_ci == 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: denoland/setup-deno@v2
+      - uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
         with:
           deno-version-file: .tool-versions
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: .tool-versions
 
       - name: Cache deps
-        uses: actions/cache@v6.1.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.cache/deno
@@ -157,14 +157,14 @@ jobs:
     if: ${{ needs.ci-scope.outputs.full_ci == 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: denoland/setup-deno@v2
+      - uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
         with:
           deno-version-file: .tool-versions
 
       - name: Cache deps
-        uses: actions/cache@v6.1.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.cache/deno
@@ -185,7 +185,7 @@ jobs:
     container:
       image: semgrep/semgrep
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Run Semgrep
         run: |
@@ -208,20 +208,20 @@ jobs:
     if: ${{ needs.ci-scope.outputs.full_ci == 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Build images
         run: docker compose -f compose.yml -f compose.dev.yml build
 
       - name: Scan profilarr
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: 'profilarr:alpine'
           severity: 'CRITICAL,HIGH'
           exit-code: '1'
 
       - name: Scan parser
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: 'profilarr-parser:alpine'
           severity: 'CRITICAL,HIGH'
@@ -235,18 +235,18 @@ jobs:
     if: ${{ needs.ci-scope.outputs.full_ci == 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: denoland/setup-deno@v2
+      - uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
         with:
           deno-version-file: .tool-versions
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: .tool-versions
 
       - name: Cache deps
-        uses: actions/cache@v6.1.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.cache/deno
@@ -264,7 +264,7 @@ jobs:
       # into the same path on a cold cache and corrupt each other.
       - name: Cache FFI plug
         id: plug-cache
-        uses: actions/cache@v6.1.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/deno/plug
           key: deno-plug-${{ runner.os }}-${{ hashFiles('deno.lock') }}-v1
@@ -280,7 +280,7 @@ jobs:
           '
 
       - name: Download build artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: profilarr-build
           path: dist/build
@@ -290,7 +290,7 @@ jobs:
 
       - name: Cache Docker images
         id: docker-cache
-        uses: actions/cache@v6.1.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: /tmp/docker-images.tar
           key: docker-images-${{ hashFiles('tests/integration/auth/docker-compose.yml') }}
@@ -316,18 +316,18 @@ jobs:
     if: ${{ needs.ci-scope.outputs.full_ci == 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: denoland/setup-deno@v2
+      - uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
         with:
           deno-version-file: .tool-versions
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: .tool-versions
 
       - name: Cache deps
-        uses: actions/cache@v6.1.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.cache/deno
@@ -339,7 +339,7 @@ jobs:
 
       - name: Cache Playwright browsers
         id: playwright-cache
-        uses: actions/cache@v6.1.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('deno.lock') }}
@@ -353,7 +353,7 @@ jobs:
         run: deno run -A npm:playwright install-deps chromium
 
       - name: Download build artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: profilarr-build
           path: dist/build
@@ -363,7 +363,7 @@ jobs:
 
       - name: Cache Docker images
         id: docker-cache
-        uses: actions/cache@v6.1.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: /tmp/docker-images.tar
           key: docker-images-${{ hashFiles('tests/integration/auth/docker-compose.yml') }}

--- a/.github/workflows/hotfix-backport.yml
+++ b/.github/workflows/hotfix-backport.yml
@@ -19,7 +19,7 @@ jobs:
     name: Backport to develop
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           token: ${{ secrets.BACKPORT_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,7 +12,7 @@ jobs:
     name: Validate PR Title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v6
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,13 +46,13 @@ jobs:
       - name: Set Image Base
         run: echo "IMAGE_BASE=ghcr.io/$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
 
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -90,7 +90,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: ${{ env.IMAGE_BASE }}/${{ matrix.image }}
           labels: |
@@ -98,7 +98,7 @@ jobs:
 
       - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: ${{ matrix.dockerfile }}
@@ -122,7 +122,7 @@ jobs:
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: digest--${{ matrix.image }}--${{ steps.digest.outputs.hash }}
           path: /tmp/digests/*
@@ -148,17 +148,17 @@ jobs:
         run: echo "IMAGE_BASE=ghcr.io/$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
 
       - name: Download digests
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: digest--${{ matrix.image }}--*
           path: /tmp/digests
           merge-multiple: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -166,7 +166,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: ${{ env.IMAGE_BASE }}/${{ matrix.image }}
           tags: |
@@ -196,12 +196,12 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
       - name: Generate release notes
-        uses: orhun/git-cliff-action@v4
+        uses: orhun/git-cliff-action@f50e11560dce63f7c33227798f90b924471a88b5 # v4.8.0
         with:
           config: cliff.toml
           args: --current --output RELEASE_NOTES.md

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 engine-strict=true
 @jsr:registry=https://npm.jsr.io
+min-release-age=7

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,5 +1,6 @@
 {
 	"nodeModulesDir": "auto",
+	"minimumDependencyAge": "P7D",
 	"imports": {
 		// Path aliases
 		"$lib/": "./src/lib/",

--- a/scripts/lint/toolchain.ts
+++ b/scripts/lint/toolchain.ts
@@ -37,6 +37,21 @@ function matchCount(source: string, pattern: RegExp): number {
 	return Array.from(source.matchAll(pattern)).length;
 }
 
+function escapeRegExp(source: string): string {
+	return source.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function actionUseCount(source: string, action: string, major: string): number {
+	const escapedAction = escapeRegExp(action);
+	const escapedMajor = escapeRegExp(major);
+	const pattern = new RegExp(
+		`uses:\\s+${escapedAction}@(?:${escapedMajor}|[0-9a-f]{40}\\s+#\\s+${escapedMajor}(?:\\.\\d+){0,2})(?:\\s|$)`,
+		'g'
+	);
+
+	return matchCount(source, pattern);
+}
+
 function requireTool(
 	versions: ToolVersions,
 	tool: keyof ToolVersions,
@@ -68,7 +83,7 @@ function checkDockerfile(source: string, denoVersion: string, violations: string
 }
 
 function checkCi(source: string, violations: string[]): void {
-	const denoSetups = matchCount(source, /uses:\s+denoland\/setup-deno@v2/g);
+	const denoSetups = actionUseCount(source, 'denoland/setup-deno', 'v2');
 	const denoVersionFiles = matchCount(source, /deno-version-file:\s+\.tool-versions/g);
 	if (denoSetups !== denoVersionFiles) {
 		violations.push(
@@ -80,7 +95,7 @@ function checkCi(source: string, violations: string[]): void {
 		violations.push(`${CI_PATH} must use deno-version-file, not deno-version`);
 	}
 
-	const nodeSetups = matchCount(source, /uses:\s+actions\/setup-node@v6/g);
+	const nodeSetups = actionUseCount(source, 'actions/setup-node', 'v6');
 	const nodeVersionFiles = matchCount(source, /node-version-file:\s+\.tool-versions/g);
 	if (nodeSetups !== nodeVersionFiles) {
 		violations.push(


### PR DESCRIPTION
## Summary

- pin GitHub Actions workflow refs to immutable commit SHAs
- increase Dependabot cooldowns from 3 days to 7 days
- add a 7-day release-age guard for npm and Deno/JSR package resolution