### PR TITLE
feat: add size-based upgrade selectors

### DIFF
--- a/docs/backend/upgrades.md
+++ b/docs/backend/upgrades.md
@@ -149,6 +149,8 @@ specifies a selector strategy and a count (items per run).
 | `oldest`            | Oldest by date added             |
 | `newest`            | Newest by date added             |
 | `lowest_score`      | Lowest custom format score first |
+| `size_desc`         | Largest size on disk first       |
+| `size_asc`          | Smallest positive size first     |
 | `most_popular`      | Highest popularity first         |
 | `least_popular`     | Lowest popularity first          |
 | `alphabetical_asc`  | A-Z by title                     |

--- a/src/lib/shared/upgrades/selectors.ts
+++ b/src/lib/shared/upgrades/selectors.ts
@@ -13,6 +13,25 @@ export interface Selector<T = any> {
 	select: (items: T[], count: number) => T[];
 }
 
+function compareSize(
+	a: { size_on_disk?: unknown },
+	b: { size_on_disk?: unknown },
+	direction: 'asc' | 'desc'
+): number {
+	const sizeA =
+		typeof a.size_on_disk === 'number' && Number.isFinite(a.size_on_disk) && a.size_on_disk > 0
+			? a.size_on_disk
+			: null;
+	const sizeB =
+		typeof b.size_on_disk === 'number' && Number.isFinite(b.size_on_disk) && b.size_on_disk > 0
+			? b.size_on_disk
+			: null;
+
+	if (sizeA === null) return sizeB === null ? 0 : 1;
+	if (sizeB === null) return -1;
+	return direction === 'asc' ? sizeA - sizeB : sizeB - sizeA;
+}
+
 /**
  * All available selectors
  */
@@ -58,6 +77,24 @@ export const selectors: Selector[] = [
 		description: 'Select items with lowest custom format score',
 		select: (items, count) => {
 			const sorted = [...items].sort((a, b) => (a.score || 0) - (b.score || 0));
+			return sorted.slice(0, count);
+		}
+	},
+	{
+		id: 'size_desc',
+		label: 'Size (Largest First)',
+		description: 'Select items with the largest size on disk first',
+		select: (items, count) => {
+			const sorted = [...items].sort((a, b) => compareSize(a, b, 'desc'));
+			return sorted.slice(0, count);
+		}
+	},
+	{
+		id: 'size_asc',
+		label: 'Size (Smallest First)',
+		description: 'Select items with the smallest positive size on disk first',
+		select: (items, count) => {
+			const sorted = [...items].sort((a, b) => compareSize(a, b, 'asc'));
 			return sorted.slice(0, count);
 		}
 	},

--- a/src/routes/arr/[id]/upgrades/components/FilterSettings.svelte
+++ b/src/routes/arr/[id]/upgrades/components/FilterSettings.svelte
@@ -74,6 +74,8 @@
 		oldest: 'Oldest first',
 		newest: 'Newest first',
 		lowest_score: 'Lowest score',
+		size_desc: 'Largest first',
+		size_asc: 'Smallest first',
 		most_popular: 'Most popular',
 		least_popular: 'Least popular',
 		alphabetical_asc: 'A-Z',

--- a/tests/unit/upgrades/selectors.test.ts
+++ b/tests/unit/upgrades/selectors.test.ts
@@ -18,6 +18,7 @@ interface MockItem {
 	dateAdded: string;
 	score: number;
 	popularity: number;
+	size_on_disk?: number;
 }
 
 class SelectorsTest extends BaseTest {
@@ -82,6 +83,8 @@ class SelectorsTest extends BaseTest {
 			assertEquals(isValidSelector('oldest'), true);
 			assertEquals(isValidSelector('newest'), true);
 			assertEquals(isValidSelector('lowest_score'), true);
+			assertEquals(isValidSelector('size_desc'), true);
+			assertEquals(isValidSelector('size_asc'), true);
 			assertEquals(isValidSelector('most_popular'), true);
 			assertEquals(isValidSelector('least_popular'), true);
 		});
@@ -93,15 +96,65 @@ class SelectorsTest extends BaseTest {
 
 		this.test('getAllSelectorIds returns all selector ids', () => {
 			const ids = getAllSelectorIds();
-			assertEquals(ids.length, 8);
+			assertEquals(ids.length, 10);
 			assert(ids.includes('random'));
 			assert(ids.includes('oldest'));
 			assert(ids.includes('newest'));
 			assert(ids.includes('lowest_score'));
+			assert(ids.includes('size_desc'));
+			assert(ids.includes('size_asc'));
 			assert(ids.includes('most_popular'));
 			assert(ids.includes('least_popular'));
 			assert(ids.includes('alphabetical_asc'));
 			assert(ids.includes('alphabetical_desc'));
+		});
+
+		// =====================
+		// Size Selectors
+		// =====================
+
+		this.test('size_desc: selects largest positive sizes first', () => {
+			const items: MockItem[] = [
+				{ id: 1, title: 'A', dateAdded: '', score: 0, popularity: 0, size_on_disk: 8 },
+				{ id: 2, title: 'B', dateAdded: '', score: 0, popularity: 0, size_on_disk: 12 },
+				{ id: 3, title: 'C', dateAdded: '', score: 0, popularity: 0, size_on_disk: 3 },
+				{ id: 4, title: 'Zero', dateAdded: '', score: 0, popularity: 0, size_on_disk: 0 },
+				{ id: 5, title: 'Missing', dateAdded: '', score: 0, popularity: 0 },
+				{ id: 6, title: 'Invalid', dateAdded: '', score: 0, popularity: 0, size_on_disk: NaN }
+			];
+			const originalOrder = items.map((item) => item.id);
+			const selector = getSelector('size_desc')!;
+			const selected = selector.select(items, 10);
+			const limited = selector.select(items, 2);
+
+			assertEquals(
+				selected.map((item) => item.id),
+				[2, 1, 3, 4, 5, 6]
+			);
+			assertEquals(
+				limited.map((item) => item.id),
+				[2, 1]
+			);
+			assertEquals(
+				items.map((item) => item.id),
+				originalOrder
+			);
+		});
+
+		this.test('size_asc: selects smallest positive sizes and puts unusable sizes last', () => {
+			const items: MockItem[] = [
+				{ id: 1, title: 'Zero', dateAdded: '', score: 0, popularity: 0, size_on_disk: 0 },
+				{ id: 2, title: 'Eight', dateAdded: '', score: 0, popularity: 0, size_on_disk: 8 },
+				{ id: 3, title: 'Missing', dateAdded: '', score: 0, popularity: 0 },
+				{ id: 4, title: 'Three', dateAdded: '', score: 0, popularity: 0, size_on_disk: 3 },
+				{ id: 5, title: 'Invalid', dateAdded: '', score: 0, popularity: 0, size_on_disk: NaN }
+			];
+			const selected = getSelector('size_asc')!.select(items, 10);
+
+			assertEquals(
+				selected.map((item) => item.id),
+				[4, 2, 1, 3, 5]
+			);
 		});
 
 		// =====================


### PR DESCRIPTION
- Add largest-first and smallest-first upgrade selection methods.
- Keep zero, missing, and invalid sizes at the end of both orderings.
- Apply the selectors consistently to live runs and filter previews.

Closes #867