### PR TITLE
fix: calculate Sonarr upgrade scores from episode files

### DIFF
--- a/docs/backend/upgrades.md
+++ b/docs/backend/upgrades.md
@@ -114,7 +114,16 @@ by dropping incompatible rules.
 
 Each filter also carries a **cutoff** (0-100%), a percentage of the quality
 profile's cutoff score. Items whose current score meets or exceeds the
-threshold are considered "cutoff met" and can be filtered out.
+threshold are considered "cutoff met" and can be filtered out. Radarr uses
+the movie file's custom format score. Sonarr uses the average custom format
+score across all existing episode files in the series; a series without files
+has not met cutoff.
+
+Sonarr episode files are fetched only when the active filter uses `cutoff_met`
+or the Lowest Score selector. Sonarr requires one episode-file request per
+file-bearing series, so Profilarr fetches them with bounded concurrency. Filter
+preview caches the results for 5 minutes; real upgrade runs always fetch fresh
+scores.
 
 ## Dynamic Filter Values
 
@@ -157,6 +166,8 @@ specifies a selector strategy and a count (items per run).
 | `alphabetical_desc` | Z-A by title                     |
 
 Selector definitions live in `src/lib/shared/upgrades/selectors.ts`.
+For Sonarr, Lowest Score uses the average custom format score across every
+episode file in the series.
 
 ## Filter Preview
 
@@ -223,8 +234,9 @@ cooldown across them.
 Dry-run mode fetches available releases for each selected item and compares
 scores without triggering actual searches. This lets users preview what the
 system would do. For Sonarr, dry runs only query monitored seasons that already
-have files; selected series without an eligible season are shown without a
-previewed upgrade.
+have files, and compare a release against the average score of files in the
+searched season. Selected series without an eligible season are shown without
+a previewed upgrade.
 
 An in-memory exclusion cache (1-hour TTL, keyed by instance ID) tracks items
 selected in previous dry runs so the same items aren't re-picked on repeated

--- a/src/lib/server/upgrades/normalize.ts
+++ b/src/lib/server/upgrades/normalize.ts
@@ -6,6 +6,7 @@
 import type {
 	RadarrMovie,
 	RadarrMovieFile,
+	SonarrEpisodeFile,
 	SonarrSeries,
 	ArrQualityProfile,
 	CustomFormatRef,
@@ -13,6 +14,7 @@ import type {
 	ScoreBreakdownItem
 } from '$lib/server/utils/arr/types.ts';
 import type { UpgradeItem } from './types.ts';
+import { averageEpisodeFileScore } from './sonarrScores.ts';
 
 function getFileName(path: string | undefined): string {
 	if (!path) return '';
@@ -158,19 +160,20 @@ export function normalizeRadarrItems(
  * @param series - The raw series from Sonarr API
  * @param profile - The quality profile
  * @param cutoffPercent - The cutoff percentage from filter config (0-100)
+ * @param episodeFiles - Episode files used to calculate the series score when hydrated
  * @param tagMap - Map of tag IDs to labels for resolving tag names
  */
 export function normalizeSonarrItem(
 	series: SonarrSeries,
 	profile: ArrQualityProfile | undefined,
-	_cutoffPercent: number,
+	cutoffPercent: number,
+	episodeFiles?: SonarrEpisodeFile[],
 	tagMap?: Map<number, string>
 ): UpgradeItem {
-	// Score: 0 for now (series-level score requires fetching all episode files)
-	const currentScore = 0;
-
-	// Cutoff: always false for now (no series-level score)
-	const cutoffMet = false;
+	const currentScore = episodeFiles ? averageEpisodeFileScore(episodeFiles) : 0;
+	const profileCutoff = profile?.cutoffFormatScore ?? 0;
+	const cutoffThreshold = (profileCutoff * cutoffPercent) / 100;
+	const cutoffMet = Boolean(episodeFiles?.length) && currentScore >= cutoffThreshold;
 
 	// Convert size to GB
 	const sizeOnDiskGB = (series.statistics?.sizeOnDisk ?? 0) / (1024 * 1024 * 1024);
@@ -244,10 +247,17 @@ export function normalizeSonarrItems(
 	seriesList: SonarrSeries[],
 	profileMap: Map<number, ArrQualityProfile>,
 	cutoffPercent: number,
+	episodeFileMap?: Map<number, SonarrEpisodeFile[]>,
 	tagMap?: Map<number, string>
 ): UpgradeItem[] {
 	return seriesList.map((series) => {
 		const profile = profileMap.get(series.qualityProfileId);
-		return normalizeSonarrItem(series, profile, cutoffPercent, tagMap);
+		return normalizeSonarrItem(
+			series,
+			profile,
+			cutoffPercent,
+			episodeFileMap?.get(series.id),
+			tagMap
+		);
 	});
 }

--- a/src/lib/server/upgrades/preview.ts
+++ b/src/lib/server/upgrades/preview.ts
@@ -23,6 +23,11 @@ import {
 import { getSelector } from '$shared/upgrades/selectors.ts';
 import { hasFilterTag, resolveTagLabel } from './cooldown.ts';
 import { normalizeRadarrItems, normalizeSonarrItems } from './normalize.ts';
+import {
+	filterNeedsSonarrScores,
+	loadSonarrEpisodeFiles,
+	type SonarrEpisodeFileMap
+} from './sonarrScores.ts';
 import type { UpgradeItem } from './types.ts';
 
 export type UpgradeFilterPreviewStatus = 'selected' | 'selectable' | 'cooldown' | 'filtered_out';
@@ -79,6 +84,7 @@ interface SonarrPreviewCacheEntry {
 	series: SonarrSeries[];
 	profiles: ArrQualityProfile[];
 	tags: ArrTag[];
+	episodeFiles?: SonarrEpisodeFileMap;
 }
 
 interface PreviewLoadResult {
@@ -298,11 +304,10 @@ async function loadSonarrItems(
 	let series: SonarrSeries[];
 	let profiles: ArrQualityProfile[];
 	let tags: ArrTag[];
+	let cacheEntry: SonarrPreviewCacheEntry;
 
 	if (cached && cached.expiresAt > now) {
-		series = cached.series;
-		profiles = cached.profiles;
-		tags = cached.tags;
+		cacheEntry = cached;
 	} else {
 		const [loadedSeries, loadedProfiles] = await Promise.all([
 			client.getAllSeries(),
@@ -310,21 +315,28 @@ async function loadSonarrItems(
 		]);
 		const loadedTags = await client.getTags();
 
-		series = loadedSeries;
-		profiles = loadedProfiles;
-		tags = loadedTags;
-
-		sonarrPreviewCache.set(instanceId, {
+		cacheEntry = {
 			expiresAt: Date.now() + PREVIEW_CACHE_TTL_MS,
-			series,
-			profiles,
-			tags
-		});
+			series: loadedSeries,
+			profiles: loadedProfiles,
+			tags: loadedTags
+		};
+		sonarrPreviewCache.set(instanceId, cacheEntry);
+	}
+
+	series = cacheEntry.series;
+	profiles = cacheEntry.profiles;
+	tags = cacheEntry.tags;
+
+	let episodeFiles: SonarrEpisodeFileMap | undefined;
+	if (filterNeedsSonarrScores(filter)) {
+		episodeFiles = await loadSonarrEpisodeFiles(client, series, cacheEntry.episodeFiles);
+		cacheEntry.episodeFiles = episodeFiles;
 	}
 
 	const profileMap = new Map(profiles.map((profile) => [profile.id, profile]));
 	const tagMap = new Map(tags.map((tag) => [tag.id, tag.label]));
-	const items = normalizeSonarrItems(series, profileMap, filter.cutoff, tagMap);
+	const items = normalizeSonarrItems(series, profileMap, filter.cutoff, episodeFiles, tagMap);
 
 	return {
 		items,

--- a/src/lib/server/upgrades/preview.ts
+++ b/src/lib/server/upgrades/preview.ts
@@ -301,9 +301,6 @@ async function loadSonarrItems(
 ): Promise<PreviewLoadResult> {
 	const cached = sonarrPreviewCache.get(instanceId);
 	const now = Date.now();
-	let series: SonarrSeries[];
-	let profiles: ArrQualityProfile[];
-	let tags: ArrTag[];
 	let cacheEntry: SonarrPreviewCacheEntry;
 
 	if (cached && cached.expiresAt > now) {
@@ -324,9 +321,7 @@ async function loadSonarrItems(
 		sonarrPreviewCache.set(instanceId, cacheEntry);
 	}
 
-	series = cacheEntry.series;
-	profiles = cacheEntry.profiles;
-	tags = cacheEntry.tags;
+	const { series, profiles, tags } = cacheEntry;
 
 	let episodeFiles: SonarrEpisodeFileMap | undefined;
 	if (filterNeedsSonarrScores(filter)) {

--- a/src/lib/server/upgrades/processor.ts
+++ b/src/lib/server/upgrades/processor.ts
@@ -9,12 +9,7 @@ import type { ArrInstance } from '$lib/server/db/queries/arrInstances.ts';
 import type { UpgradeConfig, FilterConfig } from '$shared/upgrades/filters.ts';
 import { evaluateGroup } from '$shared/upgrades/filters.ts';
 import { getSelector } from '$shared/upgrades/selectors.ts';
-import type {
-	UpgradeItem,
-	UpgradeJobLog,
-	UpgradeSelectionItem,
-	UpgradeOriginal
-} from './types.ts';
+import type { UpgradeItem, UpgradeJobLog, UpgradeSelectionItem, UpgradeOriginal } from './types.ts';
 import type {
 	RadarrMovie,
 	RadarrMovieFile,
@@ -548,10 +543,7 @@ export async function processUpgradeConfig(
 								sonarrEpisodeFiles.get(item.id) ?? [],
 								searchedSeason
 							);
-							const releases = await (client as SonarrClient).getReleases(
-								item.id,
-								searchedSeason
-							);
+							const releases = await (client as SonarrClient).getReleases(item.id, searchedSeason);
 							bestRelease = releases.find((r) => r.approved && !r.rejected);
 						}
 

--- a/src/lib/server/upgrades/processor.ts
+++ b/src/lib/server/upgrades/processor.ts
@@ -13,8 +13,7 @@ import type {
 	UpgradeItem,
 	UpgradeJobLog,
 	UpgradeSelectionItem,
-	UpgradeOriginal,
-	UpgradeOriginalEpisode
+	UpgradeOriginal
 } from './types.ts';
 import type {
 	RadarrMovie,
@@ -26,6 +25,12 @@ import type {
 	SonarrQueueItem
 } from '$lib/server/utils/arr/types.ts';
 import { normalizeRadarrItems, normalizeSonarrItems } from './normalize.ts';
+import {
+	averageEpisodeFileScore,
+	filterNeedsSonarrScores,
+	loadSonarrEpisodeFiles,
+	type SonarrEpisodeFileMap
+} from './sonarrScores.ts';
 import {
 	filterByFilterTag,
 	resolveTagLabel,
@@ -356,8 +361,8 @@ export async function processUpgradeConfig(
 
 		// Radarr-only: movie file map for original file lookup
 		let movieFileMap: Map<number, RadarrMovieFile> | undefined;
-		// Sonarr-only: episode file names cache (populated after selection)
-		const episodeFileCache = new Map<number, UpgradeOriginalEpisode[]>();
+		// Sonarr-only: episode files loaded for scoring and original-file details
+		let sonarrEpisodeFiles: SonarrEpisodeFileMap = new Map();
 
 		if (isRadarr) {
 			const radarr = client as RadarrClient;
@@ -405,14 +410,28 @@ export async function processUpgradeConfig(
 
 			tags = await sonarr.getTags();
 			const tagMap = new Map(tags.map((t) => [t.id, t.label]));
+			if (filterNeedsSonarrScores(filter)) {
+				sonarrEpisodeFiles = await loadSonarrEpisodeFiles(sonarr, allSeries);
+			}
 
-			normalizedItems = normalizeSonarrItems(allSeries, profileMap, filter.cutoff, tagMap);
+			normalizedItems = normalizeSonarrItems(
+				allSeries,
+				profileMap,
+				filter.cutoff,
+				sonarrEpisodeFiles,
+				tagMap
+			);
 			totalItems = allSeries.length;
 
 			getOriginalFile = (item: UpgradeItem) => ({
 				type: 'series' as const,
 				title: item.title,
-				episodes: episodeFileCache.get(item.id) ?? []
+				episodes: (sonarrEpisodeFiles.get(item.id) ?? []).map((file) => ({
+					seasonNumber: file.seasonNumber,
+					fileName: file.relativePath?.split('/').pop() ?? 'Unknown',
+					formats: file.customFormats?.map((format) => format.name) ?? [],
+					score: file.customFormatScore ?? 0
+				}))
 			});
 		}
 
@@ -472,23 +491,14 @@ export async function processUpgradeConfig(
 			? selector.select(availableItems, filter.count)
 			: availableItems.slice(0, filter.count);
 
-		// Fetch episode files for selected Sonarr series (only for selected items, not whole library)
+		// Fetch missing episode files for selected Sonarr series and reuse score hydration data.
 		if (!isRadarr && selectedItems.length > 0) {
 			const sonarr = client as SonarrClient;
-			for (const item of selectedItems) {
-				try {
-					const epFiles = await sonarr.getEpisodeFiles(item.id);
-					const episodes: UpgradeOriginalEpisode[] = epFiles.map((f) => ({
-						seasonNumber: f.seasonNumber,
-						fileName: f.relativePath?.split('/').pop() ?? 'Unknown',
-						formats: f.customFormats?.map((cf) => cf.name) ?? [],
-						score: f.customFormatScore ?? 0
-					}));
-					episodeFileCache.set(item.id, episodes);
-				} catch {
-					episodeFileCache.set(item.id, []);
-				}
-			}
+			sonarrEpisodeFiles = await loadSonarrEpisodeFiles(
+				sonarr,
+				selectedItems.map((item) => item._raw as SonarrSeries),
+				sonarrEpisodeFiles
+			);
 		}
 
 		// =====================================================================
@@ -512,6 +522,7 @@ export async function processUpgradeConfig(
 				for (const item of selectedItems) {
 					const original = getOriginalFile(item);
 					let searchedSeason: number | undefined;
+					let currentComparisonScore = item.score;
 					try {
 						let bestRelease:
 							| { title: string; customFormats: { name: string }[]; customFormatScore: number }
@@ -533,11 +544,18 @@ export async function processUpgradeConfig(
 								});
 								continue;
 							}
-							const releases = await (client as SonarrClient).getReleases(item.id, searchedSeason);
+							currentComparisonScore = averageEpisodeFileScore(
+								sonarrEpisodeFiles.get(item.id) ?? [],
+								searchedSeason
+							);
+							const releases = await (client as SonarrClient).getReleases(
+								item.id,
+								searchedSeason
+							);
 							bestRelease = releases.find((r) => r.approved && !r.rejected);
 						}
 
-						if (bestRelease && bestRelease.customFormatScore > item.score) {
+						if (bestRelease && bestRelease.customFormatScore > currentComparisonScore) {
 							selectionItems.push({
 								id: item.id,
 								title: item.title,

--- a/src/lib/server/upgrades/sonarrScores.ts
+++ b/src/lib/server/upgrades/sonarrScores.ts
@@ -6,14 +6,9 @@ const EPISODE_FILE_FETCH_CONCURRENCY = 10;
 
 export type SonarrEpisodeFileMap = Map<number, SonarrEpisodeFile[]>;
 
-export function averageEpisodeFileScore(
-	files: SonarrEpisodeFile[],
-	seasonNumber?: number
-): number {
+export function averageEpisodeFileScore(files: SonarrEpisodeFile[], seasonNumber?: number): number {
 	const matchingFiles =
-		seasonNumber === undefined
-			? files
-			: files.filter((file) => file.seasonNumber === seasonNumber);
+		seasonNumber === undefined ? files : files.filter((file) => file.seasonNumber === seasonNumber);
 
 	if (matchingFiles.length === 0) return 0;
 

--- a/src/lib/server/upgrades/sonarrScores.ts
+++ b/src/lib/server/upgrades/sonarrScores.ts
@@ -1,0 +1,72 @@
+import type { SonarrClient } from '$utils/arr/clients/sonarr.ts';
+import type { SonarrEpisodeFile, SonarrSeries } from '$utils/arr/types.ts';
+import { filterGroupUsesField, type FilterConfig } from '$shared/upgrades/filters.ts';
+
+const EPISODE_FILE_FETCH_CONCURRENCY = 10;
+
+export type SonarrEpisodeFileMap = Map<number, SonarrEpisodeFile[]>;
+
+export function averageEpisodeFileScore(
+	files: SonarrEpisodeFile[],
+	seasonNumber?: number
+): number {
+	const matchingFiles =
+		seasonNumber === undefined
+			? files
+			: files.filter((file) => file.seasonNumber === seasonNumber);
+
+	if (matchingFiles.length === 0) return 0;
+
+	return (
+		matchingFiles.reduce((total, file) => total + (file.customFormatScore ?? 0), 0) /
+		matchingFiles.length
+	);
+}
+
+export function filterNeedsSonarrScores(filter: FilterConfig): boolean {
+	return filter.selector === 'lowest_score' || filterGroupUsesField(filter.group, 'cutoff_met');
+}
+
+function getEpisodeFileCount(series: SonarrSeries): number | undefined {
+	if (series.statistics) return series.statistics.episodeFileCount;
+	if (series.seasons.every((season) => season.statistics)) {
+		return series.seasons.reduce(
+			(total, season) => total + (season.statistics?.episodeFileCount ?? 0),
+			0
+		);
+	}
+	return undefined;
+}
+
+export async function loadSonarrEpisodeFiles(
+	client: SonarrClient,
+	seriesList: SonarrSeries[],
+	existing: SonarrEpisodeFileMap = new Map()
+): Promise<SonarrEpisodeFileMap> {
+	const result = new Map(existing);
+	const missing = seriesList.filter((series) => !result.has(series.id));
+
+	for (let index = 0; index < missing.length; index += EPISODE_FILE_FETCH_CONCURRENCY) {
+		const batch = missing.slice(index, index + EPISODE_FILE_FETCH_CONCURRENCY);
+		const loaded = await Promise.all(
+			batch.map(async (series) => {
+				if (getEpisodeFileCount(series) === 0) {
+					return [series.id, [] as SonarrEpisodeFile[]] as const;
+				}
+
+				try {
+					return [series.id, await client.getEpisodeFiles(series.id)] as const;
+				} catch (error) {
+					const message = error instanceof Error ? error.message : String(error);
+					throw new Error(`Failed to fetch episode files for "${series.title}": ${message}`);
+				}
+			})
+		);
+
+		for (const [seriesId, files] of loaded) {
+			result.set(seriesId, files);
+		}
+	}
+
+	return result;
+}

--- a/src/lib/server/upgrades/types.ts
+++ b/src/lib/server/upgrades/types.ts
@@ -57,6 +57,7 @@ export interface UpgradeItem {
 
 	// For selectors (camelCase versions)
 	dateAdded: string;
+	/** Radarr file score, or Sonarr episode-file average when score data is required. */
 	score: number;
 
 	// Original data for API calls

--- a/src/lib/shared/upgrades/filters.ts
+++ b/src/lib/shared/upgrades/filters.ts
@@ -974,6 +974,15 @@ export function isGroup(child: FilterRule | FilterGroup): child is FilterGroup {
 	return child.type === 'group';
 }
 
+/**
+ * Check whether a filter group contains a rule for a field, including nested groups.
+ */
+export function filterGroupUsesField(group: FilterGroup, fieldId: string): boolean {
+	return group.children.some((child) =>
+		isRule(child) ? child.field === fieldId : filterGroupUsesField(child, fieldId)
+	);
+}
+
 function getMultiValueItems(value: unknown): string[] {
 	if (Array.isArray(value)) {
 		return value.map((item) => String(item).trim()).filter(Boolean);

--- a/src/lib/shared/upgrades/selectors.ts
+++ b/src/lib/shared/upgrades/selectors.ts
@@ -74,7 +74,7 @@ export const selectors: Selector[] = [
 	{
 		id: 'lowest_score',
 		label: 'Lowest Score',
-		description: 'Select items with lowest custom format score',
+		description: 'Select items with lowest custom format score (Sonarr: series average)',
 		select: (items, count) => {
 			const sorted = [...items].sort((a, b) => (a.score || 0) - (b.score || 0));
 			return sorted.slice(0, count);

--- a/src/routes/arr/upgrades/info/+page.svelte
+++ b/src/routes/arr/upgrades/info/+page.svelte
@@ -90,7 +90,7 @@
 			name: 'Cutoff %',
 			summary: 'Quality score threshold for the Cutoff Met field',
 			details:
-				'The Cutoff Met filter field checks if an item\'s custom format score has reached this percentage of the profile\'s cutoff score. Set to 80% means items below 80% of their cutoff will have "Cutoff Met = false".'
+				'The Cutoff Met filter field checks if an item\'s custom format score has reached this percentage of the profile\'s cutoff score. Radarr uses the movie file score; Sonarr uses the average score across every episode file in the series. Set to 80% means items below 80% of their cutoff will have "Cutoff Met = false".'
 		},
 		{
 			id: 'multiple-filters',

--- a/tests/unit/upgrades/filters.test.ts
+++ b/tests/unit/upgrades/filters.test.ts
@@ -27,9 +27,7 @@ class FilterEvaluationTest extends BaseTest {
 					{
 						type: 'group',
 						match: 'any',
-						children: [
-							{ type: 'rule', field: 'cutoff_met', operator: 'is', value: false }
-						]
+						children: [{ type: 'rule', field: 'cutoff_met', operator: 'is', value: false }]
 					}
 				]
 			};

--- a/tests/unit/upgrades/filters.test.ts
+++ b/tests/unit/upgrades/filters.test.ts
@@ -10,6 +10,7 @@ import {
 	evaluateGroup,
 	getDynamicFilterFieldIds,
 	getFilterFields,
+	filterGroupUsesField,
 	normalizeFilterGroup,
 	type FilterRule,
 	type FilterGroup
@@ -17,6 +18,26 @@ import {
 
 class FilterEvaluationTest extends BaseTest {
 	runTests(): void {
+		this.test('field usage detects rules in nested groups', () => {
+			const group: FilterGroup = {
+				type: 'group',
+				match: 'all',
+				children: [
+					{ type: 'rule', field: 'monitored', operator: 'is', value: true },
+					{
+						type: 'group',
+						match: 'any',
+						children: [
+							{ type: 'rule', field: 'cutoff_met', operator: 'is', value: false }
+						]
+					}
+				]
+			};
+
+			assertEquals(filterGroupUsesField(group, 'cutoff_met'), true);
+			assertEquals(filterGroupUsesField(group, 'year'), false);
+		});
+
 		// =====================
 		// Boolean Operators
 		// =====================

--- a/tests/unit/upgrades/normalize.test.ts
+++ b/tests/unit/upgrades/normalize.test.ts
@@ -14,6 +14,7 @@ import type {
 	RadarrMovie,
 	RadarrMovieFile,
 	ArrQualityProfile,
+	SonarrEpisodeFile,
 	SonarrSeries
 } from '../../../src/lib/server/utils/arr/types.ts';
 
@@ -123,6 +124,20 @@ class NormalizeTest extends BaseTest {
 				{ format: 1440, name: '1080p WEB-DL', score: 200000 },
 				{ format: 1424, name: '1080p Bluray', score: 140000 }
 			],
+			...overrides
+		};
+	}
+
+	private createMockEpisodeFile(overrides: Partial<SonarrEpisodeFile> = {}): SonarrEpisodeFile {
+		return {
+			id: 1,
+			seriesId: 1,
+			seasonNumber: 1,
+			size: 1_000_000,
+			quality: { quality: { id: 1, name: 'WEBDL-1080p' } },
+			customFormats: [],
+			customFormatScore: 0,
+			qualityCutoffNotMet: true,
 			...overrides
 		};
 	}
@@ -520,6 +535,62 @@ class NormalizeTest extends BaseTest {
 			const result = normalizeSonarrItem(series, profile, 80);
 
 			assertEquals(result.custom_formats, []);
+		});
+
+		this.test('normalizes sonarr score as the episode-file average', () => {
+			const series: SonarrSeries = {
+				id: 1,
+				title: 'Example Series',
+				qualityProfileId: 7,
+				monitored: true,
+				seasons: []
+			};
+			const profile = this.createMockProfile({ cutoffFormatScore: 201 });
+			const files = [
+				this.createMockEpisodeFile({ id: 1, customFormatScore: 100 }),
+				this.createMockEpisodeFile({ id: 2, customFormatScore: 101 })
+			];
+
+			const result = normalizeSonarrItem(series, profile, 50, files);
+
+			assertEquals(result.score, 100.5);
+			assertEquals(result.cutoff_met, true);
+		});
+
+		this.test('normalizes sonarr cutoff as not met when the average is below threshold', () => {
+			const series: SonarrSeries = {
+				id: 1,
+				title: 'Example Series',
+				qualityProfileId: 7,
+				monitored: true,
+				seasons: []
+			};
+			const profile = this.createMockProfile({ cutoffFormatScore: 400 });
+			const files = [
+				this.createMockEpisodeFile({ id: 1, customFormatScore: -100 }),
+				this.createMockEpisodeFile({ id: 2, customFormatScore: 200 })
+			];
+
+			const result = normalizeSonarrItem(series, profile, 80, files);
+
+			assertEquals(result.score, 50);
+			assertEquals(result.cutoff_met, false);
+		});
+
+		this.test('normalizes sonarr series without files as zero and cutoff not met', () => {
+			const series: SonarrSeries = {
+				id: 1,
+				title: 'Example Series',
+				qualityProfileId: 7,
+				monitored: true,
+				seasons: []
+			};
+			const profile = this.createMockProfile({ cutoffFormatScore: 0 });
+
+			const result = normalizeSonarrItem(series, profile, 100, []);
+
+			assertEquals(result.score, 0);
+			assertEquals(result.cutoff_met, false);
 		});
 
 		// =====================

--- a/tests/unit/upgrades/sonarrScores.test.ts
+++ b/tests/unit/upgrades/sonarrScores.test.ts
@@ -1,0 +1,150 @@
+import { assertEquals, assertRejects } from '@std/assert';
+import { BaseTest } from '../base/BaseTest.ts';
+import type { SonarrClient } from '$utils/arr/clients/sonarr.ts';
+import type { SonarrEpisodeFile, SonarrSeries } from '$utils/arr/types.ts';
+import type { FilterConfig } from '$shared/upgrades/filters.ts';
+import {
+	averageEpisodeFileScore,
+	filterNeedsSonarrScores,
+	loadSonarrEpisodeFiles
+} from '$lib/server/upgrades/sonarrScores.ts';
+
+class SonarrScoresTest extends BaseTest {
+	private createSeries(id: number, episodeFileCount: number): SonarrSeries {
+		return {
+			id,
+			title: `Series ${id}`,
+			qualityProfileId: 1,
+			monitored: true,
+			seasons: [],
+			statistics: {
+				seasonCount: 1,
+				episodeFileCount,
+				episodeCount: episodeFileCount,
+				totalEpisodeCount: episodeFileCount,
+				sizeOnDisk: episodeFileCount * 1_000_000,
+				percentOfEpisodes: episodeFileCount > 0 ? 100 : 0
+			}
+		};
+	}
+
+	private createEpisodeFile(
+		id: number,
+		seriesId: number,
+		seasonNumber: number,
+		customFormatScore: number
+	): SonarrEpisodeFile {
+		return {
+			id,
+			seriesId,
+			seasonNumber,
+			size: 1_000_000,
+			quality: { quality: { id: 1, name: 'WEBDL-1080p' } },
+			customFormats: [],
+			customFormatScore,
+			qualityCutoffNotMet: false
+		};
+	}
+
+	private createFilter(selector: string, field = 'monitored'): FilterConfig {
+		return {
+			id: 'filter-1',
+			name: 'Filter',
+			enabled: true,
+			selector,
+			count: 1,
+			cutoff: 100,
+			group: {
+				type: 'group',
+				match: 'all',
+				children: [{ type: 'rule', field, operator: 'is', value: true }]
+			}
+		};
+	}
+
+	runTests(): void {
+		this.test('averages all episode files or only the requested season', () => {
+			const files = [
+				this.createEpisodeFile(1, 1, 1, 100),
+				this.createEpisodeFile(2, 1, 1, 200),
+				this.createEpisodeFile(3, 1, 2, -50)
+			];
+
+			assertEquals(averageEpisodeFileScore(files), 250 / 3);
+			assertEquals(averageEpisodeFileScore(files, 1), 150);
+			assertEquals(averageEpisodeFileScore(files, 3), 0);
+		});
+
+		this.test('detects cutoff rules and the lowest-score selector', () => {
+			assertEquals(filterNeedsSonarrScores(this.createFilter('random', 'cutoff_met')), true);
+			assertEquals(filterNeedsSonarrScores(this.createFilter('lowest_score')), true);
+			assertEquals(filterNeedsSonarrScores(this.createFilter('random')), false);
+		});
+
+		this.test('loads file-bearing series and skips series without files', async () => {
+			const calls: number[] = [];
+			const client = {
+				getEpisodeFiles: (seriesId: number) => {
+					calls.push(seriesId);
+					return Promise.resolve([this.createEpisodeFile(1, seriesId, 1, 100)]);
+				}
+			} as unknown as SonarrClient;
+
+			const result = await loadSonarrEpisodeFiles(client, [
+				this.createSeries(1, 1),
+				this.createSeries(2, 0)
+			]);
+
+			assertEquals(calls, [1]);
+			assertEquals(result.get(1)?.length, 1);
+			assertEquals(result.get(2), []);
+		});
+
+		this.test('reuses existing episode files without another request', async () => {
+			const calls: number[] = [];
+			const client = {
+				getEpisodeFiles: (seriesId: number) => {
+					calls.push(seriesId);
+					return Promise.resolve([]);
+				}
+			} as unknown as SonarrClient;
+			const existing = new Map([[1, [this.createEpisodeFile(1, 1, 1, 100)]]]);
+
+			const result = await loadSonarrEpisodeFiles(client, [this.createSeries(1, 1)], existing);
+
+			assertEquals(calls, []);
+			assertEquals(result.get(1), existing.get(1));
+		});
+
+		this.test('fetches when series statistics are unavailable', async () => {
+			const calls: number[] = [];
+			const client = {
+				getEpisodeFiles: (seriesId: number) => {
+					calls.push(seriesId);
+					return Promise.resolve([]);
+				}
+			} as unknown as SonarrClient;
+			const series = this.createSeries(1, 0);
+			series.statistics = undefined;
+			series.seasons = [{ seasonNumber: 1, monitored: true }];
+
+			await loadSonarrEpisodeFiles(client, [series]);
+
+			assertEquals(calls, [1]);
+		});
+
+		this.test('identifies the series when episode-file loading fails', async () => {
+			const client = {
+				getEpisodeFiles: () => Promise.reject(new Error('unavailable'))
+			} as unknown as SonarrClient;
+
+			await assertRejects(
+				() => loadSonarrEpisodeFiles(client, [this.createSeries(3, 1)]),
+				Error,
+				'Failed to fetch episode files for "Series 3": unavailable'
+			);
+		});
+	}
+}
+
+new SonarrScoresTest().runTests();


### PR DESCRIPTION
- Calculate Sonarr cutoff state from the average custom format score across a series' episode files.
- Use series averages for Lowest Score selection and searched-season averages for dry-run comparisons.
- Fetch episode files only when score data is required and reuse preview/run data.
- Document and test Sonarr score behavior.

Closes #726