### PR TITLE
fix: improve draggable card contrast

### DIFF
--- a/src/lib/client/ui/list/DraggableCard.svelte
+++ b/src/lib/client/ui/list/DraggableCard.svelte
@@ -8,7 +8,8 @@
 
 	const variantClasses = {
 		default: 'border border-neutral-300 bg-white dark:border-neutral-700/60 dark:bg-neutral-800/50',
-		ghost: 'bg-neutral-100/60 dark:bg-neutral-800/40',
+		ghost:
+			'border border-neutral-300 bg-neutral-50 dark:border-neutral-700/60 dark:bg-neutral-800/40',
 		outline: 'border border-neutral-300 dark:border-neutral-700/60'
 	};
 </script>

--- a/src/routes/quality-profiles/[databaseId]/[id]/qualities/+page.svelte
+++ b/src/routes/quality-profiles/[databaseId]/[id]/qualities/+page.svelte
@@ -724,7 +724,11 @@
 							{#if item.type === 'group' && item.members}
 								<div class="mt-1 hidden flex-wrap gap-1 md:flex">
 									{#each item.members as member}
-										<Label variant="secondary" size="sm" rounded="md">{member.name}</Label>
+										<Label
+											customVariant="bg-white text-neutral-700 shadow-sm dark:bg-neutral-900 dark:text-neutral-300 dark:shadow-black/10"
+											size="sm"
+											rounded="md">{member.name}</Label
+										>
 									{/each}
 								</div>
 							{/if}
@@ -836,7 +840,11 @@
 					{#if item.type === 'group' && item.members}
 						<div class="mt-3 flex flex-wrap gap-1 md:hidden">
 							{#each item.members as member}
-								<Label variant="secondary" size="sm" rounded="md">{member.name}</Label>
+								<Label
+									customVariant="bg-white text-neutral-700 shadow-sm dark:bg-neutral-900 dark:text-neutral-300 dark:shadow-black/10"
+									size="sm"
+									rounded="md">{member.name}</Label
+								>
 							{/each}
 						</div>
 					{/if}

--- a/src/routes/quality-profiles/[databaseId]/[id]/qualities/components/GroupModal.svelte
+++ b/src/routes/quality-profiles/[databaseId]/[id]/qualities/components/GroupModal.svelte
@@ -210,7 +210,7 @@
 									handleToggle(item.name);
 								}
 							}}
-							className="cursor-pointer transition-colors hover:bg-neutral-50 dark:hover:bg-neutral-800"
+							className="cursor-pointer transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-800"
 							contentClass="px-3 py-2.5"
 							role="button"
 							tabindex="0"


### PR DESCRIPTION
- match draggable cards to the bordered flush-card treatment
- improve grouped-quality label contrast in light and dark themes

Closes #886