### PR TITLE
fix: persist library sort and download status filter

### DIFF
--- a/src/lib/client/stores/libraryPrefs.ts
+++ b/src/lib/client/stores/libraryPrefs.ts
@@ -1,0 +1,147 @@
+/**
+ * Persisted library view preferences.
+ * Each store loads from localStorage on creation (defaults on the server),
+ * validates via the parsers in `$shared/utils/libraryPrefs.ts`, and writes
+ * back on every change.
+ */
+
+import { writable, type Writable } from 'svelte/store';
+import { browser } from '$app/environment';
+import {
+	DEFAULT_LIBRARY_SORT,
+	LIBRARY_DOWNLOAD_STATUSES,
+	RADARR_CARD_DEFAULTS,
+	RADARR_CARD_FIELDS,
+	RADARR_DEFAULT_COLUMNS,
+	RADARR_TOGGLEABLE_COLUMNS,
+	SONARR_CARD_DEFAULTS,
+	SONARR_CARD_FIELDS,
+	SONARR_DEFAULT_COLUMNS,
+	SONARR_TOGGLEABLE_COLUMNS,
+	parseBooleanPref,
+	parseLibraryDownloadStatusesPref,
+	parseLibrarySortPref,
+	parseStringSetPref,
+	type LibraryDownloadStatus,
+	type LibrarySort
+} from '$shared/utils/libraryPrefs.ts';
+
+export interface PersistedPref<T> extends Writable<T> {
+	/** Storage key this preference is persisted under */
+	readonly storageKey: string;
+}
+
+/**
+ * Create a writable store backed by localStorage.
+ * `parse` receives the raw stored string (or null when absent) and must return
+ * a valid value; `serialize` converts a value to the stored string.
+ */
+export function createPersistedPref<T>(
+	storageKey: string,
+	parse: (raw: string | null) => T,
+	serialize: (value: T) => string
+): PersistedPref<T> {
+	let raw: string | null = null;
+	if (browser) {
+		try {
+			raw = localStorage.getItem(storageKey);
+		} catch {
+			// storage may be unavailable (private mode, quota); fall back to defaults
+		}
+	}
+
+	const store = writable<T>(parse(raw));
+
+	if (browser) {
+		store.subscribe((value) => {
+			try {
+				localStorage.setItem(storageKey, serialize(value));
+			} catch {
+				// non-fatal
+			}
+		});
+	}
+
+	return { ...store, storageKey };
+}
+
+/**
+ * Set-valued preference. Typed as `Set<string>` so the page can pass through
+ * untyped keys from the action bar; parsing still restricts values to `allowed`.
+ */
+function createSetPref<T extends string>(
+	storageKey: string,
+	allowed: readonly T[],
+	defaults: readonly T[]
+): PersistedPref<Set<string>> {
+	return createPersistedPref<Set<string>>(
+		storageKey,
+		(raw) => parseStringSetPref(raw, allowed, defaults),
+		(value) => JSON.stringify([...value])
+	);
+}
+
+/** Toggle membership of `key` in a set-valued preference. */
+export function toggleSetPref<T extends string>(pref: Writable<Set<T>>, key: T): void {
+	pref.update((current) => {
+		const next = new Set(current);
+		if (next.has(key)) next.delete(key);
+		else next.add(key);
+		return next;
+	});
+}
+
+// =============================================================================
+// Library preference stores
+// =============================================================================
+
+export function createLibraryExpandAllPref(): PersistedPref<boolean> {
+	return createPersistedPref(
+		'profilarr-library-expand-all',
+		(raw) => parseBooleanPref(raw, false),
+		String
+	);
+}
+
+export function createLibraryColumnsPref(instanceType: string): PersistedPref<Set<string>> {
+	return instanceType === 'sonarr'
+		? createSetPref(
+				'profilarr-library-sonarr-columns',
+				SONARR_TOGGLEABLE_COLUMNS,
+				SONARR_DEFAULT_COLUMNS
+			)
+		: createSetPref('profilarr-library-columns', RADARR_TOGGLEABLE_COLUMNS, RADARR_DEFAULT_COLUMNS);
+}
+
+export function createLibraryCardFieldsPref(instanceType: string): PersistedPref<Set<string>> {
+	return instanceType === 'sonarr'
+		? createSetPref(
+				'profilarr-library-card-fields-sonarr',
+				SONARR_CARD_FIELDS,
+				SONARR_CARD_DEFAULTS
+			)
+		: createSetPref('profilarr-library-card-fields', RADARR_CARD_FIELDS, RADARR_CARD_DEFAULTS);
+}
+
+export function createLibraryDownloadStatusesPref(
+	instanceId: number
+): PersistedPref<Set<LibraryDownloadStatus>> {
+	return createPersistedPref<Set<LibraryDownloadStatus>>(
+		`profilarr-library-download-status:${instanceId}`,
+		parseLibraryDownloadStatusesPref,
+		(value) => JSON.stringify([...value])
+	);
+}
+
+export function createLibrarySortPref(
+	instanceId: number,
+	instanceType: string
+): PersistedPref<LibrarySort> {
+	return createPersistedPref(
+		`profilarr-library-sort:${instanceId}`,
+		(raw) => parseLibrarySortPref(raw, instanceType),
+		JSON.stringify
+	);
+}
+
+export { DEFAULT_LIBRARY_SORT, LIBRARY_DOWNLOAD_STATUSES };

--- a/src/lib/shared/utils/libraryPrefs.ts
+++ b/src/lib/shared/utils/libraryPrefs.ts
@@ -1,0 +1,218 @@
+/**
+ * Library view preferences: option lists, defaults, and pure parsers for
+ * values persisted in localStorage. Storage access lives in
+ * `$stores/libraryPrefs.ts`; this module has no browser dependencies so it can
+ * be unit tested.
+ */
+
+export type LibraryInstanceType = 'radarr' | 'sonarr';
+
+// =============================================================================
+// Columns
+// =============================================================================
+
+export const RADARR_RELEASE_DATE_KEYS = [
+	'initialReleaseDate',
+	'theatricalReleaseDate',
+	'digitalReleaseDate',
+	'physicalReleaseDate'
+] as const;
+export type RadarrReleaseDateKey = (typeof RADARR_RELEASE_DATE_KEYS)[number];
+
+export const RADARR_TOGGLEABLE_COLUMNS = [
+	'status',
+	'qualityName',
+	'score',
+	'sizeOnDisk',
+	'popularity',
+	'dateAdded',
+	...RADARR_RELEASE_DATE_KEYS,
+	'releaseGroup'
+] as const;
+export type RadarrToggleableColumn = (typeof RADARR_TOGGLEABLE_COLUMNS)[number];
+export const RADARR_DEFAULT_COLUMNS: readonly RadarrToggleableColumn[] =
+	RADARR_TOGGLEABLE_COLUMNS.filter(
+		(key) => !RADARR_RELEASE_DATE_KEYS.includes(key as RadarrReleaseDateKey)
+	);
+
+export const SONARR_TOGGLEABLE_COLUMNS = [
+	'status',
+	'episodes',
+	'sizeOnDisk',
+	'releaseGroups',
+	'dateAdded',
+	'firstAired',
+	'previousAiring'
+] as const;
+export type SonarrToggleableColumn = (typeof SONARR_TOGGLEABLE_COLUMNS)[number];
+export const SONARR_DEFAULT_COLUMNS: readonly SonarrToggleableColumn[] =
+	SONARR_TOGGLEABLE_COLUMNS.filter((key) => key !== 'firstAired' && key !== 'previousAiring');
+
+// =============================================================================
+// Card fields
+// =============================================================================
+
+export const RADARR_CARD_FIELDS = [
+	'monitored',
+	'title',
+	'profile',
+	'size',
+	'score',
+	'quality',
+	'year',
+	'releaseGroup',
+	'status',
+	'popularity',
+	'runtime',
+	'rating',
+	'dateAdded',
+	...RADARR_RELEASE_DATE_KEYS
+] as const;
+export type RadarrCardField = (typeof RADARR_CARD_FIELDS)[number];
+export const RADARR_CARD_DEFAULTS: readonly RadarrCardField[] = [
+	'monitored',
+	'profile',
+	'size',
+	'score'
+];
+
+export const SONARR_CARD_FIELDS = [
+	'monitored',
+	'title',
+	'profile',
+	'size',
+	'episodes',
+	'year',
+	'releaseGroups',
+	'status',
+	'rating',
+	'dateAdded',
+	'firstAired',
+	'previousAiring'
+] as const;
+export type SonarrCardField = (typeof SONARR_CARD_FIELDS)[number];
+export const SONARR_CARD_DEFAULTS: readonly SonarrCardField[] = [
+	'monitored',
+	'profile',
+	'size',
+	'episodes'
+];
+
+// =============================================================================
+// Sort
+// =============================================================================
+
+export type LibrarySortDirection = 'asc' | 'desc';
+
+export interface LibrarySort {
+	key: string;
+	direction: LibrarySortDirection;
+}
+
+export interface LibrarySortOption {
+	key: string;
+	label: string;
+}
+
+const COMMON_SORT_OPTIONS: readonly LibrarySortOption[] = [
+	{ key: 'title', label: 'Title' },
+	{ key: 'size', label: 'Size' },
+	{ key: 'dateAdded', label: 'Date Added' },
+	{ key: 'year', label: 'Year' },
+	{ key: 'score', label: 'Score' }
+];
+
+const RADARR_SORT_OPTIONS: readonly LibrarySortOption[] = [
+	...COMMON_SORT_OPTIONS,
+	{ key: 'initialReleaseDate', label: 'Initial Release' },
+	{ key: 'theatricalReleaseDate', label: 'Theatrical Release' },
+	{ key: 'digitalReleaseDate', label: 'Digital Release' },
+	{ key: 'physicalReleaseDate', label: 'Physical Release' }
+];
+
+const SONARR_SORT_OPTIONS: readonly LibrarySortOption[] = [
+	...COMMON_SORT_OPTIONS,
+	{ key: 'firstAired', label: 'Series Premiere' },
+	{ key: 'previousAiring', label: 'Latest Aired Episode' }
+];
+
+export const DEFAULT_LIBRARY_SORT: LibrarySort = { key: 'title', direction: 'asc' };
+
+export function getLibrarySortOptions(instanceType: string): readonly LibrarySortOption[] {
+	if (instanceType === 'radarr') return RADARR_SORT_OPTIONS;
+	if (instanceType === 'sonarr') return SONARR_SORT_OPTIONS;
+	return COMMON_SORT_OPTIONS;
+}
+
+// =============================================================================
+// Download status
+// =============================================================================
+
+export type LibraryDownloadStatus = 'downloaded' | 'missing';
+export const LIBRARY_DOWNLOAD_STATUSES: readonly LibraryDownloadStatus[] = [
+	'downloaded',
+	'missing'
+];
+
+// =============================================================================
+// Parsers
+// =============================================================================
+
+/**
+ * Parse a stored boolean. Only the literal string "true" is truthy.
+ */
+export function parseBooleanPref(raw: string | null, fallback: boolean): boolean {
+	if (raw === null) return fallback;
+	if (raw === 'true') return true;
+	if (raw === 'false') return false;
+	return fallback;
+}
+
+/**
+ * Parse a stored JSON array into a set restricted to `allowed`.
+ * Unknown entries are dropped so removed keys don't linger in storage. An
+ * empty array is a valid selection. Malformed input returns `defaults`.
+ */
+export function parseStringSetPref<T extends string>(
+	raw: string | null,
+	allowed: readonly T[],
+	defaults: readonly T[]
+): Set<T> {
+	if (raw === null) return new Set(defaults);
+	try {
+		const parsed: unknown = JSON.parse(raw);
+		if (!Array.isArray(parsed)) return new Set(defaults);
+		const result = new Set<T>();
+		for (const value of parsed) {
+			if (allowed.includes(value as T)) result.add(value as T);
+		}
+		return result;
+	} catch {
+		return new Set(defaults);
+	}
+}
+
+/**
+ * Parse a stored sort preference for the given instance type. Keys that are
+ * not valid for the type (e.g. a Radarr release date on Sonarr) fall back to
+ * the default sort.
+ */
+export function parseLibrarySortPref(raw: string | null, instanceType: string): LibrarySort {
+	const fallback = { ...DEFAULT_LIBRARY_SORT };
+	if (raw === null) return fallback;
+	try {
+		const parsed: unknown = JSON.parse(raw);
+		if (!parsed || typeof parsed !== 'object') return fallback;
+		const { key, direction } = parsed as Record<string, unknown>;
+		if (typeof key !== 'string') return fallback;
+		if (!getLibrarySortOptions(instanceType).some((o) => o.key === key)) return fallback;
+		if (direction !== 'asc' && direction !== 'desc') return fallback;
+		return { key, direction };
+	} catch {
+		return fallback;
+	}
+}
+
+export function parseLibraryDownloadStatusesPref(raw: string | null): Set<LibraryDownloadStatus> {
+	return parseStringSetPref(raw, LIBRARY_DOWNLOAD_STATUSES, LIBRARY_DOWNLOAD_STATUSES);
+}

--- a/src/routes/arr/[id]/library/+page.svelte
+++ b/src/routes/arr/[id]/library/+page.svelte
@@ -9,6 +9,26 @@
 	import type { FilterFieldDef, FilterTag } from '$ui/filter/types';
 	import { applySmartFilters } from '$ui/filter/match';
 	import { createViewModeStore } from '$lib/client/stores/dataPage';
+	import {
+		createLibraryCardFieldsPref,
+		createLibraryColumnsPref,
+		createLibraryDownloadStatusesPref,
+		createLibraryExpandAllPref,
+		createLibrarySortPref,
+		toggleSetPref
+	} from '$stores/libraryPrefs';
+	import {
+		RADARR_CARD_FIELDS,
+		RADARR_RELEASE_DATE_KEYS,
+		RADARR_TOGGLEABLE_COLUMNS,
+		SONARR_CARD_FIELDS,
+		SONARR_TOGGLEABLE_COLUMNS,
+		type LibraryDownloadStatus,
+		type RadarrCardField,
+		type RadarrToggleableColumn,
+		type SonarrCardField,
+		type SonarrToggleableColumn
+	} from '$shared/utils/libraryPrefs';
 	import { createProgressiveList } from '$lib/client/utils/progressiveList';
 	import { getDisplayUrl } from '$lib/client/utils/arrDisplayUrl.ts';
 	import InfoModal from '$ui/modal/InfoModal.svelte';
@@ -23,8 +43,10 @@
 
 	export let data: PageData;
 
-	$: isRadarr = data.instance.type === 'radarr';
-	$: isSonarr = data.instance.type === 'sonarr';
+	$: instanceId = data.instance.id;
+	$: instanceType = data.instance.type;
+	$: isRadarr = instanceType === 'radarr';
+	$: isSonarr = instanceType === 'sonarr';
 	$: isSupported = isRadarr || isSonarr;
 
 	// ==========================================================================
@@ -42,17 +64,11 @@
 
 	// useSimpleMode is bound from LibraryActionBar, which derives it from isMobile + filterMode
 	let useSimpleMode = false;
-	type MovieDownloadStatus = 'downloaded' | 'missing';
-	let movieDownloadStatuses = new Set<MovieDownloadStatus>(['downloaded', 'missing']);
 
-	function handleMovieDownloadStatusToggle(status: MovieDownloadStatus) {
-		const next = new Set(movieDownloadStatuses);
-		if (next.has(status)) {
-			next.delete(status);
-		} else {
-			next.add(status);
-		}
-		movieDownloadStatuses = next;
+	$: movieDownloadStatusesPref = createLibraryDownloadStatusesPref(instanceId);
+
+	function handleMovieDownloadStatusToggle(status: LibraryDownloadStatus) {
+		toggleSetPref(movieDownloadStatusesPref, status);
 	}
 
 	const radarrFields: FilterFieldDef<RadarrLibraryItem>[] = [
@@ -209,23 +225,10 @@
 	// Expand All
 	// ==========================================================================
 
-	const EXPAND_ALL_STORAGE_KEY = 'profilarr-library-expand-all';
-
-	function loadExpandAll(): boolean {
-		if (!browser) return false;
-		try {
-			return localStorage.getItem(EXPAND_ALL_STORAGE_KEY) === 'true';
-		} catch {}
-		return false;
-	}
-
-	let expandAll = loadExpandAll();
+	const expandAllPref = createLibraryExpandAllPref();
 
 	function toggleExpandAll() {
-		expandAll = !expandAll;
-		if (browser) {
-			localStorage.setItem(EXPAND_ALL_STORAGE_KEY, String(expandAll));
-		}
+		expandAllPref.update((value) => !value);
 	}
 
 	// ==========================================================================
@@ -349,7 +352,6 @@
 	// Refetch if instance changes (navigation between instances)
 	$: if (browser && data.instance.id && data.instance.id !== currentInstanceId) {
 		currentInstanceId = data.instance.id;
-		movieDownloadStatuses = new Set(['downloaded', 'missing']);
 		loading = true;
 		refreshedAt = null;
 		nextRefreshAt = null;
@@ -360,58 +362,6 @@
 	// ==========================================================================
 	// Column Visibility (Radarr)
 	// ==========================================================================
-
-	const RADARR_STORAGE_KEY = 'profilarr-library-columns';
-	const RADARR_RELEASE_DATE_KEYS = [
-		'initialReleaseDate',
-		'theatricalReleaseDate',
-		'digitalReleaseDate',
-		'physicalReleaseDate'
-	] as const;
-	const RADARR_TOGGLEABLE_COLUMNS = [
-		'status',
-		'qualityName',
-		'score',
-		'sizeOnDisk',
-		'popularity',
-		'dateAdded',
-		...RADARR_RELEASE_DATE_KEYS,
-		'releaseGroup'
-	] as const;
-	const RADARR_DEFAULT_COLUMNS = RADARR_TOGGLEABLE_COLUMNS.filter(
-		(key) => !RADARR_RELEASE_DATE_KEYS.includes(key as (typeof RADARR_RELEASE_DATE_KEYS)[number])
-	);
-	type RadarrToggleableColumn = (typeof RADARR_TOGGLEABLE_COLUMNS)[number];
-
-	function loadRadarrColumnVisibility(): Set<RadarrToggleableColumn> {
-		if (!browser) return new Set<RadarrToggleableColumn>(RADARR_DEFAULT_COLUMNS);
-		try {
-			const stored = localStorage.getItem(RADARR_STORAGE_KEY);
-			if (stored) {
-				const parsed = JSON.parse(stored) as RadarrToggleableColumn[];
-				return new Set(parsed);
-			}
-		} catch {}
-		return new Set<RadarrToggleableColumn>(RADARR_DEFAULT_COLUMNS);
-	}
-
-	function saveRadarrColumnVisibility(visible: Set<RadarrToggleableColumn>) {
-		if (!browser) return;
-		localStorage.setItem(RADARR_STORAGE_KEY, JSON.stringify([...visible]));
-	}
-
-	let radarrVisibleColumns = loadRadarrColumnVisibility();
-
-	function toggleRadarrColumn(key: string) {
-		const colKey = key as RadarrToggleableColumn;
-		if (radarrVisibleColumns.has(colKey)) {
-			radarrVisibleColumns.delete(colKey);
-		} else {
-			radarrVisibleColumns.add(colKey);
-		}
-		radarrVisibleColumns = radarrVisibleColumns;
-		saveRadarrColumnVisibility(radarrVisibleColumns);
-	}
 
 	const radarrColumnLabels: Record<RadarrToggleableColumn, string> = {
 		qualityName: 'Quality',
@@ -431,51 +381,6 @@
 	// Column Visibility (Sonarr)
 	// ==========================================================================
 
-	const SONARR_STORAGE_KEY = 'profilarr-library-sonarr-columns';
-	const SONARR_TOGGLEABLE_COLUMNS = [
-		'status',
-		'episodes',
-		'sizeOnDisk',
-		'releaseGroups',
-		'dateAdded',
-		'firstAired',
-		'previousAiring'
-	] as const;
-	const SONARR_DEFAULT_COLUMNS = SONARR_TOGGLEABLE_COLUMNS.filter(
-		(key) => key !== 'firstAired' && key !== 'previousAiring'
-	);
-	type SonarrToggleableColumn = (typeof SONARR_TOGGLEABLE_COLUMNS)[number];
-
-	function loadSonarrColumnVisibility(): Set<SonarrToggleableColumn> {
-		if (!browser) return new Set<SonarrToggleableColumn>(SONARR_DEFAULT_COLUMNS);
-		try {
-			const stored = localStorage.getItem(SONARR_STORAGE_KEY);
-			if (stored) {
-				const parsed = JSON.parse(stored) as SonarrToggleableColumn[];
-				return new Set(parsed);
-			}
-		} catch {}
-		return new Set<SonarrToggleableColumn>(SONARR_DEFAULT_COLUMNS);
-	}
-
-	function saveSonarrColumnVisibility(visible: Set<SonarrToggleableColumn>) {
-		if (!browser) return;
-		localStorage.setItem(SONARR_STORAGE_KEY, JSON.stringify([...visible]));
-	}
-
-	let sonarrVisibleColumns = loadSonarrColumnVisibility();
-
-	function toggleSonarrColumn(key: string) {
-		const colKey = key as SonarrToggleableColumn;
-		if (sonarrVisibleColumns.has(colKey)) {
-			sonarrVisibleColumns.delete(colKey);
-		} else {
-			sonarrVisibleColumns.add(colKey);
-		}
-		sonarrVisibleColumns = sonarrVisibleColumns;
-		saveSonarrColumnVisibility(sonarrVisibleColumns);
-	}
-
 	const sonarrColumnLabels: Record<SonarrToggleableColumn, string> = {
 		episodes: 'Episodes',
 		sizeOnDisk: 'Size',
@@ -490,43 +395,18 @@
 	// Unified column toggle (delegates based on type)
 	// ==========================================================================
 
+	$: columnsPref = createLibraryColumnsPref(instanceType);
 	$: activeToggleableColumns = isRadarr ? RADARR_TOGGLEABLE_COLUMNS : SONARR_TOGGLEABLE_COLUMNS;
 	$: activeColumnLabels = isRadarr ? radarrColumnLabels : sonarrColumnLabels;
-	$: activeVisibleColumns = isRadarr
-		? new Set([...radarrVisibleColumns])
-		: new Set([...sonarrVisibleColumns]);
+	$: activeVisibleColumns = $columnsPref;
 
 	function toggleColumn(key: string) {
-		if (isRadarr) {
-			toggleRadarrColumn(key);
-		} else {
-			toggleSonarrColumn(key);
-		}
+		toggleSetPref(columnsPref, key);
 	}
 
 	// ==========================================================================
 	// Card Field Visibility
 	// ==========================================================================
-
-	const RADARR_CARD_STORAGE_KEY = 'profilarr-library-card-fields';
-	const RADARR_CARD_FIELDS = [
-		'monitored',
-		'title',
-		'profile',
-		'size',
-		'score',
-		'quality',
-		'year',
-		'releaseGroup',
-		'status',
-		'popularity',
-		'runtime',
-		'rating',
-		'dateAdded',
-		...RADARR_RELEASE_DATE_KEYS
-	] as const;
-	const RADARR_CARD_DEFAULTS: readonly string[] = ['monitored', 'profile', 'size', 'score'];
-	type RadarrCardField = (typeof RADARR_CARD_FIELDS)[number];
 
 	const radarrCardFieldLabels: Record<RadarrCardField, string> = {
 		monitored: 'Monitored',
@@ -548,24 +428,6 @@
 		physicalReleaseDate: 'Physical Release'
 	};
 
-	const SONARR_CARD_STORAGE_KEY = 'profilarr-library-card-fields-sonarr';
-	const SONARR_CARD_FIELDS = [
-		'monitored',
-		'title',
-		'profile',
-		'size',
-		'episodes',
-		'year',
-		'releaseGroups',
-		'status',
-		'rating',
-		'dateAdded',
-		'firstAired',
-		'previousAiring'
-	] as const;
-	const SONARR_CARD_DEFAULTS: readonly string[] = ['monitored', 'profile', 'size', 'episodes'];
-	type SonarrCardField = (typeof SONARR_CARD_FIELDS)[number];
-
 	const sonarrCardFieldLabels: Record<SonarrCardField, string> = {
 		monitored: 'Monitored',
 		title: 'Title',
@@ -581,47 +443,15 @@
 		previousAiring: 'Latest Aired Episode'
 	};
 
-	function loadCardFields<T extends string>(key: string, defaults: readonly string[]): Set<T> {
-		if (!browser) return new Set(defaults as T[]);
-		try {
-			const stored = localStorage.getItem(key);
-			if (stored) return new Set(JSON.parse(stored) as T[]);
-		} catch {}
-		return new Set(defaults as T[]);
-	}
-
-	let radarrCardFields = loadCardFields<RadarrCardField>(
-		RADARR_CARD_STORAGE_KEY,
-		RADARR_CARD_DEFAULTS
-	);
-	let sonarrCardFields = loadCardFields<SonarrCardField>(
-		SONARR_CARD_STORAGE_KEY,
-		SONARR_CARD_DEFAULTS
-	);
+	$: cardFieldsPref = createLibraryCardFieldsPref(instanceType);
 
 	function toggleCardField(key: string) {
-		if (isRadarr) {
-			const k = key as RadarrCardField;
-			if (radarrCardFields.has(k)) radarrCardFields.delete(k);
-			else radarrCardFields.add(k);
-			radarrCardFields = radarrCardFields;
-			if (browser)
-				localStorage.setItem(RADARR_CARD_STORAGE_KEY, JSON.stringify([...radarrCardFields]));
-		} else {
-			const k = key as SonarrCardField;
-			if (sonarrCardFields.has(k)) sonarrCardFields.delete(k);
-			else sonarrCardFields.add(k);
-			sonarrCardFields = sonarrCardFields;
-			if (browser)
-				localStorage.setItem(SONARR_CARD_STORAGE_KEY, JSON.stringify([...sonarrCardFields]));
-		}
+		toggleSetPref(cardFieldsPref, key);
 	}
 
 	$: activeCardFields = isRadarr ? RADARR_CARD_FIELDS : SONARR_CARD_FIELDS;
 	$: activeCardFieldLabels = isRadarr ? radarrCardFieldLabels : sonarrCardFieldLabels;
-	$: activeVisibleCardFields = isRadarr
-		? new Set([...radarrCardFields])
-		: new Set([...sonarrCardFields]);
+	$: activeVisibleCardFields = $cardFieldsPref;
 
 	// ==========================================================================
 	// Radarr Data & Columns
@@ -632,8 +462,8 @@
 	$: radarrLibrary = library as RadarrLibraryItem[];
 	$: scopedMovies = isRadarr
 		? radarrLibrary.filter((movie) => {
-				const status: MovieDownloadStatus = movie.hasFile ? 'downloaded' : 'missing';
-				return movieDownloadStatuses.has(status);
+				const status: LibraryDownloadStatus = movie.hasFile ? 'downloaded' : 'missing';
+				return $movieDownloadStatusesPref.has(status);
 			})
 		: [];
 	$: filteredMovies = (() => {
@@ -647,11 +477,11 @@
 	$: hasActiveMovieFilter = useSimpleMode ? simpleQuery.trim().length > 0 : filterTags.length > 0;
 	$: movieEmptyMessage = hasActiveMovieFilter
 		? 'No movies match the current filters'
-		: movieDownloadStatuses.size === 0
+		: $movieDownloadStatusesPref.size === 0
 			? 'No download statuses selected'
-			: movieDownloadStatuses.size === 1 && movieDownloadStatuses.has('downloaded')
+			: $movieDownloadStatusesPref.size === 1 && $movieDownloadStatusesPref.has('downloaded')
 				? 'No downloaded movies'
-				: movieDownloadStatuses.size === 1 && movieDownloadStatuses.has('missing')
+				: $movieDownloadStatusesPref.size === 1 && $movieDownloadStatusesPref.has('missing')
 					? 'No missing movies'
 					: 'No movies found';
 
@@ -682,20 +512,10 @@
 	// Card Sort
 	// ==========================================================================
 
-	let cardSortKey = 'title';
-	let cardSortDirection: 'asc' | 'desc' = 'asc';
-	$: if (
-		(isRadarr && (cardSortKey === 'firstAired' || cardSortKey === 'previousAiring')) ||
-		(isSonarr &&
-			RADARR_RELEASE_DATE_KEYS.includes(cardSortKey as (typeof RADARR_RELEASE_DATE_KEYS)[number]))
-	) {
-		cardSortKey = 'title';
-		cardSortDirection = 'asc';
-	}
+	$: sortPref = createLibrarySortPref(instanceId, instanceType);
 
 	function handleCardSort(key: string, direction: 'asc' | 'desc') {
-		cardSortKey = key;
-		cardSortDirection = direction;
+		sortPref.set({ key, direction });
 	}
 
 	function sortItems<T>(items: T[], key: string, direction: 'asc' | 'desc'): T[] {
@@ -742,8 +562,8 @@
 		});
 	}
 
-	$: sortedMovies = sortItems(filteredMovies, cardSortKey, cardSortDirection);
-	$: sortedSeries = sortItems(filteredSeries, cardSortKey, cardSortDirection);
+	$: sortedMovies = sortItems(filteredMovies, $sortPref.key, $sortPref.direction);
+	$: sortedSeries = sortItems(filteredSeries, $sortPref.key, $sortPref.direction);
 
 	// ==========================================================================
 	// Card View Progressive Loading
@@ -817,13 +637,13 @@
 			onRefresh={handleRefresh}
 			onOpen={handleOpen}
 			instanceType={data.instance.type}
-			{movieDownloadStatuses}
+			movieDownloadStatuses={$movieDownloadStatusesPref}
 			onMovieDownloadStatusToggle={handleMovieDownloadStatusToggle}
 			bind:viewMode={$viewMode}
-			{expandAll}
+			expandAll={$expandAllPref}
 			onToggleExpandAll={toggleExpandAll}
-			sortKey={cardSortKey}
-			sortDirection={cardSortDirection}
+			sortKey={$sortPref.key}
+			sortDirection={$sortPref.direction}
 			onSort={handleCardSort}
 			visibleCardFields={activeVisibleCardFields}
 			toggleableCardFields={activeCardFields}
@@ -853,7 +673,7 @@
 						data={filteredMovies}
 						loading={loading || refreshing}
 						{baseUrl}
-						{expandAll}
+						expandAll={$expandAllPref}
 						visibleColumns={activeVisibleColumns}
 						emptyMessage={movieEmptyMessage}
 					/>
@@ -879,7 +699,7 @@
 						data={filteredSeries}
 						loading={loading || refreshing}
 						{baseUrl}
-						{expandAll}
+						expandAll={$expandAllPref}
 						instanceId={data.instance.id}
 						visibleColumns={activeVisibleColumns}
 						highlightGroups={activeReleaseGroups}

--- a/src/routes/arr/[id]/library/components/LibraryActionBar.svelte
+++ b/src/routes/arr/[id]/library/components/LibraryActionBar.svelte
@@ -12,6 +12,7 @@
 		ChevronsDownUp,
 		ChevronsUpDown
 	} from '@lucide/svelte';
+	import { getLibrarySortOptions } from '$shared/utils/libraryPrefs';
 	import ActionsBar from '$ui/actions/ActionsBar.svelte';
 	import ActionButton from '$ui/actions/ActionButton.svelte';
 	import ViewToggle from '$ui/actions/ViewToggle.svelte';
@@ -60,14 +61,6 @@
 	export let onSort: (key: string, direction: 'asc' | 'desc') => void = () => {};
 	export let useSimpleMode: boolean = false;
 
-	const commonSortOptions = [
-		{ key: 'title', label: 'Title' },
-		{ key: 'size', label: 'Size' },
-		{ key: 'dateAdded', label: 'Date Added' },
-		{ key: 'year', label: 'Year' },
-		{ key: 'score', label: 'Score' }
-	];
-
 	function handleSortClick(key: string) {
 		if (sortKey === key) {
 			const newDir = sortDirection === 'asc' ? 'desc' : 'asc';
@@ -78,19 +71,7 @@
 	}
 
 	$: isRadarr = instanceType === 'radarr';
-	$: sortOptions = isRadarr
-		? [
-				...commonSortOptions,
-				{ key: 'initialReleaseDate', label: 'Initial Release' },
-				{ key: 'theatricalReleaseDate', label: 'Theatrical Release' },
-				{ key: 'digitalReleaseDate', label: 'Digital Release' },
-				{ key: 'physicalReleaseDate', label: 'Physical Release' }
-			]
-		: [
-				...commonSortOptions,
-				{ key: 'firstAired', label: 'Series Premiere' },
-				{ key: 'previousAiring', label: 'Latest Aired Episode' }
-			];
+	$: sortOptions = getLibrarySortOptions(instanceType);
 	$: filterPlaceholder = isRadarr ? 'Filter movies...' : 'Filter series...';
 	$: openLabel = isRadarr ? 'Open in Radarr' : 'Open in Sonarr';
 	$: refreshTooltip = refreshStatusText ? `Refresh · ${refreshStatusText}` : 'Refresh';

--- a/tests/unit/shared/libraryPrefs.test.ts
+++ b/tests/unit/shared/libraryPrefs.test.ts
@@ -1,0 +1,79 @@
+import { assertEquals } from '@std/assert';
+import { BaseTest } from '../base/BaseTest.ts';
+import {
+	parseBooleanPref,
+	parseLibraryDownloadStatusesPref,
+	parseLibrarySortPref,
+	parseStringSetPref
+} from '$shared/utils/libraryPrefs.ts';
+
+class LibraryPrefsTest extends BaseTest {
+	runTests(): void {
+		this.test('parseBooleanPref returns fallback for missing or invalid values', () => {
+			assertEquals(parseBooleanPref(null, false), false);
+			assertEquals(parseBooleanPref(null, true), true);
+			assertEquals(parseBooleanPref('yes', false), false);
+			assertEquals(parseBooleanPref('true', false), true);
+			assertEquals(parseBooleanPref('false', true), false);
+		});
+
+		const allowed = ['a', 'b', 'c'] as const;
+		const defaults = ['a', 'b'] as const;
+
+		this.test('parseStringSetPref returns defaults when missing or malformed', () => {
+			assertEquals(parseStringSetPref(null, allowed, defaults), new Set(['a', 'b']));
+			assertEquals(parseStringSetPref('not json', allowed, defaults), new Set(['a', 'b']));
+			assertEquals(parseStringSetPref('{"a":1}', allowed, defaults), new Set(['a', 'b']));
+		});
+
+		this.test('parseStringSetPref drops unknown keys and keeps empty selections', () => {
+			assertEquals(parseStringSetPref('["c","removed"]', allowed, defaults), new Set(['c']));
+			assertEquals(parseStringSetPref('[]', allowed, defaults), new Set());
+		});
+
+		this.test('parseLibraryDownloadStatusesPref defaults to both statuses', () => {
+			assertEquals(parseLibraryDownloadStatusesPref(null), new Set(['downloaded', 'missing']));
+			assertEquals(parseLibraryDownloadStatusesPref('["missing"]'), new Set(['missing']));
+			assertEquals(parseLibraryDownloadStatusesPref('[]'), new Set());
+		});
+
+		this.test('parseLibrarySortPref accepts valid keys for the instance type', () => {
+			assertEquals(parseLibrarySortPref('{"key":"score","direction":"desc"}', 'radarr'), {
+				key: 'score',
+				direction: 'desc'
+			});
+			assertEquals(
+				parseLibrarySortPref('{"key":"digitalReleaseDate","direction":"asc"}', 'radarr'),
+				{ key: 'digitalReleaseDate', direction: 'asc' }
+			);
+			assertEquals(parseLibrarySortPref('{"key":"firstAired","direction":"desc"}', 'sonarr'), {
+				key: 'firstAired',
+				direction: 'desc'
+			});
+		});
+
+		this.test('parseLibrarySortPref falls back for keys invalid on the instance type', () => {
+			const fallback = { key: 'title', direction: 'asc' };
+			assertEquals(
+				parseLibrarySortPref('{"key":"digitalReleaseDate","direction":"asc"}', 'sonarr'),
+				fallback
+			);
+			assertEquals(
+				parseLibrarySortPref('{"key":"firstAired","direction":"asc"}', 'radarr'),
+				fallback
+			);
+		});
+
+		this.test('parseLibrarySortPref falls back for missing or malformed values', () => {
+			const fallback = { key: 'title', direction: 'asc' };
+			assertEquals(parseLibrarySortPref(null, 'radarr'), fallback);
+			assertEquals(parseLibrarySortPref('nope', 'radarr'), fallback);
+			assertEquals(parseLibrarySortPref('["title"]', 'radarr'), fallback);
+			assertEquals(parseLibrarySortPref('{"key":"title","direction":"up"}', 'radarr'), fallback);
+			assertEquals(parseLibrarySortPref('{"key":5,"direction":"asc"}', 'radarr'), fallback);
+		});
+	}
+}
+
+const test = new LibraryPrefsTest();
+test.runTests();


### PR DESCRIPTION
- Persist the library download status filter and sort per Arr instance
- Move all library toolbar preference persistence into a shared store with validated parsing
- Drop unknown column and card field keys from stored preferences

Closes #918