### PR TITLE
feat: add release-group filtering to library views

### DIFF
--- a/src/lib/server/utils/arr/clients/sonarr.ts
+++ b/src/lib/server/utils/arr/clients/sonarr.ts
@@ -103,6 +103,22 @@ export class SonarrClient extends BaseArrClient {
 				percentOfEpisodes: s.statistics?.percentOfEpisodes ?? 0
 			}));
 
+			// Sonarr only exposes distinct release group lists (per season and aggregated
+			// per series), never per-file counts. Rank by how many seasons each group
+			// appears in as a proxy for how much of the series it accounts for.
+			const releaseGroupSeasons = new Map<string, number>();
+			for (const season of series.seasons) {
+				for (const group of season.statistics?.releaseGroups ?? []) {
+					releaseGroupSeasons.set(group, (releaseGroupSeasons.get(group) ?? 0) + 1);
+				}
+			}
+			for (const group of series.statistics?.releaseGroups ?? []) {
+				if (!releaseGroupSeasons.has(group)) releaseGroupSeasons.set(group, 0);
+			}
+			const releaseGroups = [...releaseGroupSeasons.entries()]
+				.sort(([aName, aCount], [bName, bCount]) => bCount - aCount || aName.localeCompare(bName))
+				.map(([group]) => group);
+
 			let monitoredState: 'monitored' | 'partial' | 'unmonitored';
 			if (!series.monitored) {
 				monitoredState = 'unmonitored';
@@ -132,6 +148,7 @@ export class SonarrClient extends BaseArrClient {
 				totalEpisodeCount: series.statistics?.totalEpisodeCount ?? 0,
 				sizeOnDisk: series.statistics?.sizeOnDisk ?? 0,
 				percentOfEpisodes: series.statistics?.percentOfEpisodes ?? 0,
+				releaseGroups,
 				dateAdded: series.added,
 				seasons,
 				isProfilarrProfile: profilarrProfileNames?.has(profileName) ?? false,

--- a/src/lib/server/utils/arr/types.ts
+++ b/src/lib/server/utils/arr/types.ts
@@ -366,6 +366,7 @@ export interface SonarrSeries {
 		episodeCount: number;
 		totalEpisodeCount: number;
 		sizeOnDisk: number;
+		releaseGroups?: string[];
 		percentOfEpisodes: number;
 	};
 }
@@ -604,6 +605,7 @@ export interface SonarrSeriesItem {
 	totalEpisodeCount: number;
 	sizeOnDisk: number;
 	percentOfEpisodes: number;
+	releaseGroups: string[];
 	dateAdded?: string;
 	isProfilarrProfile: boolean;
 	network?: string;

--- a/src/routes/arr/[id]/library/+page.svelte
+++ b/src/routes/arr/[id]/library/+page.svelte
@@ -73,6 +73,14 @@
 				[...new Set(items.map((m) => m.qualityName).filter(Boolean) as string[])].sort()
 		},
 		{
+			key: 'releaseGroup',
+			label: 'Release Group',
+			type: 'text',
+			accessor: (m) => m.releaseGroup ?? '',
+			suggestions: (items) =>
+				[...new Set(items.map((m) => m.releaseGroup).filter(Boolean) as string[])].sort()
+		},
+		{
 			key: 'profile',
 			label: 'Profile',
 			type: 'text',
@@ -135,6 +143,13 @@
 			accessor: (s) => s.title,
 			isDefault: true,
 			suggestions: (items) => items.map((s) => s.title).sort()
+		},
+		{
+			key: 'releaseGroup',
+			label: 'Release Group(s)',
+			type: 'text',
+			accessor: (s) => s.releaseGroups ?? [],
+			suggestions: (items) => [...new Set(items.flatMap((s) => s.releaseGroups ?? []))].sort()
 		},
 		{
 			key: 'profile',
@@ -391,7 +406,7 @@
 	const radarrColumnLabels: Record<RadarrToggleableColumn, string> = {
 		qualityName: 'Quality',
 		score: 'Score',
-		releaseGroup: 'Group',
+		releaseGroup: 'Release Group',
 		sizeOnDisk: 'Size',
 		status: 'Status',
 		popularity: 'Popularity',
@@ -403,7 +418,13 @@
 	// ==========================================================================
 
 	const SONARR_STORAGE_KEY = 'profilarr-library-sonarr-columns';
-	const SONARR_TOGGLEABLE_COLUMNS = ['status', 'episodes', 'sizeOnDisk', 'dateAdded'] as const;
+	const SONARR_TOGGLEABLE_COLUMNS = [
+		'status',
+		'episodes',
+		'sizeOnDisk',
+		'releaseGroups',
+		'dateAdded'
+	] as const;
 	type SonarrToggleableColumn = (typeof SONARR_TOGGLEABLE_COLUMNS)[number];
 
 	function loadSonarrColumnVisibility(): Set<SonarrToggleableColumn> {
@@ -439,6 +460,7 @@
 	const sonarrColumnLabels: Record<SonarrToggleableColumn, string> = {
 		episodes: 'Episodes',
 		sizeOnDisk: 'Size',
+		releaseGroups: 'Release Group(s)',
 		status: 'Status',
 		dateAdded: 'Added'
 	};
@@ -508,6 +530,7 @@
 		'size',
 		'episodes',
 		'year',
+		'releaseGroups',
 		'status',
 		'rating',
 		'dateAdded'
@@ -522,6 +545,7 @@
 		size: 'Size',
 		episodes: 'Episodes',
 		year: 'Year',
+		releaseGroups: 'Release Group(s)',
 		status: 'Status',
 		rating: 'Rating',
 		dateAdded: 'Date Added'
@@ -615,6 +639,12 @@
 		}
 		return applySmartFilters(sonarrLibrary, filterTags, sonarrFields);
 	})();
+
+	// Values of any active (non-negated) release group filter, so the Sonarr views can
+	// surface the group the user filtered on instead of the most common one.
+	$: activeReleaseGroups = useSimpleMode
+		? []
+		: filterTags.filter((t) => t.field === 'releaseGroup' && !t.negated).map((t) => t.value);
 
 	let sonarrTableView: SonarrTableView;
 
@@ -806,6 +836,7 @@
 						{expandAll}
 						instanceId={data.instance.id}
 						visibleColumns={activeVisibleColumns}
+						highlightGroups={activeReleaseGroups}
 						emptyMessage={filterTags.length > 0
 							? 'No series match the current filters'
 							: 'No series found'}
@@ -863,6 +894,7 @@
 								{baseUrl}
 								instanceId={data.instance.id}
 								visibleFields={activeVisibleCardFields}
+								highlightGroups={activeReleaseGroups}
 							/>
 						{/each}
 					</LibraryCardGrid>

--- a/src/routes/arr/[id]/library/components/RadarrTableView.svelte
+++ b/src/routes/arr/[id]/library/components/RadarrTableView.svelte
@@ -82,7 +82,7 @@
 			sortAccessor: (row) => (row.dateAdded ? new Date(row.dateAdded).getTime() : 0),
 			defaultSortDirection: 'desc'
 		},
-		{ key: 'releaseGroup', header: 'Group', align: 'left', width: 'w-28', sortable: true }
+		{ key: 'releaseGroup', header: 'Release Group', align: 'left', width: 'w-36', sortable: true }
 	];
 
 	$: columns = allColumns.filter(

--- a/src/routes/arr/[id]/library/components/SeriesCard.svelte
+++ b/src/routes/arr/[id]/library/components/SeriesCard.svelte
@@ -8,7 +8,8 @@
 		Square,
 		Clock,
 		Star,
-		Calendar
+		Calendar,
+		Users
 	} from '@lucide/svelte';
 	import Label from '$ui/label/Label.svelte';
 	import IconCheckbox from '$ui/form/IconCheckbox.svelte';
@@ -21,11 +22,13 @@
 	import InfoModal from '$ui/modal/InfoModal.svelte';
 	import DateTime from '$ui/datetime/DateTime.svelte';
 	import type { SonarrSeriesItem, SonarrSeasonItem, SonarrEpisodeItem } from '$utils/arr/types.ts';
+	import { primaryReleaseGroup } from './releaseGroups.ts';
 
 	export let series: SonarrSeriesItem;
 	export let baseUrl: string = '';
 	export let instanceId: number;
 	export let visibleFields: Set<string> = new Set();
+	export let highlightGroups: string[] = [];
 
 	$: posterUrl = series.images?.find((i) => i.coverType === 'poster')?.remoteUrl;
 	$: monitoredState = series.monitoredState;
@@ -228,6 +231,20 @@
 			</div>
 		{/if}
 
+		{#if visibleFields.has('releaseGroups') && series.releaseGroups?.length}
+			{@const groups = series.releaseGroups}
+			<Tooltip text={groups.length > 1 ? groups.join(', ') : ''} position="top">
+				<span class="flex items-center gap-1 text-xs text-neutral-500 dark:text-neutral-400">
+					<Users size={12} class="flex-shrink-0" />
+					<span class="truncate font-mono">{primaryReleaseGroup(groups, highlightGroups)}</span>
+					{#if groups.length > 1}
+						<span class="flex-shrink-0 font-mono text-neutral-400 dark:text-neutral-500"
+							>+{groups.length - 1}</span
+						>
+					{/if}
+				</span>
+			</Tooltip>
+		{/if}
 		{#if visibleFields.has('episodes')}
 			<ProgressIndicator
 				current={series.episodeFileCount}

--- a/src/routes/arr/[id]/library/components/SeriesRow.svelte
+++ b/src/routes/arr/[id]/library/components/SeriesRow.svelte
@@ -6,12 +6,14 @@
 	import Tooltip from '$ui/tooltip/Tooltip.svelte';
 	import type { SonarrSeriesItem } from '$utils/arr/types.ts';
 	import type { Column } from '$ui/table/types';
+	import { primaryReleaseGroup } from './releaseGroups.ts';
 	import { formatDate } from '$shared/utils/dates.ts';
 	import { dateFormat } from '$lib/client/stores/dateFormat.ts';
 	import { serverTimezone } from '$lib/client/stores/timezone.ts';
 
 	export let row: SonarrSeriesItem;
 	export let column: Column<SonarrSeriesItem>;
+	export let highlightGroups: string[] = [];
 
 	$: posterUrl = row.images?.find((i) => i.coverType === 'poster')?.remoteUrl;
 
@@ -81,6 +83,20 @@
 		<Label variant="info" size="sm"><svelte:component this={Clock} size={12} /> Upcoming</Label>
 	{:else}
 		<Label variant="secondary" size="sm">{row.status ?? '-'}</Label>
+	{/if}
+{:else if column.key === 'releaseGroups'}
+	{@const groups = row.releaseGroups ?? []}
+	{#if groups.length > 0}
+		<Tooltip text={groups.length > 1 ? groups.join(', ') : ''} position="top">
+			<span class="truncate font-mono text-xs text-neutral-700 dark:text-neutral-300">
+				{primaryReleaseGroup(groups, highlightGroups)}
+				{#if groups.length > 1}
+					<span class="text-neutral-500 dark:text-neutral-400">+{groups.length - 1}</span>
+				{/if}
+			</span>
+		</Tooltip>
+	{:else}
+		<span class="font-mono text-xs text-neutral-700 dark:text-neutral-300">-</span>
 	{/if}
 {:else if column.key === 'sizeOnDisk'}
 	<span class="font-mono text-xs text-neutral-700 dark:text-neutral-300"

--- a/src/routes/arr/[id]/library/components/SeriesRowSkeleton.svelte
+++ b/src/routes/arr/[id]/library/components/SeriesRowSkeleton.svelte
@@ -19,6 +19,8 @@
 	<div class="h-5 w-14 animate-pulse rounded-full bg-neutral-200 dark:bg-neutral-700"></div>
 {:else if column.key === 'sizeOnDisk'}
 	<div class="h-4 w-16 animate-pulse rounded bg-neutral-200 dark:bg-neutral-700"></div>
+{:else if column.key === 'releaseGroups'}
+	<div class="h-4 w-20 animate-pulse rounded bg-neutral-200 dark:bg-neutral-700"></div>
 {:else if column.key === 'dateAdded'}
 	<div class="h-4 w-16 animate-pulse rounded bg-neutral-200 dark:bg-neutral-700"></div>
 {/if}

--- a/src/routes/arr/[id]/library/components/SonarrTableView.svelte
+++ b/src/routes/arr/[id]/library/components/SonarrTableView.svelte
@@ -18,8 +18,15 @@
 	export let instanceId: number;
 	export let emptyMessage = 'No series found';
 	export let visibleColumns: Set<string>;
+	export let highlightGroups: string[] = [];
 
-	const TOGGLEABLE_COLUMNS = ['episodes', 'sizeOnDisk', 'status', 'dateAdded'] as const;
+	const TOGGLEABLE_COLUMNS = [
+		'episodes',
+		'sizeOnDisk',
+		'releaseGroups',
+		'status',
+		'dateAdded'
+	] as const;
 	type ToggleableColumn = (typeof TOGGLEABLE_COLUMNS)[number];
 
 	const allColumns: Column<SonarrSeriesItem>[] = [
@@ -49,6 +56,14 @@
 			sortable: true,
 			sortAccessor: (row) => row.sizeOnDisk,
 			defaultSortDirection: 'desc'
+		},
+		{
+			key: 'releaseGroups',
+			header: 'Release Group(s)',
+			align: 'left',
+			width: 'w-40',
+			sortable: true,
+			sortAccessor: (row) => row.releaseGroups?.[0] ?? ''
 		},
 		{
 			key: 'dateAdded',
@@ -212,7 +227,7 @@
 				mode="compact"
 			/>
 		{:else}
-			<SeriesRow {row} {column} />
+			<SeriesRow {row} {column} {highlightGroups} />
 		{/if}
 	</svelte:fragment>
 

--- a/src/routes/arr/[id]/library/components/releaseGroups.ts
+++ b/src/routes/arr/[id]/library/components/releaseGroups.ts
@@ -1,0 +1,15 @@
+/**
+ * Pick the release group to show for a series.
+ *
+ * `releaseGroups` arrives already ranked by how many seasons each group appears in,
+ * so the first entry is the most common one. When a release group filter is active,
+ * show a matching group instead so the row explains why it survived the filter.
+ * Matching mirrors the smart filter: case-insensitive substring.
+ */
+export function primaryReleaseGroup(groups: string[], highlightGroups: string[] = []): string {
+	if (groups.length === 0) return '';
+	const matched = groups.find((group) =>
+		highlightGroups.some((filter) => group.toLowerCase().includes(filter.toLowerCase()))
+	);
+	return matched ?? groups[0];
+}


### PR DESCRIPTION
- Add a Release Group smart filter to the Radarr library view
- Add a Release Group(s) smart filter to the Sonarr library view; a series matches any group used by its episode files
- Retain Sonarr's aggregated `statistics.releaseGroups` on the series library item, ranked by how many seasons each group appears in
- Add a toggleable Release Group(s) column and card field to the Sonarr library view, showing the leading group with `+N` and a tooltip listing the rest
- Show the filtered group instead of the leading one when a release group filter is active
- Rename Radarr's table column header from Group to Release Group

Movies and series with no downloaded files have no release group and match no selected group.

Closes #899