### PR TITLE
feat: add release date sorting to library views

### DIFF
--- a/src/lib/client/ui/table/ExpandableTable.svelte
+++ b/src/lib/client/ui/table/ExpandableTable.svelte
@@ -101,13 +101,18 @@
 
 		return [...items].sort((a, b) => {
 			let comparison = 0;
+			const aVal = column.sortAccessor ? column.sortAccessor(a) : getCellValue(a, column.key);
+			const bVal = column.sortAccessor ? column.sortAccessor(b) : getCellValue(b, column.key);
+
+			if (column.sortNullsLast) {
+				if (aVal == null && bVal == null) return 0;
+				if (aVal == null) return 1;
+				if (bVal == null) return -1;
+			}
 
 			if (column.sortComparator) {
 				comparison = column.sortComparator(a, b);
 			} else {
-				const aVal = column.sortAccessor ? column.sortAccessor(a) : getCellValue(a, column.key);
-				const bVal = column.sortAccessor ? column.sortAccessor(b) : getCellValue(b, column.key);
-
 				// Handle null/undefined
 				if (aVal == null && bVal == null) comparison = 0;
 				else if (aVal == null) comparison = 1;

--- a/src/lib/client/ui/table/Table.svelte
+++ b/src/lib/client/ui/table/Table.svelte
@@ -139,6 +139,14 @@
 		}
 
 		const sorted = [...rows].sort((a, b) => {
+			if (column.sortNullsLast) {
+				const aValue = getSortValue(a, column);
+				const bValue = getSortValue(b, column);
+				if (aValue == null && bValue == null) return 0;
+				if (aValue == null) return sortDirection === 'desc' ? -1 : 1;
+				if (bValue == null) return sortDirection === 'desc' ? 1 : -1;
+			}
+
 			if (column.sortComparator) {
 				return column.sortComparator(a, b);
 			}

--- a/src/lib/client/ui/table/types.ts
+++ b/src/lib/client/ui/table/types.ts
@@ -29,6 +29,8 @@ export interface Column<T> {
 	sortComparator?: (a: T, b: T) => number;
 	/** Default sort direction when column is first sorted */
 	defaultSortDirection?: SortDirection;
+	/** Keep null and undefined values after known values in both sort directions */
+	sortNullsLast?: boolean;
 	/** Custom cell renderer - receives the full row object */
 	cell?: (row: T) => string | Component | { html: string };
 	/** Hide column in mobile responsive layout */

--- a/src/lib/server/utils/arr/clients/radarr.ts
+++ b/src/lib/server/utils/arr/clients/radarr.ts
@@ -1,5 +1,6 @@
 import { BaseArrClient, INTERACTIVE_SEARCH_TIMEOUT_MS } from '../base.ts';
 import { HttpError } from '$utils/http/types.ts';
+import { resolveRadarrInitialReleaseDate } from '../releaseDates.ts';
 import type {
 	RadarrMovie,
 	RadarrMovieFile,
@@ -98,6 +99,7 @@ export class RadarrClient extends BaseArrClient {
 		const libraryItems: RadarrLibraryItem[] = movies.map((movie) => {
 			const profile = profileMap.get(movie.qualityProfileId);
 			const movieFile = movieFileMap.get(movie.id);
+			const initialReleaseDate = resolveRadarrInitialReleaseDate(movie);
 
 			const customFormats = movieFile?.customFormats ?? [];
 			const customFormatScore = movieFile?.customFormatScore ?? 0;
@@ -126,6 +128,10 @@ export class RadarrClient extends BaseArrClient {
 				monitored: movie.monitored ?? false,
 				status: movie.status,
 				dateAdded: movie.added,
+				initialReleaseDate,
+				theatricalReleaseDate: movie.inCinemas,
+				digitalReleaseDate: movie.digitalRelease,
+				physicalReleaseDate: movie.physicalRelease,
 				popularity: movie.popularity,
 				sizeOnDisk: movie.sizeOnDisk,
 				runtime: movie.runtime,

--- a/src/lib/server/utils/arr/clients/sonarr.ts
+++ b/src/lib/server/utils/arr/clients/sonarr.ts
@@ -161,7 +161,8 @@ export class SonarrClient extends BaseArrClient {
 				images: series.images,
 				originalLanguage: series.originalLanguage,
 				firstAired: series.firstAired,
-				lastAired: series.lastAired
+				lastAired: series.lastAired,
+				previousAiring: series.previousAiring
 			};
 		});
 	}

--- a/src/lib/server/utils/arr/releaseDates.ts
+++ b/src/lib/server/utils/arr/releaseDates.ts
@@ -1,0 +1,21 @@
+import { dateSortValue } from '$shared/utils/sort.ts';
+import type { RadarrMovie } from './types.ts';
+
+export function resolveRadarrInitialReleaseDate(movie: RadarrMovie): string | undefined {
+	if (dateSortValue(movie.inCinemas) !== null) {
+		return movie.inCinemas;
+	}
+
+	const digital = dateSortValue(movie.digitalRelease);
+	const physical = dateSortValue(movie.physicalRelease);
+
+	if (digital === null && physical === null) return undefined;
+	if (digital !== null && physical !== null && digital === physical) {
+		return movie.digitalRelease;
+	}
+	if (digital !== null && (physical === null || digital < physical)) {
+		return movie.digitalRelease;
+	}
+
+	return movie.physicalRelease;
+}

--- a/src/lib/server/utils/arr/types.ts
+++ b/src/lib/server/utils/arr/types.ts
@@ -353,6 +353,7 @@ export interface SonarrSeries {
 	certification?: string;
 	firstAired?: string;
 	lastAired?: string;
+	previousAiring?: string;
 	originalLanguage?: { id: number; name: string };
 	ratings?: { value: number; votes: number };
 	seasons: SonarrSeason[];
@@ -510,6 +511,10 @@ export interface RadarrLibraryItem {
 	monitored: boolean;
 	status?: string;
 	dateAdded?: string;
+	initialReleaseDate?: string;
+	theatricalReleaseDate?: string;
+	digitalReleaseDate?: string;
+	physicalReleaseDate?: string;
 	popularity?: number;
 	sizeOnDisk?: number;
 	runtime?: number;
@@ -618,6 +623,7 @@ export interface SonarrSeriesItem {
 	originalLanguage?: { id: number; name: string };
 	firstAired?: string;
 	lastAired?: string;
+	previousAiring?: string;
 }
 
 /**

--- a/src/lib/shared/utils/sort.ts
+++ b/src/lib/shared/utils/sort.ts
@@ -14,3 +14,24 @@ export function sortTitle(title: string | undefined): string {
 		.replace(/^[^a-z0-9]+/, '')
 		.replace(/^(the|a|an)\s+/, '');
 }
+
+export function dateSortValue(value: string | undefined): number | null {
+	if (!value) return null;
+	const timestamp = new Date(value).getTime();
+	return Number.isNaN(timestamp) ? null : timestamp;
+}
+
+export function compareOptionalDates(
+	a: string | undefined,
+	b: string | undefined,
+	direction: 'asc' | 'desc'
+): number {
+	const aValue = dateSortValue(a);
+	const bValue = dateSortValue(b);
+
+	if (aValue === null && bValue === null) return 0;
+	if (aValue === null) return 1;
+	if (bValue === null) return -1;
+
+	return direction === 'asc' ? aValue - bValue : bValue - aValue;
+}

--- a/src/routes/arr/[id]/library/+page.svelte
+++ b/src/routes/arr/[id]/library/+page.svelte
@@ -4,7 +4,7 @@
 	import { browser } from '$app/environment';
 	import type { PageData } from './$types';
 	import type { RadarrLibraryItem, SonarrSeriesItem } from '$utils/arr/types.ts';
-	import { sortTitle } from '$shared/utils/sort.ts';
+	import { compareOptionalDates, sortTitle } from '$shared/utils/sort.ts';
 	import { getPersistentSearchStore } from '$stores/search';
 	import type { FilterFieldDef, FilterTag } from '$ui/filter/types';
 	import { applySmartFilters } from '$ui/filter/match';
@@ -362,6 +362,12 @@
 	// ==========================================================================
 
 	const RADARR_STORAGE_KEY = 'profilarr-library-columns';
+	const RADARR_RELEASE_DATE_KEYS = [
+		'initialReleaseDate',
+		'theatricalReleaseDate',
+		'digitalReleaseDate',
+		'physicalReleaseDate'
+	] as const;
 	const RADARR_TOGGLEABLE_COLUMNS = [
 		'status',
 		'qualityName',
@@ -369,12 +375,16 @@
 		'sizeOnDisk',
 		'popularity',
 		'dateAdded',
+		...RADARR_RELEASE_DATE_KEYS,
 		'releaseGroup'
 	] as const;
+	const RADARR_DEFAULT_COLUMNS = RADARR_TOGGLEABLE_COLUMNS.filter(
+		(key) => !RADARR_RELEASE_DATE_KEYS.includes(key as (typeof RADARR_RELEASE_DATE_KEYS)[number])
+	);
 	type RadarrToggleableColumn = (typeof RADARR_TOGGLEABLE_COLUMNS)[number];
 
 	function loadRadarrColumnVisibility(): Set<RadarrToggleableColumn> {
-		if (!browser) return new Set(RADARR_TOGGLEABLE_COLUMNS);
+		if (!browser) return new Set<RadarrToggleableColumn>(RADARR_DEFAULT_COLUMNS);
 		try {
 			const stored = localStorage.getItem(RADARR_STORAGE_KEY);
 			if (stored) {
@@ -382,7 +392,7 @@
 				return new Set(parsed);
 			}
 		} catch {}
-		return new Set(RADARR_TOGGLEABLE_COLUMNS);
+		return new Set<RadarrToggleableColumn>(RADARR_DEFAULT_COLUMNS);
 	}
 
 	function saveRadarrColumnVisibility(visible: Set<RadarrToggleableColumn>) {
@@ -410,7 +420,11 @@
 		sizeOnDisk: 'Size',
 		status: 'Status',
 		popularity: 'Popularity',
-		dateAdded: 'Added'
+		dateAdded: 'Added',
+		initialReleaseDate: 'Initial Release',
+		theatricalReleaseDate: 'Theatrical Release',
+		digitalReleaseDate: 'Digital Release',
+		physicalReleaseDate: 'Physical Release'
 	};
 
 	// ==========================================================================
@@ -423,12 +437,17 @@
 		'episodes',
 		'sizeOnDisk',
 		'releaseGroups',
-		'dateAdded'
+		'dateAdded',
+		'firstAired',
+		'previousAiring'
 	] as const;
+	const SONARR_DEFAULT_COLUMNS = SONARR_TOGGLEABLE_COLUMNS.filter(
+		(key) => key !== 'firstAired' && key !== 'previousAiring'
+	);
 	type SonarrToggleableColumn = (typeof SONARR_TOGGLEABLE_COLUMNS)[number];
 
 	function loadSonarrColumnVisibility(): Set<SonarrToggleableColumn> {
-		if (!browser) return new Set(SONARR_TOGGLEABLE_COLUMNS);
+		if (!browser) return new Set<SonarrToggleableColumn>(SONARR_DEFAULT_COLUMNS);
 		try {
 			const stored = localStorage.getItem(SONARR_STORAGE_KEY);
 			if (stored) {
@@ -436,7 +455,7 @@
 				return new Set(parsed);
 			}
 		} catch {}
-		return new Set(SONARR_TOGGLEABLE_COLUMNS);
+		return new Set<SonarrToggleableColumn>(SONARR_DEFAULT_COLUMNS);
 	}
 
 	function saveSonarrColumnVisibility(visible: Set<SonarrToggleableColumn>) {
@@ -462,7 +481,9 @@
 		sizeOnDisk: 'Size',
 		releaseGroups: 'Release Group(s)',
 		status: 'Status',
-		dateAdded: 'Added'
+		dateAdded: 'Added',
+		firstAired: 'Series Premiere',
+		previousAiring: 'Latest Aired Episode'
 	};
 
 	// ==========================================================================
@@ -501,7 +522,8 @@
 		'popularity',
 		'runtime',
 		'rating',
-		'dateAdded'
+		'dateAdded',
+		...RADARR_RELEASE_DATE_KEYS
 	] as const;
 	const RADARR_CARD_DEFAULTS: readonly string[] = ['monitored', 'profile', 'size', 'score'];
 	type RadarrCardField = (typeof RADARR_CARD_FIELDS)[number];
@@ -519,7 +541,11 @@
 		popularity: 'Popularity',
 		runtime: 'Runtime',
 		rating: 'Rating',
-		dateAdded: 'Date Added'
+		dateAdded: 'Date Added',
+		initialReleaseDate: 'Initial Release',
+		theatricalReleaseDate: 'Theatrical Release',
+		digitalReleaseDate: 'Digital Release',
+		physicalReleaseDate: 'Physical Release'
 	};
 
 	const SONARR_CARD_STORAGE_KEY = 'profilarr-library-card-fields-sonarr';
@@ -533,7 +559,9 @@
 		'releaseGroups',
 		'status',
 		'rating',
-		'dateAdded'
+		'dateAdded',
+		'firstAired',
+		'previousAiring'
 	] as const;
 	const SONARR_CARD_DEFAULTS: readonly string[] = ['monitored', 'profile', 'size', 'episodes'];
 	type SonarrCardField = (typeof SONARR_CARD_FIELDS)[number];
@@ -548,7 +576,9 @@
 		releaseGroups: 'Release Group(s)',
 		status: 'Status',
 		rating: 'Rating',
-		dateAdded: 'Date Added'
+		dateAdded: 'Date Added',
+		firstAired: 'Series Premiere',
+		previousAiring: 'Latest Aired Episode'
 	};
 
 	function loadCardFields<T extends string>(key: string, defaults: readonly string[]): Set<T> {
@@ -654,6 +684,14 @@
 
 	let cardSortKey = 'title';
 	let cardSortDirection: 'asc' | 'desc' = 'asc';
+	$: if (
+		(isRadarr && (cardSortKey === 'firstAired' || cardSortKey === 'previousAiring')) ||
+		(isSonarr &&
+			RADARR_RELEASE_DATE_KEYS.includes(cardSortKey as (typeof RADARR_RELEASE_DATE_KEYS)[number]))
+	) {
+		cardSortKey = 'title';
+		cardSortDirection = 'asc';
+	}
 
 	function handleCardSort(key: string, direction: 'asc' | 'desc') {
 		cardSortKey = key;
@@ -662,6 +700,14 @@
 
 	function sortItems<T>(items: T[], key: string, direction: 'asc' | 'desc'): T[] {
 		return [...items].sort((a: any, b: any) => {
+			if (
+				RADARR_RELEASE_DATE_KEYS.includes(key as (typeof RADARR_RELEASE_DATE_KEYS)[number]) ||
+				key === 'firstAired' ||
+				key === 'previousAiring'
+			) {
+				return compareOptionalDates(a[key], b[key], direction);
+			}
+
 			let aVal: any;
 			let bVal: any;
 

--- a/src/routes/arr/[id]/library/components/LibraryActionBar.svelte
+++ b/src/routes/arr/[id]/library/components/LibraryActionBar.svelte
@@ -60,7 +60,7 @@
 	export let onSort: (key: string, direction: 'asc' | 'desc') => void = () => {};
 	export let useSimpleMode: boolean = false;
 
-	const sortOptions = [
+	const commonSortOptions = [
 		{ key: 'title', label: 'Title' },
 		{ key: 'size', label: 'Size' },
 		{ key: 'dateAdded', label: 'Date Added' },
@@ -78,6 +78,19 @@
 	}
 
 	$: isRadarr = instanceType === 'radarr';
+	$: sortOptions = isRadarr
+		? [
+				...commonSortOptions,
+				{ key: 'initialReleaseDate', label: 'Initial Release' },
+				{ key: 'theatricalReleaseDate', label: 'Theatrical Release' },
+				{ key: 'digitalReleaseDate', label: 'Digital Release' },
+				{ key: 'physicalReleaseDate', label: 'Physical Release' }
+			]
+		: [
+				...commonSortOptions,
+				{ key: 'firstAired', label: 'Series Premiere' },
+				{ key: 'previousAiring', label: 'Latest Aired Episode' }
+			];
 	$: filterPlaceholder = isRadarr ? 'Filter movies...' : 'Filter series...';
 	$: openLabel = isRadarr ? 'Open in Radarr' : 'Open in Sonarr';
 	$: refreshTooltip = refreshStatusText ? `Refresh · ${refreshStatusText}` : 'Refresh';

--- a/src/routes/arr/[id]/library/components/MovieCard.svelte
+++ b/src/routes/arr/[id]/library/components/MovieCard.svelte
@@ -188,14 +188,67 @@
 				{/if}
 			</div>
 		{/if}
-		{#if visibleFields.has('dateAdded') && movie.dateAdded}
+		{#if visibleFields.has('dateAdded')}
 			<span class="flex items-center gap-1 text-xs text-neutral-500 dark:text-neutral-400">
 				<Calendar size={12} />
+				<span>Added:</span>
 				<span class="font-mono"
 					><DateTime
 						value={movie.dateAdded}
 						date
-						options={{ month: 'short', day: 'numeric', year: '2-digit' }}
+						options={{ month: 'short', day: 'numeric', year: 'numeric' }}
+					/></span
+				>
+			</span>
+		{/if}
+		{#if visibleFields.has('initialReleaseDate')}
+			<span class="flex items-center gap-1 text-xs text-neutral-500 dark:text-neutral-400">
+				<Calendar size={12} />
+				<span>Initial:</span>
+				<span class="font-mono"
+					><DateTime
+						value={movie.initialReleaseDate}
+						date
+						options={{ month: 'short', day: 'numeric', year: 'numeric' }}
+					/></span
+				>
+			</span>
+		{/if}
+		{#if visibleFields.has('theatricalReleaseDate')}
+			<span class="flex items-center gap-1 text-xs text-neutral-500 dark:text-neutral-400">
+				<Calendar size={12} />
+				<span>Theatrical:</span>
+				<span class="font-mono"
+					><DateTime
+						value={movie.theatricalReleaseDate}
+						date
+						options={{ month: 'short', day: 'numeric', year: 'numeric' }}
+					/></span
+				>
+			</span>
+		{/if}
+		{#if visibleFields.has('digitalReleaseDate')}
+			<span class="flex items-center gap-1 text-xs text-neutral-500 dark:text-neutral-400">
+				<Calendar size={12} />
+				<span>Digital:</span>
+				<span class="font-mono"
+					><DateTime
+						value={movie.digitalReleaseDate}
+						date
+						options={{ month: 'short', day: 'numeric', year: 'numeric' }}
+					/></span
+				>
+			</span>
+		{/if}
+		{#if visibleFields.has('physicalReleaseDate')}
+			<span class="flex items-center gap-1 text-xs text-neutral-500 dark:text-neutral-400">
+				<Calendar size={12} />
+				<span>Physical:</span>
+				<span class="font-mono"
+					><DateTime
+						value={movie.physicalReleaseDate}
+						date
+						options={{ month: 'short', day: 'numeric', year: 'numeric' }}
 					/></span
 				>
 			</span>

--- a/src/routes/arr/[id]/library/components/MovieRow.svelte
+++ b/src/routes/arr/[id]/library/components/MovieRow.svelte
@@ -31,7 +31,7 @@
 		return formatDate(isoString, $serverTimezone, $dateFormat, {
 			month: 'short',
 			day: 'numeric',
-			year: '2-digit'
+			year: 'numeric'
 		});
 	}
 </script>
@@ -140,6 +140,22 @@
 	{:else if column.key === 'dateAdded'}
 		<span class="font-mono text-xs text-neutral-700 dark:text-neutral-300">
 			{fmtDate(row.dateAdded)}
+		</span>
+	{:else if column.key === 'initialReleaseDate'}
+		<span class="font-mono text-xs text-neutral-700 dark:text-neutral-300">
+			{fmtDate(row.initialReleaseDate)}
+		</span>
+	{:else if column.key === 'theatricalReleaseDate'}
+		<span class="font-mono text-xs text-neutral-700 dark:text-neutral-300">
+			{fmtDate(row.theatricalReleaseDate)}
+		</span>
+	{:else if column.key === 'digitalReleaseDate'}
+		<span class="font-mono text-xs text-neutral-700 dark:text-neutral-300">
+			{fmtDate(row.digitalReleaseDate)}
+		</span>
+	{:else if column.key === 'physicalReleaseDate'}
+		<span class="font-mono text-xs text-neutral-700 dark:text-neutral-300">
+			{fmtDate(row.physicalReleaseDate)}
 		</span>
 	{/if}
 {:else}

--- a/src/routes/arr/[id]/library/components/MovieRowSkeleton.svelte
+++ b/src/routes/arr/[id]/library/components/MovieRowSkeleton.svelte
@@ -30,7 +30,7 @@
 	</div>
 {:else if column.key === 'popularity'}
 	<div class="h-4 w-8 animate-pulse rounded bg-neutral-200 dark:bg-neutral-700"></div>
-{:else if column.key === 'dateAdded'}
+{:else if column.key === 'dateAdded' || column.key === 'initialReleaseDate' || column.key === 'theatricalReleaseDate' || column.key === 'digitalReleaseDate' || column.key === 'physicalReleaseDate'}
 	<div class="h-4 w-16 animate-pulse rounded bg-neutral-200 dark:bg-neutral-700"></div>
 {:else if column.key === 'actions'}
 	<div class="flex justify-center">

--- a/src/routes/arr/[id]/library/components/RadarrTableView.svelte
+++ b/src/routes/arr/[id]/library/components/RadarrTableView.svelte
@@ -4,7 +4,7 @@
 	import ExpandableTable from '$ui/table/ExpandableTable.svelte';
 	import type { Column, SortState } from '$ui/table/types';
 	import type { RadarrLibraryItem } from '$utils/arr/types.ts';
-	import { sortTitle } from '$shared/utils/sort.ts';
+	import { dateSortValue, sortTitle } from '$shared/utils/sort.ts';
 
 	import ProgressIndicator from '$ui/arr/ProgressIndicator.svelte';
 	import MovieRow from './MovieRow.svelte';
@@ -32,7 +32,11 @@
 		'sizeOnDisk',
 		'status',
 		'popularity',
-		'dateAdded'
+		'dateAdded',
+		'initialReleaseDate',
+		'theatricalReleaseDate',
+		'digitalReleaseDate',
+		'physicalReleaseDate'
 	] as const;
 	type ToggleableColumn = (typeof TOGGLEABLE_COLUMNS)[number];
 
@@ -81,6 +85,46 @@
 			sortable: true,
 			sortAccessor: (row) => (row.dateAdded ? new Date(row.dateAdded).getTime() : 0),
 			defaultSortDirection: 'desc'
+		},
+		{
+			key: 'initialReleaseDate',
+			header: 'Initial Release',
+			align: 'right',
+			width: 'w-32',
+			sortable: true,
+			sortAccessor: (row) => dateSortValue(row.initialReleaseDate),
+			defaultSortDirection: 'desc',
+			sortNullsLast: true
+		},
+		{
+			key: 'theatricalReleaseDate',
+			header: 'Theatrical Release',
+			align: 'right',
+			width: 'w-40',
+			sortable: true,
+			sortAccessor: (row) => dateSortValue(row.theatricalReleaseDate),
+			defaultSortDirection: 'desc',
+			sortNullsLast: true
+		},
+		{
+			key: 'digitalReleaseDate',
+			header: 'Digital Release',
+			align: 'right',
+			width: 'w-36',
+			sortable: true,
+			sortAccessor: (row) => dateSortValue(row.digitalReleaseDate),
+			defaultSortDirection: 'desc',
+			sortNullsLast: true
+		},
+		{
+			key: 'physicalReleaseDate',
+			header: 'Physical Release',
+			align: 'right',
+			width: 'w-36',
+			sortable: true,
+			sortAccessor: (row) => dateSortValue(row.physicalReleaseDate),
+			defaultSortDirection: 'desc',
+			sortNullsLast: true
 		},
 		{ key: 'releaseGroup', header: 'Release Group', align: 'left', width: 'w-36', sortable: true }
 	];

--- a/src/routes/arr/[id]/library/components/SeriesCard.svelte
+++ b/src/routes/arr/[id]/library/components/SeriesCard.svelte
@@ -259,14 +259,41 @@
 				<span class="font-mono">{series.ratings.value}</span>
 			</span>
 		{/if}
-		{#if visibleFields.has('dateAdded') && series.dateAdded}
+		{#if visibleFields.has('dateAdded')}
 			<span class="flex items-center gap-1 text-xs text-neutral-500 dark:text-neutral-400">
 				<Calendar size={12} />
+				<span>Added:</span>
 				<span class="font-mono"
 					><DateTime
 						value={series.dateAdded}
 						date
-						options={{ month: 'short', day: 'numeric', year: '2-digit' }}
+						options={{ month: 'short', day: 'numeric', year: 'numeric' }}
+					/></span
+				>
+			</span>
+		{/if}
+		{#if visibleFields.has('firstAired')}
+			<span class="flex items-center gap-1 text-xs text-neutral-500 dark:text-neutral-400">
+				<Calendar size={12} />
+				<span>Premiere:</span>
+				<span class="font-mono"
+					><DateTime
+						value={series.firstAired}
+						date
+						options={{ month: 'short', day: 'numeric', year: 'numeric' }}
+					/></span
+				>
+			</span>
+		{/if}
+		{#if visibleFields.has('previousAiring')}
+			<span class="flex items-center gap-1 text-xs text-neutral-500 dark:text-neutral-400">
+				<Calendar size={12} />
+				<span>Latest aired:</span>
+				<span class="font-mono"
+					><DateTime
+						value={series.previousAiring}
+						date
+						options={{ month: 'short', day: 'numeric', year: 'numeric' }}
 					/></span
 				>
 			</span>

--- a/src/routes/arr/[id]/library/components/SeriesRow.svelte
+++ b/src/routes/arr/[id]/library/components/SeriesRow.svelte
@@ -30,7 +30,7 @@
 		return formatDate(isoString, $serverTimezone, $dateFormat, {
 			month: 'short',
 			day: 'numeric',
-			year: '2-digit'
+			year: 'numeric'
 		});
 	}
 </script>
@@ -105,5 +105,13 @@
 {:else if column.key === 'dateAdded'}
 	<span class="font-mono text-xs text-neutral-700 dark:text-neutral-300"
 		>{fmtDate(row.dateAdded)}</span
+	>
+{:else if column.key === 'firstAired'}
+	<span class="font-mono text-xs text-neutral-700 dark:text-neutral-300"
+		>{fmtDate(row.firstAired)}</span
+	>
+{:else if column.key === 'previousAiring'}
+	<span class="font-mono text-xs text-neutral-700 dark:text-neutral-300"
+		>{fmtDate(row.previousAiring)}</span
 	>
 {/if}

--- a/src/routes/arr/[id]/library/components/SeriesRowSkeleton.svelte
+++ b/src/routes/arr/[id]/library/components/SeriesRowSkeleton.svelte
@@ -21,6 +21,6 @@
 	<div class="h-4 w-16 animate-pulse rounded bg-neutral-200 dark:bg-neutral-700"></div>
 {:else if column.key === 'releaseGroups'}
 	<div class="h-4 w-20 animate-pulse rounded bg-neutral-200 dark:bg-neutral-700"></div>
-{:else if column.key === 'dateAdded'}
+{:else if column.key === 'dateAdded' || column.key === 'firstAired' || column.key === 'previousAiring'}
 	<div class="h-4 w-16 animate-pulse rounded bg-neutral-200 dark:bg-neutral-700"></div>
 {/if}

--- a/src/routes/arr/[id]/library/components/SonarrTableView.svelte
+++ b/src/routes/arr/[id]/library/components/SonarrTableView.svelte
@@ -4,7 +4,7 @@
 	import ExpandableTable from '$ui/table/ExpandableTable.svelte';
 	import type { Column, SortState } from '$ui/table/types';
 	import type { SonarrSeriesItem, SonarrSeasonItem, SonarrEpisodeItem } from '$utils/arr/types.ts';
-	import { sortTitle } from '$shared/utils/sort.ts';
+	import { dateSortValue, sortTitle } from '$shared/utils/sort.ts';
 
 	import ProgressIndicator from '$ui/arr/ProgressIndicator.svelte';
 	import SeriesRow from './SeriesRow.svelte';
@@ -25,7 +25,9 @@
 		'sizeOnDisk',
 		'releaseGroups',
 		'status',
-		'dateAdded'
+		'dateAdded',
+		'firstAired',
+		'previousAiring'
 	] as const;
 	type ToggleableColumn = (typeof TOGGLEABLE_COLUMNS)[number];
 
@@ -73,6 +75,26 @@
 			sortable: true,
 			sortAccessor: (row) => (row.dateAdded ? new Date(row.dateAdded).getTime() : 0),
 			defaultSortDirection: 'desc'
+		},
+		{
+			key: 'firstAired',
+			header: 'Series Premiere',
+			align: 'right',
+			width: 'w-36',
+			sortable: true,
+			sortAccessor: (row) => dateSortValue(row.firstAired),
+			defaultSortDirection: 'desc',
+			sortNullsLast: true
+		},
+		{
+			key: 'previousAiring',
+			header: 'Latest Aired Episode',
+			align: 'right',
+			width: 'w-44',
+			sortable: true,
+			sortAccessor: (row) => dateSortValue(row.previousAiring),
+			defaultSortDirection: 'desc',
+			sortNullsLast: true
 		}
 	];
 

--- a/tests/unit/arr/releaseDates.test.ts
+++ b/tests/unit/arr/releaseDates.test.ts
@@ -1,0 +1,77 @@
+import { assertEquals } from '@std/assert';
+import { BaseTest } from '../base/BaseTest.ts';
+import { resolveRadarrInitialReleaseDate } from '../../../src/lib/server/utils/arr/releaseDates.ts';
+import type { RadarrMovie } from '../../../src/lib/server/utils/arr/types.ts';
+
+function movie(dates: Partial<RadarrMovie>): RadarrMovie {
+	return {
+		id: 1,
+		title: 'Test Movie',
+		qualityProfileId: 1,
+		hasFile: false,
+		...dates
+	};
+}
+
+class ReleaseDatesTest extends BaseTest {
+	runTests(): void {
+		this.test('prefers theatrical release over earlier availability dates', () => {
+			assertEquals(
+				resolveRadarrInitialReleaseDate(
+					movie({
+						inCinemas: '2025-03-01T00:00:00Z',
+						digitalRelease: '2025-02-01T00:00:00Z',
+						physicalRelease: '2025-01-01T00:00:00Z'
+					})
+				),
+				'2025-03-01T00:00:00Z'
+			);
+		});
+
+		this.test('uses the earliest digital or physical fallback', () => {
+			assertEquals(
+				resolveRadarrInitialReleaseDate(
+					movie({
+						digitalRelease: '2025-04-01T00:00:00Z',
+						physicalRelease: '2025-03-01T00:00:00Z'
+					})
+				),
+				'2025-03-01T00:00:00Z'
+			);
+			assertEquals(
+				resolveRadarrInitialReleaseDate(
+					movie({
+						digitalRelease: '2025-02-01T00:00:00Z',
+						physicalRelease: '2025-03-01T00:00:00Z'
+					})
+				),
+				'2025-02-01T00:00:00Z'
+			);
+		});
+
+		this.test('uses matching digital and physical fallbacks', () => {
+			assertEquals(
+				resolveRadarrInitialReleaseDate(
+					movie({
+						digitalRelease: '2025-03-01T00:00:00Z',
+						physicalRelease: '2025-03-01T00:00:00Z'
+					})
+				),
+				'2025-03-01T00:00:00Z'
+			);
+		});
+
+		this.test('skips invalid dates and returns unknown when none are valid', () => {
+			assertEquals(
+				resolveRadarrInitialReleaseDate(
+					movie({ digitalRelease: 'invalid', physicalRelease: '2025-03-01T00:00:00Z' })
+				),
+				'2025-03-01T00:00:00Z'
+			);
+			assertEquals(resolveRadarrInitialReleaseDate(movie({ inCinemas: 'invalid' })), undefined);
+		});
+	}
+}
+
+const test = new ReleaseDatesTest();
+test.runTests();

--- a/tests/unit/shared/sort.test.ts
+++ b/tests/unit/shared/sort.test.ts
@@ -1,0 +1,26 @@
+import { assertEquals } from '@std/assert';
+import { BaseTest } from '../base/BaseTest.ts';
+import { compareOptionalDates } from '../../../src/lib/shared/utils/sort.ts';
+
+class SortTest extends BaseTest {
+	runTests(): void {
+		const dates = ['2025-04-10T00:00:00Z', undefined, 'invalid', '2024-01-15T00:00:00Z'];
+
+		this.test('sorts optional dates oldest first with unknown dates last', () => {
+			assertEquals(
+				[...dates].sort((a, b) => compareOptionalDates(a, b, 'asc')),
+				['2024-01-15T00:00:00Z', '2025-04-10T00:00:00Z', 'invalid', undefined]
+			);
+		});
+
+		this.test('sorts optional dates newest first with unknown dates last', () => {
+			assertEquals(
+				[...dates].sort((a, b) => compareOptionalDates(a, b, 'desc')),
+				['2025-04-10T00:00:00Z', '2024-01-15T00:00:00Z', 'invalid', undefined]
+			);
+		});
+	}
+}
+
+const test = new SortTest();
+test.runTests();


### PR DESCRIPTION
- Add Radarr initial, theatrical, digital, and physical release dates to card and table views
- Add Sonarr premiere and latest aired dates to card and table views
- Sort missing or invalid release dates last in either direction
- Show explicit date labels with four-digit years

Closes #898