### PR TITLE
fix: populate patterns after condition type changes

### DIFF
--- a/src/routes/custom-formats/[databaseId]/[id]/conditions/components/ConditionCard.svelte
+++ b/src/routes/custom-formats/[databaseId]/[id]/conditions/components/ConditionCard.svelte
@@ -199,9 +199,7 @@
 
 	// Handle type change - reset values
 	function handleTypeChange(newType: string) {
-		const isNewPatternType = PATTERN_TYPES.includes(
-			newType as (typeof PATTERN_TYPES)[number]
-		);
+		const isNewPatternType = PATTERN_TYPES.includes(newType as (typeof PATTERN_TYPES)[number]);
 		const matchingPattern = isNewPatternType ? patternFromName(condition.name) : null;
 
 		emitChange({

--- a/src/routes/custom-formats/[databaseId]/[id]/conditions/components/ConditionCard.svelte
+++ b/src/routes/custom-formats/[databaseId]/[id]/conditions/components/ConditionCard.svelte
@@ -199,9 +199,16 @@
 
 	// Handle type change - reset values
 	function handleTypeChange(newType: string) {
+		const isNewPatternType = PATTERN_TYPES.includes(
+			newType as (typeof PATTERN_TYPES)[number]
+		);
+		const matchingPattern = isNewPatternType ? patternFromName(condition.name) : null;
+
 		emitChange({
 			type: newType,
-			patterns: undefined,
+			patterns: matchingPattern
+				? [{ name: matchingPattern.name, pattern: matchingPattern.pattern }]
+				: undefined,
 			languages: undefined,
 			sources: undefined,
 			resolutions: undefined,


### PR DESCRIPTION
- Auto-populate matching patterns when switching to a pattern-based condition type
- Keep non-pattern condition values blank after changing type

Closes #901
Related to #765