### PR TITLE
fix: correct Arr log level pagination

### DIFF
--- a/src/lib/server/utils/arr/base.ts
+++ b/src/lib/server/utils/arr/base.ts
@@ -416,7 +416,7 @@ export class BaseArrClient extends BaseHttpClient {
 		if (params.pageSize !== undefined) queryParams.set('pageSize', String(params.pageSize));
 		if (params.sortKey) queryParams.set('sortKey', params.sortKey);
 		if (params.sortDirection) queryParams.set('sortDirection', params.sortDirection);
-		if (params.level) queryParams.set('level', params.level);
+		if (params.level) queryParams.set('level', params.level.toLowerCase());
 
 		const queryString = queryParams.toString();
 		const url = `/api/${this.apiVersion}/log${queryString ? `?${queryString}` : ''}`;

--- a/src/routes/arr/[id]/logs/+page.svelte
+++ b/src/routes/arr/[id]/logs/+page.svelte
@@ -208,13 +208,6 @@
 	// Client-side search filter
 	$: filteredLogs = logs
 		? logs.records.filter((log) => {
-				if (
-					selectedLevel !== 'ALL' &&
-					normalizeLevel(log.level) !== normalizeLevel(selectedLevel)
-				) {
-					return false;
-				}
-
 				const query = $searchStore.query;
 				if (!query) return true;
 


### PR DESCRIPTION
- Normalize log-level parameters for native Arr filtering.
- Use Arr-filtered records and totals for pagination.

Closes #854