### PR TITLE
chore(deps): bump actions/setup-node to v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
         with:
           deno-version-file: .tool-versions
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .tool-versions
 
@@ -241,7 +241,7 @@ jobs:
         with:
           deno-version-file: .tool-versions
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .tool-versions
 
@@ -322,7 +322,7 @@ jobs:
         with:
           deno-version-file: .tool-versions
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .tool-versions
 

--- a/scripts/lint/toolchain.ts
+++ b/scripts/lint/toolchain.ts
@@ -95,7 +95,7 @@ function checkCi(source: string, violations: string[]): void {
 		violations.push(`${CI_PATH} must use deno-version-file, not deno-version`);
 	}
 
-	const nodeSetups = actionUseCount(source, 'actions/setup-node', 'v6');
+	const nodeSetups = actionUseCount(source, 'actions/setup-node', 'v7');
 	const nodeVersionFiles = matchCount(source, /node-version-file:\s+\.tool-versions/g);
 	if (nodeSetups !== nodeVersionFiles) {
 		violations.push(


### PR DESCRIPTION
## Summary
- upgrade actions/setup-node to v7.0.0 using the pinned upstream SHA
- update the toolchain drift check to recognize setup-node v7

Supersedes #847.