### PR TITLE
fix: add all-field entity filters

### DIFF
--- a/docs/frontend/ui.md
+++ b/docs/frontend/ui.md
@@ -410,6 +410,8 @@ Sub-components for building custom menu UIs:
   hover-bridge support.
 - **`DropdownHeader.svelte`**, **`DropdownFooter.svelte`**,
   **`DropdownItem.svelte`**: styled section header, footer, and menu item.
+  `DropdownItem` supports optional inline secondary text and a muted description
+  rendered below the main label.
   `DropdownFooter` mirrors `DropdownHeader` but uses `border-top` instead
   of `border-bottom` and sits at the end of a menu (e.g. "and 12 more").
 - **`DropdownSelect.svelte`**: the `<select>` replacement (covered under

--- a/src/lib/client/ui/dropdown/DropdownItem.svelte
+++ b/src/lib/client/ui/dropdown/DropdownItem.svelte
@@ -8,6 +8,7 @@
 	$: isSvgIcon = icon && typeof icon === 'object' && 'path' in icon;
 	export let label: string;
 	export let secondaryText: string = '';
+	export let description: string = '';
 	export let disabled: boolean = false;
 	export let danger: boolean = false;
 	export let selected: boolean = false;
@@ -66,11 +67,18 @@
 				<slot />
 			</span>
 		{:else}
-			<span class="flex-1 {labelTransformClass} {labelClass}"
-				>{label}{#if secondaryText}<span
-						class="ml-1.5 text-xs text-neutral-400 dark:text-neutral-500">{secondaryText}</span
-					>{/if}</span
-			>
+			<span class="min-w-0 flex-1 {labelClass}">
+				<span class="{labelTransformClass}"
+					>{label}{#if secondaryText}<span
+							class="ml-1.5 text-xs text-neutral-400 dark:text-neutral-500">{secondaryText}</span
+						>{/if}</span
+				>
+				{#if description}
+					<span class="mt-0.5 block text-xs leading-snug text-neutral-400 dark:text-neutral-500">
+						{description}
+					</span>
+				{/if}
+			</span>
 		{/if}
 		<IconCheckbox icon={checkIcon} checked={selected} shape="circle" color={checkColor} {compact} />
 	</button>

--- a/src/lib/client/ui/dropdown/DropdownItem.svelte
+++ b/src/lib/client/ui/dropdown/DropdownItem.svelte
@@ -68,7 +68,7 @@
 			</span>
 		{:else}
 			<span class="min-w-0 flex-1 {labelClass}">
-				<span class="{labelTransformClass}"
+				<span class={labelTransformClass}
 					>{label}{#if secondaryText}<span
 							class="ml-1.5 text-xs text-neutral-400 dark:text-neutral-500">{secondaryText}</span
 						>{/if}</span

--- a/src/lib/client/ui/filter/SmartFilterBar.svelte
+++ b/src/lib/client/ui/filter/SmartFilterBar.svelte
@@ -157,10 +157,21 @@
 	$: fieldSuggestions = (() => {
 		if (phase !== 'field') return [];
 		const q = inputValue.trim().toLowerCase();
-		if (!q) return fields.map((f) => ({ key: f.key, label: f.label, type: f.type }));
+		if (!q)
+			return fields.map((f) => ({
+				key: f.key,
+				label: f.label,
+				description: f.description ?? '',
+				type: f.type
+			}));
 		return fields
 			.filter((f) => f.label.toLowerCase().includes(q) || f.key.toLowerCase().includes(q))
-			.map((f) => ({ key: f.key, label: f.label, type: f.type }));
+			.map((f) => ({
+				key: f.key,
+				label: f.label,
+				description: f.description ?? '',
+				type: f.type
+			}));
 	})();
 
 	let remainingValueCount = 0;
@@ -197,9 +208,14 @@
 
 	$: suggestions =
 		phase === 'field'
-			? fieldSuggestions.map((f) => ({ label: f.label, hint: f.type, value: f.key }))
+			? fieldSuggestions.map((f) => ({
+					label: f.label,
+					description: f.description,
+					hint: f.type,
+					value: f.key
+				}))
 			: phase === 'value'
-				? valueSuggestions.map((s) => ({ label: s, hint: '', value: s }))
+				? valueSuggestions.map((s) => ({ label: s, description: '', hint: '', value: s }))
 				: [];
 
 	$: showNumberHint = phase === 'value' && activeFieldDef?.type === 'number';
@@ -422,6 +438,7 @@
 			{#each suggestions as suggestion, i}
 				<DropdownItem
 					label={suggestion.label}
+					description={suggestion.description}
 					highlighted={i === highlightedIndex}
 					on:click={() => handleSuggestionClick(i)}
 				/>

--- a/src/lib/client/ui/filter/types.ts
+++ b/src/lib/client/ui/filter/types.ts
@@ -4,6 +4,7 @@ export type FilterFieldType = 'text' | 'number';
 export interface FilterFieldDef<T = any> {
 	key: string;
 	label: string;
+	description?: string;
 	type: FilterFieldType;
 	accessor: (item: T) => string | number | string[] | null;
 	suggestions?: (items: T[]) => string[];

--- a/src/lib/client/utils/entitySearch.ts
+++ b/src/lib/client/utils/entitySearch.ts
@@ -1,0 +1,43 @@
+import type {
+	CustomFormatTableRow,
+	QualityProfileTableRow,
+	RegularExpressionWithTags
+} from '$shared/pcd/display.ts';
+
+function nonEmpty(values: Array<string | null | undefined>): string[] {
+	return values.filter((value): value is string => Boolean(value));
+}
+
+export function customFormatSearchValues(item: CustomFormatTableRow): string[] {
+	return nonEmpty([
+		item.name,
+		...item.tags.map((tag) => tag.name),
+		item.description,
+		...item.conditions.map((condition) => condition.name)
+	]);
+}
+
+export function qualityProfileLanguageLabel(item: QualityProfileTableRow): string {
+	if (!item.language || item.language.name === 'Original') return 'Any';
+	return item.language.name;
+}
+
+export function qualityProfileSearchValues(item: QualityProfileTableRow): string[] {
+	return nonEmpty([
+		item.name,
+		...item.tags.map((tag) => tag.name),
+		item.description,
+		qualityProfileLanguageLabel(item),
+		...item.qualities.map((quality) => quality.name)
+	]);
+}
+
+export function regularExpressionSearchValues(item: RegularExpressionWithTags): string[] {
+	return nonEmpty([
+		item.name,
+		...item.tags.map((tag) => tag.name),
+		item.pattern,
+		item.description,
+		item.regex101_id
+	]);
+}

--- a/src/routes/custom-formats/[databaseId]/+page.svelte
+++ b/src/routes/custom-formats/[databaseId]/+page.svelte
@@ -23,6 +23,7 @@
 	import { alertStore } from '$alerts/store';
 	import type { CustomFormatTableRow } from '$shared/pcd/display.ts';
 	import { copyToClipboard } from '$lib/client/utils/clipboard';
+	import { customFormatSearchValues } from '$lib/client/utils/entitySearch';
 	import type { PageData } from './$types';
 
 	export let data: PageData;
@@ -68,8 +69,16 @@
 
 	const fields: FilterFieldDef<CustomFormatTableRow>[] = [
 		{
+			key: 'all',
+			label: 'All',
+			description: 'Name, tags, description and conditions',
+			type: 'text',
+			accessor: customFormatSearchValues
+		},
+		{
 			key: 'name',
 			label: 'Name',
+			description: 'Custom format name',
 			type: 'text',
 			isDefault: true,
 			accessor: (item) => item.name,
@@ -78,6 +87,7 @@
 		{
 			key: 'tag',
 			label: 'Tag',
+			description: 'Assigned tag names',
 			type: 'text',
 			accessor: (item) => item.tags.map((t) => t.name),
 			suggestions: (items) => [...new Set(items.flatMap((i) => i.tags.map((t) => t.name)))].sort()
@@ -85,6 +95,7 @@
 		{
 			key: 'tagged',
 			label: 'Tagged',
+			description: 'Whether any tags are assigned',
 			type: 'text',
 			accessor: (item) => (item.tags.length > 0 ? 'yes' : 'no'),
 			suggestions: () => ['yes', 'no']
@@ -92,6 +103,7 @@
 		{
 			key: 'referenced',
 			label: 'Referenced',
+			description: 'Whether a quality profile uses it',
 			type: 'text',
 			accessor: (item) => (item.referenceCount > 0 ? 'yes' : 'no'),
 			suggestions: () => ['yes', 'no']
@@ -99,12 +111,14 @@
 		{
 			key: 'description',
 			label: 'Description',
+			description: 'Custom format description',
 			type: 'text',
 			accessor: (item) => item.description ?? null
 		},
 		{
 			key: 'condition',
 			label: 'Condition',
+			description: 'Condition names',
 			type: 'text',
 			accessor: (item) => item.conditions.map((c) => c.name),
 			suggestions: (items) =>
@@ -113,6 +127,7 @@
 		{
 			key: 'tests',
 			label: 'Tests',
+			description: 'Number of configured test cases',
 			type: 'number',
 			accessor: (item) => item.testCount
 		}

--- a/src/routes/quality-profiles/[databaseId]/+page.svelte
+++ b/src/routes/quality-profiles/[databaseId]/+page.svelte
@@ -22,6 +22,10 @@
 	import { alertStore } from '$alerts/store';
 	import type { QualityProfileTableRow } from '$shared/pcd/display';
 	import { copyToClipboard } from '$lib/client/utils/clipboard';
+	import {
+		qualityProfileLanguageLabel,
+		qualityProfileSearchValues
+	} from '$lib/client/utils/entitySearch';
 	import type { PageData } from './$types';
 
 	export let data: PageData;
@@ -66,8 +70,16 @@
 
 	const fields: FilterFieldDef<QualityProfileTableRow>[] = [
 		{
+			key: 'all',
+			label: 'All',
+			description: 'Name, tags, description, language and qualities',
+			type: 'text',
+			accessor: qualityProfileSearchValues
+		},
+		{
 			key: 'name',
 			label: 'Name',
+			description: 'Quality profile name',
 			type: 'text',
 			isDefault: true,
 			accessor: (item) => item.name,
@@ -76,6 +88,7 @@
 		{
 			key: 'tag',
 			label: 'Tag',
+			description: 'Assigned tag names',
 			type: 'text',
 			accessor: (item) => item.tags.map((t) => t.name),
 			suggestions: (items) => [...new Set(items.flatMap((i) => i.tags.map((t) => t.name)))].sort()
@@ -83,6 +96,7 @@
 		{
 			key: 'tagged',
 			label: 'Tagged',
+			description: 'Whether any tags are assigned',
 			type: 'text',
 			accessor: (item) => (item.tags.length > 0 ? 'yes' : 'no'),
 			suggestions: () => ['yes', 'no']
@@ -90,20 +104,23 @@
 		{
 			key: 'description',
 			label: 'Description',
+			description: 'Quality profile description',
 			type: 'text',
 			accessor: (item) => item.description ?? null
 		},
 		{
 			key: 'language',
 			label: 'Language',
+			description: 'Configured profile language',
 			type: 'text',
-			accessor: (item) => item.language?.name ?? null,
+			accessor: qualityProfileLanguageLabel,
 			suggestions: (items) =>
-				[...new Set(items.map((i) => i.language?.name).filter(Boolean) as string[])].sort()
+				[...new Set(items.map(qualityProfileLanguageLabel))].sort()
 		},
 		{
 			key: 'upgrades',
 			label: 'Upgrades',
+			description: 'Whether upgrades are allowed',
 			type: 'text',
 			accessor: (item) => (item.upgrades_allowed ? 'yes' : 'no'),
 			suggestions: () => ['yes', 'no']
@@ -111,6 +128,7 @@
 		{
 			key: 'formats',
 			label: 'Formats',
+			description: 'Number of scored custom formats',
 			type: 'number',
 			accessor: (item) => item.custom_formats.total
 		}

--- a/src/routes/quality-profiles/[databaseId]/+page.svelte
+++ b/src/routes/quality-profiles/[databaseId]/+page.svelte
@@ -114,8 +114,7 @@
 			description: 'Configured profile language',
 			type: 'text',
 			accessor: qualityProfileLanguageLabel,
-			suggestions: (items) =>
-				[...new Set(items.map(qualityProfileLanguageLabel))].sort()
+			suggestions: (items) => [...new Set(items.map(qualityProfileLanguageLabel))].sort()
 		},
 		{
 			key: 'upgrades',

--- a/src/routes/regular-expressions/[databaseId]/+page.svelte
+++ b/src/routes/regular-expressions/[databaseId]/+page.svelte
@@ -25,6 +25,7 @@
 	import { alertStore } from '$alerts/store';
 	import type { RegularExpressionWithTags } from '$shared/pcd/display';
 	import { copyToClipboard } from '$lib/client/utils/clipboard';
+	import { regularExpressionSearchValues } from '$lib/client/utils/entitySearch';
 	import type { PageData } from './$types';
 
 	export let data: PageData;
@@ -70,8 +71,16 @@
 
 	const fields: FilterFieldDef<RegularExpressionWithTags>[] = [
 		{
+			key: 'all',
+			label: 'All',
+			description: 'Name, tags, pattern, description and Regex101 ID',
+			type: 'text',
+			accessor: regularExpressionSearchValues
+		},
+		{
 			key: 'name',
 			label: 'Name',
+			description: 'Regular expression name',
 			type: 'text',
 			isDefault: true,
 			accessor: (item) => item.name,
@@ -80,6 +89,7 @@
 		{
 			key: 'tag',
 			label: 'Tag',
+			description: 'Assigned tag names',
 			type: 'text',
 			accessor: (item) => item.tags.map((t) => t.name),
 			suggestions: (items) => [...new Set(items.flatMap((i) => i.tags.map((t) => t.name)))].sort()
@@ -87,6 +97,7 @@
 		{
 			key: 'tagged',
 			label: 'Tagged',
+			description: 'Whether any tags are assigned',
 			type: 'text',
 			accessor: (item) => (item.tags.length > 0 ? 'yes' : 'no'),
 			suggestions: () => ['yes', 'no']
@@ -94,6 +105,7 @@
 		{
 			key: 'referenced',
 			label: 'Referenced',
+			description: 'Whether a custom format uses it',
 			type: 'text',
 			accessor: (item) => (item.referenceCount > 0 ? 'yes' : 'no'),
 			suggestions: () => ['yes', 'no']
@@ -101,18 +113,21 @@
 		{
 			key: 'pattern',
 			label: 'Pattern',
+			description: 'Regular expression pattern',
 			type: 'text',
 			accessor: (item) => item.pattern
 		},
 		{
 			key: 'description',
 			label: 'Description',
+			description: 'Regular expression description',
 			type: 'text',
 			accessor: (item) => item.description ?? null
 		},
 		{
 			key: 'regex101_id',
 			label: 'Regex101 ID',
+			description: 'Linked Regex101 identifier',
 			type: 'text',
 			accessor: (item) => item.regex101_id ?? null
 		}


### PR DESCRIPTION
- Add an All text filter to custom formats, quality profiles, and regular expressions.
- Add concise descriptions to smart-filter field choices.
- Keep name-only filtering as the default behavior.

Closes #769