### PR TITLE
fix: add setting to disable sync prompt

### DIFF
--- a/src/lib/server/db/migrations.ts
+++ b/src/lib/server/db/migrations.ts
@@ -70,6 +70,7 @@ import { migration as migration065 } from './migrations/065_create_arr_drift_tab
 import { migration as migration066 } from './migrations/066_add_date_format_setting.ts';
 import { migration as migration067 } from './migrations/067_enable_all_arr_instances.ts';
 import { migration as migration069 } from './migrations/069_create_arr_sync_database_priority.ts';
+import { migration as migration070 } from './migrations/070_add_sync_prompt_setting.ts';
 
 export interface Migration {
 	version: number;
@@ -358,7 +359,8 @@ export function loadMigrations(): Migration[] {
 		migration065,
 		migration066,
 		migration067,
-		migration069
+		migration069,
+		migration070
 	];
 
 	// Sort by version number

--- a/src/lib/server/db/migrations/070_add_sync_prompt_setting.ts
+++ b/src/lib/server/db/migrations/070_add_sync_prompt_setting.ts
@@ -1,0 +1,21 @@
+import type { Migration } from '../migrations.ts';
+
+/**
+ * Migration 070: Add sync prompt setting
+ *
+ * Controls whether saving an entity prompts to sync affected Arr instances.
+ */
+
+export const migration: Migration = {
+	version: 70,
+	name: 'Add sync prompt setting',
+
+	up: `
+		ALTER TABLE general_settings
+		ADD COLUMN sync_prompt_enabled INTEGER NOT NULL DEFAULT 1;
+	`,
+
+	down: `
+		ALTER TABLE general_settings DROP COLUMN sync_prompt_enabled;
+	`
+};

--- a/src/lib/server/db/queries/generalSettings.ts
+++ b/src/lib/server/db/queries/generalSettings.ts
@@ -11,6 +11,7 @@ export interface GeneralSettings {
 	date_format: DateFormat;
 	apply_default_delay_profiles: number; // 1=true, 0=false
 	fail_on_referenced_delete: number; // 1=true, 0=false
+	sync_prompt_enabled: number; // 1=true, 0=false
 	created_at: string;
 	updated_at: string;
 }
@@ -19,6 +20,7 @@ export interface UpdateGeneralSettingsInput {
 	dateFormat?: DateFormat;
 	applyDefaultDelayProfiles?: boolean;
 	failOnReferencedDelete?: boolean;
+	syncPromptEnabled?: boolean;
 }
 
 /**
@@ -50,6 +52,14 @@ export const generalSettingsQueries = {
 	},
 
 	/**
+	 * Check if entity saves should prompt to sync affected Arr instances
+	 */
+	shouldShowSyncPrompt(): boolean {
+		const settings = this.get();
+		return settings?.sync_prompt_enabled !== 0;
+	},
+
+	/**
 	 * Update general settings
 	 */
 	update(input: UpdateGeneralSettingsInput): boolean {
@@ -69,6 +79,11 @@ export const generalSettingsQueries = {
 		if (input.failOnReferencedDelete !== undefined) {
 			updates.push('fail_on_referenced_delete = ?');
 			params.push(input.failOnReferencedDelete ? 1 : 0);
+		}
+
+		if (input.syncPromptEnabled !== undefined) {
+			updates.push('sync_prompt_enabled = ?');
+			params.push(input.syncPromptEnabled ? 1 : 0);
 		}
 
 		if (updates.length === 0) {

--- a/src/lib/server/db/schema.sql
+++ b/src/lib/server/db/schema.sql
@@ -856,7 +856,7 @@ CREATE INDEX idx_rename_runs_status ON rename_runs(status);
 -- ==============================================================================
 -- TABLE: general_settings
 -- Purpose: Store general app-wide settings (singleton pattern with id=1)
--- Migration: 030_create_general_settings.ts, 064_add_fail_on_referenced_delete.ts, 066_add_date_format_setting.ts
+-- Migration: 030_create_general_settings.ts, 064_add_fail_on_referenced_delete.ts, 066_add_date_format_setting.ts, 070_add_sync_prompt_setting.ts
 -- ==============================================================================
 
 CREATE TABLE general_settings (
@@ -868,6 +868,7 @@ CREATE TABLE general_settings (
     -- Default delay profile settings
     apply_default_delay_profiles INTEGER NOT NULL DEFAULT 1,  -- 1=apply defaults when adding arr, 0=don't
     fail_on_referenced_delete INTEGER NOT NULL DEFAULT 1,     -- 1=block referenced CF/regex deletes, 0=allow cleanup ops
+    sync_prompt_enabled INTEGER NOT NULL DEFAULT 1,           -- 1=prompt after entity saves, 0=redirect normally
 
     -- Metadata
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,

--- a/src/lib/server/sync/affectedArrs.ts
+++ b/src/lib/server/sync/affectedArrs.ts
@@ -4,6 +4,7 @@
  */
 
 import { arrSyncQueries } from '$db/queries/arrSync.ts';
+import { generalSettingsQueries } from '$db/queries/generalSettings.ts';
 import { getCache } from '$pcd/index.ts';
 import type { AffectedArr } from '$shared/sync/types.ts';
 
@@ -17,7 +18,8 @@ type EntityType =
 	| 'mediaSettings';
 
 /**
- * Find all arr instances affected by an entity change
+ * Find all Arr instances to show in the post-save sync prompt.
+ * Returns no instances when the prompt is disabled.
  */
 export function getAffectedArrs({
 	entityType,
@@ -29,6 +31,8 @@ export function getAffectedArrs({
 	entityName: string;
 }): AffectedArr[] {
 	try {
+		if (!generalSettingsQueries.shouldShowSyncPrompt()) return [];
+
 		switch (entityType) {
 			case 'qualityProfile':
 				return getAffectedArrsForQualityProfile(databaseId, entityName);

--- a/src/routes/settings/general/+page.server.ts
+++ b/src/routes/settings/general/+page.server.ts
@@ -70,7 +70,8 @@ export const load = () => {
 		generalSettings: {
 			date_format: generalSetting.date_format,
 			apply_default_delay_profiles: generalSetting.apply_default_delay_profiles === 1,
-			fail_on_referenced_delete: generalSetting.fail_on_referenced_delete === 1
+			fail_on_referenced_delete: generalSetting.fail_on_referenced_delete === 1,
+			sync_prompt_enabled: generalSetting.sync_prompt_enabled === 1
 		}
 	};
 };
@@ -149,6 +150,7 @@ export const actions: Actions = {
 		// --- Behavior ---
 		const arrApplyDefaultDelayProfiles = formData.get('arr_apply_default_delay_profiles') === 'on';
 		const failOnReferencedDelete = formData.get('fail_on_referenced_delete') === 'on';
+		const syncPromptEnabled = formData.get('sync_prompt_enabled') === 'on';
 
 		// --- Persist all settings ---
 		const logUpdated = logSettingsQueries.update({
@@ -209,7 +211,8 @@ export const actions: Actions = {
 		const arrUpdated = generalSettingsQueries.update({
 			dateFormat,
 			applyDefaultDelayProfiles: arrApplyDefaultDelayProfiles,
-			failOnReferencedDelete
+			failOnReferencedDelete,
+			syncPromptEnabled
 		});
 
 		if (!arrUpdated) {
@@ -238,7 +241,8 @@ export const actions: Actions = {
 				aiModel,
 				dateFormat,
 				arrApplyDefaultDelayProfiles,
-				failOnReferencedDelete
+				failOnReferencedDelete,
+				syncPromptEnabled
 			}
 		});
 

--- a/src/routes/settings/general/+page.svelte
+++ b/src/routes/settings/general/+page.svelte
@@ -68,6 +68,7 @@
 	// Behavior
 	let arrApplyDefaultDelayProfiles = data.generalSettings.apply_default_delay_profiles;
 	let failOnReferencedDelete = data.generalSettings.fail_on_referenced_delete;
+	let syncPromptEnabled = data.generalSettings.sync_prompt_enabled;
 
 	// UI (client-side stores)
 	let uiNavIconStyle: NavIconStyle = 'lucide';
@@ -153,6 +154,7 @@
 			tmdb_api_key: tmdbApiKey,
 			arr_apply_default_delay_profiles: arrApplyDefaultDelayProfiles,
 			fail_on_referenced_delete: failOnReferencedDelete,
+			sync_prompt_enabled: syncPromptEnabled,
 			ui_nav_icon_style: uiNavIconStyle,
 			ui_alert_position: uiAlertPosition,
 			ui_alert_duration_seconds: uiAlertDurationSeconds,
@@ -466,6 +468,17 @@
 							update('fail_on_referenced_delete', e.detail);
 						}}
 					/>
+					<Toggle
+						label="Prompt to Sync Changes"
+						checked={syncPromptEnabled}
+						infoHeader="Prompt to Sync Changes"
+						infoBody="When enabled, Profilarr prompts you to sync affected Arr instances after saving an entity. Disable this to return normally without offering an immediate sync."
+						fullWidth
+						on:change={(e) => {
+							syncPromptEnabled = e.detail;
+							update('sync_prompt_enabled', e.detail);
+						}}
+					/>
 					<input
 						type="hidden"
 						name="arr_apply_default_delay_profiles"
@@ -475,6 +488,11 @@
 						type="hidden"
 						name="fail_on_referenced_delete"
 						value={failOnReferencedDelete ? 'on' : ''}
+					/>
+					<input
+						type="hidden"
+						name="sync_prompt_enabled"
+						value={syncPromptEnabled ? 'on' : ''}
 					/>
 				</div>
 			</ExpandableCard>

--- a/src/routes/settings/general/+page.svelte
+++ b/src/routes/settings/general/+page.svelte
@@ -489,11 +489,7 @@
 						name="fail_on_referenced_delete"
 						value={failOnReferencedDelete ? 'on' : ''}
 					/>
-					<input
-						type="hidden"
-						name="sync_prompt_enabled"
-						value={syncPromptEnabled ? 'on' : ''}
-					/>
+					<input type="hidden" name="sync_prompt_enabled" value={syncPromptEnabled ? 'on' : ''} />
 				</div>
 			</ExpandableCard>
 

--- a/tests/integration/backups/specs/settings.test.ts
+++ b/tests/integration/backups/specs/settings.test.ts
@@ -108,6 +108,7 @@ async function saveGeneralSettings(fields: {
 		{
 			date_format: 'auto',
 			arr_apply_default_delay_profiles: 'on',
+			sync_prompt_enabled: 'on',
 			backup_enabled: 'on',
 			backup_schedule: fields.backupSchedule,
 			backup_retention_days: String(fields.backupRetentionDays),


### PR DESCRIPTION
- Add an app-wide Behavior setting for post-save sync prompts
- Skip affected Arr lookup when the prompt is disabled
- Keep existing behavior enabled by default

Closes #719