### PR TITLE
fix: reap orphaned container processes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,6 +213,32 @@ jobs:
       - name: Build images
         run: docker compose -f compose.yml -f compose.dev.yml build
 
+      - name: Verify container init reaps orphaned processes
+        run: |
+          container_name=profilarr-init-test
+          cleanup() {
+            docker rm -f "$container_name" > /dev/null 2>&1 || true
+          }
+          trap cleanup EXIT
+
+          docker run --name "$container_name" --detach profilarr:alpine
+
+          pid_one=$(docker exec "$container_name" cat /proc/1/comm)
+          if [ "$pid_one" != "tini" ]; then
+            echo "Expected tini to run as PID 1, found: $pid_one"
+            exit 1
+          fi
+
+          docker exec "$container_name" sh -c 'sh -c "sleep 0.1 &"'
+          sleep 1
+
+          if docker exec "$container_name" sh -c \
+            'awk '\''$3 == "Z" { found=1 } END { exit !found }'\'' /proc/[0-9]*/stat'; then
+            echo "Found a zombie process after creating a short-lived orphan"
+            docker exec "$container_name" ps -ef
+            exit 1
+          fi
+
       - name: Scan profilarr
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -100,6 +100,7 @@ LABEL org.opencontainers.image.licenses="AGPL-3.0"
 # - sqlite-libs: SQLite shared library for FFI
 # - bash: Entrypoint uses bash
 # - shadow: Provides usermod/groupmod for PUID/PGID runtime changes
+# - tini: PID 1 init for signal forwarding and orphaned process reaping
 RUN apk add --no-cache \
     git \
     tar \
@@ -109,6 +110,7 @@ RUN apk add --no-cache \
     sqlite-libs \
     bash \
     shadow \
+    tini \
     && apk upgrade --no-cache
 
 # Create application directory
@@ -155,7 +157,7 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
 # Volume for persistent data
 VOLUME /config
 
-# Entrypoint handles PUID/PGID/UMASK then runs the app
-# Starts as root for chown/useradd, drops to PUID via su-exec before exec
+# Tini runs as PID 1 to forward signals and reap orphaned child processes.
+# The entrypoint handles PUID/PGID/UMASK, then drops privileges and runs the app.
 # nosemgrep: dockerfile.security.missing-user-entrypoint.missing-user-entrypoint
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT ["/sbin/tini", "--", "/entrypoint.sh"]


### PR DESCRIPTION
- Run Profilarr under tini so detached Git maintenance processes are reaped and shutdown signals are forwarded.
- Add a container smoke check covering PID 1 and orphan reaping.

Closes #894