### PR TITLE
ci: add rolling major-version image tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,6 +173,7 @@ jobs:
             type=raw,value=develop,enable=${{ github.ref == 'refs/heads/develop' }}
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
             type=semver,pattern={{version}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=semver,pattern={{major}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
 
       - name: Create manifest list and push
         working-directory: /tmp/digests


### PR DESCRIPTION
## Summary

Adds a rolling major-version tag to release images, so users can pin
`profilarr:2` (and `profilarr-parser:2`) and automatically receive minor
and point releases without editing their compose file on every version bump.

Closes #827.

## Change

One line added to the `manifest` job's metadata step in `release.yml`: