### PR TITLE
chore: accept changelog skip footer

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -44,7 +44,7 @@ topo_order_commits = true
 sort_commits = "oldest"
 
 commit_parsers = [
-	{ footer = "^changelog: ?ignore", skip = true },
+	{ footer = "^changelog: ?(ignore|skip)", skip = true },
 	{ message = "^feat", group = "<!-- 0 -->✨ Features" },
 	{ message = "^fix", group = "<!-- 1 -->🐛 Fixes" },
 	{ message = "^perf", group = "<!-- 2 -->⚡ Performance" },

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -127,6 +127,8 @@ message when squash merging the PR:
 changelog: ignore
 ```
 
+`changelog: skip` works too; both spellings are matched.
+
 For a commit that has already been merged without the footer, add its full SHA
 to `.cliffignore`.
 


### PR DESCRIPTION
- Match `changelog: skip` as well as `changelog: ignore` in the git-cliff footer parser.
- Note both spellings in DEVELOPMENT.md.
- Retroactively drops #904 from the release notes, which was merged with the `skip` spelling.