### PR TITLE
fix: make rename job timeouts configurable

### DIFF
--- a/docs/backend/rename.md
+++ b/docs/backend/rename.md
@@ -80,7 +80,9 @@ enabling live runs.
 4. **Folder rename** (if `renameFolders` is enabled) -- groups items by root
    folder and calls the Arr editor endpoint per group. Folder renames spawn a
    background "Bulk Move" command; `waitForSpawnedCommand` polls `getCommands`
-   every second for up to 30 seconds to find and await it.
+   every second for up to `RENAME_COMMAND_WAIT_MS` (30 seconds by default) to
+   find and await it. If no command appears in that window the processor logs a
+   warning and moves on to the next batch.
 5. **After snapshot** -- captures the same entities again.
 6. **Diff** -- `diffSnapshots()` compares before/after by entity ID. Folder
    path changes and file relative path changes (matched by file ID) are
@@ -112,6 +114,24 @@ instance):
 The job system manages scheduling via `nextRunAt` / `lastRunAt`. After each
 run, the handler calculates the next cron occurrence and updates `nextRunAt`.
 See [jobs.md](./jobs.md) for the dispatch and scheduling details.
+
+### Timeouts
+
+Two environment variables bound the rename job. Both are read by
+[Config](./utilities.md#config) and apply to every instance:
+
+| Variable                    | Default | Purpose                                                            |
+| --------------------------- | ------- | ------------------------------------------------------------------ |
+| `RENAME_REQUEST_TIMEOUT_MS` | `30000` | HTTP timeout for every Arr request the rename job makes            |
+| `RENAME_COMMAND_WAIT_MS`    | `30000` | How long to wait for the Arr to spawn its background Bulk Move job |
+
+Both defaults preserve the job's existing behaviour, so an unconfigured instance
+is unaffected. Large libraries on slow storage need both raised **together**: the
+rename job issues the same full-library requests the library refresh job makes
+with `LIBRARY_REQUEST_TIMEOUT_MS`, so `RENAME_REQUEST_TIMEOUT_MS` is the one to
+raise first -- but doing so on its own still leaves the Bulk Move wait at 30
+seconds, after which the processor proceeds without waiting and the snapshot diff
+undercounts what was renamed.
 
 ## Logging
 

--- a/docs/backend/utilities.md
+++ b/docs/backend/utilities.md
@@ -56,6 +56,7 @@ configuration. Key properties:
 | `parserUrl` | `PARSER_HOST/PORT` | Parser microservice URL          |
 | `oidc`      | `OIDC_*`           | OIDC discovery URL, client creds |
 | `timezone`  | `TZ`               | Fallback to system timezone      |
+| `rename`    | `RENAME_*`         | Rename job request/command waits |
 
 The `paths` object computes derived directories (logs, database, backups,
 data) from `basePath`. `init()` creates all required directories at startup

--- a/src/lib/server/rename/processor.ts
+++ b/src/lib/server/rename/processor.ts
@@ -18,6 +18,7 @@ import { logRenameRun, logRenameError } from './logger.ts';
 import { notifications } from '$notifications/definitions/index.ts';
 import { notificationManager } from '$notifications/NotificationManager.ts';
 import { logger } from '$logger/logger.ts';
+import { config } from '$config';
 
 import {
 	createLog,
@@ -62,8 +63,10 @@ async function waitForSpawnedCommand(
 	label: string
 ): Promise<void> {
 	// Poll for the new command to appear (may take a moment)
-	for (let attempt = 0; attempt < 30; attempt++) {
-		await new Promise((r) => setTimeout(r, 1000));
+	const pollIntervalMs = 1000;
+	const maxAttempts = Math.max(1, Math.ceil(config.rename.commandWaitMs / pollIntervalMs));
+	for (let attempt = 0; attempt < maxAttempts; attempt++) {
+		await new Promise((r) => setTimeout(r, pollIntervalMs));
 
 		const commands = await client.getCommands();
 		const newCmd = commands.find(
@@ -90,9 +93,12 @@ async function waitForSpawnedCommand(
 		}
 	}
 
-	await logger.warn(`No spawned command found for ${label} after 30s, proceeding`, {
-		source: SOURCE
-	});
+	await logger.warn(
+		`No spawned command found for ${label} after ${(maxAttempts * pollIntervalMs) / 1000}s, proceeding`,
+		{
+			source: SOURCE
+		}
+	);
 }
 
 // =========================================================================
@@ -254,7 +260,8 @@ export async function processRenameConfig(
 		const client = createArrClient(
 			instance.type as 'radarr' | 'sonarr',
 			instance.url,
-			instance.api_key
+			instance.api_key,
+			{ timeout: config.rename.requestTimeoutMs }
 		);
 
 		let adapter: RenameAdapter;

--- a/src/lib/server/utils/config/config.ts
+++ b/src/lib/server/utils/config/config.ts
@@ -6,6 +6,24 @@ export type AuthMode = 'on' | 'off' | 'oidc';
 
 export const PROFILARR_API_KEY_MIN_LENGTH = 32;
 
+// Rename job defaults. Both preserve the job's existing behaviour: the request
+// timeout is BaseHttpClient's own fallback, which the rename call site currently
+// inherits by passing no options, and the command wait is the loop bound that is
+// currently hardcoded. Raising either is opt-in via the environment.
+const RENAME_REQUEST_TIMEOUT_DEFAULT_MS = 30000;
+const RENAME_COMMAND_WAIT_DEFAULT_MS = 30000;
+
+/**
+ * Read a positive integer from the environment, falling back to `fallback` when
+ * the variable is unset, unparseable, or not positive.
+ */
+function positiveIntEnv(name: string, fallback: number): number {
+	const raw = Deno.env.get(name);
+	if (!raw) return fallback;
+	const parsed = parseInt(raw, 10);
+	return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
 class Config {
 	private basePath: string;
 	public readonly timezone: string;
@@ -21,6 +39,10 @@ class Config {
 		clientSecret: string | null;
 	};
 	public readonly bulletinUrl: string;
+	public readonly rename: {
+		requestTimeoutMs: number;
+		commandWaitMs: number;
+	};
 
 	constructor() {
 		// Default base path logic:
@@ -83,6 +105,17 @@ class Config {
 			Deno.env.get('PROFILARR_BULLETIN_URL') ||
 			'https://raw.githubusercontent.com/Dictionarry-Hub/bulletin/main'
 		).replace(/\/+$/, '');
+
+		// Rename job timeouts. `requestTimeoutMs` is the HTTP timeout for every arr
+		// request the rename job makes; `commandWaitMs` bounds how long it waits for
+		// the arr to spawn its background Bulk Move command after a folder rename.
+		this.rename = {
+			requestTimeoutMs: positiveIntEnv(
+				'RENAME_REQUEST_TIMEOUT_MS',
+				RENAME_REQUEST_TIMEOUT_DEFAULT_MS
+			),
+			commandWaitMs: positiveIntEnv('RENAME_COMMAND_WAIT_MS', RENAME_COMMAND_WAIT_DEFAULT_MS)
+		};
 	}
 
 	/**


### PR DESCRIPTION
# fix: make rename job timeouts configurable

## The defect

The rename job builds its arr client with no options:

```ts
// src/lib/server/rename/processor.ts
const client = createArrClient(
    instance.type as 'radarr' | 'sonarr',
    instance.url,
    instance.api_key
);
```

`createArrClient` forwards `options` to `RadarrClient` / `SonarrClient`, which pass `options?.timeout` up to `BaseHttpClient`. With no options, that lands on the generic default:

```ts
// src/lib/server/utils/http/client.ts:19
this.timeout = options?.timeout ?? 30000;
```

So the rename job runs with a 30 second HTTP timeout. It then issues the same full-library requests the library refresh job makes — `getMovies()`, `getAllSeries()`, `getEpisodeFiles()` per series — plus a preview call per item. On a large library backed by slow storage Radarr/Sonarr take longer than 30 seconds to answer, `AbortController` fires, and `BaseHttpClient` throws `HttpError('Request timeout', 408)`. `processFolderRename` catches it and records:

```
Folder rename failed for root "<path>": Request timeout
```

The run is marked `failed`.

## The internal inconsistency

30 seconds was never chosen for this path. It is the `BaseHttpClient` fallback, inherited because the call site passes nothing. Every other path that can run long already overrides it:

| Path                            | Timeout (ms) |     | Where                                                                  |
| ------------------------------- | -----------: | --- | ---------------------------------------------------------------------- |
| Library refresh job             |       300000 | 5m  | `jobs/handlers/arrLibraryRefresh.ts:54` (`LIBRARY_REQUEST_TIMEOUT_MS`) |
| Library routes (movies, series) |       300000 | 5m  | `routes/arr/[id]/library/{movies,series}/+server.ts` (same constant)   |
| Upgrade preview and processor   |       120000 | 2m  | `upgrades/preview.ts:411-412`, `upgrades/processor.ts:342`             |
| Interactive search              |       120000 | 2m  | `arr/clients/radarr.ts:205`, `arr/clients/sonarr.ts:346`               |
| Connection test                 |         3000 | 3s  | `routes/arr/validate/+server.ts:22` (deliberately short, `retries: 0`) |
| **Rename job**                  |    **30000** | 30s | `rename/processor.ts:254` — inherited default, nothing passed          |

The rename job does strictly more work than the library refresh job, which was given 300 seconds precisely because these requests are slow.

## There are two 30 second ceilings

Raising the HTTP timeout alone is not enough. `waitForSpawnedCommand` has a second, independent 30 second wall:

```ts
// src/lib/server/rename/processor.ts
for (let attempt = 0; attempt < 30; attempt++) {
    await new Promise((r) => setTimeout(r, 1000));
    const commands = await client.getCommands();
    ...
}
await logger.warn(`No spawned command found for ${label} after 30s, proceeding`, ...);
```

After the editor endpoint spawns a background "Bulk Move", this polls for the new command to appear. If it does not appear within 30 polls it logs a warning and **returns** — it does not throw.

That makes the second ceiling worse than a failure, because it is silent. Once the HTTP timeout is raised, a slow arr that takes more than 30 seconds to surface the Bulk Move no longer errors; instead the processor moves straight to the next batch and then to the after-snapshot while the move is still running. `diffSnapshots()` compares a library mid-move, so the run reports `success` with folder and file counts that undercount what actually changed. The job looks fixed and is still wrong.

Note that the warning string also hardcodes `30s`, so it would lie as soon as the loop bound changed.

## What changed

Two environment variables, read in `Config` alongside every other env var, with a small `positiveIntEnv` helper so an unset, unparseable, or non-positive value falls back to the default:

| Variable                    | Default | Effect                                                             |
| --------------------------- | ------- | ------------------------------------------------------------------ |
| `RENAME_REQUEST_TIMEOUT_MS` | `30000` | HTTP timeout for every arr request the rename job makes            |
| `RENAME_COMMAND_WAIT_MS`    | `30000` | How long to wait for the arr to spawn its background Bulk Move job |

- `src/lib/server/utils/config/config.ts` — adds `config.rename` (`requestTimeoutMs`, `commandWaitMs`), the two module-level defaults, and a `positiveIntEnv` helper.
- `src/lib/server/rename/processor.ts` — passes `{ timeout: config.rename.requestTimeoutMs }` at the one client-creation site, and derives `waitForSpawnedCommand`'s loop bound from `config.rename.commandWaitMs` at the existing 1 second poll interval. The warning message now reports the configured window instead of a hardcoded `30s`.
- `docs/backend/rename.md`, `docs/backend/utilities.md` — document both variables.

### On the defaults

**Neither default changes current behaviour.** `RENAME_REQUEST_TIMEOUT_MS` defaults to 30000, which is what the call site inherits from `BaseHttpClient` today, and `RENAME_COMMAND_WAIT_MS` defaults to 30000, which is the loop bound that is currently hardcoded. An instance that sets neither behaves exactly as it does now. This change adds the ability to raise them; it does not decide for anyone where they should sit.

Operators on large libraries backed by slow storage will want to raise both. `RENAME_REQUEST_TIMEOUT_MS` is the one to raise first, since the rename job makes the same full-library requests the library refresh job makes with `LIBRARY_REQUEST_TIMEOUT_MS` (300000) -- but raising it alone leaves the second ceiling in place, with the silent undercount described above.

The two windows are kept as separate knobs rather than one because they bound different things. The command wait is paid in full whenever the arr legitimately spawns no command (nothing needed moving in that batch), once per batch. Tying it to the request timeout would make a large Radarr library with nothing to move sit for the whole request timeout per 50-item batch.

## How to verify

Defaults, and rejection of bad input:

```
$ deno eval --ext=ts "import {config} from './src/lib/server/utils/config/config.ts'; console.log(JSON.stringify(config.rename));"
{"requestTimeoutMs":30000,"commandWaitMs":30000}

$ RENAME_REQUEST_TIMEOUT_MS=600000 RENAME_COMMAND_WAIT_MS=600000 deno eval --ext=ts "..."
{"requestTimeoutMs":600000,"commandWaitMs":600000}

$ RENAME_REQUEST_TIMEOUT_MS=0 RENAME_COMMAND_WAIT_MS=abc deno eval --ext=ts "..."
{"requestTimeoutMs":30000,"commandWaitMs":30000}
```

Against a real instance: run a rename job with `renameFolders` enabled on a library large enough that the editor request exceeds 30 seconds. Unconfigured, the run fails with `Folder rename failed for root "<path>": Request timeout`, before and after this change alike. Set `RENAME_REQUEST_TIMEOUT_MS=300000` and the run completes. To exercise the second ceiling, set `RENAME_COMMAND_WAIT_MS=5000` and confirm the log reads `No spawned command found for <label> after 5s, proceeding`.

## Validation

Run with Deno 2.8.3 and Node 22 per `.tool-versions`:

- `deno task lint` — passes. Prettier clean across 490 files, `deno lint` clean, and all six custom lint tasks pass.
- `deno task check` — passes. `check:server` clean; `check:client` reports `5360 FILES 0 ERRORS 0 WARNINGS`.
- `deno task test` — `578 passed | 0 failed`. `deno task test unit rename` alone is `30 passed | 0 failed`.
- `deno task build` — succeeds (Vite build plus `deno compile`).
- `deno task test integration` — `79 specs passed in 118.3s` (Docker-backed suites auto-managed and torn down by the runner).
- `deno task test e2e auth` — `2 passed`.
- `deno task test zap --baseline` — passes. `FAIL-NEW: 0, WARN-NEW: 11, PASS: 56` across both scanned instances (`AUTH=on` and `AUTH=off`). The 11 warnings are pre-existing passive-scan findings about response headers (CSP, Permissions-Policy, COEP, anti-CSRF tokens); this change adds no routes, no request handlers and no headers, so it does not touch them.

None of the integration, E2E or ZAP suites cover the rename job. They exercise this change only as a regression check; the behavioural evidence is the timeout arithmetic above.

